### PR TITLE
ToDoGardenSwitch 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenSwitch.swift
@@ -1,5 +1,5 @@
 //
-//  UISwitch+ToDoGardenSwitch.swift
+//  ToDoGardenSwitch.swift
 //
 //
 //  Created by SONG on 3/1/24.

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenSwitch.swift
@@ -20,7 +20,7 @@ public final class ToDoGardenSwitch: UISwitch {
     self.isOn = isOn
   }
   
-  required init?(coder: NSCoder) {
+  public required init?(coder: NSCoder) {
     super.init(coder: coder)
     self.setupOnTintColor()
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
@@ -14,14 +14,13 @@ public final class ToDoGardenSwitch: UISwitch {
     super.init(frame: .zero)
     self.isOn = isOn
     self.setupOnTintColor()
-    self.setupOffTintColor()
+  }
   }
   
   required init?(coder: NSCoder) {
     super.init(coder: coder)
     self.isOn = false
     self.setupOnTintColor()
-    self.setupOffTintColor()
   }
   
   public override func layoutSubviews() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
@@ -5,8 +5,8 @@
 //  Created by SONG on 3/1/24.
 //
 
-import UIKit.UISwitch
 import ToDoGardenUIResource
+import UIKit.UISwitch
 
 extension UISwitch {
   public func toDoGardenSwitchStyle(isOn: Bool) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
@@ -10,6 +10,7 @@ import ToDoGardenUIResource
 
 extension UISwitch {
   public func ToDoGardenSwitchStyle() {
+    self.setupOnTintColor()
   }
 }
 
@@ -17,6 +18,7 @@ extension UISwitch {
 
 extension UISwitch {
   private func setupOnTintColor() {
+    self.onTintColor = UIColor.toDoGardenGreenDark
   }
   
   private func setupOffTintColor() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
@@ -1,0 +1,24 @@
+//
+//  UISwitch+ToDoGardenSwitch.swift
+//
+//
+//  Created by SONG on 3/1/24.
+//
+
+import UIKit.UISwitch
+import ToDoGardenUIResource
+
+extension UISwitch {
+  public func ToDoGardenSwitchStyle() {
+  }
+}
+
+// MARK: - private functions
+
+extension UISwitch {
+  private func setupOnTintColor() {
+  }
+  
+  private func setupOffTintColor() {
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
@@ -10,16 +10,18 @@ import UIKit.UISwitch
 import ToDoGardenUIResource
 
 public final class ToDoGardenSwitch: UISwitch {
-  public init(isOn: Bool) {
+  public init() {
     super.init(frame: .zero)
-    self.isOn = isOn
     self.setupOnTintColor()
   }
+  
+  public convenience init(isOn: Bool) {
+    self.init()
+    self.isOn = isOn
   }
   
   required init?(coder: NSCoder) {
     super.init(coder: coder)
-    self.isOn = false
     self.setupOnTintColor()
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
@@ -5,25 +5,39 @@
 //  Created by SONG on 3/1/24.
 //
 
-import ToDoGardenUIResource
 import UIKit.UISwitch
 
-extension UISwitch {
-  public func toDoGardenSwitchStyle(isOn: Bool) {
+import ToDoGardenUIResource
+
+public final class ToDoGardenSwitch: UISwitch {
+  public init(isOn: Bool) {
+    super.init(frame: .zero)
     self.isOn = isOn
     self.setupOnTintColor()
+    self.setupOffTintColor()
+  }
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.isOn = false
+    self.setupOnTintColor()
+    self.setupOffTintColor()
+  }
+  
+  public override func layoutSubviews() {
+    super.layoutSubviews()
     self.setupOffTintColor()
   }
 }
 
 // MARK: - private functions
 
-extension UISwitch {
+extension ToDoGardenSwitch {
   private func setupOnTintColor() {
     self.onTintColor = UIColor.toDoGardenGreenDark
   }
   
   private func setupOffTintColor() {
-    self.subviews.first?.subviews.first?.backgroundColor = UIColor.toDoGardenGreenGray
+      self.subviews.first?.subviews.first?.backgroundColor = UIColor.toDoGardenGreenGray
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
@@ -11,6 +11,7 @@ import ToDoGardenUIResource
 extension UISwitch {
   public func ToDoGardenSwitchStyle() {
     self.setupOnTintColor()
+    self.setupOffTintColor()
   }
 }
 
@@ -22,5 +23,6 @@ extension UISwitch {
   }
   
   private func setupOffTintColor() {
+    self.subviews.first?.subviews.first?.backgroundColor = UIColor.toDoGardenGreenGray
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
@@ -38,6 +38,7 @@ extension ToDoGardenSwitch {
   }
   
   private func setupOffTintColor() {
-      self.subviews.first?.subviews.first?.backgroundColor = UIColor.toDoGardenGreenGray
+    let offBackgroundView = self.subviews.first?.subviews.first
+    offBackgroundView?.backgroundColor = UIColor.toDoGardenGreenGray
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
@@ -9,7 +9,8 @@ import UIKit.UISwitch
 import ToDoGardenUIResource
 
 extension UISwitch {
-  public func ToDoGardenSwitchStyle() {
+  public func ToDoGardenSwitchStyle(isOn: Bool) {
+    self.isOn = isOn
     self.setupOnTintColor()
     self.setupOffTintColor()
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UISwitch+ToDoGardenSwitch.swift
@@ -9,7 +9,7 @@ import UIKit.UISwitch
 import ToDoGardenUIResource
 
 extension UISwitch {
-  public func ToDoGardenSwitchStyle(isOn: Bool) {
+  public func toDoGardenSwitchStyle(isOn: Bool) {
     self.isOn = isOn
     self.setupOnTintColor()
     self.setupOffTintColor()


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #19 
## 🎉 변경 사항
- UISwitch의 extension을 통해 ToDoGardenSwitch 를 사용할 수 있습니다.
## 📌 PR Point
- isOn 파라미터를 통해 초기상태(On/Off)를 결정할 수 있습니다. 
``` swift
let switch = UISwitch()
switch.ToDoGardenSwitchStyle(isOn:false)
```
- 아래와 같이 표시됩니다.

![Simulator Screen Recording - iPhone 15 Pro - 2024-03-05 at 14 32 12](https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/2f4b1226-9d75-4188-a841-b291e123d5b6)


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?