### PR TITLE
PretendardFont 중복 설정 관련 오류 수정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/Sources/Application/AppDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/Sources/Application/AppDelegate.swift
@@ -7,6 +7,21 @@
 
 import UIKit
 
+import ToDoGardenUIResource
+
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
+	func application(
+		_ application: UIApplication,
+		didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+	) -> Bool {
+		self.registerCustomFonts()
+		return true
+	}
+}
+
+extension AppDelegate {
+	private func registerCustomFonts() {
+		PretendardFont.register()
+	}
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIFont+ToDoGarden.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIFont+ToDoGarden.swift
@@ -94,6 +94,7 @@ public enum PretendardFont: String, CaseIterable {
 	public static func register() {
 		guard PretendardFont.isPretendardFontRegistered == false
 		else { return }
+		defer { PretendardFont.isPretendardFontRegistered = true }
 		
 		PretendardFont.allCases.forEach { font in
 			guard let url = Bundle.module.url(

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIFont+ToDoGarden.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIFont+ToDoGarden.swift
@@ -89,10 +89,10 @@ public enum PretendardFont: String, CaseIterable {
 	}
 	
 	/// Font의 register는 한번만 되어야하기 때문에 아래의 flag 변수를 사용합니다.
-	private static var isPretendardFontRegisterd: Bool = false
+	private static var isPretendardFontRegistered: Bool = false
 	
 	public static func register() {
-		guard PretendardFont.isPretendardFontRegisterd == false
+		guard PretendardFont.isPretendardFontRegistered == false
 		else { return }
 		
 		PretendardFont.allCases.forEach { font in


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #27 

## 🎉 변경 사항
- 폰트 등록관련 플래그 변수의 오타를 수정하였습니다. 
`isPretendardFontRegisterd` => `isPretendardFontRegistered
- 프리텐다드 폰트 등록 시점을 변경하였습니다.
- 폰트 등록 후 플래그 변수를 올바르게 설정하도록 변경하였습니다.

## 📌 PR Point
- 관련 테스트 코드는 테스트 코드 서포트 관련 패키지 추가 후 작성할 예정입니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?