### PR TITLE
GardenSummaryView Constant 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenSummaryView.swift
@@ -58,3 +58,33 @@ extension Constant.GardenSummaryView {
     public let height: CGFloat
   }
 }
+
+extension Constant.GardenSummaryView {
+  public static let primary = ViewState(
+    backPlane:
+      BackPlaneState(
+        width: Constant.GardenSummaryView.Layout.backPlaneWidth,
+        height: Constant.GardenSummaryView.Layout.backPlaneHeight,
+        cornerRadius: Constant.GardenSummaryView.Layout.cornerRadius,
+        borderWidth: Constant.GardenSummaryView.Layout.borderWidth
+      ),
+    firstUnitItem: UnitItemState(
+      title: Constant.GardenSummaryView.Content.averageTimeTitle,
+      titleLeftMargin: Constant.GardenSummaryView.Layout.titleLeftMargin,
+      titleTopMargin: Constant.GardenSummaryView.Layout.titleTopMargin,
+      decriptionRightMargin: Constant.GardenSummaryView.Layout.decriptionRightMargin,
+      decriptionBottomMargin: Constant.GardenSummaryView.Layout.decriptionBottomMargin
+    ),
+    secondUnitItem: UnitItemState(
+      title: Constant.GardenSummaryView.Content.averageCompleteTitle,
+      titleLeftMargin: Constant.GardenSummaryView.Layout.titleLeftMargin,
+      titleTopMargin: Constant.GardenSummaryView.Layout.titleTopMargin,
+      decriptionRightMargin: Constant.GardenSummaryView.Layout.decriptionRightMargin,
+      decriptionBottomMargin: Constant.GardenSummaryView.Layout.decriptionBottomMargin
+    ),
+    line: LineState(
+      width: Constant.GardenSummaryView.Layout.lineWidth,
+      height: Constant.GardenSummaryView.Layout.lineHeight
+    )
+  )
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenSummaryView.swift
@@ -1,0 +1,12 @@
+//
+//  Constant+GardenSummaryView.swift
+//
+//
+//  Created by SONG on 5/4/24.
+//
+
+import Foundation
+
+extension Constant.GardenSummaryView {
+
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenSummaryView.swift
@@ -8,5 +8,8 @@
 import Foundation
 
 extension Constant.GardenSummaryView {
-
+  public enum Content {
+    static let averageTimeTitle: String = "평균 집중 시간"
+    static let averageCompleteTitle: String = "평균 완료 수"
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenSummaryView.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Constant.GardenSummaryView {
-  public enum Content {
+  private enum Content {
     static let averageTimeTitle: String = "평균 집중 시간"
     static let averageCompleteTitle: String = "평균 완료 수"
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenSummaryView.swift
@@ -12,4 +12,20 @@ extension Constant.GardenSummaryView {
     static let averageTimeTitle: String = "평균 집중 시간"
     static let averageCompleteTitle: String = "평균 완료 수"
   }
+  
+  private enum Layout {
+    static let backPlaneWidth: CGFloat = 331.0
+    static let backPlaneHeight: CGFloat = 103.0
+    static let cornerRadius: CGFloat = 10.0
+    static let borderWidth: CGFloat = 1.0
+    
+    static let titleLeftMargin: CGFloat = 10.0
+    static let titleTopMargin: CGFloat = 11.0
+    
+    static let decriptionRightMargin: CGFloat = -30.0
+    static let decriptionBottomMargin: CGFloat = -20.0
+    
+    static let lineWidth: CGFloat = 2.0
+    static let lineHeight: CGFloat = 56.5
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenSummaryView.swift
@@ -29,3 +29,32 @@ extension Constant.GardenSummaryView {
     static let lineHeight: CGFloat = 56.5
   }
 }
+
+extension Constant.GardenSummaryView {
+  public struct ViewState {
+    public let backPlane: BackPlaneState
+    public let firstUnitItem: UnitItemState
+    public let secondUnitItem: UnitItemState
+    public let line: LineState
+  }
+  
+  public struct BackPlaneState {
+    public let width: CGFloat
+    public let height: CGFloat
+    public let cornerRadius: CGFloat
+    public let borderWidth: CGFloat
+  }
+  
+  public struct UnitItemState {
+    public let title: String
+    public let titleLeftMargin: CGFloat
+    public let titleTopMargin: CGFloat
+    public let decriptionRightMargin: CGFloat
+    public let decriptionBottomMargin: CGFloat
+  }
+  
+  public struct LineState {
+    public let width: CGFloat
+    public let height: CGFloat
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -13,4 +13,5 @@ public enum Constant {
   public enum SearchGardenButton {}
   public enum ToDoGardenAlertView {}
   public enum ToDoCheckBoxButton {}
+  public enum GardenSummaryView {}
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #112 
## 🎉 변경 사항
- GardenSummaryView 에 필요한 Constant를 모아놓은 Constant+GardenSummaryView 를 생성하였습니다. 
## 📌 PR Point

### 구현 상세 

<img width="549" alt="스크린샷 2024-05-04 오후 7 21 18" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/e9452e7b-302e-4f12-843c-352a81ad3d72">

 ↑ 두개의 UnitItem이 스택뷰 내부에 배치되는 구조입니다. 

<img width="543" alt="스크린샷 2024-05-04 오후 7 23 26" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/22b67ceb-a06d-4dc8-af5a-e95648906f9b">

↑  Description이라고 명명한 부분은 계속 변하는 값이기 떄문에 Constant로 전달하지 않습니다.

### 추후 논의가 필요한 부분인 Constant 관련 PR입니다. 논의 결과에 따라 수정사항이 생기면, 머지 이후에라도 수정하도록 하겠습니다!

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?