### PR TITLE
SearchGardenButton Constant 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SearchGardenButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SearchGardenButton.swift
@@ -9,8 +9,13 @@ import Foundation
 
 extension Constant.SearchGardenButton {
   public enum Layout {}
+  public enum ImageView {}
 }
 
 extension Constant.SearchGardenButton.Layout {
   public static let cornerRadius: CGFloat = 12
+}
+
+extension Constant.SearchGardenButton.ImageView {
+  public static let trailingConstraint: CGFloat = -12.5
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SearchGardenButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SearchGardenButton.swift
@@ -1,0 +1,11 @@
+//
+//  Constant+SearchGardenButton.swift
+//
+//
+//  Created by Wood on 4/19/24.
+//
+
+import Foundation
+
+extension Constant.SearchGardenButton {
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SearchGardenButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SearchGardenButton.swift
@@ -9,6 +9,9 @@ import Foundation
 
 extension Constant.SearchGardenButton {
   public enum Layout {}
+}
+
+extension Constant.SearchGardenButton.Layout {
   public enum ImageView {}
 }
 
@@ -16,6 +19,6 @@ extension Constant.SearchGardenButton.Layout {
   public static let cornerRadius: CGFloat = 12
 }
 
-extension Constant.SearchGardenButton.ImageView {
+extension Constant.SearchGardenButton.Layout.ImageView {
   public static let trailingConstraint: CGFloat = -12.5
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SearchGardenButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SearchGardenButton.swift
@@ -8,4 +8,9 @@
 import Foundation
 
 extension Constant.SearchGardenButton {
+  public enum Layout {}
+}
+
+extension Constant.SearchGardenButton.Layout {
+  public static let cornerRadius: CGFloat = 12
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SearchGardenButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SearchGardenButton.swift
@@ -20,5 +20,5 @@ extension Constant.SearchGardenButton.Layout {
 }
 
 extension Constant.SearchGardenButton.Layout.ImageView {
-  public static let trailingConstraint: CGFloat = -12.5
+  public static let trailingMargin: CGFloat = 12.5
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -10,4 +10,5 @@ public enum Constant {
   public enum AddUnderlinedTextButton {}
   public enum PeriodSegmentedControl {}
   public enum ProfileImageView {}
+  public enum SearchGardenButton {}
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #78

## 🎉 변경 사항
- Constant에 SearchGardenButton에 필요한 레이아웃 관련 상수들을 추가하였습니다.

## 📌 PR Point
필요한 레이아웃 상수는 총 두가지 입니다.
1. cornerRadius: 고정값 12 (버튼의 높이가 24이므로 절반 값)

<img width="467" alt="스크린샷 2024-04-19 15 02 16" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/46d4a154-35a2-45ff-bae0-62253c2db0f1">

2. trailingConstrant: 돋보기 이미지와 버튼 사이 오른쪽 간격 고정값
Figma 앱에서 오른쪽 간격을 보여주는 화면을 캡쳐할 수 없어 직접 사진에 그렸습니다.
<img width="1068" alt="스크린샷 2024-04-19 15 07 14" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/9348d8df-50ff-4af4-a0fc-2dd580d438b0">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?