### PR TITLE
NSMutableAttributedString 밑줄 생성 관련 Extension 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/NSMutableAttributedString+addUnderline.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/NSMutableAttributedString+addUnderline.swift
@@ -25,8 +25,8 @@ extension NSMutableAttributedString {
     let attributedString = self
     attributedString.addAttributes(
       [
-        NSAttributedString.Key.underlineStyle : NSUnderlineStyle.single.rawValue,
-        NSAttributedString.Key.underlineColor : underlineColor,
+        NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue,
+        NSAttributedString.Key.underlineColor: underlineColor,
       ],
       range: NSRange(location: location, length: length)
     )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/NSMutableAttributedString+addUnderline.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/NSMutableAttributedString+addUnderline.swift
@@ -20,8 +20,8 @@ extension NSMutableAttributedString {
   ) {
     self.addAttributes(
       [
-        NSAttributedString.Key.underlineStyle : NSUnderlineStyle.single.rawValue,
-        NSAttributedString.Key.underlineColor : color,
+        NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue,
+        NSAttributedString.Key.underlineColor: color
       ],
       range: NSRange(location: location, length: length)
     )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/NSMutableAttributedString+addUnderline.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/NSMutableAttributedString+addUnderline.swift
@@ -26,7 +26,7 @@ extension NSMutableAttributedString {
     attributedString.addAttributes(
       [
         NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue,
-        NSAttributedString.Key.underlineColor: underlineColor,
+        NSAttributedString.Key.underlineColor: underlineColor
       ],
       range: NSRange(location: location, length: length)
     )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/NSMutableAttributedString+addUnderline.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/NSMutableAttributedString+addUnderline.swift
@@ -10,11 +10,11 @@ import UIKit.UIColor
 extension NSMutableAttributedString {
   /// 밑줄을 추가하는 함수입니다.
   /// - Parameters:
-  ///   - color: 추가할 밑줄의 색상입니다.
+  ///   - underlineColor: 추가할 밑줄의 색상입니다.
   ///   - location: 추가할 밑줄의 시작점입니다.
   ///   - length: 추가할 밑줄의 끝점입니다.
   public func addUnderline(
-    with color: UIColor,
+    with underlineColor: UIColor,
     from location: Int,
     to length: Int
   ) -> NSMutableAttributedString? {
@@ -26,7 +26,7 @@ extension NSMutableAttributedString {
     attributedString.addAttributes(
       [
         NSAttributedString.Key.underlineStyle : NSUnderlineStyle.single.rawValue,
-        NSAttributedString.Key.underlineColor : color,
+        NSAttributedString.Key.underlineColor : underlineColor,
       ],
       range: NSRange(location: location, length: length)
     )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/NSMutableAttributedString+addUnderline.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/NSMutableAttributedString+addUnderline.swift
@@ -18,7 +18,7 @@ extension NSMutableAttributedString {
     from location: Int,
     to length: Int
   ) -> NSMutableAttributedString? {
-    guard self.checkRangeToAddUnderlineIsValid(with: location, and: length) else {
+    guard self.isValidRangeToAddUnderline(with: location, and: length) else {
       return nil
     }
 
@@ -34,7 +34,7 @@ extension NSMutableAttributedString {
     return attributedString
   }
 
-  private func checkRangeToAddUnderlineIsValid(
+  private func isValidRangeToAddUnderline(
     with location: Int,
     and length: Int
   ) -> Bool {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/NSMutableAttributedString+addUnderline.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/NSMutableAttributedString+addUnderline.swift
@@ -1,0 +1,29 @@
+//
+//  NSMutableAttributedString+addUnderline.swift
+//
+//
+//  Created by Wood on 3/1/24.
+//
+
+import UIKit.UIColor
+
+extension NSMutableAttributedString {
+  /// 밑줄을 추가하는 함수입니다.
+  /// - Parameters:
+  ///   - color: 추가할 밑줄의 색상입니다.
+  ///   - location: 추가할 밑줄의 시작점입니다.
+  ///   - length: 추가할 밑줄의 끝점입니다.
+  public func addUnderline(
+    with color: UIColor,
+    from location: Int,
+    to length: Int
+  ) {
+    self.addAttributes(
+      [
+        NSAttributedString.Key.underlineStyle : NSUnderlineStyle.single.rawValue,
+        NSAttributedString.Key.underlineColor : color,
+      ],
+      range: NSRange(location: location, length: length)
+    )
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/NSMutableAttributedString+addUnderline.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/NSMutableAttributedString+addUnderline.swift
@@ -17,13 +17,36 @@ extension NSMutableAttributedString {
     with color: UIColor,
     from location: Int,
     to length: Int
-  ) {
-    self.addAttributes(
+  ) -> NSMutableAttributedString? {
+    guard self.checkRangeToAddUnderlineIsValid(with: location, and: length) else {
+      return nil
+    }
+
+    let attributedString = self
+    attributedString.addAttributes(
       [
-        NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue,
-        NSAttributedString.Key.underlineColor: color
+        NSAttributedString.Key.underlineStyle : NSUnderlineStyle.single.rawValue,
+        NSAttributedString.Key.underlineColor : color,
       ],
       range: NSRange(location: location, length: length)
     )
+
+    return attributedString
+  }
+
+  private func checkRangeToAddUnderlineIsValid(
+    with location: Int,
+    and length: Int
+  ) -> Bool {
+    let minimumLocation = 0
+    guard minimumLocation <= location && location < self.length else {
+      return false
+    }
+    
+    guard location < length && length <= self.length else {
+      return false
+    }
+    
+    return true
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #39 

## 🎉 변경 사항
- NSMutableAttributedText에서 지정한 범위에 원하는 색상의 밑줄을 생성하는 함수를 구현하였습니다.

## 📌 PR Point

- 디자인 요구사항인 모든 텍스트가 아닌 일부 텍스트에만 밑줄을 추가할 수 있도록 범위를 지정할 수 있게 구현하였습니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?