### PR TITLE
ProfileImageView Constant 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ProfileImageView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ProfileImageView.swift
@@ -6,3 +6,12 @@
 //
 
 import Foundation
+
+extension Constant.ProfileImageView {
+  public enum Size {
+    public static let small  = CGSize(width: 36, height: 36)
+    public static let medium = CGSize(width: 56, height: 56)
+    public static let large  = CGSize(width: 86, height: 86)
+    public static let xLarge = CGSize(width: 241, height: 241)
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ProfileImageView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ProfileImageView.swift
@@ -1,0 +1,8 @@
+//
+//  Constant+ProfileImageView.swift
+//
+//
+//  Created by Wood on 4/7/24.
+//
+
+import Foundation

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -8,4 +8,5 @@
 public enum Constant {
   public enum ToDoGardenBoxButton { }
   public enum AddUnderlinedTextButton {}
+  public enum ProfileImageView {}
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #60 

## 🎉 변경 사항
- ProfileImageView의 Size 타입을 ToDoGardenUIConstant 타겟에 추가하였습니다.
- Size 타입은  `small, medium, large, xlarge`를 가집니다.

## 📌 PR Point
- 프로퍼티 네이밍
- 코드 컨벤션 준수 여부 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?