### PR TITLE
ToDoGardenAlertView Constant 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
@@ -87,103 +87,151 @@ extension Constant.ToDoGardenAlertView.Content {
     case stopConcentration
   }
   
+  private struct Layout {
+    static let commonWidth: CGFloat = 273.0
+    static let cornerRadius: CGFloat = 20.0
+    
+    static let heightForVertical: CGFloat = 246.0
+    static let titleTopMarginForVertical: CGFloat = 24.0
+    static let descriptionTopMarginForVertical: CGFloat = 61.0
+    static let stackviewHeightForVertical: CGFloat = 43.0
+    
+    static let heightForHorizontal: CGFloat = 206.0
+    static let titleTopMarginForHorizontal: CGFloat = 42.0
+    static let descriptionTopMarginForHorizontal: CGFloat = 84.0
+    static let stackviewHeightForHorizontal: CGFloat = 51.0
+  }
+
   public var viewState: ViewState {
+    let layoutConstant = Constant.ToDoGardenAlertView.Content.Layout.self
+    
     switch self {
     case .welldone:
       return ViewState(
-        backPlane: BackPlaneState(width: 273.0, height: 246.0, cornerRadius: 20.0),
-        title: TitleViewState(text: "수고했어요!", topMargin: 24.0),
-        description: DescriptionViewState(text: "오늘도 열심히 집중한 당신!\n이제 조금 쉬어볼까요?", topMargin: 61.0),
+        backPlane: BackPlaneState(
+          width: layoutConstant.commonWidth,
+          height: layoutConstant.heightForVertical,
+          cornerRadius: layoutConstant.cornerRadius
+        ),
+        title: TitleViewState(text: "수고했어요!", topMargin: layoutConstant.titleTopMarginForVertical),
+        description: DescriptionViewState(text: "오늘도 열심히 집중한 당신!\n이제 조금 쉬어볼까요?", topMargin: layoutConstant.descriptionTopMarginForVertical),
         buttons: [
           ButtonLabelState(text: "휴식하기", isRed: false, buttonActionType: ButtonActionType.stopConcentration),
           ButtonLabelState(text: "더 집중하기", isRed: false, buttonActionType: ButtonActionType.keepConcentration),
           ButtonLabelState(text: "홈으로", isRed: true, buttonActionType: ButtonActionType.goHome)
         ],
-        stackView: StackViewState(isHorizontal: false, height: 43.0)
+        stackView: StackViewState(isHorizontal: false, height: layoutConstant.stackviewHeightForVertical)
       )
       
     case .askToStop:
       return ViewState(
-        backPlane: BackPlaneState(width: 273.0, height: 206.0, cornerRadius: 20.0),
-        title: TitleViewState(text: "그만할까요?", topMargin: 42.0),
-        description: DescriptionViewState(text: "그만하면\n기록으로 돌아갈 수 있어요.", topMargin: 84.0),
+        backPlane: BackPlaneState(
+          width: layoutConstant.commonWidth,
+          height: layoutConstant.heightForHorizontal,
+          cornerRadius: layoutConstant.cornerRadius
+        ),
+        title: TitleViewState(text: "그만할까요?", topMargin: layoutConstant.titleTopMarginForHorizontal),
+        description: DescriptionViewState(text: "그만하면\n기록으로 돌아갈 수 있어요.", topMargin: layoutConstant.descriptionTopMarginForHorizontal),
         buttons: [
           ButtonLabelState(text: "포기하기", isRed: true, buttonActionType: ButtonActionType.stopConcentration),
           ButtonLabelState(text: "집중하기", isRed: false, buttonActionType: ButtonActionType.cancel)
         ],
-        stackView: StackViewState(isHorizontal: true, height: 51.0)
+        stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)
       )
       
     case .fullyCharged:
       return ViewState(
-        backPlane: BackPlaneState(width: 273.0, height: 206.0, cornerRadius: 20.0),
-        title: TitleViewState(text: "충전완료!", topMargin: 42.0),
-        description: DescriptionViewState(text: "이제 다시 열심히\n힘을 내볼까요?", topMargin: 84.0),
+        backPlane: BackPlaneState(
+          width: layoutConstant.commonWidth,
+          height: layoutConstant.heightForHorizontal,
+          cornerRadius: layoutConstant.cornerRadius),
+        title: TitleViewState(text: "충전완료!", topMargin: layoutConstant.titleTopMarginForHorizontal),
+        description: DescriptionViewState(text: "이제 다시 열심히\n힘을 내볼까요?", topMargin: layoutConstant.descriptionTopMarginForHorizontal),
         buttons: [
           ButtonLabelState(text: "홈으로", isRed: true, buttonActionType: ButtonActionType.goHome),
           ButtonLabelState(text: "집중하기", isRed: false, buttonActionType: ButtonActionType.keepConcentration)
         ],
-        stackView: StackViewState(isHorizontal: true, height: 51.0)
+        stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)
       )
       
     case .askToDeleteToDo:
       return ViewState(
-        backPlane: BackPlaneState(width: 273.0, height: 206.0, cornerRadius: 20.0),
-        title: TitleViewState(text: "삭제할까요?", topMargin: 42.0),
-        description: DescriptionViewState(text: "한 번 삭제하면 되돌릴 수 없어요.", topMargin: 84.0),
+        backPlane: BackPlaneState(
+          width: layoutConstant.commonWidth,
+          height: layoutConstant.heightForHorizontal,
+          cornerRadius: layoutConstant.cornerRadius
+        ),
+        title: TitleViewState(text: "삭제할까요?", topMargin: layoutConstant.titleTopMarginForHorizontal),
+        description: DescriptionViewState(text: "한 번 삭제하면 되돌릴 수 없어요.", topMargin: layoutConstant.descriptionTopMarginForHorizontal),
         buttons: [
           ButtonLabelState(text: "취소하기", isRed: false, buttonActionType: ButtonActionType.cancel),
           ButtonLabelState(text: "삭제하기", isRed: true, buttonActionType: ButtonActionType.delete)
         ],
-        stackView: StackViewState(isHorizontal: true, height: 51.0)
+        stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)
       )
       
     case .askToDeleteGroup:
       return ViewState(
-        backPlane: BackPlaneState(width: 273.0, height: 206.0, cornerRadius: 20.0),
-        title: TitleViewState(text: "그룹을 삭제하시겠습니까?", topMargin: 42.0),
-        description: DescriptionViewState(text: "그룹에 포함되어 있던\n투두들은 모두 삭제됩니다", topMargin: 84.0),
+        backPlane: BackPlaneState(
+          width: layoutConstant.commonWidth,
+          height: layoutConstant.heightForHorizontal,
+          cornerRadius: layoutConstant.cornerRadius
+        ),
+        title: TitleViewState(text: "그룹을 삭제하시겠습니까?", topMargin: layoutConstant.titleTopMarginForHorizontal),
+        description: DescriptionViewState(text: "그룹에 포함되어 있던\n투두들은 모두 삭제됩니다", topMargin: layoutConstant.descriptionTopMarginForHorizontal),
         buttons: [
           ButtonLabelState(text: "취소", isRed: false, buttonActionType: ButtonActionType.cancel),
           ButtonLabelState(text: "삭제하기", isRed: true, buttonActionType: ButtonActionType.delete)
         ],
-        stackView: StackViewState(isHorizontal: true, height: 51.0)
+        stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)
       )
       
     case .askToUnsubscribe:
       return ViewState(
-        backPlane: BackPlaneState(width: 273.0, height: 206.0, cornerRadius: 20.0),
-        title: TitleViewState(text: "서비스 탈퇴", topMargin: 42.0),
-        description: DescriptionViewState(text: "정말로 탈퇴하시겠습니까?\n회원 탈퇴 시 모든 정보는\n복구할 수 없습니다.", topMargin: 84.0),
+        backPlane: BackPlaneState(
+          width: layoutConstant.commonWidth,
+          height: layoutConstant.heightForHorizontal,
+          cornerRadius: layoutConstant.cornerRadius
+        ),
+        title: TitleViewState(text: "서비스 탈퇴", topMargin: layoutConstant.titleTopMarginForHorizontal),
+        description: DescriptionViewState(text: "정말로 탈퇴하시겠습니까?\n회원 탈퇴 시 모든 정보는\n복구할 수 없습니다.", topMargin: layoutConstant.descriptionTopMarginForHorizontal),
         buttons: [
           ButtonLabelState(text: "탈퇴하기", isRed: true, buttonActionType: ButtonActionType.unsubscribe),
           ButtonLabelState(text: "취소", isRed: false, buttonActionType: ButtonActionType.cancel)
         ],
-        stackView: StackViewState(isHorizontal: true, height: 51.0)
+        stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)
       )
       
     case .askToLogout:
       return ViewState(
-        backPlane: BackPlaneState(width: 273.0, height: 206.0, cornerRadius: 20.0),
-        title: TitleViewState(text: "로그아웃", topMargin: 42.0),
-        description: DescriptionViewState(text: "정말 로그아웃 하시겠습니까?", topMargin: 84.0),
+        backPlane: BackPlaneState(
+          width: layoutConstant.commonWidth,
+          height: layoutConstant.heightForHorizontal,
+          cornerRadius: layoutConstant.cornerRadius
+        ),
+        title: TitleViewState(text: "로그아웃", topMargin: layoutConstant.titleTopMarginForHorizontal),
+        description: DescriptionViewState(text: "정말 로그아웃 하시겠습니까?", topMargin: layoutConstant.descriptionTopMarginForHorizontal),
         buttons: [
           ButtonLabelState(text: "로그아웃", isRed: true, buttonActionType: ButtonActionType.logout),
           ButtonLabelState(text: "취소", isRed: false, buttonActionType: ButtonActionType.cancel)
         ],
-        stackView: StackViewState(isHorizontal: true, height: 51.0)
+        stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)
       )
       
     case .askToStopResting:
       return ViewState(
-        backPlane: BackPlaneState(width: 273.0, height: 206.0, cornerRadius: 20.0),
-        title: TitleViewState(text: "그만 쉴까요?", topMargin: 42.0),
-        description: DescriptionViewState(text: "이제 다시 열심히\n힘을 내볼까요?", topMargin: 84.0),
+        backPlane: BackPlaneState(
+          width: layoutConstant.commonWidth,
+          height: layoutConstant.heightForHorizontal,
+          cornerRadius: layoutConstant.cornerRadius
+        ),
+        title: TitleViewState(text: "그만 쉴까요?", topMargin: layoutConstant.titleTopMarginForHorizontal),
+        description: DescriptionViewState(text: "이제 다시 열심히\n힘을 내볼까요?", topMargin: layoutConstant.descriptionTopMarginForHorizontal),
         buttons: [
           ButtonLabelState(text: "홈으로", isRed: true, buttonActionType: ButtonActionType.goHome),
           ButtonLabelState(text: "집중하기", isRed: false, buttonActionType: ButtonActionType.keepConcentration)
         ],
-        stackView: StackViewState(isHorizontal: true, height: 51.0)
+        stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)
       )
     }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
@@ -18,6 +18,7 @@ extension Constant.ToDoGardenAlertView {
     case askToDeleteGroup
     case askToUnsubscribe
     case askToLogout
+    case askToStopResting
   }
 }
 
@@ -169,6 +170,18 @@ extension Constant.ToDoGardenAlertView.Content {
         buttons: [
           ButtonLabelState(text: "로그아웃", isRed: true, buttonActionType: ButtonActionType.logout),
           ButtonLabelState(text: "취소", isRed: false, buttonActionType: ButtonActionType.cancel)
+        ],
+        stackView: StackViewState(isHorizontal: true, height: 51.0)
+      )
+      
+    case .askToStopResting:
+      return ViewState(
+        backPlane: BackPlaneState(width: 273.0, height: 206.0, cornerRadius: 20.0),
+        title: TitleViewState(text: "그만 쉴까요?", topMargin: 42.0),
+        description: DescriptionViewState(text: "이제 다시 열심히\n힘을 내볼까요?", topMargin: 84.0),
+        buttons: [
+          ButtonLabelState(text: "홈으로", isRed: true, buttonActionType: ButtonActionType.goHome),
+          ButtonLabelState(text: "집중하기", isRed: false, buttonActionType: ButtonActionType.keepConcentration)
         ],
         stackView: StackViewState(isHorizontal: true, height: 51.0)
       )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
@@ -8,5 +8,10 @@
 import Foundation
 
 extension Constant.ToDoGardenAlertView {
+  public enum Alpha {}
+}
 
+extension Constant.ToDoGardenAlertView.Alpha {
+  public static let touchedAlpha = 0.7
+  public static let normalAlpha = 1.0
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
@@ -9,6 +9,16 @@ import Foundation
 
 extension Constant.ToDoGardenAlertView {
   public enum Alpha {}
+  
+  public enum Content {
+    case welldone
+    case askToStop
+    case fullyCharged
+    case askToDeleteToDo
+    case askToDeleteGroup
+    case askToUnsubscribe
+    case askToLogout
+  }
 }
 
 extension Constant.ToDoGardenAlertView.Alpha {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
@@ -114,7 +114,10 @@ extension Constant.ToDoGardenAlertView.Content {
           cornerRadius: layoutConstant.cornerRadius
         ),
         title: TitleViewState(text: "수고했어요!", topMargin: layoutConstant.titleTopMarginForVertical),
-        description: DescriptionViewState(text: "오늘도 열심히 집중한 당신!\n이제 조금 쉬어볼까요?", topMargin: layoutConstant.descriptionTopMarginForVertical),
+        description: DescriptionViewState(
+          text: "오늘도 열심히 집중한 당신!\n이제 조금 쉬어볼까요?",
+          topMargin: layoutConstant.descriptionTopMarginForVertical
+        ),
         buttons: [
           ButtonLabelState(text: "휴식하기", isRed: false, buttonActionType: ButtonActionType.stopConcentration),
           ButtonLabelState(text: "더 집중하기", isRed: false, buttonActionType: ButtonActionType.keepConcentration),
@@ -131,7 +134,10 @@ extension Constant.ToDoGardenAlertView.Content {
           cornerRadius: layoutConstant.cornerRadius
         ),
         title: TitleViewState(text: "그만할까요?", topMargin: layoutConstant.titleTopMarginForHorizontal),
-        description: DescriptionViewState(text: "그만하면\n기록으로 돌아갈 수 있어요.", topMargin: layoutConstant.descriptionTopMarginForHorizontal),
+        description: DescriptionViewState(
+          text: "그만하면\n기록으로 돌아갈 수 있어요.",
+          topMargin: layoutConstant.descriptionTopMarginForHorizontal
+        ),
         buttons: [
           ButtonLabelState(text: "포기하기", isRed: true, buttonActionType: ButtonActionType.stopConcentration),
           ButtonLabelState(text: "집중하기", isRed: false, buttonActionType: ButtonActionType.cancel)
@@ -146,7 +152,10 @@ extension Constant.ToDoGardenAlertView.Content {
           height: layoutConstant.heightForHorizontal,
           cornerRadius: layoutConstant.cornerRadius),
         title: TitleViewState(text: "충전완료!", topMargin: layoutConstant.titleTopMarginForHorizontal),
-        description: DescriptionViewState(text: "이제 다시 열심히\n힘을 내볼까요?", topMargin: layoutConstant.descriptionTopMarginForHorizontal),
+        description: DescriptionViewState(
+          text: "이제 다시 열심히\n힘을 내볼까요?",
+          topMargin: layoutConstant.descriptionTopMarginForHorizontal
+        ),
         buttons: [
           ButtonLabelState(text: "홈으로", isRed: true, buttonActionType: ButtonActionType.goHome),
           ButtonLabelState(text: "집중하기", isRed: false, buttonActionType: ButtonActionType.keepConcentration)
@@ -162,7 +171,10 @@ extension Constant.ToDoGardenAlertView.Content {
           cornerRadius: layoutConstant.cornerRadius
         ),
         title: TitleViewState(text: "삭제할까요?", topMargin: layoutConstant.titleTopMarginForHorizontal),
-        description: DescriptionViewState(text: "한 번 삭제하면 되돌릴 수 없어요.", topMargin: layoutConstant.descriptionTopMarginForHorizontal),
+        description: DescriptionViewState(
+          text: "한 번 삭제하면 되돌릴 수 없어요.",
+          topMargin: layoutConstant.descriptionTopMarginForHorizontal
+        ),
         buttons: [
           ButtonLabelState(text: "취소하기", isRed: false, buttonActionType: ButtonActionType.cancel),
           ButtonLabelState(text: "삭제하기", isRed: true, buttonActionType: ButtonActionType.delete)
@@ -178,7 +190,10 @@ extension Constant.ToDoGardenAlertView.Content {
           cornerRadius: layoutConstant.cornerRadius
         ),
         title: TitleViewState(text: "그룹을 삭제하시겠습니까?", topMargin: layoutConstant.titleTopMarginForHorizontal),
-        description: DescriptionViewState(text: "그룹에 포함되어 있던\n투두들은 모두 삭제됩니다", topMargin: layoutConstant.descriptionTopMarginForHorizontal),
+        description: DescriptionViewState(
+          text: "그룹에 포함되어 있던\n투두들은 모두 삭제됩니다",
+          topMargin: layoutConstant.descriptionTopMarginForHorizontal
+        ),
         buttons: [
           ButtonLabelState(text: "취소", isRed: false, buttonActionType: ButtonActionType.cancel),
           ButtonLabelState(text: "삭제하기", isRed: true, buttonActionType: ButtonActionType.delete)
@@ -194,7 +209,10 @@ extension Constant.ToDoGardenAlertView.Content {
           cornerRadius: layoutConstant.cornerRadius
         ),
         title: TitleViewState(text: "서비스 탈퇴", topMargin: layoutConstant.titleTopMarginForHorizontal),
-        description: DescriptionViewState(text: "정말로 탈퇴하시겠습니까?\n회원 탈퇴 시 모든 정보는\n복구할 수 없습니다.", topMargin: layoutConstant.descriptionTopMarginForHorizontal),
+        description: DescriptionViewState(
+          text: "정말로 탈퇴하시겠습니까?\n회원 탈퇴 시 모든 정보는\n복구할 수 없습니다.",
+          topMargin: layoutConstant.descriptionTopMarginForHorizontal
+        ),
         buttons: [
           ButtonLabelState(text: "탈퇴하기", isRed: true, buttonActionType: ButtonActionType.unsubscribe),
           ButtonLabelState(text: "취소", isRed: false, buttonActionType: ButtonActionType.cancel)
@@ -210,7 +228,10 @@ extension Constant.ToDoGardenAlertView.Content {
           cornerRadius: layoutConstant.cornerRadius
         ),
         title: TitleViewState(text: "로그아웃", topMargin: layoutConstant.titleTopMarginForHorizontal),
-        description: DescriptionViewState(text: "정말 로그아웃 하시겠습니까?", topMargin: layoutConstant.descriptionTopMarginForHorizontal),
+        description: DescriptionViewState(
+          text: "정말 로그아웃 하시겠습니까?",
+          topMargin: layoutConstant.descriptionTopMarginForHorizontal
+        ),
         buttons: [
           ButtonLabelState(text: "로그아웃", isRed: true, buttonActionType: ButtonActionType.logout),
           ButtonLabelState(text: "취소", isRed: false, buttonActionType: ButtonActionType.cancel)
@@ -226,7 +247,10 @@ extension Constant.ToDoGardenAlertView.Content {
           cornerRadius: layoutConstant.cornerRadius
         ),
         title: TitleViewState(text: "그만 쉴까요?", topMargin: layoutConstant.titleTopMarginForHorizontal),
-        description: DescriptionViewState(text: "이제 다시 열심히\n힘을 내볼까요?", topMargin: layoutConstant.descriptionTopMarginForHorizontal),
+        description: DescriptionViewState(
+          text: "이제 다시 열심히\n힘을 내볼까요?",
+          topMargin: layoutConstant.descriptionTopMarginForHorizontal
+        ),
         buttons: [
           ButtonLabelState(text: "홈으로", isRed: true, buttonActionType: ButtonActionType.goHome),
           ButtonLabelState(text: "집중하기", isRed: false, buttonActionType: ButtonActionType.keepConcentration)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
@@ -85,4 +85,93 @@ extension Constant.ToDoGardenAlertView.Content {
     case logout
     case stopConcentration
   }
+  
+  public var viewState: ViewState {
+    switch self {
+    case .welldone:
+      return ViewState(
+        backPlane: BackPlaneState(width: 273.0, height: 246.0, cornerRadius: 20.0),
+        title: TitleViewState(text: "수고했어요!", topMargin: 24.0),
+        description: DescriptionViewState(text: "오늘도 열심히 집중한 당신!\n이제 조금 쉬어볼까요?", topMargin: 61.0),
+        buttons: [
+          ButtonLabelState(text: "휴식하기", isRed: false, buttonActionType: ButtonActionType.stopConcentration),
+          ButtonLabelState(text: "더 집중하기", isRed: false, buttonActionType: ButtonActionType.keepConcentration),
+          ButtonLabelState(text: "홈으로", isRed: true, buttonActionType: ButtonActionType.goHome)
+        ],
+        stackView: StackViewState(isHorizontal: false, height: 43.0)
+      )
+      
+    case .askToStop:
+      return ViewState(
+        backPlane: BackPlaneState(width: 273.0, height: 206.0, cornerRadius: 20.0),
+        title: TitleViewState(text: "그만할까요?", topMargin: 42.0),
+        description: DescriptionViewState(text: "그만하면\n기록으로 돌아갈 수 있어요.", topMargin: 84.0),
+        buttons: [
+          ButtonLabelState(text: "포기하기", isRed: true, buttonActionType: ButtonActionType.stopConcentration),
+          ButtonLabelState(text: "집중하기", isRed: false, buttonActionType: ButtonActionType.cancel)
+        ],
+        stackView: StackViewState(isHorizontal: true, height: 51.0)
+      )
+      
+    case .fullyCharged:
+      return ViewState(
+        backPlane: BackPlaneState(width: 273.0, height: 206.0, cornerRadius: 20.0),
+        title: TitleViewState(text: "충전완료!", topMargin: 42.0),
+        description: DescriptionViewState(text: "이제 다시 열심히\n힘을 내볼까요?", topMargin: 84.0),
+        buttons: [
+          ButtonLabelState(text: "홈으로", isRed: true, buttonActionType: ButtonActionType.goHome),
+          ButtonLabelState(text: "집중하기", isRed: false, buttonActionType: ButtonActionType.keepConcentration)
+        ],
+        stackView: StackViewState(isHorizontal: true, height: 51.0)
+      )
+      
+    case .askToDeleteToDo:
+      return ViewState(
+        backPlane: BackPlaneState(width: 273.0, height: 206.0, cornerRadius: 20.0),
+        title: TitleViewState(text: "삭제할까요?", topMargin: 42.0),
+        description: DescriptionViewState(text: "한 번 삭제하면 되돌릴 수 없어요.", topMargin: 84.0),
+        buttons: [
+          ButtonLabelState(text: "취소하기", isRed: false, buttonActionType: ButtonActionType.cancel),
+          ButtonLabelState(text: "삭제하기", isRed: true, buttonActionType: ButtonActionType.delete)
+        ],
+        stackView: StackViewState(isHorizontal: true, height: 51.0)
+      )
+      
+    case .askToDeleteGroup:
+      return ViewState(
+        backPlane: BackPlaneState(width: 273.0, height: 206.0, cornerRadius: 20.0),
+        title: TitleViewState(text: "그룹을 삭제하시겠습니까?", topMargin: 42.0),
+        description: DescriptionViewState(text: "그룹에 포함되어 있던\n투두들은 모두 삭제됩니다", topMargin: 84.0),
+        buttons: [
+          ButtonLabelState(text: "취소", isRed: false, buttonActionType: ButtonActionType.cancel),
+          ButtonLabelState(text: "삭제하기", isRed: true, buttonActionType: ButtonActionType.delete)
+        ],
+        stackView: StackViewState(isHorizontal: true, height: 51.0)
+      )
+      
+    case .askToUnsubscribe:
+      return ViewState(
+        backPlane: BackPlaneState(width: 273.0, height: 206.0, cornerRadius: 20.0),
+        title: TitleViewState(text: "서비스 탈퇴", topMargin: 42.0),
+        description: DescriptionViewState(text: "정말로 탈퇴하시겠습니까?\n회원 탈퇴 시 모든 정보는\n복구할 수 없습니다.", topMargin: 84.0),
+        buttons: [
+          ButtonLabelState(text: "탈퇴하기", isRed: true, buttonActionType: ButtonActionType.unsubscribe),
+          ButtonLabelState(text: "취소", isRed: false, buttonActionType: ButtonActionType.cancel)
+        ],
+        stackView: StackViewState(isHorizontal: true, height: 51.0)
+      )
+      
+    case .askToLogout:
+      return ViewState(
+        backPlane: BackPlaneState(width: 273.0, height: 206.0, cornerRadius: 20.0),
+        title: TitleViewState(text: "로그아웃", topMargin: 42.0),
+        description: DescriptionViewState(text: "정말 로그아웃 하시겠습니까?", topMargin: 84.0),
+        buttons: [
+          ButtonLabelState(text: "로그아웃", isRed: true, buttonActionType: ButtonActionType.logout),
+          ButtonLabelState(text: "취소", isRed: false, buttonActionType: ButtonActionType.cancel)
+        ],
+        stackView: StackViewState(isHorizontal: true, height: 51.0)
+      )
+    }
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
@@ -1,0 +1,12 @@
+//
+//  Constant+ToDoGardenAlertView.swift
+//
+//
+//  Created by SONG on 4/30/24.
+//
+
+import Foundation
+
+extension Constant.ToDoGardenAlertView {
+
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
@@ -25,3 +25,64 @@ extension Constant.ToDoGardenAlertView.Alpha {
   public static let touchedAlpha = 0.7
   public static let normalAlpha = 1.0
 }
+
+extension Constant.ToDoGardenAlertView.Content {
+  public struct ViewState {
+    public let backPlane: BackPlaneState
+    public let title: TitleViewState
+    public let description: DescriptionViewState
+    public let buttons: [ButtonLabelState]
+    public let stackView: StackViewState
+  }
+  
+  public struct BackPlaneState {
+    public let width: CGFloat
+    public let height: CGFloat
+    public let cornerRadius: CGFloat
+  }
+  
+  public struct TitleViewState {
+    public let text: String
+    public let topMargin: CGFloat
+  }
+  
+  public struct DescriptionViewState {
+    public let text: String
+    public let topMargin: CGFloat
+    public let numberOfLines: Int
+    
+    init(text: String, topMargin: CGFloat, numberOfLines: Int = 2) {
+      self.text = text
+      self.topMargin = topMargin
+      self.numberOfLines = numberOfLines
+    }
+  }
+  
+  public struct ButtonLabelState {
+    public let text: String
+    public let isRed: Bool
+    public let buttonActionType: ButtonActionType
+  }
+  
+  public struct StackViewState {
+    public let isHorizontal: Bool
+    public let height: CGFloat
+    public let dividerThickness: CGFloat
+    
+    init(isHorizontal: Bool, height: CGFloat, dividerThickness: CGFloat = 1.0) {
+      self.isHorizontal = isHorizontal
+      self.height = height
+      self.dividerThickness = dividerThickness
+    }
+  }
+  
+  public enum ButtonActionType {
+    case cancel
+    case keepConcentration
+    case goHome
+    case delete
+    case unsubscribe
+    case logout
+    case stopConcentration
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -11,4 +11,5 @@ public enum Constant {
   public enum PeriodSegmentedControl {}
   public enum ProfileImageView {}
   public enum SearchGardenButton {}
+  public enum ToDoGardenAlertView {}
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #95 
## 🎉 변경 사항

- Constant+ToDoGardenAlertView.swift 파일 추가
- ToDoAlertController에 띄울 ToDoAlertView에 대한 Constant를 모아놓은 컨테이너 객체를 구현했습니다. 
## 📌 PR Point

### 구현상세

- 각 case마다 담고 있는 Content가 달라 가지 수가 꽤 많다고 생각하여, `public static let` 으로 선언하여 뽑아쓰기엔 오히려 헷갈릴 것 같고 불편할 것 같다고 판단했습니다.

<img width="619" alt="스크린샷 2024-04-30 오후 6 45 44" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/2bc735b3-7e25-4e28-bcbf-8a2934f8d191">

```swift
  public enum Content {
    case welldone
    case askToStop
    case fullyCharged
    case askToDeleteToDo
    case askToDeleteGroup
    case askToUnsubscribe
    case askToLogout
    case askToStopResting
  }
```

---

- ToDoGardenAlertView를 구성하는 UI마다 필요한 상태값들을 Struct로 정의하고, 그 Struct들을 캡슐화한 `viewState` 프로퍼티가 존재하며, View단에 전달되면 사실상 뷰모델처럼 사용됩니다. 

```swift
public var viewState: ViewState { ... }

  public struct ViewState {
    public let backPlane: BackPlaneState
    public let title: TitleViewState
    public let description: DescriptionViewState
    public let buttons: [ButtonLabelState]
    public let stackView: StackViewState
  }
```

---

- view의 두가지 스타일에 대한 차이는 이미지 상에 `화살표` 로 표시된 값에 대한 Constant를 다르게 할당함으로써 해결하였고, 스택뷰의 축 방향은 `StackViewState 의 isHorizontal : Bool` 로 구분하여 전달됩니다. 
<img width="726" alt="스크린샷 2024-04-30 오후 6 47 44" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/89b935b3-dcde-4d6e-a165-c3e1d66fc1b9">

```swift
  public struct StackViewState {
    public let isHorizontal: Bool
    ...
  }
```

___

- 현재 구현상으로는, 사용하는 쪽에서는 case만 지정해주면 쉽게 사용할 수 있습니다. 
```swift
    let vc1 = ToDoGardenAlertController(for: ToDoGardenAlertView.Configuration.askToStopResting)
    let vc2 = ToDoGardenAlertController(for: ToDoGardenAlertView.Configuration.welldone)
```

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?