### PR TITLE
ToDoGardenBoxButton 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -15,9 +15,7 @@ public final class ToDoGardenBoxButton: UIButton {
       self.updateBackgroundColor()
     }
   }
-  
-  private var isRoundRect: Bool?
-  
+
   init() {
     super.init(frame: CGRect.zero)
   }
@@ -58,10 +56,11 @@ extension ToDoGardenBoxButton {
       text: String,
       size : CGSize
   ) {
-    self.isRoundRect = isRoundRect
+    if isRoundRect {
+      self.setupCornerRadius(with: size.height / 2)
+    }
     self.setTitle(text, for: UIControl.State.normal)
     self.setupFont()
-    self.setupCornerRadius(with: size.height / 2)
     self.setupActionToChangeAlpha()
   }
   
@@ -70,11 +69,7 @@ extension ToDoGardenBoxButton {
   }
   
   private func setupCornerRadius(with value: CGFloat) {
-    guard let isRoundRect = self.isRoundRect else { return }
-    
-    if isRoundRect {
       self.layer.cornerRadius = value
-    }
   }
   
   private func setupActionToChangeAlpha() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -14,6 +14,8 @@ public final class ToDoGardenBoxButton: UIButton {
     }
   }
   
+  private var isRoundRect: Bool?
+  
   init() {
     super.init(frame: CGRect.zero)
     enable()
@@ -25,6 +27,11 @@ public final class ToDoGardenBoxButton: UIButton {
     sizeType: CGSize
   ) {
     self.init()
+    self.setup(
+      isRoundRect,
+      text,
+      sizeType
+    )
   }
   
   required init?(coder: NSCoder) {
@@ -44,6 +51,29 @@ public final class ToDoGardenBoxButton: UIButton {
 // private method
 
 extension ToDoGardenBoxButton {
+  private func setup(
+    _ isRoundRect: Bool,
+    _ text: String,
+    _ size: CGSize
+  ) {
+    self.isRoundRect = isRoundRect
+    self.setTitle(text, for: UIControl.State.normal)
+    self.setupFont()
+    self.setupCornerRadius(with: size.height / 2)
+  }
+  
+  private func setupFont() {
+    self.titleLabel?.font = UIFont.pretendardHeadBold
+  }
+  
+  private func setupCornerRadius(with value: CGFloat) {
+    guard let isRoundRect = self.isRoundRect else { return }
+    
+    if isRoundRect {
+      self.layer.cornerRadius = value
+    }
+  }
+  
   private func updateBackgroundColor() {
     if self.isEnabled {
       self.backgroundColor = UIColor.toDoGardenGreenDark

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -59,6 +59,7 @@ extension ToDoGardenBoxButton {
     if isRoundRect {
       self.setupCornerRadius(with: size.height / 2)
     }
+    self.updateBackgroundColor()
     self.setTitle(text, for: UIControl.State.normal)
     self.setupTitleFont()
     self.setupActionToChangeAlpha()

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -25,15 +25,15 @@ public final class ToDoGardenBoxButton: UIButton {
   public convenience init(
     isRoundRect: Bool,
     text: String,
-    sizeType: CGSize
+    size: CGSize,
     isEnabled: Bool
   ) {
     self.init()
     self.isEnabled = isEnabled
     self.setup(
-      isRoundRect,
-      text,
-      sizeType
+      isRoundRect: isRoundRect,
+      text: text,
+      size: size
     )
   }
   
@@ -54,9 +54,9 @@ public final class ToDoGardenBoxButton: UIButton {
 
 extension ToDoGardenBoxButton {
   private func setup(
-    _ isRoundRect: Bool,
-    _ text: String,
-    _ size: CGSize
+      isRoundRect: Bool,
+      text: String,
+      size : CGSize
   ) {
     self.isRoundRect = isRoundRect
     self.setTitle(text, for: UIControl.State.normal)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -7,6 +7,8 @@
 
 import UIKit.UIButton
 
+import ToDoGardenUIConstant
+
 public final class ToDoGardenBoxButton: UIButton {
   public override var isEnabled: Bool {
     didSet {
@@ -60,6 +62,7 @@ extension ToDoGardenBoxButton {
     self.setTitle(text, for: UIControl.State.normal)
     self.setupFont()
     self.setupCornerRadius(with: size.height / 2)
+    self.setupActionToChangeAlpha()
   }
   
   private func setupFont() {
@@ -72,6 +75,34 @@ extension ToDoGardenBoxButton {
     if isRoundRect {
       self.layer.cornerRadius = value
     }
+  }
+  
+  private func setupActionToChangeAlpha() {
+    self.setupTouchDownAction()
+    self.setupTouchUpAction()
+  }
+  
+  private func setupTouchDownAction() {
+    let touchDownAction = UIAction { [weak self] _ in
+      self?.alpha = Constant.ToDoGardenBoxButton.Alpha.highlighted
+    }
+    
+    self.addAction(touchDownAction, for: UIControl.Event.touchDown)
+  }
+  
+  private func setupTouchUpAction() {
+    let touchUpAction = UIAction { [weak self] _ in
+      self?.alpha = Constant.ToDoGardenBoxButton.Alpha.normal
+    }
+    
+    self.addAction(
+      touchUpAction,
+      for: [
+        UIControl.Event.touchUpInside,
+        UIControl.Event.touchUpOutside,
+        UIControl.Event.touchCancel
+      ]
+    )
   }
   
   private func updateBackgroundColor() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -15,7 +15,7 @@ public final class ToDoGardenBoxButton: UIButton {
       self.updateBackgroundColor()
     }
   }
-
+  
   init() {
     super.init(frame: CGRect.zero)
   }
@@ -52,9 +52,9 @@ public final class ToDoGardenBoxButton: UIButton {
 
 extension ToDoGardenBoxButton {
   private func setup(
-      isRoundRect: Bool,
-      text: String,
-      size : CGSize
+    isRoundRect: Bool,
+    text: String,
+    size: CGSize
   ) {
     if isRoundRect {
       self.setupCornerRadius(with: size.height / 2)
@@ -69,7 +69,7 @@ extension ToDoGardenBoxButton {
   }
   
   private func setupCornerRadius(with value: CGFloat) {
-      self.layer.cornerRadius = value
+    self.layer.cornerRadius = value
   }
   
   private func setupActionToChangeAlpha() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -48,7 +48,7 @@ public final class ToDoGardenBoxButton: UIButton {
   }
 }
 
-// private method
+// MARK: - private functions
 
 extension ToDoGardenBoxButton {
   private func setup(

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -1,0 +1,11 @@
+//
+//  ToDoGardenBoxButton.swift
+//
+//
+//  Created by SONG on 3/22/24.
+//
+
+import UIKit.UIButton
+
+public final class ToDoGardenBoxButton: UIButton {
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -8,8 +8,15 @@
 import UIKit.UIButton
 
 public final class ToDoGardenBoxButton: UIButton {
+  public override var isEnabled: Bool {
+    didSet {
+      self.updateBackgroundColor()
+    }
+  }
+  
   init() {
     super.init(frame: CGRect.zero)
+    enable()
   }
   
   public convenience init(
@@ -22,5 +29,26 @@ public final class ToDoGardenBoxButton: UIButton {
   
   required init?(coder: NSCoder) {
     super.init(coder: coder)
+    enable()
+  }
+  
+  public func enable() {
+    self.isEnabled = true
+  }
+  
+  public func disable() {
+    self.isEnabled = false
+  }
+}
+
+// private method
+
+extension ToDoGardenBoxButton {
+  private func updateBackgroundColor() {
+    if self.isEnabled {
+      self.backgroundColor = UIColor.toDoGardenGreenDark
+    } else {
+      self.backgroundColor = UIColor.toDoGardenGreenGray
+    }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -20,15 +20,16 @@ public final class ToDoGardenBoxButton: UIButton {
   
   init() {
     super.init(frame: CGRect.zero)
-    enable()
   }
   
   public convenience init(
     isRoundRect: Bool,
     text: String,
     sizeType: CGSize
+    isEnabled: Bool
   ) {
     self.init()
+    self.isEnabled = isEnabled
     self.setup(
       isRoundRect,
       text,
@@ -38,7 +39,6 @@ public final class ToDoGardenBoxButton: UIButton {
   
   required init?(coder: NSCoder) {
     super.init(coder: coder)
-    enable()
   }
   
   public func enable() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -60,11 +60,11 @@ extension ToDoGardenBoxButton {
       self.setupCornerRadius(with: size.height / 2)
     }
     self.setTitle(text, for: UIControl.State.normal)
-    self.setupFont()
+    self.setupTitleFont()
     self.setupActionToChangeAlpha()
   }
   
-  private func setupFont() {
+  private func setupTitleFont() {
     self.titleLabel?.font = UIFont.pretendardHeadBold
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenBoxButton.swift
@@ -8,4 +8,19 @@
 import UIKit.UIButton
 
 public final class ToDoGardenBoxButton: UIButton {
+  init() {
+    super.init(frame: CGRect.zero)
+  }
+  
+  public convenience init(
+    isRoundRect: Bool,
+    text: String,
+    sizeType: CGSize
+  ) {
+    self.init()
+  }
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #43 

## 🎉 변경 사항

- ToDoGardenBoxButton 구현 
   - 3가지 Size를 설정할 수 있습니다.
   - enable/disable 상태 변경이 가능합니다.
   - 터치에 대한 highlight 효과

- 필요한 constant를 ToDoGardenBoxButtonConstant에 정의하였습니다.

## 📌 PR Point

- ToDoButtonBoxButton 클래스로 아래와 같은  버튼들을 표시할 수 있습니다. 

![Simulator Screen Recording - iPhone 15 Pro - 2024-03-20 at 18 41 05](https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/9f12c467-7f31-4c02-81e5-d8de45f89de2)
** 하이라이트 효과의 경우 disable에선 작동하지 않습니다.

- 인스턴스 생성시 , 어떤 종류의 버튼인지 알 수 있도록 init()을 구성하였습니다.
```swift
init(
    isRoundRect: Bool, // roundRect 여부
    text: String, // 버튼에 들어갈 text
    sizeType: CGSize // 버튼 size 
  )
```