### PR TITLE
RemainingTimeView 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
@@ -13,16 +13,27 @@ public final class RemainingTimeView: UIView {
 	public init() {
 		self.remainingTimeLabel = UILabel()
 		super.init(frame: CGRect.zero)
+		self.setupUIAppearance()
 	}
 	
 	public required init?(coder: NSCoder) {
 		self.remainingTimeLabel = UILabel()
 		super.init(coder: coder)
+		self.setupUIAppearance()
+	}
+extension RemainingTimeView {
+	private func setupUIAppearance() {
+		RemainingTimeViewStyle.apply(for: self, with: self.remainingTimeLabel)
 	}
 }
 
 /// RemainingTimeView의 UI Style을 설정해주는 타입입니다.
 fileprivate enum RemainingTimeViewStyle {
+	fileprivate static func apply(for remainingTimeView: UIView, with remainingTimeLabel: UILabel) {
+		RemainingTimeViewStyle.roundedCorner(remainingTimeView)
+		RemainingTimeViewStyle.setupRemainingTimeLabelLayout(for: remainingTimeView, with: remainingTimeLabel)
+		RemainingTimeViewStyle.setupFontForRemainingTimeLabel(remainingTimeLabel)
+	}
 }
 
 extension RemainingTimeViewStyle {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
@@ -31,6 +31,16 @@ extension RemainingTimeViewStyle {
 		view.layer.cornerRadius = 6
 	}
 	
+	fileprivate static func setupRemainingTimeLabelLayout(for remainingTimeView: UIView, with remainingTimeLabel: UILabel) {
+		remainingTimeView.addSubview(remainingTimeLabel)
+		remainingTimeLabel.usingAutolayout()
+		
+		NSLayoutConstraint.activate([
+			remainingTimeLabel.centerXAnchor.constraint(equalTo: remainingTimeView.centerXAnchor),
+			remainingTimeLabel.centerYAnchor.constraint(equalTo: remainingTimeView.centerYAnchor)
+		])
+	}
+	
 	fileprivate static func setupFontForRemainingTimeLabel(_ remainingTimeLabel: UILabel) {
 		remainingTimeLabel.font = UIFont.pretendardBodyBold
 	}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
@@ -23,5 +23,11 @@ public final class RemainingTimeView: UIView {
 
 /// RemainingTimeView의 UI Style을 설정해주는 타입입니다.
 fileprivate enum RemainingTimeViewStyle {
+}
 
+extension RemainingTimeViewStyle {
+	fileprivate static func roundedCorner(_ view: UIView) {
+		view.clipsToBounds = true
+		view.layer.cornerRadius = 6
+	}
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
@@ -20,3 +20,8 @@ public final class RemainingTimeView: UIView {
 		super.init(coder: coder)
 	}
 }
+
+/// RemainingTimeView의 UI Style을 설정해주는 타입입니다.
+fileprivate enum RemainingTimeViewStyle {
+
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
@@ -56,7 +56,10 @@ extension RemainingTimeViewStyle {
 		view.layer.cornerRadius = 6
 	}
 	
-	private static func setupRemainingTimeLabelLayout(for remainingTimeView: RemainingTimeView, with remainingTimeLabel: UILabel) {
+	private static func setupRemainingTimeLabelLayout(
+		for remainingTimeView: RemainingTimeView,
+		with remainingTimeLabel: UILabel
+	) {
 		remainingTimeView.addSubview(remainingTimeLabel)
 		remainingTimeLabel.usingAutolayout()
 		

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
@@ -30,4 +30,8 @@ extension RemainingTimeViewStyle {
 		view.clipsToBounds = true
 		view.layer.cornerRadius = 6
 	}
+	
+	fileprivate static func setupFontForRemainingTimeLabel(_ remainingTimeLabel: UILabel) {
+		remainingTimeLabel.font = UIFont.pretendardBodyBold
+	}
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
@@ -8,11 +8,15 @@
 import UIKit
 
 public final class RemainingTimeView: UIView {
+	private let remainingTimeLabel: UILabel
+	
 	public init() {
+		self.remainingTimeLabel = UILabel()
 		super.init(frame: CGRect.zero)
 	}
 	
 	public required init?(coder: NSCoder) {
+		self.remainingTimeLabel = UILabel()
 		super.init(coder: coder)
 	}
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
@@ -42,8 +42,8 @@ extension RemainingTimeView {
 }
 
 /// RemainingTimeView의 UI Style을 설정해주는 타입입니다.
-fileprivate enum RemainingTimeViewStyle {
-	fileprivate static func apply(for remainingTimeView: UIView, with remainingTimeLabel: UILabel) {
+private enum RemainingTimeViewStyle {
+	fileprivate static func apply(for remainingTimeView: RemainingTimeView, with remainingTimeLabel: UILabel) {
 		RemainingTimeViewStyle.roundedCorner(remainingTimeView)
 		RemainingTimeViewStyle.setupRemainingTimeLabelLayout(for: remainingTimeView, with: remainingTimeLabel)
 		RemainingTimeViewStyle.setupFontForRemainingTimeLabel(remainingTimeLabel)
@@ -51,12 +51,12 @@ fileprivate enum RemainingTimeViewStyle {
 }
 
 extension RemainingTimeViewStyle {
-	fileprivate static func roundedCorner(_ view: UIView) {
+	private static func roundedCorner(_ view: RemainingTimeView) {
 		view.clipsToBounds = true
 		view.layer.cornerRadius = 6
 	}
 	
-	fileprivate static func setupRemainingTimeLabelLayout(for remainingTimeView: UIView, with remainingTimeLabel: UILabel) {
+	private static func setupRemainingTimeLabelLayout(for remainingTimeView: RemainingTimeView, with remainingTimeLabel: UILabel) {
 		remainingTimeView.addSubview(remainingTimeLabel)
 		remainingTimeLabel.usingAutolayout()
 		
@@ -66,7 +66,7 @@ extension RemainingTimeViewStyle {
 		])
 	}
 	
-	fileprivate static func setupFontForRemainingTimeLabel(_ remainingTimeLabel: UILabel) {
+	private static func setupFontForRemainingTimeLabel(_ remainingTimeLabel: UILabel) {
 		remainingTimeLabel.font = UIFont.pretendardBodyBold
 	}
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
@@ -1,0 +1,18 @@
+//
+//  RemainingTimeView.swift
+//
+//
+//  Created by Noah on 3/1/24.
+//
+
+import UIKit
+
+public final class RemainingTimeView: UIView {
+	public init() {
+		super.init(frame: CGRect.zero)
+	}
+	
+	public required init?(coder: NSCoder) {
+		super.init(coder: coder)
+	}
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
@@ -21,6 +21,20 @@ public final class RemainingTimeView: UIView {
 		super.init(coder: coder)
 		self.setupUIAppearance()
 	}
+	
+	public func updateRemainigTime(with time: String) {
+		self.remainingTimeLabel.text = time
+	}
+	
+	public func updateBackgroundColorForBreakTime() {
+		self.backgroundColor = UIColor.toDoGardenLeaf
+	}
+	
+	public func updateBackgroundColorForFoucsTime() {
+		self.backgroundColor = UIColor.toDoGardenLightRed
+	}
+}
+
 extension RemainingTimeView {
 	private func setupUIAppearance() {
 		RemainingTimeViewStyle.apply(for: self, with: self.remainingTimeLabel)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RemainingTimeView.swift
@@ -22,7 +22,7 @@ public final class RemainingTimeView: UIView {
 		self.setupUIAppearance()
 	}
 	
-	public func updateRemainigTime(with time: String) {
+	public func updateRemainingTime(with time: String) {
 		self.remainingTimeLabel.text = time
 	}
 	


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #30 

## 🎉 변경 사항
- 타이머의 남은 시간을 보여주는 `RemainingTimeView`를 추가하였습니다.
- UI의 스타일을 설정하는 타입을 따로 분리하였습니다.
- 외부에서 정보 업데이트를 위해 호출하는 함수를 추가하였습니다.

## 📌 PR Point


| 휴식시간	| 집중시간	|
|----------------	|----------------	|
| <img width="372" alt="Screenshot 2024-03-01 at 7 55 59 PM" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/63908856/23817aa9-d874-4a04-823b-3fb9b37666b9"> | <img width="372" alt="Screenshot 2024-03-01 at 7 56 28 PM" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/63908856/14700b17-4840-4254-98be-ae7549b6f543"> |



## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?