### PR TITLE
ToDoGardenBoxButtonConstant 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenBoxButton.swift
@@ -1,0 +1,10 @@
+//
+//  Constant+ToDoGardenBoxButton.swift
+//
+//
+//  Created by SONG on 3/21/24.
+//
+
+extension Constant.ToDoGardenBoxButton {
+  
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenBoxButton.swift
@@ -12,4 +12,43 @@ extension Constant.ToDoGardenBoxButton {
     public static let normal: CGFloat = 1.0
     public static let highlighted: CGFloat = 0.7
   }
+  
+  public enum Size {
+    case primary
+    case secondary
+    case tertiary
+    
+    public var width: CGFloat {
+      switch self {
+      case Constant.ToDoGardenBoxButton.Size.primary:
+        return 302.0
+      case Constant.ToDoGardenBoxButton.Size.secondary:
+        return 287.0
+      case Constant.ToDoGardenBoxButton.Size.tertiary:
+        return 288.0
+      }
+    }
+    
+    public var height: CGFloat {
+      switch self {
+      case Constant.ToDoGardenBoxButton.Size.primary:
+        return 49.0
+      case Constant.ToDoGardenBoxButton.Size.secondary:
+        return 55.0
+      case Constant.ToDoGardenBoxButton.Size.tertiary:
+        return 49.0
+      }
+    }
+    
+    public var cornerRadius: CGFloat {
+      switch self {
+      case Constant.ToDoGardenBoxButton.Size.primary:
+        return 49.0 / 2
+      case Constant.ToDoGardenBoxButton.Size.secondary:
+        return 55.0 / 2
+      case Constant.ToDoGardenBoxButton.Size.tertiary:
+        return 49.0 / 2
+      }
+    }
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenBoxButton.swift
@@ -14,41 +14,8 @@ extension Constant.ToDoGardenBoxButton {
   }
   
   public enum Size {
-    case primary
-    case secondary
-    case tertiary
-    
-    public var width: CGFloat {
-      switch self {
-      case Constant.ToDoGardenBoxButton.Size.primary:
-        return 302.0
-      case Constant.ToDoGardenBoxButton.Size.secondary:
-        return 287.0
-      case Constant.ToDoGardenBoxButton.Size.tertiary:
-        return 288.0
-      }
-    }
-    
-    public var height: CGFloat {
-      switch self {
-      case Constant.ToDoGardenBoxButton.Size.primary:
-        return 49.0
-      case Constant.ToDoGardenBoxButton.Size.secondary:
-        return 55.0
-      case Constant.ToDoGardenBoxButton.Size.tertiary:
-        return 49.0
-      }
-    }
-    
-    public var cornerRadius: CGFloat {
-      switch self {
-      case Constant.ToDoGardenBoxButton.Size.primary:
-        return 49.0 / 2
-      case Constant.ToDoGardenBoxButton.Size.secondary:
-        return 55.0 / 2
-      case Constant.ToDoGardenBoxButton.Size.tertiary:
-        return 49.0 / 2
-      }
-    }
+    public static let primary = CGSize(width: 302.0, height: 49.0)
+    public static let secondary = CGSize(width: 287.0, height: 55.0)
+    public static let tertiary = CGSize(width: 288.0, height: 49.0)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenBoxButton.swift
@@ -5,6 +5,11 @@
 //  Created by SONG on 3/21/24.
 //
 
+import CoreGraphics
+
 extension Constant.ToDoGardenBoxButton {
-  
+  public enum Alpha {
+    public static let normal: CGFloat = 1.0
+    public static let highlighted: CGFloat = 0.7
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenBoxButton.swift
@@ -14,8 +14,8 @@ extension Constant.ToDoGardenBoxButton {
   }
   
   public enum Size {
-    public static let primary = CGSize(width: 302.0, height: 49.0)
-    public static let secondary = CGSize(width: 287.0, height: 55.0)
-    public static let tertiary = CGSize(width: 288.0, height: 49.0)
+    public static let primary: CGSize = CGSize(width: 302.0, height: 49.0)
+    public static let secondary: CGSize = CGSize(width: 287.0, height: 55.0)
+    public static let tertiary: CGSize = CGSize(width: 288.0, height: 49.0)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenBoxButton.swift
@@ -5,7 +5,7 @@
 //  Created by SONG on 3/21/24.
 //
 
-import CoreGraphics
+import Foundation
 
 extension Constant.ToDoGardenBoxButton {
   public enum Alpha {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -6,5 +6,5 @@
 //
 
 public enum Constant {
-  
+  public enum ToDoGardenBoxButton{ }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -6,5 +6,5 @@
 //
 
 public enum Constant {
-  public enum ToDoGardenBoxButton{ }
+  public enum ToDoGardenBoxButton { }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #49 
## 🎉 변경 사항
- ToDoGardenUIConstant에 ToDoGardenBoxButtonConstant를 추가합니다. 
## 📌 PR Point
- ToDoGardenBoxButton에 필요한 Constant들을 정의하였습니다. 
- 아래와 같이 사용가능합니다.

```swift
    Constant.ToDoGardenBoxButton.Alpha.highlighted
    Constant.ToDoGardenBoxButton.Size.primary.width
```
## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?