### PR TITLE
PeriodSegmentedControl 컴포넌트 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -80,7 +80,7 @@ extension PeriodSegmentedControl {
     self.periodSegmentedControlGestureRecognizer = PeriodSegmentedControlGestureRecognizer(
       target: self,
       panAction: #selector(self.panned),
-      tapAction: nil,
+      tapAction: #selector(self.tapped),
       longpressAction: nil
     )
   }
@@ -142,6 +142,21 @@ extension PeriodSegmentedControl {
       UIView.animate(withDuration: 0.3) {
         self.periodSegmentedControlAppearance.transformIndicatorViewOriginalScale()
       }
+    default: break
+    }
+  }
+  
+  @objc private func tapped(_ recognizer: UITapGestureRecognizer) {
+    switch recognizer.state {
+    case .recognized:
+      let touchLocation: CGPoint = recognizer.location(in: self)
+      let closestX = self.calculateClosestX(from: touchLocation.x)
+      
+      UIView.animate(withDuration: 0.15) {
+        self.periodSegmentedControlAppearance.moveIndicatorView(to: closestX)
+      }
+      self.hapticGenerator.selectionChanged()
+      self.expectedXPosition = closestX
     default: break
     }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -11,12 +11,14 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 public final class PeriodSegmentedControl: UIControl {
+  private let items: [String]
+  private let feedbackGenerator: UISelectionFeedbackGenerator
   private let periodSegmentedControlAppearance: PeriodSegmentedControlAppearance
   private var periodSegmentedControlGestureRecognizer: PeriodSegmentedControlGestureRecognizer?
-  private let items: [String]
   
   public init(items: [String] = Constant.PeriodSegmentedControl.Content.defaultItems) {
     self.items = items
+    self.feedbackGenerator = UISelectionFeedbackGenerator()
     self.periodSegmentedControlAppearance = PeriodSegmentedControlAppearance(with: self.items)
     self.periodSegmentedControlGestureRecognizer = nil
     super.init(frame: CGRect.zero)
@@ -25,6 +27,7 @@ public final class PeriodSegmentedControl: UIControl {
   
   required init?(coder: NSCoder) {
     self.items = Constant.PeriodSegmentedControl.Content.defaultItems
+    self.feedbackGenerator = UISelectionFeedbackGenerator()
     self.periodSegmentedControlAppearance = PeriodSegmentedControlAppearance(with: self.items)
     self.periodSegmentedControlGestureRecognizer = nil
     super.init(coder: coder)
@@ -48,6 +51,7 @@ public final class PeriodSegmentedControl: UIControl {
 //MARK: - private functions
 extension PeriodSegmentedControl {
   private func setup() {
+    self.setupFeedbackGenerator()
     self.setupAppearance()
     self.setupGestureRecognizer()
   }
@@ -97,4 +101,9 @@ extension PeriodSegmentedControl {
     }
     return closestX
   }
+  
+  private func setupFeedbackGenerator() {
+    self.feedbackGenerator.prepare()
+  }
+}
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -12,11 +12,13 @@ import ToDoGardenUIResource
 
 public final class PeriodSegmentedControl: UIControl {
   private let periodSegmentedControlAppearance: PeriodSegmentedControlAppearance
+  private var periodSegmentedControlGestureRecognizer: PeriodSegmentedControlGestureRecognizer?
   private let items: [String]
   
   public init(items: [String] = Constant.PeriodSegmentedControl.Content.defaultItems) {
     self.items = items
     self.periodSegmentedControlAppearance = PeriodSegmentedControlAppearance(with: self.items)
+    self.periodSegmentedControlGestureRecognizer = nil
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -24,6 +26,7 @@ public final class PeriodSegmentedControl: UIControl {
   required init?(coder: NSCoder) {
     self.items = Constant.PeriodSegmentedControl.Content.defaultItems
     self.periodSegmentedControlAppearance = PeriodSegmentedControlAppearance(with: self.items)
+    self.periodSegmentedControlGestureRecognizer = nil
     super.init(coder: coder)
     self.setup()
   }
@@ -46,6 +49,7 @@ public final class PeriodSegmentedControl: UIControl {
 extension PeriodSegmentedControl {
   private func setup() {
     self.setupAppearance()
+    self.setupGestureRecognizer()
   }
   
   private func setupAppearance() {
@@ -60,6 +64,15 @@ extension PeriodSegmentedControl {
         appearance.centerXAnchor.constraint(equalTo: self.centerXAnchor),
         appearance.centerYAnchor.constraint(equalTo: self.centerYAnchor)
       ]
+    )
+  }
+  
+  private func setupGestureRecognizer() {
+    self.periodSegmentedControlGestureRecognizer = PeriodSegmentedControlGestureRecognizer(
+      target: self,
+      panAction: nil,
+      tapAction: nil,
+      longpressAction: nil
     )
   }
   
@@ -84,5 +97,4 @@ extension PeriodSegmentedControl {
     }
     return closestX
   }
-
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -15,12 +15,15 @@ public final class PeriodSegmentedControl: UIControl {
   private let feedbackGenerator: UISelectionFeedbackGenerator
   private let periodSegmentedControlAppearance: PeriodSegmentedControlAppearance
   private var periodSegmentedControlGestureRecognizer: PeriodSegmentedControlGestureRecognizer?
+  private var expectedXPosition: CGFloat
   
   public init(items: [String] = Constant.PeriodSegmentedControl.Content.defaultItems) {
     self.items = items
     self.feedbackGenerator = UISelectionFeedbackGenerator()
     self.periodSegmentedControlAppearance = PeriodSegmentedControlAppearance(with: self.items)
     self.periodSegmentedControlGestureRecognizer = nil
+    self.expectedXPosition = Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition +
+      Constant.PeriodSegmentedControl.Layout.itemWidth
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -30,6 +33,8 @@ public final class PeriodSegmentedControl: UIControl {
     self.feedbackGenerator = UISelectionFeedbackGenerator()
     self.periodSegmentedControlAppearance = PeriodSegmentedControlAppearance(with: self.items)
     self.periodSegmentedControlGestureRecognizer = nil
+    self.expectedXPosition = Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition +
+      Constant.PeriodSegmentedControl.Layout.itemWidth
     super.init(coder: coder)
     self.setup()
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -51,6 +51,11 @@ public final class PeriodSegmentedControl: UIControl {
     super.draw(rect)
     self.periodSegmentedControlAppearance.moveIndicatorView(to: self.periodSegmentedControlAppearance.getIndicatorViewCenter())
   }
+  
+  public func highlightedIndex() -> Int? {
+    let currentX = self.calculateClosestX(from: self.expectedXPosition)
+    return currentX.calculateHighlightedIndex()
+  }
 }
 
 //MARK: - private functions
@@ -178,5 +183,14 @@ extension PeriodSegmentedControl {
       
     default: break
     }
+  }
+}
+
+private extension CGFloat {
+  func calculateHighlightedIndex() -> Int? {
+    let firstItemCenterX = Int(Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition)
+    let itemWidth = Int(Constant.PeriodSegmentedControl.Layout.itemWidth)
+    
+    return (Int(self) - firstItemCenterX) / itemWidth
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -14,12 +14,14 @@ public final class PeriodSegmentedControl: UIControl {
   private let items: [String]
   private let feedbackGenerator: UISelectionFeedbackGenerator
   private let periodSegmentedControlAppearance: PeriodSegmentedControlAppearance
+  private var targetXPosition: [CGFloat]
   private var periodSegmentedControlGestureRecognizer: PeriodSegmentedControlGestureRecognizer?
   private var expectedXPosition: CGFloat
   
   public init(items: [String] = Constant.PeriodSegmentedControl.Content.defaultItems) {
     self.items = items
     self.feedbackGenerator = UISelectionFeedbackGenerator()
+    self.targetXPosition = []
     self.periodSegmentedControlAppearance = PeriodSegmentedControlAppearance(with: self.items)
     self.periodSegmentedControlGestureRecognizer = nil
     self.expectedXPosition = Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition +
@@ -31,6 +33,7 @@ public final class PeriodSegmentedControl: UIControl {
   required init?(coder: NSCoder) {
     self.items = Constant.PeriodSegmentedControl.Content.defaultItems
     self.feedbackGenerator = UISelectionFeedbackGenerator()
+    self.targetXPosition = []
     self.periodSegmentedControlAppearance = PeriodSegmentedControlAppearance(with: self.items)
     self.periodSegmentedControlGestureRecognizer = nil
     self.expectedXPosition = Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition +
@@ -63,9 +66,21 @@ public final class PeriodSegmentedControl: UIControl {
 // MARK: - private functions
 extension PeriodSegmentedControl {
   private func setup() {
+    self.setupTargetXPosition()
     self.setupFeedbackGenerator()
     self.setupAppearanceLayout()
     self.setupGestureRecognizer()
+  }
+  
+  private func setupTargetXPosition(){
+    let itemWidth = Constant.PeriodSegmentedControl.Layout.itemWidth
+    let firstCenter = Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition
+    var targets: [CGFloat] = []
+    
+    for index in 0..<self.items.count {
+      targets.append(firstCenter + (itemWidth * CGFloat(index)))
+    }
+    self.targetXPosition = targets
   }
   
   private func setupAppearanceLayout() {
@@ -93,18 +108,10 @@ extension PeriodSegmentedControl {
   }
   
   private func calculateClosestX(from touchX: CGFloat) -> CGFloat {
-    let itemWidth = Constant.PeriodSegmentedControl.Layout.itemWidth
-    let firstCenter = Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition
-    var targetXArray: [CGFloat] = []
+    var closestX = self.targetXPosition[0]
+    var shortestDistance = abs(self.targetXPosition[0] - touchX)
     
-    for index in 0..<self.items.count {
-      targetXArray.append(firstCenter + (itemWidth * CGFloat(index)))
-    }
-          
-    var closestX = targetXArray[0]
-    var shortestDistance = abs(targetXArray[0] - touchX)
-    
-    for targetX in targetXArray {
+    for targetX in self.targetXPosition {
       let distance = abs(targetX - touchX)
       if distance < shortestDistance {
         shortestDistance = distance

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -11,20 +11,42 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 public final class PeriodSegmentedControl: UIControl {
+  private let periodSegmentedControlAppearance: PeriodSegmentedControlAppearance
   private let items: [String]
   
   public init(items: [String] = Constant.PeriodSegmentedControl.Content.defaultItems) {
     self.items = items
+    self.periodSegmentedControlAppearance = PeriodSegmentedControlAppearance(with: self.items)
     super.init(frame: CGRect.zero)
+    self.setup()
   }
   
   required init?(coder: NSCoder) {
     self.items = Constant.PeriodSegmentedControl.Content.defaultItems
+    self.periodSegmentedControlAppearance = PeriodSegmentedControlAppearance(with: self.items)
     super.init(coder: coder)
+    self.setup()
   }
 }
 
 //MARK: - private functions
 extension PeriodSegmentedControl {
+  private func setup() {
+    self.setupAppearance()
+  }
   
+  private func setupAppearance() {
+    let appearance = self.periodSegmentedControlAppearance.getAssembledView()
+    self.addSubview(appearance)
+    
+    appearance.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate(
+      [
+        appearance.widthAnchor.constraint(equalTo: self.widthAnchor),
+        appearance.heightAnchor.constraint(equalTo: self.heightAnchor),
+        appearance.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+        appearance.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+      ]
+    )
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -186,6 +186,13 @@ extension PeriodSegmentedControl {
   }
 }
 
+// MARK: - about UIGestureRecognizerDelegate
+
+extension PeriodSegmentedControl: UIGestureRecognizerDelegate {
+  public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+    return gestureRecognizer is UIPanGestureRecognizer && otherGestureRecognizer is UILongPressGestureRecognizer
+  }
+}
 private extension CGFloat {
   func calculateHighlightedIndex() -> Int? {
     let firstItemCenterX = Int(Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -5,7 +5,7 @@
 //  Created by SONG on 4/12/24.
 //
 
-import UIKit.UIControl
+import UIKit
 
 import ToDoGardenUIConstant
 import ToDoGardenUIResource

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -72,7 +72,7 @@ extension PeriodSegmentedControl {
     let appearance = self.periodSegmentedControlAppearance.getAssembledView()
     self.addSubview(appearance)
     
-    appearance.translatesAutoresizingMaskIntoConstraints = false
+    appearance.usingAutolayout()
     NSLayoutConstraint.activate(
       [
         appearance.widthAnchor.constraint(equalTo: self.widthAnchor),

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -49,7 +49,9 @@ public final class PeriodSegmentedControl: UIControl {
   
   override public func draw(_ rect: CGRect) {
     super.draw(rect)
-    self.periodSegmentedControlAppearance.moveIndicatorView(to: self.periodSegmentedControlAppearance.getIndicatorViewCenter())
+    self.periodSegmentedControlAppearance.moveIndicatorView(
+      to: self.periodSegmentedControlAppearance.getIndicatorViewCenter()
+    )
   }
   
   public func highlightedIndex() -> Int? {
@@ -58,7 +60,7 @@ public final class PeriodSegmentedControl: UIControl {
   }
 }
 
-//MARK: - private functions
+// MARK: - private functions
 extension PeriodSegmentedControl {
   private func setup() {
     self.setupFeedbackGenerator()
@@ -189,7 +191,10 @@ extension PeriodSegmentedControl {
 // MARK: - about UIGestureRecognizerDelegate
 
 extension PeriodSegmentedControl: UIGestureRecognizerDelegate {
-  public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+  public func gestureRecognizer(
+    _ gestureRecognizer: UIGestureRecognizer,
+    shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+  ) -> Bool {
     return gestureRecognizer is UIPanGestureRecognizer && otherGestureRecognizer is UILongPressGestureRecognizer
   }
 }
@@ -197,11 +202,11 @@ extension PeriodSegmentedControl: UIGestureRecognizerDelegate {
 // MARK: - for customizing
 
 extension PeriodSegmentedControl {
-  public func setBackgroundImage(image : UIImage) {
+  public func setBackgroundImage(image: UIImage) {
     self.periodSegmentedControlAppearance.changeBackgroundImage(image)
   }
   
-  public func setIndicatorImage(image : UIImage) {
+  public func setIndicatorImage(image: UIImage) {
     self.periodSegmentedControlAppearance.changeIndicatorImage(image)
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -35,6 +35,11 @@ public final class PeriodSegmentedControl: UIControl {
     let height = constants.height
     return CGSize(width: width, height: height)
   }
+  
+  override public func draw(_ rect: CGRect) {
+    super.draw(rect)
+    self.periodSegmentedControlAppearance.moveIndicatorView(to: self.periodSegmentedControlAppearance.getIndicatorViewCenter())
+  }
 }
 
 //MARK: - private functions

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -30,7 +30,7 @@ public final class PeriodSegmentedControl: UIControl {
     self.setup()
   }
   
-  required init?(coder: NSCoder) {
+  public required init?(coder: NSCoder) {
     self.items = Constant.PeriodSegmentedControl.Content.defaultItems
     self.feedbackGenerator = UISelectionFeedbackGenerator()
     self.targetXPositions = []

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -86,7 +86,7 @@ extension PeriodSegmentedControl {
       target: self,
       panAction: #selector(self.panned),
       tapAction: #selector(self.tapped),
-      longpressAction: nil
+      longpressAction: #selector(self.longpressed)
     )
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -72,7 +72,7 @@ extension PeriodSegmentedControl {
     self.setupGestureRecognizer()
   }
   
-  private func setupTargetXPosition(){
+  private func setupTargetXPosition() {
     let itemWidth = Constant.PeriodSegmentedControl.Layout.itemWidth
     let firstCenter = Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition
     var targets: [CGFloat] = []

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -14,14 +14,14 @@ public final class PeriodSegmentedControl: UIControl {
   private let items: [String]
   private let feedbackGenerator: UISelectionFeedbackGenerator
   private let periodSegmentedControlAppearance: PeriodSegmentedControlAppearance
-  private var targetXPosition: [CGFloat]
+  private var targetXPositions: [CGFloat]
   private var periodSegmentedControlGestureRecognizer: PeriodSegmentedControlGestureRecognizer?
   private var expectedXPosition: CGFloat
   
   public init(items: [String] = Constant.PeriodSegmentedControl.Content.defaultItems) {
     self.items = items
     self.feedbackGenerator = UISelectionFeedbackGenerator()
-    self.targetXPosition = []
+    self.targetXPositions = []
     self.periodSegmentedControlAppearance = PeriodSegmentedControlAppearance(with: self.items)
     self.periodSegmentedControlGestureRecognizer = nil
     self.expectedXPosition = Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition +
@@ -33,7 +33,7 @@ public final class PeriodSegmentedControl: UIControl {
   required init?(coder: NSCoder) {
     self.items = Constant.PeriodSegmentedControl.Content.defaultItems
     self.feedbackGenerator = UISelectionFeedbackGenerator()
-    self.targetXPosition = []
+    self.targetXPositions = []
     self.periodSegmentedControlAppearance = PeriodSegmentedControlAppearance(with: self.items)
     self.periodSegmentedControlGestureRecognizer = nil
     self.expectedXPosition = Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition +
@@ -43,10 +43,10 @@ public final class PeriodSegmentedControl: UIControl {
   }
   
   public override var intrinsicContentSize: CGSize {
-    let constants = Constant.PeriodSegmentedControl.Layout.self
-    let itemsWidth = constants.itemWidth * CGFloat(self.items.count)
-    let width = constants.innerPadding + itemsWidth + constants.innerPadding
-    let height = constants.height
+    let layoutConstants = Constant.PeriodSegmentedControl.Layout.self
+    let itemsWidth = layoutConstants.itemWidth * CGFloat(self.items.count)
+    let width = layoutConstants.innerPadding + itemsWidth + layoutConstants.innerPadding
+    let height = layoutConstants.height
     return CGSize(width: width, height: height)
   }
   
@@ -80,7 +80,7 @@ extension PeriodSegmentedControl {
     for index in 0..<self.items.count {
       targets.append(firstCenter + (itemWidth * CGFloat(index)))
     }
-    self.targetXPosition = targets
+    self.targetXPositions = targets
   }
   
   private func setupAppearanceLayout() {
@@ -108,10 +108,10 @@ extension PeriodSegmentedControl {
   }
   
   private func calculateClosestX(from touchX: CGFloat) -> CGFloat {
-    var closestX = self.targetXPosition[0]
-    var shortestDistance = abs(self.targetXPosition[0] - touchX)
+    var closestX = self.targetXPositions[0]
+    var shortestDistance = abs(self.targetXPositions[0] - touchX)
     
-    for targetX in self.targetXPosition {
+    for targetX in self.targetXPositions {
       let distance = abs(targetX - touchX)
       if distance < shortestDistance {
         shortestDistance = distance
@@ -168,7 +168,9 @@ extension PeriodSegmentedControl {
       self.handleGestureStateBegan()
     case UIGestureRecognizer.State.changed:
       self.handleGestureStateChanged(with: recognizer)
-    case UIGestureRecognizer.State.ended, UIGestureRecognizer.State.cancelled, UIGestureRecognizer.State.failed:
+    case UIGestureRecognizer.State.ended,
+      UIGestureRecognizer.State.cancelled,
+      UIGestureRecognizer.State.failed:
       self.handleGestureStateEnded()
     default:
       break
@@ -196,7 +198,9 @@ extension PeriodSegmentedControl {
     case UIGestureRecognizer.State.began:
       self.handleGestureStateBegan()
       self.feedbackGenerator.selectionChanged()
-    case UIGestureRecognizer.State.ended, UIGestureRecognizer.State.cancelled, UIGestureRecognizer.State.failed:
+    case UIGestureRecognizer.State.ended,
+      UIGestureRecognizer.State.cancelled,
+      UIGestureRecognizer.State.failed:
       self.handleGestureStateEnded()
     default:
       break

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -79,7 +79,7 @@ extension PeriodSegmentedControl {
   private func setupGestureRecognizer() {
     self.periodSegmentedControlGestureRecognizer = PeriodSegmentedControlGestureRecognizer(
       target: self,
-      panAction: nil,
+      panAction: #selector(self.panned),
       tapAction: nil,
       longpressAction: nil
     )
@@ -111,4 +111,38 @@ extension PeriodSegmentedControl {
     self.feedbackGenerator.prepare()
   }
 }
+
+// MARK: - gesture event functions
+
+extension PeriodSegmentedControl {
+  @objc private func panned(_ recognizer: UIPanGestureRecognizer) {
+    switch recognizer.state {
+    case .began:
+      UIView.animate(withDuration: 0.3) {
+        self.periodSegmentedControlAppearance.transformIndicatorViewDownScale()
+      }
+    case .changed:
+      let translation = recognizer.translation(in: self)
+      let indicatorViewCenterX = self.periodSegmentedControlAppearance.getIndicatorViewCenter()
+      
+      let newX = self.expectedXPosition + translation.x
+      let closestX = self.calculateClosestX(from: newX)
+      
+      if indicatorViewCenterX != closestX {
+        UIView.animate(withDuration: 0.15) {
+          self.periodSegmentedControlAppearance.moveIndicatorView(to: closestX)
+        }
+        self.feedbackGenerator.selectionChanged()
+        self.expectedXPosition = closestX
+      }
+      self.expectedXPosition = newX
+      
+      recognizer.setTranslation(CGPoint.zero, in: self)
+    case .ended, .cancelled, .failed:
+      UIView.animate(withDuration: 0.3) {
+        self.periodSegmentedControlAppearance.transformIndicatorViewOriginalScale()
+      }
+    default: break
+    }
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -193,6 +193,23 @@ extension PeriodSegmentedControl: UIGestureRecognizerDelegate {
     return gestureRecognizer is UIPanGestureRecognizer && otherGestureRecognizer is UILongPressGestureRecognizer
   }
 }
+
+// MARK: - for customizing
+
+extension PeriodSegmentedControl {
+  public func setBackgroundImage(image : UIImage) {
+    self.periodSegmentedControlAppearance.changeBackgroundImage(image)
+  }
+  
+  public func setIndicatorImage(image : UIImage) {
+    self.periodSegmentedControlAppearance.changeIndicatorImage(image)
+  }
+  
+  public func setInitialSelectedItem(index: Int) {
+    self.periodSegmentedControlAppearance.changeInitialSelectedItem(index: index, numberOfItems: self.items.count)
+  }
+}
+
 private extension CGFloat {
   func calculateHighlightedIndex() -> Int? {
     let firstItemCenterX = Int(Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -62,4 +62,27 @@ extension PeriodSegmentedControl {
       ]
     )
   }
+  
+  private func calculateClosestX(from touchX: CGFloat) -> CGFloat {
+    let itemWidth = Constant.PeriodSegmentedControl.Layout.itemWidth
+    let firstCenter = Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition
+    var targetXArray: [CGFloat] = []
+    
+    for index in 0..<self.items.count {
+      targetXArray.append(firstCenter + (itemWidth * CGFloat(index)))
+    }
+          
+    var closestX = targetXArray[0]
+    var shortestDistance = abs(targetXArray[0] - touchX)
+    
+    for targetX in targetXArray {
+      let distance = abs(targetX - touchX)
+      if distance < shortestDistance {
+        shortestDistance = distance
+        closestX = targetX
+      }
+    }
+    return closestX
+  }
+
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -11,12 +11,15 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 public final class PeriodSegmentedControl: UIControl {
+  private let items: [String]
   
   public init(items: [String] = Constant.PeriodSegmentedControl.Content.defaultItems) {
+    self.items = items
     super.init(frame: CGRect.zero)
   }
   
   required init?(coder: NSCoder) {
+    self.items = Constant.PeriodSegmentedControl.Content.defaultItems
     super.init(coder: coder)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -25,7 +25,7 @@ public final class PeriodSegmentedControl: UIControl {
     self.periodSegmentedControlAppearance = PeriodSegmentedControlAppearance(with: self.items)
     self.periodSegmentedControlGestureRecognizer = nil
     self.expectedXPosition = Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition +
-      Constant.PeriodSegmentedControl.Layout.itemWidth
+    Constant.PeriodSegmentedControl.Layout.itemWidth
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -37,7 +37,7 @@ public final class PeriodSegmentedControl: UIControl {
     self.periodSegmentedControlAppearance = PeriodSegmentedControlAppearance(with: self.items)
     self.periodSegmentedControlGestureRecognizer = nil
     self.expectedXPosition = Constant.PeriodSegmentedControl.Layout.firstItemCenterXPosition +
-      Constant.PeriodSegmentedControl.Layout.itemWidth
+    Constant.PeriodSegmentedControl.Layout.itemWidth
     super.init(coder: coder)
     self.setup()
   }
@@ -129,43 +129,56 @@ extension PeriodSegmentedControl {
 // MARK: - gesture event functions
 
 extension PeriodSegmentedControl {
+  private func handleGestureStateBegan() {
+    UIView.animate(withDuration: 0.3) {
+      self.periodSegmentedControlAppearance.transformIndicatorViewDownScale()
+    }
+  }
+  
+  private func handleGestureStateChanged(with recognizer: UIGestureRecognizer) {
+    guard let panRecognizer = recognizer as? UIPanGestureRecognizer else { return }
+    
+    let translation = panRecognizer.translation(in: self)
+    let indicatorViewCenterX = self.periodSegmentedControlAppearance.getIndicatorViewCenter()
+    let newX = self.expectedXPosition + translation.x
+    let closestX = self.calculateClosestX(from: newX)
+    
+    if indicatorViewCenterX != closestX {
+      UIView.animate(withDuration: 0.15) {
+        self.periodSegmentedControlAppearance.moveIndicatorView(to: closestX)
+      }
+      self.feedbackGenerator.selectionChanged()
+      self.expectedXPosition = closestX
+    }
+    
+    self.expectedXPosition = newX
+    panRecognizer.setTranslation(.zero, in: self)
+  }
+  
+  private func handleGestureStateEnded() {
+    UIView.animate(withDuration: 0.3) {
+      self.periodSegmentedControlAppearance.transformIndicatorViewOriginalScale()
+    }
+    self.feedbackGenerator.selectionChanged()
+  }
+  
   @objc private func panned(_ recognizer: UIPanGestureRecognizer) {
     switch recognizer.state {
     case UIGestureRecognizer.State.began:
-      UIView.animate(withDuration: 0.3) {
-        self.periodSegmentedControlAppearance.transformIndicatorViewDownScale()
-      }
+      self.handleGestureStateBegan()
     case UIGestureRecognizer.State.changed:
-      let translation = recognizer.translation(in: self)
-      let indicatorViewCenterX = self.periodSegmentedControlAppearance.getIndicatorViewCenter()
-      
-      let newX = self.expectedXPosition + translation.x
-      let closestX = self.calculateClosestX(from: newX)
-      
-      if indicatorViewCenterX != closestX {
-        UIView.animate(withDuration: 0.15) {
-          self.periodSegmentedControlAppearance.moveIndicatorView(to: closestX)
-        }
-        self.feedbackGenerator.selectionChanged()
-        self.expectedXPosition = closestX
-      }
-      self.expectedXPosition = newX
-      
-      recognizer.setTranslation(CGPoint.zero, in: self)
-    case UIGestureRecognizer.State.ended,
-      UIGestureRecognizer.State.cancelled,
-      UIGestureRecognizer.State.failed:
-      UIView.animate(withDuration: 0.3) {
-        self.periodSegmentedControlAppearance.transformIndicatorViewOriginalScale()
-      }
-    default: break
+      self.handleGestureStateChanged(with: recognizer)
+    case UIGestureRecognizer.State.ended, UIGestureRecognizer.State.cancelled, UIGestureRecognizer.State.failed:
+      self.handleGestureStateEnded()
+    default:
+      break
     }
   }
   
   @objc private func tapped(_ recognizer: UITapGestureRecognizer) {
     switch recognizer.state {
     case UIGestureRecognizer.State.recognized:
-      let touchLocation: CGPoint = recognizer.location(in: self)
+      let touchLocation = recognizer.location(in: self)
       let closestX = self.calculateClosestX(from: touchLocation.x)
       
       UIView.animate(withDuration: 0.15) {
@@ -173,26 +186,20 @@ extension PeriodSegmentedControl {
       }
       self.feedbackGenerator.selectionChanged()
       self.expectedXPosition = closestX
-    default: break
+    default:
+      break
     }
   }
   
   @objc private func longpressed(_ recognizer: UILongPressGestureRecognizer) {
     switch recognizer.state {
     case UIGestureRecognizer.State.began:
-      UIView.animate(withDuration: 0.3) {
-        self.periodSegmentedControlAppearance.transformIndicatorViewDownScale()
-      }
+      self.handleGestureStateBegan()
       self.feedbackGenerator.selectionChanged()
-      
-    case UIGestureRecognizer.State.ended,
-      UIGestureRecognizer.State.cancelled,
-      UIGestureRecognizer.State.failed:
-      UIView.animate(withDuration: 0.3) {
-        self.periodSegmentedControlAppearance.transformIndicatorViewOriginalScale()
-      }
-      
-    default: break
+    case UIGestureRecognizer.State.ended, UIGestureRecognizer.State.cancelled, UIGestureRecognizer.State.failed:
+      self.handleGestureStateEnded()
+    default:
+      break
     }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -27,6 +27,14 @@ public final class PeriodSegmentedControl: UIControl {
     super.init(coder: coder)
     self.setup()
   }
+  
+  public override var intrinsicContentSize: CGSize {
+    let constants = Constant.PeriodSegmentedControl.Layout.self
+    let itemsWidth = constants.itemWidth * CGFloat(self.items.count)
+    let width = constants.innerPadding + itemsWidth + constants.innerPadding
+    let height = constants.height
+    return CGSize(width: width, height: height)
+  }
 }
 
 //MARK: - private functions

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -64,11 +64,11 @@ public final class PeriodSegmentedControl: UIControl {
 extension PeriodSegmentedControl {
   private func setup() {
     self.setupFeedbackGenerator()
-    self.setupAppearance()
+    self.setupAppearanceLayout()
     self.setupGestureRecognizer()
   }
   
-  private func setupAppearance() {
+  private func setupAppearanceLayout() {
     let appearance = self.periodSegmentedControlAppearance.getAssembledView()
     self.addSubview(appearance)
     

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -131,11 +131,11 @@ extension PeriodSegmentedControl {
 extension PeriodSegmentedControl {
   @objc private func panned(_ recognizer: UIPanGestureRecognizer) {
     switch recognizer.state {
-    case .began:
+    case UIGestureRecognizer.State.began:
       UIView.animate(withDuration: 0.3) {
         self.periodSegmentedControlAppearance.transformIndicatorViewDownScale()
       }
-    case .changed:
+    case UIGestureRecognizer.State.changed:
       let translation = recognizer.translation(in: self)
       let indicatorViewCenterX = self.periodSegmentedControlAppearance.getIndicatorViewCenter()
       
@@ -152,7 +152,9 @@ extension PeriodSegmentedControl {
       self.expectedXPosition = newX
       
       recognizer.setTranslation(CGPoint.zero, in: self)
-    case .ended, .cancelled, .failed:
+    case UIGestureRecognizer.State.ended,
+      UIGestureRecognizer.State.cancelled,
+      UIGestureRecognizer.State.failed:
       UIView.animate(withDuration: 0.3) {
         self.periodSegmentedControlAppearance.transformIndicatorViewOriginalScale()
       }
@@ -162,7 +164,7 @@ extension PeriodSegmentedControl {
   
   @objc private func tapped(_ recognizer: UITapGestureRecognizer) {
     switch recognizer.state {
-    case .recognized:
+    case UIGestureRecognizer.State.recognized:
       let touchLocation: CGPoint = recognizer.location(in: self)
       let closestX = self.calculateClosestX(from: touchLocation.x)
       

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -155,8 +155,27 @@ extension PeriodSegmentedControl {
       UIView.animate(withDuration: 0.15) {
         self.periodSegmentedControlAppearance.moveIndicatorView(to: closestX)
       }
-      self.hapticGenerator.selectionChanged()
+      self.feedbackGenerator.selectionChanged()
       self.expectedXPosition = closestX
+    default: break
+    }
+  }
+  
+  @objc private func longpressed(_ recognizer: UILongPressGestureRecognizer) {
+    switch recognizer.state {
+    case UIGestureRecognizer.State.began:
+      UIView.animate(withDuration: 0.3) {
+        self.periodSegmentedControlAppearance.transformIndicatorViewDownScale()
+      }
+      self.feedbackGenerator.selectionChanged()
+      
+    case UIGestureRecognizer.State.ended,
+      UIGestureRecognizer.State.cancelled,
+      UIGestureRecognizer.State.failed:
+      UIView.animate(withDuration: 0.3) {
+        self.periodSegmentedControlAppearance.transformIndicatorViewOriginalScale()
+      }
+      
     default: break
     }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -1,0 +1,27 @@
+//
+//  PeriodSegmentedControl.swift
+//
+//
+//  Created by SONG on 4/12/24.
+//
+
+import UIKit.UIControl
+
+import ToDoGardenUIConstant
+import ToDoGardenUIResource
+
+public final class PeriodSegmentedControl: UIControl {
+  
+  public init(items: [String] = Constant.PeriodSegmentedControl.Content.defaultItems) {
+    super.init(frame: CGRect.zero)
+  }
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
+}
+
+//MARK: - private functions
+extension PeriodSegmentedControl {
+  
+}


### PR DESCRIPTION
## 💡 관련 이슈
- #72 
## 🎉 변경 사항

패키지 외부에서 사용할 수 있는 PeriodSegmentedControl 컴포넌트를 추가하였습니다. 
구현 사항은 아래와 같습니다. 

- 외부에서 간편하게 사용가능합니다. 
```swift
let segmentControlDefault = PeriodSegmentedControl() // 기본값인 일,주,월 표시
// OR
let segmentControlCustom = PeriodSegmentedControl(items:["안","녕","하","세","요"])

//layoutConstraint는 Position만 잡아주면 됩니다. 
    NSLayoutConstraint.activate(
      [   
          self.segmentControl.leadingAnchor.constraint(equalTo: self.view.leadingAnchor,constant: 70),
          self.segmentControl.topAnchor.constraint(equalTo: self.rectButton1.bottomAnchor, constant: 150)
      ]
    )
```
- Tap, Pan, Longpress GestureEvent에 대해서 반응합니다. 
   - 이벤트 처리시, UI변경에 따라 햅틱효과가 발생합니다.
   - Pan과 Longpress는 동시에 이벤트처리가 이루어집니다. 
   - `highlightedIndex()`를 통해 현재 활성화된 아이템의 인덱스를 반환할 수 있습니다. 
   ```swift
   self.segmentControl.highlightedIndex() // output : 1
   ```
   - 아래 메소드를 사용해 생성이후 배경 이미지,인디케이터 이미지,최초로 활성화되는 인덱스를 지정해줄 수 있습니다. 
![스크린샷 2024-04-22 오후 12 48 53](https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/fde41d9a-68e9-4656-b4f5-b8c6c4e4470b)

## 📌 PR Point

### Overview
- 실험결과 기대한대로 정상 동작합니다. 
- 컴포넌트를 구성하는 객체의 역할요약은 아래 이미지와 같습니다. 
<img width="874" alt="스크린샷 2024-04-19 오후 5 09 51" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/9c4da0d0-3cfc-4071-a223-8e0c5f94e0b2">

- `PeriodSegmentedControl`에서 `PeriodSegmentedControlGestureRecognizer` 통해 제스처 이벤트를 감지하고, 좌표를 계산하여 `PeriodSegmentedControlAppearance`에게 전달하면 UI가 변화하는 구조입니다. 
- `PeriodSegmentedControlAppearance`와 `PeriodSegmentedControlGestureRecognizer` 간의 의존성은 없습니다. 

### intrinsicContentSize를 재정의한 이유 

<img width="90" alt="스크린샷 2024-04-19 오후 5 28 26" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/b41e7d78-a3fe-4f5f-bd13-7b10a5d2c585">
<img width="177" alt="스크린샷 2024-04-19 오후 5 29 32" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/4ae3fc8a-bfcb-42f4-9fbd-b0954738c364">
<img width="66" alt="스크린샷 2024-04-19 오후 5 30 17" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/887f648c-0b18-4487-ba7f-91d89e263fee">

item이 추가 또는 제거 되는 상황에서도 일정한 height을 유지하고, 예쁘게 item들을 감싸는 width를 가지길 바라며 
`override` 하였습니다. 덕분에 사용하는 쪽에서는 width와 height에 대한 layoutConstraints를 잡아주지 않아도 됩니다. 

###  draw를 재정의한 이유
백그라운드로 갔다가 포그라운드로 진입할 때, UI 변경사항이 적용되지 않는 `회귀` 버그가 있었습니다. 
   - ex: '월' 로 이동시켰다가 백그라운드 갔다오면 초기값인 '주' 로 돌아가있음
   - `회귀` 버그는 부르기 편하게 제가 정의한 이름입니다 ^^
백 -> 포 과정에서 layoutSubview, draw가 호출되는 점을 이용하여 `회귀` 버그를 해결하고자 하였습니다. 원인 분석을 하던 중, layoutSubview 이후, draw 이전인 어느 시점에 `회귀`가 일어나는 것을 확인했고, draw에서 `회귀`를 무시하고 내가 의도한 위치로의 재조정을 위해 `override`하였습니다. 

그리고 저는 정확한 원인을 아직도 모릅니다. 

### 매직넘버 대책 
 Constant에 대한 PR을 새로 생성하여 후처리 예정입니다.  

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?