### PR TITLE
TodoGardenAlertView 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -89,7 +89,7 @@ extension ToDoGardenAlertView {
     for (index, item) in configuration.contents.buttons.enumerated() {
       let button = UIButton()
       button.backgroundColor = UIColor.clear
-      let textColor = item.isRed ? UIColor.toDoGardenRed: UIColor.toDoGardenGreenDark
+      let textColor = item.isRed ? UIColor.toDoGardenEditButtonRed: UIColor.toDoGardenGreenDark
       let attributedTitle = NSAttributedString(
         string: item.text,
         attributes: [

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -166,6 +166,33 @@ extension ToDoGardenAlertView {
       }
     }
   }
+  
+  private func setupItemsLayout(
+    with item: UIButton,
+    in stackView: UIStackView,
+    count: Int
+  ) {
+    item.usingAutolayout()
+    stackView.addArrangedSubview(item)
+    
+    if self.configuration.contents.stackView.isHorizontal {
+      NSLayoutConstraint.activate(
+        [
+          item.widthAnchor.constraint(equalToConstant: self.configuration.contents.backPlane.width / CGFloat(count)),
+          item.topAnchor.constraint(equalTo: stackView.topAnchor),
+          item.bottomAnchor.constraint(equalTo: stackView.bottomAnchor)
+        ]
+      )
+    } else {
+      NSLayoutConstraint.activate(
+        [
+          item.widthAnchor.constraint(equalToConstant: self.configuration.contents.backPlane.width),
+          item.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+          item.trailingAnchor.constraint(equalTo: stackView.trailingAnchor)
+        ]
+      )
+    }
+  }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -96,8 +96,7 @@ extension ToDoGardenAlertView {
   
   private func buildButtons() -> [UIButton] {
     var buttons: [UIButton] = []
-    
-    for item in configuration.contents.buttons {
+    for (index, item) in configuration.contents.buttons.enumerated() {
       let button = UIButton()
       button.backgroundColor = UIColor.clear
       let textColor = item.isRed ? UIColor.toDoGardenRed: UIColor.toDoGardenGreenDark
@@ -109,13 +108,13 @@ extension ToDoGardenAlertView {
         ]
       )
       button.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
-      self.addButtonTouchActions(at: button)
+      self.addButtonTouchActions(at: button, index: index)
       buttons.append(button)
     }
     return buttons
   }
   
-  private func addButtonTouchActions(at button: UIButton) {
+  private func addButtonTouchActions(at button: UIButton, index: Int) {
     let touchedAlpha = Constant.ToDoGardenAlertView.Alpha.touchedAlpha
     let normalAlpha = Constant.ToDoGardenAlertView.Alpha.normalAlpha
     button.addAction(
@@ -125,6 +124,10 @@ extension ToDoGardenAlertView {
     button.addAction(
       UIAction(handler: { [weak button] _ in button?.alpha = normalAlpha }),
       for: .touchUpInside
+    )
+    button.addAction(
+      UIAction(handler: { [weak self] _ in self?.buttonTouched(at: index) }),
+      for: UIControl.Event.touchUpInside
     )
   }
   
@@ -241,6 +244,25 @@ extension ToDoGardenAlertView {
     let lineView = UIView()
     lineView.backgroundColor = UIColor.toDoGardenGreenGray
     return lineView
+  }
+  
+  private func buttonTouched(at index: Int) {
+    switch self.configuration.contents.buttons[index].buttonActionType {
+    case .cancel:
+      self.delegate?.didTapCancel()
+    case .keepConcentration:
+      self.delegate?.didTapKeepConcentration()
+    case .goHome:
+      self.delegate?.didTapGoHome()
+    case .delete:
+      self.delegate?.didTapDelete()
+    case .unsubscribe:
+      self.delegate?.didTapUnsubscribe()
+    case .logout:
+      self.delegate?.didTapLogout()
+    case .stopConcentration:
+      self.delegate?.didTapStopConcentration()
+    }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -1,0 +1,42 @@
+//
+//  ToDoGardenAlertView.swift
+//
+//
+//  Created by SONG on 5/4/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+
+final public class ToDoGardenAlertView: UIView {
+  private var configuration: Configuration
+  
+  init(configuration: Configuration) {
+    self.configuration = configuration
+    super.init(frame: CGRect.zero)
+    self.build()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func build() {
+    
+  }
+  
+}
+
+extension ToDoGardenAlertView {
+  public struct Configuration {
+    let contents: Constant.ToDoGardenAlertView.Content.ViewState
+    
+    public init(
+      contents: Constant.ToDoGardenAlertView.Content.ViewState
+    ) {
+      self.contents = contents
+    }
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -220,6 +220,21 @@ extension ToDoGardenAlertView {
       )
     }
   }
+  
+  private func addHorizontalTopLine(on stackView: UIStackView) {
+    let lineView = self.generateLine()
+    let thickness = self.configuration.contents.stackView.dividerThickness
+    lineView.backgroundColor = UIColor.toDoGardenGreenGray
+    lineView.usingAutolayout()
+    stackView.addSubview(lineView)
+    
+    NSLayoutConstraint.activate([
+      lineView.heightAnchor.constraint(equalToConstant: thickness),
+      lineView.topAnchor.constraint(equalTo: stackView.topAnchor),
+      lineView.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+      lineView.trailingAnchor.constraint(equalTo: stackView.trailingAnchor)
+    ])
+  }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -126,6 +126,33 @@ extension ToDoGardenAlertView {
       for: .touchUpInside
     )
   }
+  
+  private func configureStackViewLayout(at stackView: UIStackView, buttonsCount: Int) {
+    if self.configuration.contents.stackView.isHorizontal {
+      stackView.axis = NSLayoutConstraint.Axis.horizontal
+    } else {
+      stackView.axis = NSLayoutConstraint.Axis.vertical
+    }
+    stackView.distribution = UIStackView.Distribution.fillProportionally
+    stackView.alignment = UIStackView.Alignment.fill
+    stackView.usingAutolayout()
+    self.addSubview(stackView)
+    NSLayoutConstraint.activate(
+      [
+        stackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+        stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+        stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+      ]
+    )
+    let height = self.configuration.contents.stackView.height
+    if self.configuration.contents.stackView.isHorizontal {
+      stackView.heightAnchor.constraint(equalToConstant: height).isActive = true
+    } else {
+      let buttonCount = CGFloat(buttonsCount)
+      stackView.heightAnchor.constraint(equalToConstant: height * buttonCount).isActive = true
+    }
+  }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -78,6 +78,8 @@ extension ToDoGardenAlertView {
   
   private func buildStackView() {
     let bottomStackView = UIStackView()
+    bottomStackView.distribution = UIStackView.Distribution.fillProportionally
+    bottomStackView.alignment = UIStackView.Alignment.fill
     let buttons = self.buildButtons()
     self.addStackedContents(with: buttons, at: bottomStackView)
     self.configureStackViewLayout(at: bottomStackView, buttonsCount: buttons.count)
@@ -127,8 +129,7 @@ extension ToDoGardenAlertView {
     } else {
       stackView.axis = NSLayoutConstraint.Axis.vertical
     }
-    stackView.distribution = UIStackView.Distribution.fillProportionally
-    stackView.alignment = UIStackView.Alignment.fill
+
     stackView.usingAutolayout()
     self.addSubview(stackView)
     NSLayoutConstraint.activate(

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -31,9 +31,35 @@ final public class ToDoGardenAlertView: UIView {
   }
   
   private func build() {
+    // MARK: - BackgroundColor
+    self.backgroundColor = UIColor.toDoGardenWhite
+    
+    // MARK: - CornerRadius
+    self.layer.cornerRadius = self.configuration.contents.backPlane.cornerRadius
+    
+    // MARK: - Title
+    self.buildTitleLabel()
+    
+    // MARK: - Description
+    self.buildDescription()
+    
+    // MARK: - StackView
+    self.buildStackView()
+  }
+}
+
+extension ToDoGardenAlertView {
+  private func buildTitleLabel() {
     
   }
   
+  private func buildDescription() {
+    
+  }
+  
+  private func buildStackView() {
+    
+  }
 }
 
 extension ToDoGardenAlertView {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -109,11 +109,11 @@ extension ToDoGardenAlertView {
     let normalAlpha = Constant.ToDoGardenAlertView.Alpha.normalAlpha
     button.addAction(
       UIAction(handler: { [weak button] _ in button?.alpha = touchedAlpha }),
-      for: .touchDown
+      for: UIControl.Event.touchDown
     )
     button.addAction(
       UIAction(handler: { [weak button] _ in button?.alpha = normalAlpha }),
-      for: .touchUpInside
+      for: UIControl.Event.touchUpInside
     )
     button.addAction(
       UIAction(handler: { [weak self] _ in self?.buttonTouched(at: index) }),

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -86,7 +86,46 @@ extension ToDoGardenAlertView {
   }
   
   private func buildStackView() {
+    let bottomStackView = UIStackView()
+    let buttons = self.buildButtons()
+    self.addStackedContents(with: buttons, at: bottomStackView)
+    self.configureStackViewLayout(at: bottomStackView, buttonsCount: buttons.count)
+    self.addHorizontalTopLine(on: bottomStackView)
+  }
+  
+  private func buildButtons() -> [UIButton] {
+    var buttons: [UIButton] = []
     
+    for item in configuration.contents.buttons {
+      let button = UIButton()
+      button.backgroundColor = UIColor.clear
+      let textColor = item.isRed ? UIColor.toDoGardenRed: UIColor.toDoGardenGreenDark
+      let attributedTitle = NSAttributedString(
+        string: item.text,
+        attributes: [
+          .font: UIFont.pretendardDetailRegular,
+          .foregroundColor: textColor
+        ]
+      )
+      button.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
+      self.addButtonTouchActions(at: button)
+      buttons.append(button)
+    }
+    return buttons
+  }
+  
+  private func addButtonTouchActions(at button: UIButton) {
+    let touchedAlpha = Constant.ToDoGardenAlertView.Alpha.touchedAlpha
+    let normalAlpha = Constant.ToDoGardenAlertView.Alpha.normalAlpha
+    button.addAction(
+      UIAction(handler: { [weak button] _ in button?.alpha = touchedAlpha }),
+      for: .touchDown
+    )
+    button.addAction(
+      UIAction(handler: { [weak button] _ in button?.alpha = normalAlpha }),
+      for: .touchUpInside
+    )
+  }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -193,6 +193,33 @@ extension ToDoGardenAlertView {
       )
     }
   }
+  
+  private func setupDivierLayout(
+    with divider: UIView,
+    at stackView: UIStackView,
+    width: CGFloat
+  ) {
+    divider.usingAutolayout()
+    stackView.addArrangedSubview(divider)
+    
+    if self.configuration.contents.stackView.isHorizontal {
+      NSLayoutConstraint.activate(
+        [
+          divider.widthAnchor.constraint(equalToConstant: width),
+          divider.topAnchor.constraint(equalTo: stackView.topAnchor),
+          divider.bottomAnchor.constraint(equalTo: stackView.bottomAnchor)
+        ]
+      )
+    } else {
+      NSLayoutConstraint.activate(
+        [
+          divider.heightAnchor.constraint(equalToConstant: width),
+          divider.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+          divider.trailingAnchor.constraint(equalTo: stackView.trailingAnchor)
+        ]
+      )
+    }
+  }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -153,6 +153,19 @@ extension ToDoGardenAlertView {
       stackView.heightAnchor.constraint(equalToConstant: height * buttonCount).isActive = true
     }
   }
+  
+  private func addStackedContents(with buttons: [UIButton], at stackView: UIStackView) {
+    let one = self.configuration.contents.stackView.dividerThickness
+    
+    for (index, item) in buttons.enumerated() {
+      self.setupItemsLayout(with: item, in: stackView, count: buttons.count)
+      
+      if index < buttons.count - Int(one) {
+        let divider = self.generateLine()
+        self.setupDivierLayout(with: divider, at: stackView, width: one)
+      }
+    }
+  }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -10,6 +10,7 @@ import UIKit
 import ToDoGardenUIConstant
 
 final public class ToDoGardenAlertView: UIView {
+  var delegate: ToDoGardenAlertViewDelegate?
   private var configuration: Configuration
   
   init(configuration: Configuration) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -65,7 +65,24 @@ extension ToDoGardenAlertView {
   }
   
   private func buildDescription() {
+    let descriptionView = UILabel()
+    descriptionView.numberOfLines = self.configuration.contents.description.numberOfLines
+    descriptionView.text = self.configuration.contents.description.text
+    descriptionView.font = UIFont.pretendardDetailRegular
+    descriptionView.textColor = UIColor.toDoGardenGreenDark
+    descriptionView.textAlignment = NSTextAlignment.center
     
+    descriptionView.translatesAutoresizingMaskIntoConstraints = false
+    self.addSubview(descriptionView)
+    NSLayoutConstraint.activate(
+      [
+        descriptionView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+        descriptionView.topAnchor.constraint(
+          equalTo: self.topAnchor,
+          constant: self.configuration.contents.description.topMargin
+        )
+      ]
+    )
   }
   
   private func buildStackView() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -235,6 +235,11 @@ extension ToDoGardenAlertView {
       lineView.trailingAnchor.constraint(equalTo: stackView.trailingAnchor)
     ])
   }
+  
+  private func generateLine() -> UIView {
+    let lineView = UIView()
+    lineView.backgroundColor = UIColor.toDoGardenGreenGray
+    return lineView
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -32,19 +32,10 @@ final public class ToDoGardenAlertView: UIView {
   }
   
   private func build() {
-    // MARK: - BackgroundColor
     self.backgroundColor = UIColor.toDoGardenWhite
-    
-    // MARK: - CornerRadius
     self.layer.cornerRadius = self.configuration.contents.backPlane.cornerRadius
-    
-    // MARK: - Title
     self.buildTitleLabel()
-    
-    // MARK: - Description
     self.buildDescription()
-    
-    // MARK: - StackView
     self.buildStackView()
   }
 }
@@ -72,8 +63,7 @@ extension ToDoGardenAlertView {
     descriptionView.font = UIFont.pretendardDetailRegular
     descriptionView.textColor = UIColor.toDoGardenGreenDark
     descriptionView.textAlignment = NSTextAlignment.center
-    
-    descriptionView.translatesAutoresizingMaskIntoConstraints = false
+    descriptionView.usingAutolayout()
     self.addSubview(descriptionView)
     NSLayoutConstraint.activate(
       [
@@ -103,8 +93,8 @@ extension ToDoGardenAlertView {
       let attributedTitle = NSAttributedString(
         string: item.text,
         attributes: [
-          .font: UIFont.pretendardDetailRegular,
-          .foregroundColor: textColor
+          NSAttributedString.Key.font: UIFont.pretendardDetailRegular,
+          NSAttributedString.Key.foregroundColor: textColor
         ]
       )
       button.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
@@ -163,7 +153,6 @@ extension ToDoGardenAlertView {
     
     for (index, item) in buttons.enumerated() {
       self.setupItemsLayout(with: item, in: stackView, count: buttons.count)
-      
       if index < buttons.count - Int(one) {
         let divider = self.generateLine()
         self.setupDivierLayout(with: divider, at: stackView, width: one)
@@ -231,7 +220,6 @@ extension ToDoGardenAlertView {
     lineView.backgroundColor = UIColor.toDoGardenGreenGray
     lineView.usingAutolayout()
     stackView.addSubview(lineView)
-    
     NSLayoutConstraint.activate([
       lineView.heightAnchor.constraint(equalToConstant: thickness),
       lineView.topAnchor.constraint(equalTo: stackView.topAnchor),
@@ -270,9 +258,7 @@ extension ToDoGardenAlertView {
   public struct Configuration {
     let contents: Constant.ToDoGardenAlertView.Content.ViewState
     
-    public init(
-      contents: Constant.ToDoGardenAlertView.Content.ViewState
-    ) {
+    public init(contents: Constant.ToDoGardenAlertView.Content.ViewState) {
       self.contents = contents
     }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -23,6 +23,13 @@ final public class ToDoGardenAlertView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
   
+  public override var intrinsicContentSize: CGSize {
+    return CGSize(
+      width: self.configuration.contents.backPlane.width,
+      height: self.configuration.contents.backPlane.height
+    )
+  }
+  
   private func build() {
     
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -254,3 +254,37 @@ extension ToDoGardenAlertView {
     }
   }
 }
+
+extension ToDoGardenAlertView.Configuration {
+  public static let fullyCharged: Self = ToDoGardenAlertView.Configuration.init(
+    contents: Constant.ToDoGardenAlertView.Content.fullyCharged.viewState
+  )
+  
+  public static let welldone: Self = ToDoGardenAlertView.Configuration.init(
+    contents: Constant.ToDoGardenAlertView.Content.welldone.viewState
+  )
+  
+  public static let askToStop: Self = ToDoGardenAlertView.Configuration.init(
+    contents: Constant.ToDoGardenAlertView.Content.askToStop.viewState
+  )
+  
+  public static let askToLogout: Self = ToDoGardenAlertView.Configuration.init(
+    contents: Constant.ToDoGardenAlertView.Content.askToLogout.viewState
+  )
+  
+  public static let askToUnsubscribe: Self = ToDoGardenAlertView.Configuration.init(
+    contents: Constant.ToDoGardenAlertView.Content.askToUnsubscribe.viewState
+  )
+  
+  public static let askToDeleteGroup: Self = ToDoGardenAlertView.Configuration.init(
+    contents: Constant.ToDoGardenAlertView.Content.askToDeleteGroup.viewState
+  )
+  
+  public static let askToDeleteToDo: Self = ToDoGardenAlertView.Configuration.init(
+    contents: Constant.ToDoGardenAlertView.Content.askToDeleteToDo.viewState
+  )
+  
+  public static let askToStopResting: Self = ToDoGardenAlertView.Configuration.init(
+    contents: Constant.ToDoGardenAlertView.Content.askToStopResting.viewState
+  )
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -50,7 +50,18 @@ final public class ToDoGardenAlertView: UIView {
 
 extension ToDoGardenAlertView {
   private func buildTitleLabel() {
-    
+    let label = UILabel()
+    label.text = self.configuration.contents.title.text
+    label.font = UIFont.pretendardHeadBold
+    label.textColor = UIColor.toDoGardenGreenDark
+    label.usingAutolayout()
+    self.addSubview(label)
+    NSLayoutConstraint.activate(
+      [
+        label.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+        label.topAnchor.constraint(equalTo: self.topAnchor, constant: self.configuration.contents.title.topMargin)
+      ]
+    )
   }
   
   private func buildDescription() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertViewDelegate.swift
@@ -1,0 +1,18 @@
+//
+//  ToDoGardenAlertViewDelegate.swift
+//
+//
+//  Created by SONG on 5/4/24.
+//
+
+import Foundation
+
+protocol ToDoGardenAlertViewDelegate: AnyObject {
+  func didTapCancel()
+  func didTapKeepConcentration()
+  func didTapGoHome()
+  func didTapDelete()
+  func didTapUnsubscribe()
+  func didTapLogout()
+  func didTapStopConcentration()
+}


### PR DESCRIPTION
## 💡 관련 이슈
- #110 
## 🎉 변경 사항
- TodoGardenAlertView.swift 추가 
- TodoGardenAlertViewDelegate.swift 추가
## 📌 PR Point

### 뷰 미리보기 

<img width="657" alt="스크린샷 2024-05-04 오후 6 15 14" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/58ffe1ce-ce84-4b76-afff-e6c06dbfdb32">

- 위 이미지의 뷰인 TodoGardenAlertView 를 만들었습니다. 

- 다음 PR인 TodoGardenAlertController에 포함시킬 뷰 객체입니다. 

____

### AlertView의 다양한 케이스에 대한 구현

```swift
extension ToDoGardenAlertView.Configuration {
  public static let fullyCharged: Self = ToDoGardenAlertView.Configuration.init(
    contents: Constant.ToDoGardenAlertView.Content.fullyCharged.viewState
  )
  
  public static let welldone: Self = ToDoGardenAlertView.Configuration.init(
    contents: Constant.ToDoGardenAlertView.Content.welldone.viewState
  )
  
  public static let askToStop: Self = ToDoGardenAlertView.Configuration.init(
    contents: Constant.ToDoGardenAlertView.Content.askToStop.viewState
  )
  
  public static let askToLogout: Self = ToDoGardenAlertView.Configuration.init(
    contents: Constant.ToDoGardenAlertView.Content.askToLogout.viewState
  )
  
  public static let askToUnsubscribe: Self = ToDoGardenAlertView.Configuration.init(
    contents: Constant.ToDoGardenAlertView.Content.askToUnsubscribe.viewState
  )
  
  public static let askToDeleteGroup: Self = ToDoGardenAlertView.Configuration.init(
    contents: Constant.ToDoGardenAlertView.Content.askToDeleteGroup.viewState
  )
  
  public static let askToDeleteToDo: Self = ToDoGardenAlertView.Configuration.init(
    contents: Constant.ToDoGardenAlertView.Content.askToDeleteToDo.viewState
  )
  
  public static let askToStopResting: Self = ToDoGardenAlertView.Configuration.init(
    contents: Constant.ToDoGardenAlertView.Content.askToStopResting.viewState
  )
}
```
- figma 상으로 확인가능한 모든 케이스에 대해 표시가능합니다. 

_____

### Button의 다양한 케이스에 대한 대처 

```swift
protocol ToDoGardenAlertViewDelegate: AnyObject {
  func didTapCancel()
  func didTapKeepConcentration()
  func didTapGoHome()
  func didTapDelete()
  func didTapUnsubscribe()
  func didTapLogout()
  func didTapStopConcentration()
}
```
- 버튼을 눌렀을때, 버튼의 종류마다 다른 액션이 요구될 것입니다. VIP사이클에 들어갔을 때 어떤식으로 동작할 지 확신이 서지 않지만, 일단 각 버튼에 대한 액션을 ViewControllable 단에서 접근할 수 있도록 해당 프로토콜을 ToDoGardenAlertController에 채택시켜놓는 방식으로 길을 확보해 놓았습니다. 

- 이 부분은 화면단위 개발에 들어가면, 개선이 필요할 수도 있다고 생각합니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?