### PR TITLE
TimerControl Button 스타일 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden.xcodeproj/project.pbxproj
+++ b/ToDo-Garden/ToDo-Garden.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		4F0DF12C2B4EABCE00097B7D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0DF12B2B4EABCE00097B7D /* AppDelegate.swift */; };
 		4F0DF12E2B4EABCE00097B7D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0DF12D2B4EABCE00097B7D /* SceneDelegate.swift */; };
 		4F0DF1382B4EABD000097B7D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F0DF1362B4EABD000097B7D /* LaunchScreen.storyboard */; };
+		4F3D03842B8EF89800C495E5 /* ToDoGardenUIComponent in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3D03832B8EF89800C495E5 /* ToDoGardenUIComponent */; };
 		4F3D03862B8EF89800C495E5 /* ToDoGardenUIResource in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3D03852B8EF89800C495E5 /* ToDoGardenUIResource */; };
 		4FC8C1092B8336A100BA223E /* ToDoGardenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC8C1082B8336A100BA223E /* ToDoGardenTests.swift */; };
 		4FC8C1512B8C575A00BA223E /* ToDoGardenUIAPI in Frameworks */ = {isa = PBXBuildFile; productRef = 4FC8C1502B8C575A00BA223E /* ToDoGardenUIAPI */; };
@@ -46,6 +47,7 @@
 			files = (
 				4FC8C1512B8C575A00BA223E /* ToDoGardenUIAPI in Frameworks */,
 				4F3D03862B8EF89800C495E5 /* ToDoGardenUIResource in Frameworks */,
+				4F3D03842B8EF89800C495E5 /* ToDoGardenUIComponent in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -149,6 +151,7 @@
 			name = "ToDo-Garden";
 			packageProductDependencies = (
 				4FC8C1502B8C575A00BA223E /* ToDoGardenUIAPI */,
+				4F3D03832B8EF89800C495E5 /* ToDoGardenUIComponent */,
 				4F3D03852B8EF89800C495E5 /* ToDoGardenUIResource */,
 			);
 			productName = "ToDo-Garden";
@@ -512,6 +515,10 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		4F3D03832B8EF89800C495E5 /* ToDoGardenUIComponent */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ToDoGardenUIComponent;
+		};
 		4F3D03852B8EF89800C495E5 /* ToDoGardenUIResource */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ToDoGardenUIResource;

--- a/ToDo-Garden/ToDoGardenUI/Package.swift
+++ b/ToDo-Garden/ToDoGardenUI/Package.swift
@@ -12,12 +12,20 @@ let package = Package(
 			targets: ["ToDoGardenUIAPI"]
 		),
 		.library(
+			name: "ToDoGardenUIComponent",
+			targets: ["ToDoGardenUIComponent"]
+		),
+		.library(
 			name: "ToDoGardenUIResource",
 			targets: ["ToDoGardenUIResource"]
 		)
 	],
 	targets: [
 		.target(name: "ToDoGardenUIAPI"),
+		.target(
+			name: "ToDoGardenUIComponent",
+			dependencies: ["ToDoGardenUIResource"]
+		),
 		.target(
 			name: "ToDoGardenUIResource",
 			resources: [

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+TimerControlButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+TimerControlButton.swift
@@ -27,14 +27,14 @@ extension UIButton {
 	private func setupDestructiveStyleBackgroundImage() {
 		self.setBackgroundImage(
 			UIImage.timerControlButtonDestructiveBackground,
-			for: .normal
+			for: UIControl.State.normal
 		)
 	}
 	
 	private func setupDefaultStyleBackgroundImage() {
 		self.setBackgroundImage(
 			UIImage.timerControlButtonDefaultBackground,
-			for: .normal
+			for: UIControl.State.normal
 		)
 	}
 	
@@ -47,6 +47,6 @@ extension UIButton {
 			]
 		)
 		
-		self.setAttributedTitle(attributedTitle, for: .normal)
+		self.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
 	}
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+TimerControlButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+TimerControlButton.swift
@@ -1,0 +1,9 @@
+//
+//  UIButton+TimerControlButton.swift
+//
+//
+//  Created by Noah on 2/28/24.
+//
+
+import UIKit
+

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+TimerControlButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+TimerControlButton.swift
@@ -7,3 +7,34 @@
 
 import UIKit
 
+import ToDoGardenUIResource
+
+extension UIButton {
+	public func timerControlButtonDestructiveStyle(with title: String) {
+		self.setupDestructiveStyleBackgroundImage()
+		self.setupTitleForTimerControlButton(with: title)
+	}
+}
+
+// MARK: - private functions
+
+extension UIButton {
+	private func setupDestructiveStyleBackgroundImage() {
+		self.setBackgroundImage(
+			UIImage.timerControlButtonDestructiveBackground,
+			for: .normal
+		)
+	}
+	
+	private func setupTitleForTimerControlButton(with title: String) {
+		let attributedTitle = NSAttributedString(
+			string: title,
+			attributes: [
+				NSAttributedString.Key.font: UIFont.pretendardBodySemiBold15,
+				NSAttributedString.Key.foregroundColor: UIColor.white
+			]
+		)
+		
+		self.setAttributedTitle(attributedTitle, for: .normal)
+	}
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+TimerControlButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+TimerControlButton.swift
@@ -14,6 +14,11 @@ extension UIButton {
 		self.setupDestructiveStyleBackgroundImage()
 		self.setupTitleForTimerControlButton(with: title)
 	}
+	
+	public func timerControlButtonDefaultStyle(with title: String) {
+		self.setupDefaultStyleBackgroundImage()
+		self.setupTitleForTimerControlButton(with: title)
+	}
 }
 
 // MARK: - private functions
@@ -22,6 +27,13 @@ extension UIButton {
 	private func setupDestructiveStyleBackgroundImage() {
 		self.setBackgroundImage(
 			UIImage.timerControlButtonDestructiveBackground,
+			for: .normal
+		)
+	}
+	
+	private func setupDefaultStyleBackgroundImage() {
+		self.setBackgroundImage(
+			UIImage.timerControlButtonDefaultBackground,
 			for: .normal
 		)
 	}


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #23 

## 🎉 변경 사항
- `UIButton`에 TimerControl Button 스타일을 적용하는 함수를 추가하였습니다.

## 📌 PR Point
- `UIButton`을 상속받아 새로운 타입을 만드는 것보다, 기존의 `UIButton` 타입을 활용하되 extension을 이용해 button의 style을 적용하는 함수를 추가하도록 하였습니다.
- 모듈 구조를 이용해 모든 `UIButton`이 해당 extension을 사용하는 것이 아닌 프로젝트의 재사용 가능한 UIComponent를 관리하는 모듈인 `ToDoGardenUIComponent`를 import하는 곳에서만 해당 style을 적용하는 함수를 사용할 수 있도록 하여 모든 `UIButton`이 해당 extension을 가지게 되는 강결합 문제를 해결하도록 하였습니다.

사용 예:

```swift
/.../
import ToDoGardenUIComponent

let giveUpButton = UIButton()
giveUpButton.timerControlButtonDefaultStyle(with: "포기하기")
```

| `default` 스타일	| `destructive` 스타일	|
|----------------	|----------------	|
| <img width="372" height="812" alt="Screenshot 2024-02-28 at 9 16 17 PM" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/63908856/d3a4d0cd-f1ba-4a70-b3b7-30961d255b06">|<img width="372" height="812" alt="Screenshot 2024-02-28 at 9 17 24 PM" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/63908856/74fde947-2055-41a8-bcd1-d33f3de81274">|




## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?