### PR TITLE
ToDoCheckBoxButton 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -23,9 +23,7 @@ public final class ToDoCheckBoxButton: UIButton {
       style: UIImpactFeedbackGenerator.FeedbackStyle.heavy
     )
     super.init(frame: CGRect.zero)
-    self.updateState()
-    self.setupToDoCompleteAnimation()
-    self.setupUI()
+    self.setup()
   }
 
   @available(*, unavailable)
@@ -37,6 +35,13 @@ public final class ToDoCheckBoxButton: UIButton {
 // MARK: Private Functions
 
 extension ToDoCheckBoxButton {
+  private func setup() {
+    self.updateState()
+    self.setupAction()
+    self.setupToDoCompleteAnimation()
+    self.setupUI()
+  }
+
   private func updateState() {
     if self.checkBoxModel.isToDoDone {
       self.completeToDo()
@@ -55,6 +60,28 @@ extension ToDoCheckBoxButton {
   private func resetToDo() {
     self.isSelected = false
     self.backgroundColor = UIColor.toDoGardenWhite
+  }
+}
+
+// MARK: Set Up Action
+
+extension ToDoCheckBoxButton {
+  private func setupAction() {
+    self.addAction(
+      self.makeButtonAction(),
+      for: UIControl.Event.touchUpInside
+    )
+  }
+
+  private func makeButtonAction() -> UIAction {
+    return UIAction { [weak self] _ in
+      guard let self else { return }
+      if self.isSelected {
+        self.resetToDo()
+      } else {
+        self.completeToDo()
+      }
+    }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -24,6 +24,8 @@ public final class ToDoCheckBoxButton: UIButton {
     )
     super.init(frame: CGRect.zero)
     self.updateState()
+    self.setupToDoCompleteAnimation()
+    self.setupUI()
   }
 
   @available(*, unavailable)
@@ -118,6 +120,24 @@ extension ToDoCheckBoxButton {
       y: bezierPath.currentPoint.y - offsetYToEndPoint
     )
     bezierPath.addLine(to: endPoint)
+  }
+}
+
+// MARK: set up UI
+
+extension ToDoCheckBoxButton {
+  private func setupUI() {
+    self.setupBorder()
+    self.setupRoundedCorner()
+  }
+
+  private func setupBorder() {
+    self.layer.borderColor = self.checkBoxModel.groupColor.cgColor
+    self.layer.borderWidth = self.checkBoxModel.borderWidth
+  }
+
+  private func setupRoundedCorner() {
+    self.layer.cornerRadius = self.checkBoxModel.cornerRadius
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -11,12 +11,38 @@ import ToDoGardenUIResource
 import ToDoGardenUIConstant
 
 public final class ToDoCheckBoxButton: UIButton {
-  public init() {
+  private var checkBoxModel: ToDoCheckBoxButton.CheckBoxModel
+
+  public init(checkBoxModel: ToDoCheckBoxButton.CheckBoxModel) {
+    self.checkBoxModel = checkBoxModel
     super.init(frame: CGRect.zero)
   }
 
   @available(*, unavailable)
   public required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: CheckBox Model
+
+extension ToDoCheckBoxButton {
+  public struct CheckBoxModel {
+    var isToDoDone: Bool
+    var groupColor: UIColor
+    var borderWidth: CGFloat
+    var cornerRadius: CGFloat
+
+    public init(
+      isToDoDone: Bool,
+      groupColor: UIColor,
+      borderWidth: CGFloat = Constant.ToDoCheckBoxButton.Layout.borderWidth,
+      cornerRadius: CGFloat = Constant.ToDoCheckBoxButton.Layout.cornerRadius
+    ) {
+      self.isToDoDone = isToDoDone
+      self.groupColor = groupColor
+      self.borderWidth = borderWidth
+      self.cornerRadius = cornerRadius
+    }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -1,0 +1,22 @@
+//
+//  ToDoCheckBoxButton.swift
+//
+//
+//  Created by Wood on 5/2/24.
+//
+
+import UIKit
+
+import ToDoGardenUIResource
+import ToDoGardenUIConstant
+
+public final class ToDoCheckBoxButton: UIButton {
+  public init() {
+    super.init(frame: CGRect.zero)
+  }
+
+  @available(*, unavailable)
+  public required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -5,6 +5,7 @@
 //  Created by Wood on 5/2/24.
 //
 
+import AVFoundation
 import UIKit
 
 import ToDoGardenUIConstant
@@ -12,8 +13,12 @@ import ToDoGardenUIResource
 
 public final class ToDoCheckBoxButton: UIButton {
   private var checkBoxModel: ToDoCheckBoxButton.CheckBoxModel
+  private var impactGenerator: UIImpactFeedbackGenerator
 
   public init(checkBoxModel: ToDoCheckBoxButton.CheckBoxModel) {
+    self.impactGenerator = UIImpactFeedbackGenerator(
+      style: UIImpactFeedbackGenerator.FeedbackStyle.heavy
+    )
     self.checkBoxModel = checkBoxModel
     super.init(frame: CGRect.zero)
     self.updateState()
@@ -39,6 +44,7 @@ extension ToDoCheckBoxButton {
   private func completeToDo() {
     self.isSelected = true
     self.backgroundColor = self.checkBoxModel.groupColor
+    self.impactGenerator.impactOccurred(intensity: Constant.ToDoCheckBoxButton.Action.impactIntesity)
   }
 
   private func resetToDo() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -7,8 +7,8 @@
 
 import UIKit
 
-import ToDoGardenUIResource
 import ToDoGardenUIConstant
+import ToDoGardenUIResource
 
 public final class ToDoCheckBoxButton: UIButton {
   private var checkBoxModel: ToDoCheckBoxButton.CheckBoxModel
@@ -16,11 +16,34 @@ public final class ToDoCheckBoxButton: UIButton {
   public init(checkBoxModel: ToDoCheckBoxButton.CheckBoxModel) {
     self.checkBoxModel = checkBoxModel
     super.init(frame: CGRect.zero)
+    self.updateState()
   }
 
   @available(*, unavailable)
   public required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: Private Functions
+
+extension ToDoCheckBoxButton {
+  private func updateState() {
+    if self.checkBoxModel.isToDoDone {
+      self.completeToDo()
+    } else {
+      self.resetToDo()
+    }
+  }
+
+  private func completeToDo() {
+    self.isSelected = true
+    self.backgroundColor = self.checkBoxModel.groupColor
+  }
+
+  private func resetToDo() {
+    self.isSelected = false
+    self.backgroundColor = UIColor.toDoGardenWhite
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -13,13 +13,15 @@ import ToDoGardenUIResource
 
 public final class ToDoCheckBoxButton: UIButton {
   private var checkBoxModel: ToDoCheckBoxButton.CheckBoxModel
+  private var checkmarkDrawingLayer: CAShapeLayer
   private var impactGenerator: UIImpactFeedbackGenerator
 
   public init(checkBoxModel: ToDoCheckBoxButton.CheckBoxModel) {
+    self.checkBoxModel = checkBoxModel
+    self.checkmarkDrawingLayer = CAShapeLayer()
     self.impactGenerator = UIImpactFeedbackGenerator(
       style: UIImpactFeedbackGenerator.FeedbackStyle.heavy
     )
-    self.checkBoxModel = checkBoxModel
     super.init(frame: CGRect.zero)
     self.updateState()
   }
@@ -45,11 +47,77 @@ extension ToDoCheckBoxButton {
     self.isSelected = true
     self.backgroundColor = self.checkBoxModel.groupColor
     self.impactGenerator.impactOccurred(intensity: Constant.ToDoCheckBoxButton.Action.impactIntesity)
+    self.drawCompleteToDoAnimation()
   }
 
   private func resetToDo() {
     self.isSelected = false
     self.backgroundColor = UIColor.toDoGardenWhite
+  }
+}
+
+// MARK: Set up Animation
+
+extension ToDoCheckBoxButton {
+  private func setupToDoCompleteAnimation() {
+    self.setupAnimationUI()
+    self.setupAnimationPath()
+  }
+
+  private func drawCompleteToDoAnimation() {
+    let animation = CABasicAnimation(keyPath: Constant.ToDoCheckBoxButton.Animation.keyPath)
+    animation.duration = Constant.ToDoCheckBoxButton.Animation.duration
+    animation.fromValue = Constant.ToDoCheckBoxButton.Animation.fromValue
+    animation.toValue = Constant.ToDoCheckBoxButton.Animation.toValue
+    animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+    self.checkmarkDrawingLayer.add(animation, forKey: nil)
+  }
+
+  private func setupAnimationUI() {
+    self.checkmarkDrawingLayer.lineWidth = Constant.ToDoCheckBoxButton.Layout.lineWidth
+    self.checkmarkDrawingLayer.fillColor = UIColor.clear.cgColor
+    self.checkmarkDrawingLayer.strokeColor = UIColor.white.cgColor
+    self.checkmarkDrawingLayer.lineCap = CAShapeLayerLineCap.round
+    self.checkmarkDrawingLayer.lineJoin = CAShapeLayerLineJoin.round
+    self.layer.addSublayer(self.checkmarkDrawingLayer)
+  }
+
+  private func setupAnimationPath() {
+    let bezierPath = UIBezierPath()
+    self.setupStartPoint(to: bezierPath)
+    self.setupMiddlePoint(to: bezierPath)
+    self.setupEndPoint(to: bezierPath)
+    self.checkmarkDrawingLayer.path = bezierPath.cgPath
+  }
+
+  private func setupStartPoint(to bezierPath: UIBezierPath) {
+    let offsetXToStartPoint = Constant.ToDoCheckBoxButton.Animation.Path.offsetXToStartPoint
+    let offsetYToStartPoint = Constant.ToDoCheckBoxButton.Animation.Path.offsetYToStartPoint
+    let startPoint = CGPoint(
+      x: self.frame.origin.x + offsetXToStartPoint,
+      y: self.frame.origin.x + offsetYToStartPoint
+    )
+    bezierPath.move(to: startPoint)
+  }
+
+  private func setupMiddlePoint(to bezierPath: UIBezierPath) {
+    let offsetXToMiddlePoint = Constant.ToDoCheckBoxButton.Animation.Path.offsetXToMiddlePoint
+    let offsetYToMiddlePoint = Constant.ToDoCheckBoxButton.Animation.Path.offsetYToMiddlePoint
+    let middlePoint = CGPoint(
+      x: bezierPath.currentPoint.x + offsetXToMiddlePoint,
+      y: bezierPath.currentPoint.y + offsetYToMiddlePoint
+    )
+    bezierPath.addLine(to: middlePoint)
+  }
+
+  private func setupEndPoint(to bezierPath: UIBezierPath) {
+    let offsetXToEndPoint = Constant.ToDoCheckBoxButton.Animation.Path.offsetXToEndPoint
+    let offsetYToEndPoint = Constant.ToDoCheckBoxButton.Animation.Path.offsetYToEndPoint
+    let endPoint = CGPoint(
+      x: bezierPath.currentPoint.x + offsetXToEndPoint,
+      y: bezierPath.currentPoint.y - offsetYToEndPoint
+    )
+    bezierPath.addLine(to: endPoint)
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -190,3 +190,19 @@ extension ToDoCheckBoxButton {
     }
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let button = ToDoCheckBoxButton(
+    checkBoxModel: ToDoCheckBoxButton.CheckBoxModel.init(
+      isToDoDone: true,
+      groupColor: UIColor.toDoGardenBlue
+    )
+  )
+  button.translatesAutoresizingMaskIntoConstraints = false
+  button.widthAnchor.constraint(equalToConstant: Constant.ToDoCheckBoxButton.Size.priamry.width).isActive = true
+  button.heightAnchor.constraint(equalToConstant: Constant.ToDoCheckBoxButton.Size.priamry.height).isActive = true
+  return button
+}
+#endif


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #46

## 🎉 변경 사항
- 투두 목록에서 투두를 완료했을 때 사용하는 체크박스 버튼을 구현했습니다.

## 📌 PR Point
### 투두 완료 애니메이션
버튼이 눌렸을 때 내부에 체크표시 모양을 그리도록 구현했습니다.
- 추가적으로 버튼을 눌렸을 때 진동을 발생합니다.

### 크기 제약
버튼의 크기가 18x18일 때만 정확한 위치에 체크박스 애니메이션이 그려집니다.
해당 크기를 벗어나면, 이상한 위치에 그려질 가능성이 높습니다.
- 이를 방지하고자 `Constant.ToDoCheckBoxButton`에 Size를 명시하였습니다.

<img src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/9a8f0b07-53bf-4314-b396-785561324108" width="300" height="650">

#

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?