### PR TITLE
ToDoCheckBoxButton Constant 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
@@ -10,6 +10,7 @@ import Foundation
 extension Constant.ToDoCheckBoxButton {
   public enum Layout { }
   public enum Action { }
+  public enum Animation { }
 }
 
 extension Constant.ToDoCheckBoxButton.Layout {
@@ -19,4 +20,12 @@ extension Constant.ToDoCheckBoxButton.Layout {
 
 extension Constant.ToDoCheckBoxButton.Action {
   public static let impactIntesity: CGFloat = 0.6
+}
+
+extension Constant.ToDoCheckBoxButton.Animation {
+  public static let lineWidth: CGFloat = 1.0
+  public static let keyPath: String = "strokeEnd"
+  public static let duration: CGFloat = 0.4
+  public static let fromValue: CGFloat = 0.0
+  public static let toValue: CGFloat = 1.0
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
@@ -1,0 +1,12 @@
+//
+//  Constant+ToDoCheckBoxButton.swift
+//
+//
+//  Created by Wood on 5/1/24.
+//
+
+import Foundation
+
+extension Constant.ToDoCheckBoxButton {
+  
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
@@ -21,6 +21,7 @@ extension Constant.ToDoCheckBoxButton.Size {
 extension Constant.ToDoCheckBoxButton.Layout {
   public static let borderWidth: CGFloat = 0.6
   public static let cornerRadius: CGFloat = 3.0
+  public static let lineWidth: CGFloat = 1.0
 }
 
 extension Constant.ToDoCheckBoxButton.Action {
@@ -28,7 +29,6 @@ extension Constant.ToDoCheckBoxButton.Action {
 }
 
 extension Constant.ToDoCheckBoxButton.Animation {
-  public static let lineWidth: CGFloat = 1.0
   public static let keyPath: String = "strokeEnd"
   public static let duration: CGFloat = 0.4
   public static let fromValue: CGFloat = 0.0

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
@@ -9,9 +9,14 @@ import Foundation
 
 extension Constant.ToDoCheckBoxButton {
   public enum Layout { }
+  public enum Action { }
 }
 
 extension Constant.ToDoCheckBoxButton.Layout {
   public static let borderWidth: CGFloat = 0.6
   public static let cornerRadius: CGFloat = 3.0
+}
+
+extension Constant.ToDoCheckBoxButton.Action {
+  public static let impactIntesity: CGFloat = 0.6
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
@@ -29,3 +29,14 @@ extension Constant.ToDoCheckBoxButton.Animation {
   public static let fromValue: CGFloat = 0.0
   public static let toValue: CGFloat = 1.0
 }
+
+extension Constant.ToDoCheckBoxButton.Animation {
+  public enum Path {
+    public static let offsetXToStartPoint: CGFloat = 4.0
+    public static let offsetYToStartPoint: CGFloat = 7.5
+    public static let offsetXToMiddlePoint: CGFloat = 3.5
+    public static let offsetYToMiddlePoint: CGFloat = 5.5
+    public static let offsetXToEndPoint: CGFloat = 6.0
+    public static let offsetYToEndPoint: CGFloat = 8.5
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
@@ -8,9 +8,14 @@
 import Foundation
 
 extension Constant.ToDoCheckBoxButton {
+  public enum Size { }
   public enum Layout { }
   public enum Action { }
   public enum Animation { }
+}
+
+extension Constant.ToDoCheckBoxButton.Size {
+  public static let priamry = CGSize(width: 18, height: 18)
 }
 
 extension Constant.ToDoCheckBoxButton.Layout {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
@@ -8,5 +8,10 @@
 import Foundation
 
 extension Constant.ToDoCheckBoxButton {
-  
+  public enum Layout { }
+}
+
+extension Constant.ToDoCheckBoxButton.Layout {
+  public static let borderWidth: CGFloat = 0.6
+  public static let cornerRadius: CGFloat = 3.0
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -12,4 +12,5 @@ public enum Constant {
   public enum ProfileImageView {}
   public enum SearchGardenButton {}
   public enum ToDoGardenAlertView {}
+  public enum ToDoCheckBoxButton {}
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #104 

## 🎉 변경 사항
- ToDoCheckBoxButton에 필요한 Constant 값들을 ToDoGardenUIConstant 모듈에 추가합니다.

## 📌 PR Point
1. impactIntensity: 투두가 완료되었을 때, 생성할 진동의 세기입니다.

2. Animation: 애니메이션 설정에 필요한 속성들을 가집니다.

3. Path: 투두 완료시 생성할 애니메이션을 보시면 다음과 같습니다.

애니메이션이 그릴 경로에는 **시작지점, 중간점, 끝점** 총 3개의 포인트가 존재합니다.
offsetXToPoint 변수들은 해당 지점으로 이동하는데 필요한 **X와 Y만큼의 거리**를 가집니다.
<img width="200" alt="스크린샷 2024-05-01 15 24 14" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/14f3e5b7-8b5c-43bb-8aea-e54ae5244cb2">


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?