### PR TITLE
ProfileImageView 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
@@ -7,8 +7,12 @@
 
 import UIKit.UIImageView
 
+import ToDoGardenUIConstant
+import ToDoGardenUIResource
+
 public final class ProfileImageView: UIImageView {
   private var size: CGSize
+  private var imageLoadTask: Task<(), Error>?
 
   public init(size: CGSize) {
     self.size = size
@@ -20,6 +24,23 @@ public final class ProfileImageView: UIImageView {
     self.size = CGSize()
     super.init(coder: coder)
     ProfileImageViewStyle.apply(to: self, with: self.size)
+  }
+
+  public func setupImage(with image: UIImage) {
+    guard self.imageLoadTask == nil || self.imageLoadTask?.isCancelled == false
+    else { return }
+    
+    self.imageLoadTask = Task { [weak self] in
+      guard let self else { return }
+
+      if let preparedImage = await image.byPreparingThumbnail(ofSize: self.size) {
+        self.image = preparedImage
+      }
+    }
+  }
+  
+  deinit {
+    self.imageLoadTask?.cancel()
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
@@ -23,6 +23,12 @@ public final class ProfileImageView: UIImageView {
 
 private enum ProfileImageViewStyle {
   fileprivate static func apply(to imageView: UIImageView, with size: CGSize) {
-    
+    self.setupRoundedCorner(to: imageView, with: size)
+  }
+}
+
+extension ProfileImageViewStyle {
+  private static func setupRoundedCorner(to imageView: UIImageView, with size: CGSize) {
+    imageView.layer.cornerRadius = size.height / 2
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
@@ -11,7 +11,7 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 public final class ProfileImageView: UIImageView {
-  private var size: CGSize
+  private let size: CGSize
   private var imageLoadTask: Task<(), Error>?
 
   public init(size: CGSize) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
@@ -20,3 +20,9 @@ public final class ProfileImageView: UIImageView {
     super.init(coder: coder)
   }
 }
+
+private enum ProfileImageViewStyle {
+  fileprivate static func apply(to imageView: UIImageView, with size: CGSize) {
+    
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
@@ -12,7 +12,7 @@ import ToDoGardenUIResource
 
 public final class ProfileImageView: UIImageView {
   private let size: CGSize
-  private var imageLoadTask: Task<(), Error>?
+  private var imageLoadTask: Task<(), Never>?
 
   public init(size: CGSize) {
     self.size = size
@@ -32,13 +32,7 @@ public final class ProfileImageView: UIImageView {
     guard self.imageLoadTask == nil || self.imageLoadTask?.isCancelled == false
     else { return }
 
-    self.imageLoadTask = Task { [weak self] in
-      guard let self else { return }
-
-      if let preparedImage = await image.byPreparingThumbnail(ofSize: self.size) {
-        self.image = preparedImage
-      }
-    }
+    self.imageLoadTask = self.createImageLoadTask(with: image)
   }
 
   deinit {
@@ -48,10 +42,21 @@ public final class ProfileImageView: UIImageView {
 
 extension ProfileImageView {
   private func setupDefaultImage() {
-    if self.size == Constant.ProfileImageView.Size.small {
-      self.setupImage(with: UIImage.defaultFriendProfileImage)
-    } else {
-      self.setupImage(with: UIImage.defaultProfileImage)
+    let defaultImage = self.size == Constant.ProfileImageView.Size.small ?
+    UIImage.defaultFriendProfileImage : UIImage.defaultProfileImage
+
+    self.imageLoadTask = self.createImageLoadTask(with: defaultImage)
+  }
+
+  private func createImageLoadTask(with image: UIImage) -> Task<(), Never> {
+    return Task { [weak self] in
+      guard let self = self else { return }
+
+      if let resizedImage = await image.byPreparingThumbnail(ofSize: self.size) {
+        self.image = resizedImage
+      } else {
+        self.image = image
+      }
     }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
@@ -8,7 +8,15 @@
 import UIKit.UIImageView
 
 public final class ProfileImageView: UIImageView {
+  private var size: CGSize
+
+  public init(size: CGSize) {
+    self.size = size
+    super.init(frame: CGRect.zero)
+  }
+
   required init?(coder: NSCoder) {
+    self.size = CGSize()
     super.init(coder: coder)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
@@ -50,8 +50,7 @@ extension ProfileImageView {
   private func setupDefaultImage() {
     if self.size == Constant.ProfileImageView.Size.small {
       self.setupImage(with: UIImage.defaultFriendProfileImage)
-    }
-    else {
+    } else {
       self.setupImage(with: UIImage.defaultProfileImage)
     }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
@@ -13,22 +13,30 @@ public final class ProfileImageView: UIImageView {
   public init(size: CGSize) {
     self.size = size
     super.init(frame: CGRect.zero)
+    ProfileImageViewStyle.apply(to: self, with: self.size)
   }
 
   required init?(coder: NSCoder) {
     self.size = CGSize()
     super.init(coder: coder)
+    ProfileImageViewStyle.apply(to: self, with: self.size)
   }
 }
 
 private enum ProfileImageViewStyle {
   fileprivate static func apply(to imageView: UIImageView, with size: CGSize) {
     self.setupRoundedCorner(to: imageView, with: size)
+    self.setupContentAppearnce(to: imageView)
   }
 }
 
 extension ProfileImageViewStyle {
   private static func setupRoundedCorner(to imageView: UIImageView, with size: CGSize) {
     imageView.layer.cornerRadius = size.height / 2
+  }
+  
+  private static func setupContentAppearnce(to imageView: UIImageView) {
+    imageView.contentMode = UIView.ContentMode.scaleAspectFill
+    imageView.clipsToBounds = true
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
@@ -1,0 +1,14 @@
+//
+//  ProfileImageView.swift
+//
+//
+//  Created by Wood on 4/7/24.
+//
+
+import UIKit.UIImageView
+
+public final class ProfileImageView: UIImageView {
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ProfileImageView.swift
@@ -18,18 +18,20 @@ public final class ProfileImageView: UIImageView {
     self.size = size
     super.init(frame: CGRect.zero)
     ProfileImageViewStyle.apply(to: self, with: self.size)
+    self.setupDefaultImage()
   }
 
   required init?(coder: NSCoder) {
     self.size = CGSize()
     super.init(coder: coder)
     ProfileImageViewStyle.apply(to: self, with: self.size)
+    self.setupDefaultImage()
   }
 
   public func setupImage(with image: UIImage) {
     guard self.imageLoadTask == nil || self.imageLoadTask?.isCancelled == false
     else { return }
-    
+
     self.imageLoadTask = Task { [weak self] in
       guard let self else { return }
 
@@ -38,9 +40,20 @@ public final class ProfileImageView: UIImageView {
       }
     }
   }
-  
+
   deinit {
     self.imageLoadTask?.cancel()
+  }
+}
+
+extension ProfileImageView {
+  private func setupDefaultImage() {
+    if self.size == Constant.ProfileImageView.Size.small {
+      self.setupImage(with: UIImage.defaultFriendProfileImage)
+    }
+    else {
+      self.setupImage(with: UIImage.defaultProfileImage)
+    }
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #66

## 🎉 변경 사항
- ToDoGardenUIComponent 타겟에 ProfileImageView를 구현하였습니다.
  - UIConstant에 선언된 정해진 Size 타입을 이용하여 초기화 해서 사용해야합니다.
  - 초기화시 입력받은 Size에 따라 기본 이미지를 할당합니다.
  - 비동기 작업을 이용한 이미지 로딩
    - 3bd5a5a4ee38d3d41bfd91bca7cb9f395ad848c0

## 📌 PR Point
- 실행 화면은 다음과 같습니다.

|기본 이미지|커스텀 이미지|
|---|---|
|![Simulator Screenshot - iPhone 15 - 2024-04-09 at 23 01 32](https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/97213a36-2a4e-45e3-9231-a794e65d17a1)|![Simulator Screenshot - iPhone 15 - 2024-04-10 at 16 21 13](https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/fc28e61c-64de-46e9-9689-f25ba28f6113)|

- 이미지 디코딩 과정을 백그라운드 스레드에서 비동기적으로 실행하도록 Task를 사용하였습니다.
  - ProfileImageView 객체 deinit 호출시 이미지 로딩 Task 취소하도록 구현하였습니다.
  - 이미지 디코딩 과정에 대한 자세한 설명을 노션에 기록했습니다.
    - [백그라운드 이미지 로딩](https://mixolydian-macadamia-d9b.notion.site/ec09998ae69a41c2847d3adcaf109790?pvs=4)

- 코드 컨벤션 준수 여부

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?