### PR TITLE
PeriodSegmentedControlGestureRecognizer 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlGestureRecognizer.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlGestureRecognizer.swift
@@ -20,5 +20,11 @@ final class PeriodSegmentedControlGestureRecognizer {
     target.addGestureRecognizer(panRecognizer)
     target.addGestureRecognizer(tapRecognizer)
     target.addGestureRecognizer(longpressRecognizer)
+    
+    self.setupPanRecognizer(with: target as? UIGestureRecognizerDelegate)
+  }
+  
+  private func setupPanRecognizer(with target: UIGestureRecognizerDelegate?) {
+    self.panRecognizer.delegate = target
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlGestureRecognizer.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlGestureRecognizer.swift
@@ -22,12 +22,15 @@ final class PeriodSegmentedControlGestureRecognizer {
     self.tapRecognizer = UITapGestureRecognizer(target: target, action: tapAction)
     self.longpressRecognizer = UILongPressGestureRecognizer(target: target, action: longpressAction)
     
+    self.addGestureRecognizers(on: target)
+    self.setupPanRecognizer(with: target as? UIGestureRecognizerDelegate)
+    self.setupLongpressRecognizer()
+  }
+  
+  private func addGestureRecognizers(on target: UIControl) {
     target.addGestureRecognizer(panRecognizer)
     target.addGestureRecognizer(tapRecognizer)
     target.addGestureRecognizer(longpressRecognizer)
-    
-    self.setupPanRecognizer(with: target as? UIGestureRecognizerDelegate)
-    self.setupLongpressRecognizer()
   }
   
   private func setupPanRecognizer(with target: UIGestureRecognizerDelegate?) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlGestureRecognizer.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlGestureRecognizer.swift
@@ -22,9 +22,14 @@ final class PeriodSegmentedControlGestureRecognizer {
     target.addGestureRecognizer(longpressRecognizer)
     
     self.setupPanRecognizer(with: target as? UIGestureRecognizerDelegate)
+    self.setupLongpressRecognizer()
   }
   
   private func setupPanRecognizer(with target: UIGestureRecognizerDelegate?) {
     self.panRecognizer.delegate = target
+  }
+  
+  private func setupLongpressRecognizer() {
+    self.longpressRecognizer.minimumPressDuration = 0.2
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlGestureRecognizer.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlGestureRecognizer.swift
@@ -17,5 +17,8 @@ final class PeriodSegmentedControlGestureRecognizer {
     self.tapRecognizer = UITapGestureRecognizer(target: target, action: tapAction)
     self.longpressRecognizer = UILongPressGestureRecognizer(target: target, action: longpressAction)
     
+    target.addGestureRecognizer(panRecognizer)
+    target.addGestureRecognizer(tapRecognizer)
+    target.addGestureRecognizer(longpressRecognizer)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlGestureRecognizer.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlGestureRecognizer.swift
@@ -5,8 +5,17 @@
 //  Created by SONG on 4/17/24.
 //
 
-import Foundation
+import UIKit
 
 final class PeriodSegmentedControlGestureRecognizer {
+  private let panRecognizer: UIPanGestureRecognizer
+  private let tapRecognizer: UITapGestureRecognizer
+  private let longpressRecognizer: UILongPressGestureRecognizer
   
+  init(target: UIControl, panAction: Selector?, tapAction: Selector?, longpressAction: Selector?) {
+    self.panRecognizer = UIPanGestureRecognizer(target: target, action: panAction)
+    self.tapRecognizer = UITapGestureRecognizer(target: target, action: tapAction)
+    self.longpressRecognizer = UILongPressGestureRecognizer(target: target, action: longpressAction)
+    
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlGestureRecognizer.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlGestureRecognizer.swift
@@ -1,0 +1,12 @@
+//
+//  PeriodSegmentedControlGestureRecognizer.swift
+//
+//
+//  Created by SONG on 4/17/24.
+//
+
+import Foundation
+
+final class PeriodSegmentedControlGestureRecognizer {
+  
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlGestureRecognizer.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControlGestureRecognizer.swift
@@ -12,7 +12,12 @@ final class PeriodSegmentedControlGestureRecognizer {
   private let tapRecognizer: UITapGestureRecognizer
   private let longpressRecognizer: UILongPressGestureRecognizer
   
-  init(target: UIControl, panAction: Selector?, tapAction: Selector?, longpressAction: Selector?) {
+  init(
+    target: UIControl,
+    panAction: Selector?,
+    tapAction: Selector?,
+    longpressAction: Selector?
+  ) {
     self.panRecognizer = UIPanGestureRecognizer(target: target, action: panAction)
     self.tapRecognizer = UITapGestureRecognizer(target: target, action: tapAction)
     self.longpressRecognizer = UILongPressGestureRecognizer(target: target, action: longpressAction)


### PR DESCRIPTION
## 💡 관련 이슈
- #73 
## 🎉 변경 사항
- 제스처 인식기 객체들을 캡슐화하여 역할을 분리시킨 새로운 타입을 정의합니다. 
## 📌 PR Point
- `PeriodSegmentedControlGestureRecognizer` 는 3개의 UIGestureRecognizer를 가지고 있습니다. 
- UIGestureRecognizer를 생성하며, 제스처 이벤트를 수신하는 역할을 합니다. 
   + 이벤트 처리는 UIControl을 상속받은 `PeriodSegmentedControl`에서 이루어집니다.

```swift
self.panRecognizer.delegate = target
```
- line 29의 해당 코드는 `PeriodSegmentedControlGestureRecognizer`를 가지고 있는 `PeriodSegmentedControl`에서 사용될 예정입니다. (Pan과 LongPress의 이벤트가 동시에 발생하는 case 처리) 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?