### PR TITLE
ToDoGardenBoxButton 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -10,8 +10,15 @@ import UIKit.UIButton
 import ToDoGardenUIConstant
 
 public class ToDoGardenBoxButton: UIButton {
+  public override var isEnabled: Bool {
+    didSet{
+      self.updateBackgroundColor()
+    }
+  }
+  
   init() {
     super.init(frame: CGRect.zero)
+    self.enable()
   }
   
   public convenience init(
@@ -24,6 +31,27 @@ public class ToDoGardenBoxButton: UIButton {
   
   required init?(coder: NSCoder) {
     super.init(coder: coder)
+    self.enable()
   }
   
+  public func enable() {
+    self.isEnabled = true
+  }
+  
+  public func disable() {
+    self.isEnabled = false
+  }
+}
+
+//private method
+
+extension ToDoGardenBoxButton {
+  private func updateBackgroundColor() {
+    if self.isEnabled {
+      self.backgroundColor = UIColor.toDoGardenGreenDark
+    }
+    else {
+      self.backgroundColor = UIColor.toDoGardenGreenGray
+    }
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -61,7 +61,7 @@ extension ToDoGardenBoxButton {
     self.isRoundRect = isRoundRect
     self.setTitle(text, for: UIControl.State.normal)
     self.setupFont()
-    self.setCornerRadius(value: sizeType.cornerRadius)
+    self.setupCornerRadius(value: sizeType.cornerRadius)
     self.setupActionToChangeAlpha()
   }
   
@@ -72,6 +72,22 @@ extension ToDoGardenBoxButton {
   private func setupActionToChangeAlpha() {
     self.setupTouchDownAction()
     self.setupTouchUpAction()
+  }
+  
+  private func setupCornerRadius(value: CGFloat) {
+    guard let isRoundRect = self.isRoundRect else { return }
+    
+    if isRoundRect {
+      self.layer.cornerRadius = value
+    }
+  }
+  
+  private func updateBackgroundColor() {
+    if self.isEnabled {
+      self.backgroundColor = UIColor.toDoGardenGreenDark
+    } else {
+      self.backgroundColor = UIColor.toDoGardenGreenGray
+    }
   }
   
   private func setupTouchDownAction() {
@@ -95,21 +111,5 @@ extension ToDoGardenBoxButton {
         UIControl.Event.touchCancel
       ]
     )
-  }
-  
-  private func setCornerRadius(value: CGFloat) {
-    guard let isRoundRect = self.isRoundRect else { return }
-    
-    if isRoundRect {
-      self.layer.cornerRadius = value
-    }
-  }
-  
-  private func updateBackgroundColor() {
-    if self.isEnabled {
-      self.backgroundColor = UIColor.toDoGardenGreenDark
-    } else {
-      self.backgroundColor = UIColor.toDoGardenGreenGray
-    }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -70,15 +70,22 @@ extension ToDoGardenBoxButton {
   }
   
   private func setupActionToChangeAlpha() {
+    self.setupTouchDownAction()
+    self.setupTouchUpAction()
+  }
+  
+  private func setupTouchDownAction() {
     let touchDownAction = UIAction { [weak self] _ in
       self?.alpha = ToDoGardenBoxButtonConstant.Alpha.highlighted.value
     }
     
+    self.addAction(touchDownAction, for: UIControl.Event.touchDown)
+  }
+  
+  private func setupTouchUpAction() {
     let touchUpAction = UIAction { [weak self] _ in
       self?.alpha = ToDoGardenBoxButtonConstant.Alpha.normal.value
     }
-    
-    self.addAction(touchDownAction, for: UIControl.Event.touchDown)
     
     self.addAction(
       touchUpAction,

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -7,6 +7,23 @@
 
 import UIKit.UIButton
 
+import ToDoGardenUIConstant
+
 public class ToDoGardenBoxButton: UIButton {
+  init() {
+    super.init(frame: CGRect.zero)
+  }
+  
+  public convenience init(
+    isRoundRect: Bool,
+    text: String,
+    sizeType: ToDoGardenBoxButtonConstant.Size
+  ) {
+    self.init()
+  }
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
   
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -57,8 +57,26 @@ extension ToDoGardenBoxButton {
     self.setTitle(text, for: UIControl.State.normal)
     self.titleLabel?.font = UIFont.pretendardHeadBold
     self.setCornerRadius(value: sizeType.cornerRadius)
+    self.setupActionToChangeAlpha()
   }
   
+  private func setupActionToChangeAlpha() {
+    let touchDownAction = UIAction { [weak self] _ in
+      self?.alpha = ToDoGardenBoxButtonConstant.Alpha.highlighted.value
+    }
+    
+    let touchUpAction = UIAction { [weak self] _ in
+      self?.alpha = ToDoGardenBoxButtonConstant.Alpha.normal.value
+    }
+    
+    self.addAction(touchDownAction, for: UIControl.Event.touchDown)
+    
+    self.addAction(touchUpAction, for: [
+      UIControl.Event.touchUpInside,
+      UIControl.Event.touchUpOutside,
+      UIControl.Event.touchCancel
+    ])
+  }
   
   private func setCornerRadius(value: CGFloat) {
     if self.isRoundRect {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -16,6 +16,8 @@ public class ToDoGardenBoxButton: UIButton {
     }
   }
   
+  private var isRoundRect: Bool = true
+  
   init() {
     super.init(frame: CGRect.zero)
     self.enable()
@@ -46,6 +48,24 @@ public class ToDoGardenBoxButton: UIButton {
 //private method
 
 extension ToDoGardenBoxButton {
+  private func setup(
+    _ isRoundRect: Bool,
+    _ text: String,
+    _ sizeType: ToDoGardenBoxButtonConstant.Size
+  ) {
+    self.isRoundRect = isRoundRect
+    self.setTitle(text, for: UIControl.State.normal)
+    self.titleLabel?.font = UIFont.pretendardHeadBold
+    self.setCornerRadius(value: sizeType.cornerRadius)
+  }
+  
+  
+  private func setCornerRadius(value: CGFloat) {
+    if self.isRoundRect {
+      self.layer.cornerRadius = value
+    }
+  }
+  
   private func updateBackgroundColor() {
     if self.isEnabled {
       self.backgroundColor = UIColor.toDoGardenGreenDark

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -29,6 +29,11 @@ public class ToDoGardenBoxButton: UIButton {
     sizeType: ToDoGardenBoxButtonConstant.Size
   ) {
     self.init()
+    self.setup(
+      isRoundRect,
+      text,
+      sizeType
+    )
   }
   
   required init?(coder: NSCoder) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -1,0 +1,12 @@
+//
+//  ToDoGardenBoxButton.swift
+//
+//
+//  Created by SONG on 3/20/24.
+//
+
+import UIKit.UIButton
+
+public class ToDoGardenBoxButton: UIButton {
+  
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -55,9 +55,13 @@ extension ToDoGardenBoxButton {
   ) {
     self.isRoundRect = isRoundRect
     self.setTitle(text, for: UIControl.State.normal)
-    self.titleLabel?.font = UIFont.pretendardHeadBold
+    self.setupFont()
     self.setCornerRadius(value: sizeType.cornerRadius)
     self.setupActionToChangeAlpha()
+  }
+  
+  private func setupFont() {
+    self.titleLabel?.font = UIFont.pretendardHeadBold
   }
   
   private func setupActionToChangeAlpha() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -9,14 +9,14 @@ import UIKit.UIButton
 
 import ToDoGardenUIConstant
 
-public class ToDoGardenBoxButton: UIButton {
+public final class ToDoGardenBoxButton: UIButton {
   public override var isEnabled: Bool {
-    didSet{
+    didSet {
       self.updateBackgroundColor()
     }
   }
   
-  private var isRoundRect: Bool = true
+  private var isRoundRect: Bool?
   
   init() {
     super.init(frame: CGRect.zero)
@@ -50,7 +50,7 @@ public class ToDoGardenBoxButton: UIButton {
   }
 }
 
-//private method
+// private method
 
 extension ToDoGardenBoxButton {
   private func setup(
@@ -80,15 +80,20 @@ extension ToDoGardenBoxButton {
     
     self.addAction(touchDownAction, for: UIControl.Event.touchDown)
     
-    self.addAction(touchUpAction, for: [
-      UIControl.Event.touchUpInside,
-      UIControl.Event.touchUpOutside,
-      UIControl.Event.touchCancel
-    ])
+    self.addAction(
+      touchUpAction,
+      for: [
+        UIControl.Event.touchUpInside,
+        UIControl.Event.touchUpOutside,
+        UIControl.Event.touchCancel
+      ]
+    )
   }
   
   private func setCornerRadius(value: CGFloat) {
-    if self.isRoundRect {
+    guard let isRoundRect = self.isRoundRect else { return }
+    
+    if isRoundRect {
       self.layer.cornerRadius = value
     }
   }
@@ -96,8 +101,7 @@ extension ToDoGardenBoxButton {
   private func updateBackgroundColor() {
     if self.isEnabled {
       self.backgroundColor = UIColor.toDoGardenGreenDark
-    }
-    else {
+    } else {
       self.backgroundColor = UIColor.toDoGardenGreenGray
     }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/File.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/File.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  
-//
-//  Created by SONG on 3/7/24.
-//
-
-import Foundation

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/ToDoGardenBoxButtonConstant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/ToDoGardenBoxButtonConstant.swift
@@ -1,0 +1,12 @@
+//
+//  ToDoGardenBoxButtonConstant.swift
+//
+//
+//  Created by SONG on 3/7/24.
+//
+
+import Foundation
+
+public enum ToDoGardenBoxButtonConstant {
+  
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/ToDoGardenBoxButtonConstant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/ToDoGardenBoxButtonConstant.swift
@@ -8,5 +8,56 @@
 import Foundation
 
 public enum ToDoGardenBoxButtonConstant {
+  public enum Alpha {
+    case highlighted
+    case normal
+    
+    public var value: CGFloat {
+      switch self {
+      case ToDoGardenBoxButtonConstant.Alpha.highlighted:
+        return 0.7
+      case ToDoGardenBoxButtonConstant.Alpha.normal:
+        return 1.0
+      }
+    }
+  }
   
+  public enum Size {
+    case primary
+    case secondary
+    case tertiary
+    
+    public var width: CGFloat {
+      switch self {
+      case ToDoGardenBoxButtonConstant.Size.primary:
+        return 302.0
+      case ToDoGardenBoxButtonConstant.Size.secondary:
+        return 287.0
+      case ToDoGardenBoxButtonConstant.Size.tertiary:
+        return 288.0
+      }
+    }
+    
+    public var height: CGFloat {
+      switch self {
+      case ToDoGardenBoxButtonConstant.Size.primary:
+        return 49.0
+      case ToDoGardenBoxButtonConstant.Size.secondary:
+        return 55.0
+      case ToDoGardenBoxButtonConstant.Size.tertiary:
+        return 49.0
+      }
+    }
+    
+    public var cornerRadius: CGFloat {
+      switch self {
+      case ToDoGardenBoxButtonConstant.Size.primary:
+        return 49.0 / 2
+      case ToDoGardenBoxButtonConstant.Size.secondary:
+        return 55.0 / 2
+      case ToDoGardenBoxButtonConstant.Size.tertiary:
+        return 49.0 / 2
+      }
+    }
+  }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #43 

## 🎉 변경 사항

- ToDoGardenBoxButton 구현 
   - 3가지 Size를 설정할 수 있습니다.
   - enable/disable 상태 변경이 가능합니다.
   - 터치에 대한 highlight 효과

- 필요한 constant를 ToDoGardenBoxButtonConstant에 정의하였습니다.

## 📌 PR Point

- ToDoButtonBoxButton 클래스로 아래와 같은  버튼들을 표시할 수 있습니다. 

![Simulator Screen Recording - iPhone 15 Pro - 2024-03-20 at 18 41 05](https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/9f12c467-7f31-4c02-81e5-d8de45f89de2)
** 하이라이트 효과의 경우 disable에선 작동하지 않습니다.

- 인스턴스 생성시 , 어떤 종류의 버튼인지 알 수 있도록 init()을 구성하였습니다.
```swift
init(
    isRoundRect: Bool, // roundRect 여부
    text: String, // 버튼에 들어갈 text
    sizeType: ToDoGardenBoxButtonConstant.Size // 버튼 size 
  )
```

- 지금 방법 vs 다른 방법 

View의 size를 결정하는 방법에 대한 이야기를 하고싶습니다. 
1) 현재 적용되어있는 방법은, layoutConstraint를 통해 position과 , size를 세팅해주어야 합니다. 
- 다른 컴포넌트들과 일관성있는 layout 적용 방법일 것 같아서 일단 이렇게 했습니다.

2) 파라미터로 Size를 받고있으니, 객체 내부에서 Size를 미리 정의하고, 외부에서는  layoutConstraint로 position만 정의하자. 
- 파라미터로 Size를 받고 있는 이유는 아래와 같습니다. 
    - 인스턴스 생성문을 통해 어떤 size의 버튼인지 알 수 있게 해줌 
    - Size마다 적용되는 각기 다른 코너래디우스 값을 상수로 쉽게 받아올 수 있음 

두 방법중 어떤 방법을 택하는 것이 괜찮아 보이나요? 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?