### PR TITLE
CreateToDoButton 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
@@ -15,11 +15,32 @@ public final class CreateToDoButton: UIButton {
   public init(primaryModel: CreateToDoButton.PrimaryModel) {
     self.primaryModel = primaryModel
     super.init(frame: CGRect.zero)
+    self.setupUI()
   }
 
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: Private Functions
+
+extension CreateToDoButton {
+  private func setupUI() {
+    self.setupConfiguration()
+    self.setupContentsLayout()
+  }
+
+  private func setupConfiguration() {
+    let configuration = UIButton.Configuration.filled()
+    self.configuration = configuration
+  }
+
+  private func setupContentsLayout() {
+    self.configuration?.contentInsets = self.primaryModel.contentInsets
+    self.configuration?.imagePadding = self.primaryModel.imagePadding
+    self.configuration?.imagePlacement = NSDirectionalRectEdge.trailing
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
@@ -23,14 +23,30 @@ public final class CreateToDoButton: UIButton {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+
+  public func updateTitle(with groupName: String) {
+    self.configuration?.attributedTitle = self.makeAttributedTitle(with: groupName)
+  }
 }
 
 // MARK: Private Functions
 
 extension CreateToDoButton {
+  private func makeAttributedTitle(with groupName: String) -> AttributedString {
+    let attributes = AttributeContainer(
+      [
+        NSAttributedString.Key.font: UIFont.pretendardBodyBold,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    )
+    return AttributedString(
+      groupName,
+      attributes: attributes
+    )
+  }
+
   private func setupUI() {
     self.setupConfiguration()
-    self.setupTitle()
     self.setupRightImage()
     self.setupBackgroundColor()
     self.setupContentsLayout()
@@ -40,20 +56,6 @@ extension CreateToDoButton {
     var configuration = UIButton.Configuration.filled()
     configuration.cornerStyle = UIButton.Configuration.CornerStyle.capsule
     self.configuration = configuration
-  }
-
-  private func setupTitle() {
-    let attributes = AttributeContainer(
-      [
-        NSAttributedString.Key.font: UIFont.pretendardBodyBold,
-        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
-      ]
-    )
-    let attributedTtile = AttributedString(
-      self.primaryModel.title,
-      attributes: attributes
-    )
-    self.configuration?.attributedTitle = attributedTtile
   }
 
   private func setupBackgroundColor() {
@@ -75,21 +77,24 @@ extension CreateToDoButton {
 
 extension CreateToDoButton {
   public struct PrimaryModel {
-    var title: String
-    var imagePadding: CGFloat
-    var contentInsets: NSDirectionalEdgeInsets
-    var image: UIImage
+    let imagePadding: CGFloat
+    let contentInsets: NSDirectionalEdgeInsets
+    let image: UIImage
+    let font: UIFont
+    let textColor: UIColor
 
     public init(
-      title: String,
       imagePadding: CGFloat = Constant.CreateToDoButton.Layout.Primary.imagePadding,
       contentInsets: NSDirectionalEdgeInsets = Constant.CreateToDoButton.Layout.Primary.contentInsets,
-      image: UIImage = UIImage.createToDoButtonImage
+      image: UIImage = UIImage.createToDoButtonImage,
+      font: UIFont = UIFont.pretendardBodyBold,
+      textColor: UIColor = UIColor.toDoGardenGreenDark
     ) {
-      self.title = title
       self.imagePadding = imagePadding
       self.contentInsets = contentInsets
       self.image = image
+      self.font = font
+      self.textColor = textColor
     }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 public final class CreateToDoButton: UIButton {
@@ -36,7 +37,8 @@ extension CreateToDoButton {
   }
 
   private func setupConfiguration() {
-    let configuration = UIButton.Configuration.filled()
+    var configuration = UIButton.Configuration.filled()
+    configuration.cornerStyle = UIButton.Configuration.CornerStyle.capsule
     self.configuration = configuration
   }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
@@ -30,6 +30,7 @@ extension CreateToDoButton {
   private func setupUI() {
     self.setupConfiguration()
     self.setupTitle()
+    self.setupRightImage()
     self.setupContentsLayout()
   }
 
@@ -50,6 +51,10 @@ extension CreateToDoButton {
        attributes: attributes
      )
      self.configuration?.attributedTitle = attributedTtile
+  }
+
+  private func setupRightImage() {
+    self.configuration?.image = self.primaryModel.image
   }
 
   private func setupContentsLayout() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
@@ -43,17 +43,17 @@ extension CreateToDoButton {
   }
 
   private func setupTitle() {
-     let attributes = AttributeContainer(
-       [
-         NSAttributedString.Key.font : UIFont.pretendardBodyBold,
-         NSAttributedString.Key.foregroundColor : UIColor.toDoGardenGreenDark
-       ]
-     )
-     let attributedTtile = AttributedString(
-       self.primaryModel.title,
-       attributes: attributes
-     )
-     self.configuration?.attributedTitle = attributedTtile
+    let attributes = AttributeContainer(
+      [
+        NSAttributedString.Key.font: UIFont.pretendardBodyBold,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    )
+    let attributedTtile = AttributedString(
+      self.primaryModel.title,
+      attributes: attributes
+    )
+    self.configuration?.attributedTitle = attributedTtile
   }
 
   private func setupBackgroundColor() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
@@ -31,6 +31,7 @@ extension CreateToDoButton {
     self.setupConfiguration()
     self.setupTitle()
     self.setupRightImage()
+    self.setupBackgroundColor()
     self.setupContentsLayout()
   }
 
@@ -51,6 +52,10 @@ extension CreateToDoButton {
        attributes: attributes
      )
      self.configuration?.attributedTitle = attributedTtile
+  }
+
+  private func setupBackgroundColor() {
+    self.configuration?.baseBackgroundColor = UIColor.toDoGardenGreenBackground
   }
 
   private func setupRightImage() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
@@ -1,0 +1,19 @@
+//
+//  CreateToDoButton.swift
+//
+//
+//  Created by Wood on 5/2/24.
+//
+
+import UIKit
+
+public final class CreateToDoButton: UIButton {
+  
+  public init() {
+    super.init(frame: CGRect.zero)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
@@ -29,12 +29,27 @@ public final class CreateToDoButton: UIButton {
 extension CreateToDoButton {
   private func setupUI() {
     self.setupConfiguration()
+    self.setupTitle()
     self.setupContentsLayout()
   }
 
   private func setupConfiguration() {
     let configuration = UIButton.Configuration.filled()
     self.configuration = configuration
+  }
+
+  private func setupTitle() {
+     let attributes = AttributeContainer(
+       [
+         NSAttributedString.Key.font : UIFont.pretendardBodyBold,
+         NSAttributedString.Key.foregroundColor : UIColor.toDoGardenGreenDark
+       ]
+     )
+     let attributedTtile = AttributedString(
+       self.primaryModel.title,
+       attributes: attributes
+     )
+     self.configuration?.attributedTitle = attributedTtile
   }
 
   private func setupContentsLayout() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
@@ -7,13 +7,41 @@
 
 import UIKit
 
+import ToDoGardenUIResource
+
 public final class CreateToDoButton: UIButton {
-  
-  public init() {
+  private var primaryModel: CreateToDoButton.PrimaryModel
+
+  public init(primaryModel: CreateToDoButton.PrimaryModel) {
+    self.primaryModel = primaryModel
     super.init(frame: CGRect.zero)
   }
 
+  @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: Primary Model
+
+extension CreateToDoButton {
+  public struct PrimaryModel {
+    var title: String
+    var imagePadding: CGFloat
+    var contentInsets: NSDirectionalEdgeInsets
+    var image: UIImage
+
+    public init(
+      title: String,
+      imagePadding: CGFloat = Constant.CreateToDoButton.Layout.Primary.imagePadding,
+      contentInsets: NSDirectionalEdgeInsets = Constant.CreateToDoButton.Layout.Primary.contentInsets,
+      image: UIImage = UIImage.createToDoButtonImage
+    ) {
+      self.title = title
+      self.imagePadding = imagePadding
+      self.contentInsets = contentInsets
+      self.image = image
+    }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CreateToDoButton.swift
@@ -11,10 +11,10 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 public final class CreateToDoButton: UIButton {
-  private var primaryModel: CreateToDoButton.PrimaryModel
+  private var model: CreateToDoButton.Model
 
-  public init(primaryModel: CreateToDoButton.PrimaryModel) {
-    self.primaryModel = primaryModel
+  public init(model: CreateToDoButton.Model) {
+    self.model = model
     super.init(frame: CGRect.zero)
     self.setupUI()
   }
@@ -63,12 +63,12 @@ extension CreateToDoButton {
   }
 
   private func setupRightImage() {
-    self.configuration?.image = self.primaryModel.image
+    self.configuration?.image = self.model.image
   }
 
   private func setupContentsLayout() {
-    self.configuration?.contentInsets = self.primaryModel.contentInsets
-    self.configuration?.imagePadding = self.primaryModel.imagePadding
+    self.configuration?.contentInsets = self.model.contentInsets
+    self.configuration?.imagePadding = self.model.imagePadding
     self.configuration?.imagePlacement = NSDirectionalRectEdge.trailing
   }
 }
@@ -76,25 +76,21 @@ extension CreateToDoButton {
 // MARK: Primary Model
 
 extension CreateToDoButton {
-  public struct PrimaryModel {
+  public struct Model {
     let imagePadding: CGFloat
     let contentInsets: NSDirectionalEdgeInsets
     let image: UIImage
     let font: UIFont
     let textColor: UIColor
-
-    public init(
-      imagePadding: CGFloat = Constant.CreateToDoButton.Layout.Primary.imagePadding,
-      contentInsets: NSDirectionalEdgeInsets = Constant.CreateToDoButton.Layout.Primary.contentInsets,
-      image: UIImage = UIImage.createToDoButtonImage,
-      font: UIFont = UIFont.pretendardBodyBold,
-      textColor: UIColor = UIColor.toDoGardenGreenDark
-    ) {
-      self.imagePadding = imagePadding
-      self.contentInsets = contentInsets
-      self.image = image
-      self.font = font
-      self.textColor = textColor
-    }
   }
+}
+
+extension CreateToDoButton.Model {
+  public static let primary = CreateToDoButton.Model(
+    imagePadding: Constant.CreateToDoButton.Layout.Primary.imagePadding,
+    contentInsets: Constant.CreateToDoButton.Layout.Primary.contentInsets,
+    image: UIImage.createToDoButtonImage,
+    font: UIFont.pretendardBodyBold,
+    textColor: UIColor.toDoGardenGreenDark
+  )
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #107

## 🎉 변경 사항
- 투두 생성시 사용하는 버튼을 UIComponent 타겟에 추가하였습니다.

## 📌 PR Point
### 1. PrimaryModel
버튼에 사용되는 레이아웃관련 상수나 이미지들을 프로퍼티로 가지는 구조체입니다.
해당 객체를 이용해 버튼 이니셜라이저에서 입력받을 수 있게 구현하였습니다.

### 2. 화면 스크린샷
<img src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/c99e823c-3951-4065-9cee-5f4d09b69133" width="300" height="650">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?