### PR TITLE
ViewController 추상화

### DIFF
--- a/ToDo-Garden/ToDo-Garden.xcodeproj/project.pbxproj
+++ b/ToDo-Garden/ToDo-Garden.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		4FC8C1062B8336A100BA223E /* ToDo-GardenTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ToDo-GardenTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4FC8C1082B8336A100BA223E /* ToDoGardenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoGardenTests.swift; sourceTree = "<group>"; };
 		4FC8C10F2B83375500BA223E /* ToDo-GardenTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "ToDo-GardenTestPlan.xctestplan"; sourceTree = "<group>"; };
+		4FC8C14A2B87562600BA223E /* ToDoGardenUI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = ToDoGardenUI; sourceTree = "<group>"; };
 		4FDA5E382B4FF1E4006506ED /* Asset.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Asset.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -57,6 +58,7 @@
 		4F0DF11F2B4EABCE00097B7D = {
 			isa = PBXGroup;
 			children = (
+				4FC8C14A2B87562600BA223E /* ToDoGardenUI */,
 				4F0DF12A2B4EABCE00097B7D /* ToDo-Garden */,
 				4FC8C1072B8336A100BA223E /* ToDo-GardenTests */,
 				4F0DF1292B4EABCE00097B7D /* Products */,

--- a/ToDo-Garden/ToDo-Garden.xcodeproj/project.pbxproj
+++ b/ToDo-Garden/ToDo-Garden.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4F0DF12E2B4EABCE00097B7D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0DF12D2B4EABCE00097B7D /* SceneDelegate.swift */; };
 		4F0DF1382B4EABD000097B7D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F0DF1362B4EABD000097B7D /* LaunchScreen.storyboard */; };
 		4FC8C1092B8336A100BA223E /* ToDoGardenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC8C1082B8336A100BA223E /* ToDoGardenTests.swift */; };
+		4FC8C1512B8C575A00BA223E /* ToDoGardenUIAPI in Frameworks */ = {isa = PBXBuildFile; productRef = 4FC8C1502B8C575A00BA223E /* ToDoGardenUIAPI */; };
 		4FDA5E392B4FF1E4006506ED /* Asset.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4FDA5E382B4FF1E4006506ED /* Asset.xcassets */; };
 /* End PBXBuildFile section */
 
@@ -42,6 +43,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4FC8C1512B8C575A00BA223E /* ToDoGardenUIAPI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -62,6 +64,7 @@
 				4F0DF12A2B4EABCE00097B7D /* ToDo-Garden */,
 				4FC8C1072B8336A100BA223E /* ToDo-GardenTests */,
 				4F0DF1292B4EABCE00097B7D /* Products */,
+				4FC8C14F2B8C575A00BA223E /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -109,6 +112,13 @@
 			path = "ToDo-GardenTests";
 			sourceTree = "<group>";
 		};
+		4FC8C14F2B8C575A00BA223E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		4FDA5E372B4FF1B0006506ED /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -135,6 +145,9 @@
 			dependencies = (
 			);
 			name = "ToDo-Garden";
+			packageProductDependencies = (
+				4FC8C1502B8C575A00BA223E /* ToDoGardenUIAPI */,
+			);
 			productName = "ToDo-Garden";
 			productReference = 4F0DF1282B4EABCE00097B7D /* ToDo-Garden.app */;
 			productType = "com.apple.product-type.application";
@@ -494,6 +507,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		4FC8C1502B8C575A00BA223E /* ToDoGardenUIAPI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ToDoGardenUIAPI;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 4F0DF1202B4EABCE00097B7D /* Project object */;
 }

--- a/ToDo-Garden/ToDoGardenUI/.gitignore
+++ b/ToDo-Garden/ToDoGardenUI/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/ToDo-Garden/ToDoGardenUI/Package.swift
+++ b/ToDo-Garden/ToDoGardenUI/Package.swift
@@ -1,0 +1,8 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+	name: "ToDoGardenUI",
+)

--- a/ToDo-Garden/ToDoGardenUI/Package.swift
+++ b/ToDo-Garden/ToDoGardenUI/Package.swift
@@ -5,4 +5,14 @@ import PackageDescription
 
 let package = Package(
 	name: "ToDoGardenUI",
+	platforms: [.iOS(.v15)],
+	products: [
+		.library(
+			name: "ToDoGardenUIAPI",
+			targets: ["ToDoGardenUIAPI"]
+		)
+	],
+	targets: [
+		.target(name: "ToDoGardenUIAPI")
+	]
 )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/ViewControllable.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/ViewControllable.swift
@@ -1,0 +1,4 @@
+import UIKit.UIViewController
+
+public protocol ViewControllable where Self: UIViewController {
+}


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #17 

## 🎉 변경 사항
- 화면객체간 소스코드 의존성을 끊어내고,객체의 생성과 사용을 분리하도록 하기위해 `ViewControllable` 프로토콜을 추가하여 화면객체인 `UIViewController`가 해당 프로토콜을 채택하도록 하여 `UIViewController` 타입을 추상화하여, 해당 객체를 생성하는 쪽에서 타입 정보외에 `UIViewController`의 구체적인 정보에 대해 접근하지 못하도록 하였습니다.
- ToDo-Garden의 UI관련 패키지인 `ToDoGardenUI` Package를 추가하였습니다.
- `ToDoGardenUI` 패키지에서 외부로 드러내야하는 인터페이스가 담긴 모듈을 추가하여,구현체 모듈과 인터페이스 모듈(`ToDoGardenUIAPI`)을 분리하도록 하였습니다.

## 📌 PR Point
아래의 셀프체크 리스트 중 체크되어있지 않은 부분은 프로젝트 설정 작업 후 진행합니다.
## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?