### PR TITLE
PeriodSegmentedControlAppearance 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlAppearance.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlAppearance.swift
@@ -78,7 +78,7 @@ extension PeriodSegmentedControlAppearance {
   }
   
   private func setupStackView() {
-    let padding = Constant.PeriodSegmentedControl.Layout.innerPadding
+    let margin = Constant.PeriodSegmentedControl.Layout.innerPadding
     
     self.itemsStackView.axis = NSLayoutConstraint.Axis.horizontal
     self.itemsStackView.distribution = UIStackView.Distribution.fillEqually
@@ -87,8 +87,8 @@ extension PeriodSegmentedControlAppearance {
     self.itemsStackView.usingAutolayout()
     NSLayoutConstraint.activate(
       [
-        self.itemsStackView.leadingAnchor.constraint(equalTo: self.backgroundView.leadingAnchor, constant: padding),
-        self.itemsStackView.trailingAnchor.constraint(equalTo: self.backgroundView.trailingAnchor, constant: -padding),
+        self.itemsStackView.leadingAnchor.constraint(equalTo: self.backgroundView.leadingAnchor, constant: margin),
+        self.itemsStackView.trailingAnchor.constraint(equalTo: self.backgroundView.trailingAnchor, constant: -margin),
         self.itemsStackView.centerYAnchor.constraint(equalTo: self.backgroundView.centerYAnchor)
       ]
     )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlAppearance.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlAppearance.swift
@@ -30,6 +30,10 @@ final class PeriodSegmentedControlAppearance {
     self.setup(with: items)
   }
   
+  func getAssembledView() -> UIView {
+    return self.backgroundView
+  }
+  
   func moveIndicatorView(to xPosition: CGFloat) {
     self.indicatorViewCurrentX = xPosition
     self.indicatorView.center.x = self.indicatorViewCurrentX

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlAppearance.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlAppearance.swift
@@ -91,8 +91,8 @@ extension PeriodSegmentedControlAppearance {
     self.itemsStackView.usingAutolayout()
     NSLayoutConstraint.activate(
       [
-        self.itemsStackView.leadingAnchor.constraint(equalTo: self.backgroundView.leadingAnchor,constant: padding),
-        self.itemsStackView.trailingAnchor.constraint(equalTo: self.backgroundView.trailingAnchor,constant: -padding),
+        self.itemsStackView.leadingAnchor.constraint(equalTo: self.backgroundView.leadingAnchor, constant: padding),
+        self.itemsStackView.trailingAnchor.constraint(equalTo: self.backgroundView.trailingAnchor, constant: -padding),
         self.itemsStackView.centerYAnchor.constraint(equalTo: self.backgroundView.centerYAnchor)
       ]
     )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlAppearance.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlAppearance.swift
@@ -15,18 +15,14 @@ final class PeriodSegmentedControlAppearance {
   private let indicatorView: UIImageView
   private let itemsStackView: UIStackView
   
-  private var indicatorViewCurrentX: CGFloat = {
-    let initialPosition = (
-      Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition +
-      Constant.PeriodSegmentedControl.Layout.itemWidth
-    )
-    return initialPosition
-  }()
+  private var indicatorViewCurrentX: CGFloat
   
   init(with items: [String]) {
     self.backgroundView = UIImageView(image: UIImage.periodSegmentedControlBackground)
     self.indicatorView = UIImageView(image: UIImage.periodSegmentedControlIndicator)
     self.itemsStackView = UIStackView()
+    self.indicatorViewCurrentX = Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition +
+    Constant.PeriodSegmentedControl.Layout.itemWidth
     self.setup(with: items)
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlAppearance.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlAppearance.swift
@@ -11,6 +11,7 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 final class PeriodSegmentedControlAppearance {
+  private let backgroundView: UIImageView
   private let indicatorView: UIImageView
   private let itemsStackView: UIStackView
   
@@ -23,6 +24,7 @@ final class PeriodSegmentedControlAppearance {
   }()
   
   init(with items: [String]) {
+    self.backgroundView = UIImageView(image: UIImage.periodSegmentedControlBackground)
     self.indicatorView = UIImageView(image: UIImage.periodSegmentedControlIndicator)
     self.itemsStackView = UIStackView()
     self.setup(with: items)
@@ -57,21 +59,20 @@ extension PeriodSegmentedControlAppearance {
   }
   
   private func setupBackgroundView() {
-    self.image = UIImage.periodSegmentedControlBackground
-    self.isUserInteractionEnabled = true
-    self.contentMode = ContentMode.scaleToFill
+    self.backgroundView.isUserInteractionEnabled = true
+    self.backgroundView.contentMode = UIView.ContentMode.scaleToFill
   }
   
   private func setupIndicatorViewLayout() {
     let indicatorViewWidth = Constant.PeriodSegmentedControl.Layout.indicatorViewWidth
-    self.addSubview(self.indicatorView)
+    self.backgroundView.addSubview(self.indicatorView)
     
     self.indicatorView.usingAutolayout()
     NSLayoutConstraint.activate(
       [
         self.indicatorView.widthAnchor.constraint(equalToConstant: indicatorViewWidth),
         self.indicatorView.heightAnchor.constraint(equalToConstant: indicatorViewWidth),
-        self.indicatorView.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+        self.indicatorView.centerYAnchor.constraint(equalTo: self.backgroundView.centerYAnchor)
       ]
     )
   }
@@ -81,14 +82,14 @@ extension PeriodSegmentedControlAppearance {
     
     self.itemsStackView.axis = NSLayoutConstraint.Axis.horizontal
     self.itemsStackView.distribution = UIStackView.Distribution.fillEqually
-    self.addSubview(self.itemsStackView)
+    self.backgroundView.addSubview(self.itemsStackView)
     
     self.itemsStackView.usingAutolayout()
     NSLayoutConstraint.activate(
       [
-        self.itemsStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: padding),
-        self.itemsStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -padding),
-        self.itemsStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+        self.itemsStackView.leadingAnchor.constraint(equalTo: self.backgroundView.leadingAnchor,constant: padding),
+        self.itemsStackView.trailingAnchor.constraint(equalTo: self.backgroundView.trailingAnchor,constant: -padding),
+        self.itemsStackView.centerYAnchor.constraint(equalTo: self.backgroundView.centerYAnchor)
       ]
     )
   }
@@ -118,7 +119,7 @@ extension PeriodSegmentedControlAppearance {
 
 extension PeriodSegmentedControlAppearance {
   func changeBackgroundImage(_ image: UIImage) {
-    self.image = image
+    self.backgroundView.image = image
   }
   
   func changeIndicatorImage(_ image: UIImage) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlAppearance.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlAppearance.swift
@@ -10,7 +10,7 @@ import UIKit.UIView
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
-final class PeriodSegmentedControlAppearance: UIImageView {
+final class PeriodSegmentedControlAppearance {
   private let indicatorView: UIImageView
   private let itemsStackView: UIStackView
   
@@ -22,26 +22,10 @@ final class PeriodSegmentedControlAppearance: UIImageView {
     return initialPosition
   }()
   
-  init() {
+  init(with items: [String]) {
     self.indicatorView = UIImageView(image: UIImage.periodSegmentedControlIndicator)
     self.itemsStackView = UIStackView()
-    super.init(frame: CGRect.zero)
-  }
-  
-  convenience init(with items: [String]) {
-    self.init()
     self.setup(with: items)
-  }
-  
-  required init?(coder: NSCoder) {
-    self.indicatorView = UIImageView(image: UIImage.periodSegmentedControlIndicator)
-    self.itemsStackView = UIStackView()
-    super.init(coder: coder)
-  }
-  
-  public override func layoutSubviews() {
-    super.layoutSubviews()
-    self.indicatorView.center.x = self.indicatorViewCurrentX
   }
   
   func moveIndicatorView(to xPosition: CGFloat) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlAppearance.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlAppearance.swift
@@ -10,7 +10,7 @@ import UIKit.UIView
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
-final class PeriodSegmentedControlBaseView: UIImageView {
+final class PeriodSegmentedControlAppearance: UIImageView {
   private let indicatorView: UIImageView
   private let itemsStackView: UIStackView
   
@@ -64,7 +64,7 @@ final class PeriodSegmentedControlBaseView: UIImageView {
 
 // MARK: - private functions
 
-extension PeriodSegmentedControlBaseView {
+extension PeriodSegmentedControlAppearance {
   private func setup(with items: [String]) {
     self.setupBackgroundView()
     self.setupIndicatorViewLayout()
@@ -132,7 +132,7 @@ extension PeriodSegmentedControlBaseView {
 
 // MARK: - for customizing
 
-extension PeriodSegmentedControlBaseView {
+extension PeriodSegmentedControlAppearance {
   func changeBackgroundImage(_ image: UIImage) {
     self.image = image
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -43,6 +43,11 @@ final class PeriodSegmentedControlBaseView: UIImageView {
     super.layoutSubviews()
     self.indicatorView.center.x = self.indicatorViewCurrentX
   }
+  
+  func moveIndicatorView(to x: CGFloat) {
+    self.indicatorViewCurrentX = x
+    self.indicatorView.center.x = self.indicatorViewCurrentX
+  }
 }
 
 //MARK: - private functions

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -7,6 +7,8 @@
 
 import UIKit.UIView
 
+import ToDoGardenUIResource
+
 final class PeriodSegmentedControlBaseView: UIImageView {
   
   init() {
@@ -15,6 +17,7 @@ final class PeriodSegmentedControlBaseView: UIImageView {
   
   convenience init(with items: [String]) {
     self.init()
+    self.setup(with: items)
   }
   
   required init?(coder: NSCoder) {
@@ -24,4 +27,13 @@ final class PeriodSegmentedControlBaseView: UIImageView {
 
 //MARK: - private functions
 extension PeriodSegmentedControlBaseView {
+  private func setup(with items: [String]) {
+    self.setupBackgroundView()
+  }
+  
+  private func setupBackgroundView() {
+    self.image = UIImage.periodSegmentedControlBackground
+    self.isUserInteractionEnabled = true
+    self.contentMode = ContentMode.scaleToFill
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -44,13 +44,13 @@ final class PeriodSegmentedControlBaseView: UIImageView {
     self.indicatorView.center.x = self.indicatorViewCurrentX
   }
   
-  func moveIndicatorView(to x: CGFloat) {
-    self.indicatorViewCurrentX = x
+  func moveIndicatorView(to xPosition: CGFloat) {
+    self.indicatorViewCurrentX = xPosition
     self.indicatorView.center.x = self.indicatorViewCurrentX
   }
 }
 
-//MARK: - private functions
+// MARK: - private functions
 
 extension PeriodSegmentedControlBaseView {
   private func setup(with items: [String]) {
@@ -90,8 +90,8 @@ extension PeriodSegmentedControlBaseView {
     self.itemsStackView.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate(
       [
-        self.itemsStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor,constant: padding),
-        self.itemsStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor,constant: -padding),
+        self.itemsStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: padding),
+        self.itemsStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -padding),
         self.itemsStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor)
       ]
     )
@@ -118,14 +118,14 @@ extension PeriodSegmentedControlBaseView {
   }
 }
 
-//MARK: - for customizing
+// MARK: - for customizing
 
 extension PeriodSegmentedControlBaseView {
-  public func changeBackgroundImage(_ image : UIImage){
+  public func changeBackgroundImage(_ image: UIImage) {
     self.image = image
   }
   
-  public func changeIndicatorImage(_ image : UIImage){
+  public func changeIndicatorImage(_ image: UIImage) {
     self.indicatorView.image = image
   }
   
@@ -143,4 +143,3 @@ extension PeriodSegmentedControlBaseView {
     self.indicatorViewCurrentX = startPoint + additionalWeight
   }
 }
-

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -14,6 +14,14 @@ final class PeriodSegmentedControlBaseView: UIImageView {
   var indicatorView: UIImageView
   var itemsStackView: UIStackView
   
+  private var indicatorViewCurrentX: CGFloat = {
+    let initialPosition = (
+      Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition +
+      Constant.PeriodSegmentedControl.Layout.itemWidth
+    )
+    return initialPosition
+  }()
+  
   init() {
     self.indicatorView = UIImageView(image: UIImage.periodSegmentedControlIndicator)
     self.itemsStackView = UIStackView()
@@ -29,6 +37,11 @@ final class PeriodSegmentedControlBaseView: UIImageView {
     self.indicatorView = UIImageView(image: UIImage.periodSegmentedControlIndicator)
     self.itemsStackView = UIStackView()
     super.init(coder: coder)
+  }
+  
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    self.indicatorView.center.x = self.indicatorViewCurrentX
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -130,7 +130,7 @@ extension PeriodSegmentedControlBaseView {
   }
   
   func changeInitialSelectedItem(index: Int, numberOfItems: Int) {
-    if index >= numberOfItems || index < Int.zero {
+    guard index < numberOfItems && index >= Int.zero else {
       return
     }
     

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -51,6 +51,7 @@ final class PeriodSegmentedControlBaseView: UIImageView {
 }
 
 //MARK: - private functions
+
 extension PeriodSegmentedControlBaseView {
   private func setup(with items: [String]) {
     self.setupBackgroundView()
@@ -116,3 +117,30 @@ extension PeriodSegmentedControlBaseView {
     }
   }
 }
+
+//MARK: - for customizing
+
+extension PeriodSegmentedControlBaseView {
+  public func changeBackgroundImage(_ image : UIImage){
+    self.image = image
+  }
+  
+  public func changeIndicatorImage(_ image : UIImage){
+    self.indicatorView.image = image
+  }
+  
+  public func changeInitialSelectedItem(index: Int, numberOfSegments: Int) {
+    if index >= numberOfSegments || index < Int.zero {
+      return
+    }
+    
+    let startPoint = Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition
+    let additionalWeight = (
+      Constant.PeriodSegmentedControl.Layout.itemWidth *
+      CGFloat(index)
+    )
+    
+    self.indicatorViewCurrentX = startPoint + additionalWeight
+  }
+}
+

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -11,8 +11,8 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 final class PeriodSegmentedControlBaseView: UIImageView {
-  var indicatorView: UIImageView
-  var itemsStackView: UIStackView
+  private let indicatorView: UIImageView
+  private let itemsStackView: UIStackView
   
   private var indicatorViewCurrentX: CGFloat = {
     let initialPosition = (

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -112,12 +112,12 @@ extension PeriodSegmentedControlBaseView {
   private func setupLabels(with items: [String]) {
     let segmentWidth = Constant.PeriodSegmentedControl.Layout.itemWidth
     
-    for item in items {
+    for labelTitle in items {
       let label = UILabel()
       label.frame.size.width = segmentWidth
       
       let attributedTitle = NSAttributedString(
-        string: item,
+        string: labelTitle,
         attributes: [
           NSAttributedString.Key.font: UIFont.pretendardBodyMedium,
           NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -121,16 +121,16 @@ extension PeriodSegmentedControlBaseView {
 // MARK: - for customizing
 
 extension PeriodSegmentedControlBaseView {
-  public func changeBackgroundImage(_ image: UIImage) {
+  func changeBackgroundImage(_ image: UIImage) {
     self.image = image
   }
   
-  public func changeIndicatorImage(_ image: UIImage) {
+  func changeIndicatorImage(_ image: UIImage) {
     self.indicatorView.image = image
   }
   
-  public func changeInitialSelectedItem(index: Int, numberOfSegments: Int) {
-    if index >= numberOfSegments || index < Int.zero {
+  func changeInitialSelectedItem(index: Int, numberOfItems: Int) {
+    if index >= numberOfItems || index < Int.zero {
       return
     }
     

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -7,11 +7,14 @@
 
 import UIKit.UIView
 
+import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 final class PeriodSegmentedControlBaseView: UIImageView {
+  var indicatorView: UIImageView
   
   init() {
+    self.indicatorView = UIImageView(image: UIImage.periodSegmentedControlIndicator)
     super.init(frame: CGRect.zero)
   }
   
@@ -21,6 +24,7 @@ final class PeriodSegmentedControlBaseView: UIImageView {
   }
   
   required init?(coder: NSCoder) {
+    self.indicatorView = UIImageView(image: UIImage.periodSegmentedControlIndicator)
     super.init(coder: coder)
   }
 }
@@ -29,11 +33,26 @@ final class PeriodSegmentedControlBaseView: UIImageView {
 extension PeriodSegmentedControlBaseView {
   private func setup(with items: [String]) {
     self.setupBackgroundView()
+    self.setupIndicatorView()
   }
   
   private func setupBackgroundView() {
     self.image = UIImage.periodSegmentedControlBackground
     self.isUserInteractionEnabled = true
     self.contentMode = ContentMode.scaleToFill
+  }
+  
+  private func setupIndicatorView() {
+    let indicatorViewWidth = Constant.PeriodSegmentedControl.Layout.indicatorViewWidth
+    self.addSubview(self.indicatorView)
+    
+    self.indicatorView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate(
+      [
+        self.indicatorView.widthAnchor.constraint(equalToConstant: indicatorViewWidth),
+        self.indicatorView.heightAnchor.constraint(equalToConstant: indicatorViewWidth),
+        self.indicatorView.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+      ]
+    )
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -12,9 +12,11 @@ import ToDoGardenUIResource
 
 final class PeriodSegmentedControlBaseView: UIImageView {
   var indicatorView: UIImageView
+  var itemsStackView: UIStackView
   
   init() {
     self.indicatorView = UIImageView(image: UIImage.periodSegmentedControlIndicator)
+    self.itemsStackView = UIStackView()
     super.init(frame: CGRect.zero)
   }
   
@@ -25,6 +27,7 @@ final class PeriodSegmentedControlBaseView: UIImageView {
   
   required init?(coder: NSCoder) {
     self.indicatorView = UIImageView(image: UIImage.periodSegmentedControlIndicator)
+    self.itemsStackView = UIStackView()
     super.init(coder: coder)
   }
 }
@@ -34,6 +37,7 @@ extension PeriodSegmentedControlBaseView {
   private func setup(with items: [String]) {
     self.setupBackgroundView()
     self.setupIndicatorView()
+    self.setupStackView()
   }
   
   private func setupBackgroundView() {
@@ -52,6 +56,23 @@ extension PeriodSegmentedControlBaseView {
         self.indicatorView.widthAnchor.constraint(equalToConstant: indicatorViewWidth),
         self.indicatorView.heightAnchor.constraint(equalToConstant: indicatorViewWidth),
         self.indicatorView.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+      ]
+    )
+  }
+  
+  private func setupStackView() {
+    let padding = Constant.PeriodSegmentedControl.Layout.innerPadding
+    
+    self.itemsStackView.axis = NSLayoutConstraint.Axis.horizontal
+    self.itemsStackView.distribution = UIStackView.Distribution.fillEqually
+    self.addSubview(self.itemsStackView)
+    
+    self.itemsStackView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate(
+      [
+        self.itemsStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor,constant: padding),
+        self.itemsStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor,constant: -padding),
+        self.itemsStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor)
       ]
     )
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -70,7 +70,7 @@ extension PeriodSegmentedControlBaseView {
     let indicatorViewWidth = Constant.PeriodSegmentedControl.Layout.indicatorViewWidth
     self.addSubview(self.indicatorView)
     
-    self.indicatorView.translatesAutoresizingMaskIntoConstraints = false
+    self.indicatorView.usingAutolayout()
     NSLayoutConstraint.activate(
       [
         self.indicatorView.widthAnchor.constraint(equalToConstant: indicatorViewWidth),
@@ -87,7 +87,7 @@ extension PeriodSegmentedControlBaseView {
     self.itemsStackView.distribution = UIStackView.Distribution.fillEqually
     self.addSubview(self.itemsStackView)
     
-    self.itemsStackView.translatesAutoresizingMaskIntoConstraints = false
+    self.itemsStackView.usingAutolayout()
     NSLayoutConstraint.activate(
       [
         self.itemsStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: padding),

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -55,7 +55,7 @@ final class PeriodSegmentedControlBaseView: UIImageView {
 extension PeriodSegmentedControlBaseView {
   private func setup(with items: [String]) {
     self.setupBackgroundView()
-    self.setupIndicatorView()
+    self.setupIndicatorViewLayout()
     self.setupStackView()
     self.setupLabels(with: items)
   }
@@ -66,7 +66,7 @@ extension PeriodSegmentedControlBaseView {
     self.contentMode = ContentMode.scaleToFill
   }
   
-  private func setupIndicatorView() {
+  private func setupIndicatorViewLayout() {
     let indicatorViewWidth = Constant.PeriodSegmentedControl.Layout.indicatorViewWidth
     self.addSubview(self.indicatorView)
     

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -38,6 +38,7 @@ extension PeriodSegmentedControlBaseView {
     self.setupBackgroundView()
     self.setupIndicatorView()
     self.setupStackView()
+    self.setupLabels(with: items)
   }
   
   private func setupBackgroundView() {
@@ -75,5 +76,25 @@ extension PeriodSegmentedControlBaseView {
         self.itemsStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor)
       ]
     )
+  }
+  
+  private func setupLabels(with items: [String]) {
+    let segmentWidth = Constant.PeriodSegmentedControl.Layout.itemWidth
+    
+    for item in items {
+      let label = UILabel()
+      label.frame.size.width = segmentWidth
+      
+      let attributedTitle = NSAttributedString(
+        string: item,
+        attributes: [
+          NSAttributedString.Key.font: UIFont.pretendardBodyMedium,
+          NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+        ]
+      )
+      label.attributedText = attributedTitle
+      label.textAlignment = NSTextAlignment.center
+      self.itemsStackView.addArrangedSubview(label)
+    }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -1,0 +1,27 @@
+//
+//  PeriodSegmentedControlBaseView.swift
+//
+//
+//  Created by SONG on 4/10/24.
+//
+
+import UIKit.UIView
+
+final class PeriodSegmentedControlBaseView: UIImageView {
+  
+  init() {
+    super.init(frame: CGRect.zero)
+  }
+  
+  convenience init(with items: [String]) {
+    self.init()
+  }
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
+}
+
+//MARK: - private functions
+extension PeriodSegmentedControlBaseView {
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlBaseView.swift
@@ -48,6 +48,18 @@ final class PeriodSegmentedControlBaseView: UIImageView {
     self.indicatorViewCurrentX = xPosition
     self.indicatorView.center.x = self.indicatorViewCurrentX
   }
+  
+  func transformIndicatorViewDownScale() {
+    self.indicatorView.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
+  }
+  
+  func transformIndicatorViewOriginalScale() {
+    self.indicatorView.transform = CGAffineTransform.identity
+  }
+  
+  func getIndicatorViewCenter() -> CGFloat {
+    return self.indicatorViewCurrentX
+  }
 }
 
 // MARK: - private functions


### PR DESCRIPTION
## 💡 관련 이슈
- #65 
## 🎉 변경 사항
`PeriodSegmentedControl`에 필요한 view 객체들만 따로 분리한 타입입니다. 
사용자 상호작용과 관련된 gestureRecognizer, feedbackGenerator 등은 `PeriodSegmentedControlBaseView`의 슈퍼뷰인 `PeriodSegmentedControl`에서 동작이 구현될 예정입니다. 

## 📌 PR Point
구현내용을 요약하자면 아래와 같습니다.
- 표시될 label에 대하여
   - 생성 및 레이아웃 정의
   - 기본값이 아닌 텍스트를 넣거나, 개수 변경 가능

- 표시될 indicatorView에 대하여
   - 생성 및 레이아웃 정의
   - 좌표 변경 동작
   - 기본값이 아닌 이미지를 indicatorView의 이미지로 사용할 수 있음
   
- 표시될 backgroundView에 대하여 
   - `PeriodSegmentedControlBaseView`의 self가 backgroundView역할을 합니다.
   - 생성 및 레이아웃 정의
   - 기본값이 아닌 이미지를 backgroundView의 이미지로 사용할 수 있음
   
+ 생성 이후에 changeBackgroundImage, changeIndicatorImage, changeInitialSelectedItem 를 호출하지 않는다면, 아래와 같은 기본값으로 표시됩니다.
<img width="425" alt="스크린샷 2024-04-11 오후 3 04 10" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/16fceb03-1994-459b-b0fc-00260f1b7ae8">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?