### PR TITLE
AddButton 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -16,6 +16,11 @@ extension UIButton {
 
 extension UIButton {
   private func setupUIAppearance(with title: String) {
+    AddButtonStyle.apply(for: self, with: title)
+  }
+}
+
+private enum AddButtonStyle {
   }
 }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -22,7 +22,9 @@ extension UIButton {
 
 private enum AddButtonStyle {
   fileprivate static func apply(for button: UIButton, with title: String) {
-    
+    AddButtonStyle.setupImage(for: button)
+    AddButtonStyle.setupTintColorWhenStateChanged(for: button)
+    AddButtonStyle.setupTitle(for: button, with: title)
   }
 }
 
@@ -71,5 +73,25 @@ extension AddButtonStyle {
     guard let attributedTitle = AddButtonStyle.convertAttributedTitle(from: title, with: UIColor.toDoGardenGreenDark.withAlphaComponent(alphaWhenHighlighted))
     else { return }
     button.setAttributedTitle(attributedTitle, for: UIControl.State.highlighted)
+  }
+
+  private static func convertAttributedTitle(from title: String, with titleColor: UIColor) -> NSMutableAttributedString? {
+    let baselineOffset: CGFloat = 5.0
+    let startPoint = 0
+    let endPoint = title.count
+    let attributedString = NSMutableAttributedString(
+      string: title,
+      attributes: [
+        NSAttributedString.Key.baselineOffset: baselineOffset,
+        NSAttributedString.Key.font: UIFont.pretendardBodySemiBold,
+        NSAttributedString.Key.foregroundColor: titleColor
+      ]
+    )
+
+    return attributedString.addUnderline(
+      with: titleColor,
+      from: startPoint,
+      to: endPoint
+    )
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -56,4 +56,13 @@ extension AddButtonStyle {
     AddButtonStyle.setupTitleForNormalState(for: button, with: title)
     AddButtonStyle.setupTitleForHighlightedState(for: button, with: title)
   }
+
+  private static func setupTitleForNormalState(
+    for button: UIButton,
+    with title: String
+  ) {
+    guard let attributedTitle = AddButtonStyle.convertAttributedTitle(from: title, with: UIColor.toDoGardenGreenDark)
+    else { return }
+    button.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -75,11 +75,14 @@ extension AddButtonStyle {
     for button: UIButton,
     with title: String
   ) {
-    guard let attributedTitle = AddButtonStyle.convertAttributedTitle(
+    let attributedTitle = AddButtonStyle.makeAttributedTitle(
       from: title,
       with: UIColor.toDoGardenGreenDark
     )
-    else { return }
+    self.addUnderline(
+      to: attributedTitle,
+      with: UIColor.toDoGardenGreenDark
+    )
 
     button.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
   }
@@ -89,11 +92,14 @@ extension AddButtonStyle {
     with title: String
   ) {
     let alphaWhenHighlighted: CGFloat = 0.5
-    guard let attributedTitle = AddButtonStyle.convertAttributedTitle(
+    let attributedTitle = AddButtonStyle.makeAttributedTitle(
       from: title,
       with: UIColor.toDoGardenGreenDark.withAlphaComponent(alphaWhenHighlighted)
     )
-    else { return }
+    self.addUnderline(
+      to: attributedTitle,
+      with: UIColor.toDoGardenGreenDark.withAlphaComponent(alphaWhenHighlighted)
+    )
 
     button.setAttributedTitle(attributedTitle, for: UIControl.State.highlighted)
   }
@@ -101,7 +107,7 @@ extension AddButtonStyle {
   private static func convertAttributedTitle(
     from title: String,
     with titleColor: UIColor
-  ) -> NSMutableAttributedString? {
+  ) -> NSMutableAttributedString {
     let baselineOffset: CGFloat = 5.0
     let startPoint = 0
     let endPoint = title.count
@@ -114,8 +120,17 @@ extension AddButtonStyle {
       ]
     )
 
-    return attributedString.addUnderline(
-      with: titleColor,
+    return attributedString
+  }
+  
+  private static func addUnderline(
+    to title: NSMutableAttributedString,
+    with unedrlineColor: UIColor
+  ) {
+    let startPoint = 0
+    let endPoint = title.length
+    title.addUnderline(
+      with: unedrlineColor,
       from: startPoint,
       to: endPoint
     )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -51,4 +51,9 @@ extension AddButtonStyle {
       }
     }
   }
+
+  private static func setupTitle(for button: UIButton, with title: String) {
+    AddButtonStyle.setupTitleForNormalState(for: button, with: title)
+    AddButtonStyle.setupTitleForHighlightedState(for: button, with: title)
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -63,7 +63,10 @@ extension AddButtonStyle {
     for button: UIButton,
     with title: String
   ) {
-    guard let attributedTitle = AddButtonStyle.convertAttributedTitle(from: title, with: UIColor.toDoGardenGreenDark)
+    guard let attributedTitle = AddButtonStyle.convertAttributedTitle(
+      from: title,
+      with: UIColor.toDoGardenGreenDark
+    )
     else { return }
     button.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
   }
@@ -73,7 +76,10 @@ extension AddButtonStyle {
     with title: String
   ) {
     let alphaWhenHighlighted: CGFloat = 0.5
-    guard let attributedTitle = AddButtonStyle.convertAttributedTitle(from: title, with: UIColor.toDoGardenGreenDark.withAlphaComponent(alphaWhenHighlighted))
+    guard let attributedTitle = AddButtonStyle.convertAttributedTitle(
+      from: title,
+      with: UIColor.toDoGardenGreenDark.withAlphaComponent(alphaWhenHighlighted)
+    )
     else { return }
     button.setAttributedTitle(attributedTitle, for: UIControl.State.highlighted)
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -63,6 +63,7 @@ extension AddButtonStyle {
       with: UIColor.toDoGardenGreenDark
     )
     else { return }
+
     button.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
   }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -10,13 +10,7 @@ import UIKit.UIButton
 import ToDoGardenUIResource
 
 extension UIButton {
-  public func addButtonStyle(with title: String) {
-    self.setupUIAppearance(with: title)
-  }
-}
-
-extension UIButton {
-  private func setupUIAppearance(with title: String) {
+  public func applyAddButtonStyle(with title: String) {
     AddButtonStyle.apply(for: self, with: title)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -21,7 +21,7 @@ extension UIButton {
 }
 
 private enum AddButtonStyle {
-  }
-}
+  fileprivate static func apply(for button: UIButton, with title: String) {
+    
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -16,7 +16,15 @@ extension UIButton {
 }
 
 private enum AddButtonStyle {
-  fileprivate static func apply(for button: UIButton, with title: String) {
+  fileprivate static func apply(
+    for button: UIButton,
+    with title: String
+  ) {
+    AddButtonStyle.applyConfiguration(
+      for: button,
+      with: UIButton.Configuration.plain()
+    )
+    AddButtonStyle.configureImage(for: button)
     AddButtonStyle.setupImage(for: button)
     AddButtonStyle.setupTintColorWhenStateChanged(for: button)
     AddButtonStyle.setupTitle(for: button, with: title)
@@ -24,14 +32,23 @@ private enum AddButtonStyle {
 }
 
 extension AddButtonStyle {
+  private static func applyConfiguration(
+    for button: UIButton,
+    with configuration: UIButton.Configuration
+  ) {
+    button.configuration = configuration
+  }
+
+  private static func configureImage(for button: UIButton) {
+    let imagePadding: CGFloat = 4.0
+    button.configuration?.imagePadding = imagePadding
+    button.configuration?.imagePlacement = NSDirectionalRectEdge.leading
+  }
+
   private static func setupImage(for button: UIButton) {
     let renderingMode = UIImage.RenderingMode.alwaysTemplate
-    let imagePadding: CGFloat = 4.0
-    var configuration = UIButton.Configuration.plain()
-    configuration.image = UIImage.addButton.withRenderingMode(renderingMode)
-    configuration.imagePadding = imagePadding
-    configuration.imagePlacement = NSDirectionalRectEdge.leading
-    button.configuration = configuration
+    let addButtonImage = UIImage.addButton.withRenderingMode(renderingMode)
+    button.setImage(addButtonImage, for: UIControl.State.normal)
   }
 
   /// 버튼의 상태에 따라 tintColor를 변경해 이미지 색상을 변화시키도록 설정하는 메서드입니다.

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -79,7 +79,7 @@ extension AddButtonStyle {
       from: title,
       with: UIColor.toDoGardenGreenDark
     )
-    self.addUnderline(
+    AddButtonStyle.addUnderline(
       to: attributedTitle,
       with: UIColor.toDoGardenGreenDark
     )
@@ -96,7 +96,7 @@ extension AddButtonStyle {
       from: title,
       with: UIColor.toDoGardenGreenDark.withAlphaComponent(alphaWhenHighlighted)
     )
-    self.addUnderline(
+    AddButtonStyle.addUnderline(
       to: attributedTitle,
       with: UIColor.toDoGardenGreenDark.withAlphaComponent(alphaWhenHighlighted)
     )
@@ -104,7 +104,7 @@ extension AddButtonStyle {
     button.setAttributedTitle(attributedTitle, for: UIControl.State.highlighted)
   }
 
-  private static func convertAttributedTitle(
+  private static func makeAttributedTitle(
     from title: String,
     with titleColor: UIColor
   ) -> NSMutableAttributedString {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -5,8 +5,9 @@
 //  Created by Wood on 3/4/24.
 //
 
-import ToDoGardenUIResource
 import UIKit.UIButton
+
+import ToDoGardenUIResource
 
 extension UIButton {
   public func addButtonStyle(with title: String) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -77,6 +77,7 @@ extension AddButtonStyle {
       with: UIColor.toDoGardenGreenDark.withAlphaComponent(alphaWhenHighlighted)
     )
     else { return }
+
     button.setAttributedTitle(attributedTitle, for: UIControl.State.highlighted)
   }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -1,0 +1,14 @@
+//
+//  UIButton+addButton.swift
+//
+//
+//  Created by Wood on 3/4/24.
+//
+
+import ToDoGardenUIResource
+import UIKit.UIButton
+
+extension UIButton {
+  public func addButtonStyle(with title: String) {
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -10,5 +10,13 @@ import UIKit.UIButton
 
 extension UIButton {
   public func addButtonStyle(with title: String) {
+    self.setupUIAppearance(with: title)
+  }
+}
+
+extension UIButton {
+  private func setupUIAppearance(with title: String) {
+  }
+}
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -25,3 +25,15 @@ private enum AddButtonStyle {
     
   }
 }
+
+extension AddButtonStyle {
+  private static func setupImage(for button: UIButton) {
+    let renderingMode = UIImage.RenderingMode.alwaysTemplate
+    let imagePadding: CGFloat = 4.0
+    var configuration = UIButton.Configuration.plain()
+    configuration.image = UIImage.addButton.withRenderingMode(renderingMode)
+    configuration.imagePadding = imagePadding
+    configuration.imagePlacement = NSDirectionalRectEdge.leading
+    button.configuration = configuration
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -36,4 +36,19 @@ extension AddButtonStyle {
     configuration.imagePlacement = NSDirectionalRectEdge.leading
     button.configuration = configuration
   }
+
+  /// 버튼의 상태에 따라 tintColor를 변경해 이미지 색상을 변화시키도록 설정하는 메서드입니다.
+  private static func setupTintColorWhenStateChanged(for button: UIButton) {
+    button.configurationUpdateHandler = { button in
+      switch button.state {
+      case UIControl.State.normal:
+        button.tintColor = UIColor.toDoGardenGreenDark
+      case UIControl.State.highlighted:
+        let alphaWhenHighlighted: CGFloat = 0.5
+        button.tintColor = UIColor.toDoGardenGreenDark.withAlphaComponent(alphaWhenHighlighted)
+      default:
+        return
+      }
+    }
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -68,14 +68,20 @@ extension AddButtonStyle {
     button.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
   }
 
-  private static func setupTitleForHighlightedState(for button: UIButton, with title: String) {
+  private static func setupTitleForHighlightedState(
+    for button: UIButton,
+    with title: String
+  ) {
     let alphaWhenHighlighted: CGFloat = 0.5
     guard let attributedTitle = AddButtonStyle.convertAttributedTitle(from: title, with: UIColor.toDoGardenGreenDark.withAlphaComponent(alphaWhenHighlighted))
     else { return }
     button.setAttributedTitle(attributedTitle, for: UIControl.State.highlighted)
   }
 
-  private static func convertAttributedTitle(from title: String, with titleColor: UIColor) -> NSMutableAttributedString? {
+  private static func convertAttributedTitle(
+    from title: String,
+    with titleColor: UIColor
+  ) -> NSMutableAttributedString? {
     let baselineOffset: CGFloat = 5.0
     let startPoint = 0
     let endPoint = title.count

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+AddButton.swift
@@ -65,4 +65,11 @@ extension AddButtonStyle {
     else { return }
     button.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
   }
+
+  private static func setupTitleForHighlightedState(for button: UIButton, with title: String) {
+    let alphaWhenHighlighted: CGFloat = 0.5
+    guard let attributedTitle = AddButtonStyle.convertAttributedTitle(from: title, with: UIColor.toDoGardenGreenDark.withAlphaComponent(alphaWhenHighlighted))
+    else { return }
+    button.setAttributedTitle(attributedTitle, for: UIControl.State.highlighted)
+  }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #38

## 🎉 변경 사항
- 그룹 및 리마인더를 추가하는 버튼인 **AddButton**을 추가하였습니다.
- 버튼의 스타일을 적용하는  **AddButtonSTyle**타입을 분리하였습니다.
- 버튼이 눌렸을 때 사용자가 인식할 수 있도록 색상의 alpha값을 낮추도록 설정하였습니다.

## 📌 PR Point
<img src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/d7f20fa0-8e56-4a14-af7b-8098354d9e0f" width="230" height="500">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?