### PR TITLE
GitHub Actions SwiftLint 설정 파일 추가

### DIFF
--- a/.github/workflows/danger_swiftlint.yml
+++ b/.github/workflows/danger_swiftlint.yml
@@ -1,0 +1,18 @@
+name: Danger SwiftLint
+
+on:
+  pull_request:
+
+jobs:
+  Danger:
+    runs-on: ubuntu-latest
+
+    permissions: write-all
+
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Danger
+        uses: 417-72KI/danger-swiftlint@v5.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,33 @@
+disabled_rules:
+  - todo
+  - trailing_whitespace
+
+opt_in_rules:
+  - force_unwrapping
+  - indentation_width
+  - sorted_imports
+  - multiline_arguments
+  - multiline_parameters_brackets
+
+analyzer_rules:
+  - explicit_self
+
+included:
+  - ToDo-Garden/ToDo-Garden/
+
+excluded:
+    - ToDo-Garden/*/Package.swift
+
+indentation_width:
+  indentation_width: 2
+
+force_unwrapping:
+  severity: error
+
+function_body_length:
+  - 25 # warning
+  - 35 # error
+
+type_body_length:
+  - 300 # warning
+  - 400 # error

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -1,0 +1,24 @@
+import Danger
+import Foundation
+
+let danger = Danger()
+let editedFiles = danger.git.modifiedFiles + danger.git.createdFiles
+
+// 투두가든 템플릿을 이용해서 Scene 생성시 최대 9개의 파일이 생성됩니다.
+// 하나의 PR에 수정된 파일이 최대 9개를 넘지 않도록 합니다.
+if editedFiles.count > 10 {
+	warn("PR의 단위가 너무 큽니다. \n 다음부터는 PR 단위를 작게 만들 수 있도록 노력해주세요 💪")
+}
+
+let swiftLintViolations = SwiftLint.lint(inline: true, configFile: ".swiftlint.yml")
+
+if swiftLintViolations.isEmpty {
+	markdown("✅ 모든 파일이 코드 컨벤션을 준수했어요")
+	markdown("| ✅ | 🙇🏻‍♂️ 고생 많으셨습니다. |\n|---|----------------------------------------------|")
+} else {
+	warn("코드 컨벤션 관련 문제를 발견했어요 merge하기 전 확인해주세요 :)")
+	markdown("## 🔎👮  Files with violations")
+	for violation in swiftLintViolations {
+		markdown("- \(violation.file) - \(violation.reason) at line \(violation.line)")
+	}
+}


### PR DESCRIPTION
## 💡 관련 이슈
- related: #11 

## 🎉 변경 사항
- GitHub Actions를 이용해 Pull Request 생성 시 SwiftLint violation을 확인할 수 있도록 하였습니다.

## 📌 PR Point
- 기존의 Danger의 공식문서에서 가이드하는 방식은 이미지에 SwiftLint를 포함하고 있지 않기에 SwiftLint 도커 이미지를 빌드하는 과정이 오래걸렸습니다.
  - 따라서 docker hub에서 빌드된 도커 이미지를 가져오는 방식을 사용하는 [workflow](https://github.com/417-72KI/danger-swiftlint)를 선택하였습니다.
  - 결과적으로 GitHub Actions의 실행시간을 4분(ubuntu-latest 기준)에서 1분 20초로 줄일 수 있었습니다.
- 아래의 셀프체크 리스트 중 체크되어있지 않은 부분은 프로젝트 설정 작업 후 진행합니다.
## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [ ]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?