### PR TITLE
SearchGardenButton 스타일 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
@@ -20,6 +20,7 @@ private enum SearchGardenButtonStyle {
   fileprivate static func apply(to button: UIButton) {
     self.setupBackgroundColor(to: button)
     self.setupRoundedCorner(to: button)
+    self.setupNormalStateImage(to: button)
   }
 }
 
@@ -30,5 +31,9 @@ extension SearchGardenButtonStyle {
 
   private static func setupRoundedCorner(to button: UIButton) {
     button.layer.cornerRadius = Constant.SearchGardenButton.Layout.cornerRadius
+  }
+
+  private static func setupNormalStateImage(to button: UIButton) {
+    button.setImage(UIImage.searchIconImage, for: UIControl.State.normal)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
@@ -7,6 +7,7 @@
 
 import UIKit.UIButton
 
+import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 extension UIButton {
@@ -17,12 +18,17 @@ extension UIButton {
 
 private enum SearchGardenButtonStyle {
   fileprivate static func apply(to button: UIButton) {
-    SearchGardenButtonStyle.setupBackgroundColor(to: button)
+    self.setupBackgroundColor(to: button)
+    self.setupRoundedCorner(to: button)
   }
 }
 
 extension SearchGardenButtonStyle {
   private static func setupBackgroundColor(to button: UIButton) {
     button.backgroundColor = UIColor.toDoGardenGreenBackground
+  }
+
+  private static func setupRoundedCorner(to button: UIButton) {
+    button.layer.cornerRadius = Constant.SearchGardenButton.Layout.cornerRadius
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
@@ -9,6 +9,12 @@ import UIKit.UIButton
 
 extension UIButton {
   public func searchGardenButtonStyle() {
+    SearchGardenButtonStyle.apply(to: self)
+  }
+}
+
+private enum SearchGardenButtonStyle {
+  fileprivate static func apply(to button: UIButton) {
     
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
@@ -21,6 +21,7 @@ private enum SearchGardenButtonStyle {
     self.setupBackgroundColor(to: button)
     self.setupRoundedCorner(to: button)
     self.setupNormalStateImage(to: button)
+    self.setupButtonImageViewContentMode(to: button)
     self.setupButtonImageViewLayout(to: button)
   }
 }
@@ -36,6 +37,10 @@ extension SearchGardenButtonStyle {
 
   private static func setupNormalStateImage(to button: UIButton) {
     button.setImage(UIImage.searchIconImage, for: UIControl.State.normal)
+  }
+
+  private static func setupButtonImageViewContentMode(to button: UIButton) {
+    button.imageView?.contentMode = UIView.ContentMode.right
   }
 
   private static func setupButtonImageViewLayout(to button: UIButton) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
@@ -21,6 +21,7 @@ private enum SearchGardenButtonStyle {
     self.setupBackgroundColor(to: button)
     self.setupRoundedCorner(to: button)
     self.setupNormalStateImage(to: button)
+    self.setupButtonImageViewLayout(to: button)
   }
 }
 
@@ -35,5 +36,14 @@ extension SearchGardenButtonStyle {
 
   private static func setupNormalStateImage(to button: UIButton) {
     button.setImage(UIImage.searchIconImage, for: UIControl.State.normal)
+  }
+
+  private static func setupButtonImageViewLayout(to button: UIButton) {
+    button.imageView?.translatesAutoresizingMaskIntoConstraints = false
+
+    button.imageView?.trailingAnchor.constraint(
+      equalTo: button.trailingAnchor,
+      constant: -Constant.SearchGardenButton.Layout.ImageView.trailingMargin
+    ).isActive = true
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
@@ -44,7 +44,7 @@ extension SearchGardenButtonStyle {
   }
 
   private static func setupButtonImageViewLayout(to button: UIButton) {
-    button.imageView?.translatesAutoresizingMaskIntoConstraints = false
+    button.imageView?.usingAutolayout()
 
     button.imageView?.trailingAnchor.constraint(
       equalTo: button.trailingAnchor,

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
@@ -1,0 +1,14 @@
+//
+//  UIButton+SearchGardenButton.swift
+//
+//
+//  Created by Wood on 4/19/24.
+//
+
+import UIKit.UIButton
+
+extension UIButton {
+  public func searchGardenButtonStyle() {
+    
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
@@ -5,7 +5,7 @@
 //  Created by Wood on 4/19/24.
 //
 
-import UIKit.UIButton
+import UIKit
 
 import ToDoGardenUIConstant
 import ToDoGardenUIResource

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIButton+SearchGardenButton.swift
@@ -7,6 +7,8 @@
 
 import UIKit.UIButton
 
+import ToDoGardenUIResource
+
 extension UIButton {
   public func searchGardenButtonStyle() {
     SearchGardenButtonStyle.apply(to: self)
@@ -15,6 +17,12 @@ extension UIButton {
 
 private enum SearchGardenButtonStyle {
   fileprivate static func apply(to button: UIButton) {
-    
+    SearchGardenButtonStyle.setupBackgroundColor(to: button)
+  }
+}
+
+extension SearchGardenButtonStyle {
+  private static func setupBackgroundColor(to button: UIButton) {
+    button.backgroundColor = UIColor.toDoGardenGreenBackground
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #81 

## 🎉 변경 사항
- 가든 검색 버튼 스타일을 적용하는 함수를 구현하였습니다.

## 📌 PR Point
1. 돋보기 이미지가 버튼의 오른쪽에 위치하도록 버튼 이미지뷰에 오토레이아웃을 설정했습니다.
2. UI를 적용하는 함수를 분리하기 위해 SearchGardenButtonStyle 타입을 선언하였습니다.

<img src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/1975d481-bf32-4cfd-8d50-e02950ae0060" width="300" height="650">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?