### PR TITLE
AddButton 오토레이아웃 관련 Constant 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AddButton.swift
@@ -1,0 +1,16 @@
+//
+//  Constant+AddButton.swift
+//
+//
+//  Created by Wood on 3/22/24.
+//
+
+import Foundation
+
+extension Constant.AddButton {
+  public enum Layout {}
+}
+
+extension Constant.AddButton.Layout {
+  public static let imagePadding: CGFloat = 4.0
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AddButton.swift
@@ -7,21 +7,21 @@
 
 import Foundation
 
-extension Constant.AddButton {
+extension Constant.AddUnderlinedTextButton {
   public enum Layout {}
   public enum Alpha {}
   public enum Title {}
 }
 
-extension Constant.AddButton.Layout {
+extension Constant.AddUnderlinedTextButton.Layout {
   public static let imagePadding: CGFloat = 4.0
 }
 
-extension Constant.AddButton.Alpha {
+extension Constant.AddUnderlinedTextButton.Alpha {
   public static let highlighted: CGFloat = 0.7
 }
 
-extension Constant.AddButton.Title {
+extension Constant.AddUnderlinedTextButton.Title {
   public static let baselineOffset: CGFloat = 5.0
   public static let startPoint: CGFloat = 0
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AddButton.swift
@@ -10,6 +10,7 @@ import Foundation
 extension Constant.AddButton {
   public enum Layout {}
   public enum Alpha {}
+  public enum Title {}
 }
 
 extension Constant.AddButton.Layout {
@@ -18,4 +19,9 @@ extension Constant.AddButton.Layout {
 
 extension Constant.AddButton.Alpha {
   public static let highlighted: CGFloat = 0.7
+}
+
+extension Constant.AddButton.Title {
+  public static let baselineOffset: CGFloat = 5.0
+  public static let startPoint: CGFloat = 0
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AddButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AddButton.swift
@@ -9,8 +9,13 @@ import Foundation
 
 extension Constant.AddButton {
   public enum Layout {}
+  public enum Alpha {}
 }
 
 extension Constant.AddButton.Layout {
   public static let imagePadding: CGFloat = 4.0
+}
+
+extension Constant.AddButton.Alpha {
+  public static let highlighted: CGFloat = 0.7
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AddUnderlinedTextButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AddUnderlinedTextButton.swift
@@ -1,5 +1,5 @@
 //
-//  Constant+AddButton.swift
+//  Constant+AddUnderlinedTextButton.swift
 //
 //
 //  Created by Wood on 3/22/24.

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -7,5 +7,5 @@
 
 public enum Constant {
   public enum ToDoGardenBoxButton { }
-  public enum AddButton {}
+  public enum AddUnderlinedTextButton {}
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -7,4 +7,5 @@
 
 public enum Constant {
   public enum ToDoGardenBoxButton { }
+  public enum AddButton {}
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #47 

## 🎉 변경 사항
- ToDoGardenUIConstant 모듈에 AddButton에 필요한 레이아웃 관련 상수들을 추가합니다.

## 📌 PR Point
- 용도에 맞는 별도의 타입을 생성하고 관련 상수들은 확장하여 내부에 선언하였습니다.
``` Swift
extension Constant.AddButton {
  public enum Layout {}
  public enum Alpha {}
  public enum Title {}
}

extension Constant.AddButton.Layout {
  public static let imagePadding: CGFloat = 4.0
}
```

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?