### PR TITLE
ToDoGardenAlertController 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertController.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertController.swift
@@ -31,6 +31,13 @@ public final class ToDoGardenAlertController: UIViewController {
   }
   
   private func layout() {
-    
+    self.view.addSubview(self.alertView)
+    self.alertView.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        self.alertView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+        self.alertView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
+      ]
+    )
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertController.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertController.swift
@@ -72,3 +72,11 @@ extension ToDoGardenAlertController: ToDoGardenAlertViewDelegate {
     print("그만하기 버튼 실행할 코드")
   }
 }
+
+// #if DEBUG
+// @available(iOS 17.0, *)
+// #Preview {
+//   let view = ToDoGardenAlertController(for: .askToDeleteGroup)
+//   return view
+// }
+// #endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertController.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertController.swift
@@ -15,6 +15,7 @@ public final class ToDoGardenAlertController: UIViewController {
   public init(for alertType: ToDoGardenAlertView.Configuration) {
     self.alertView = ToDoGardenAlertView(configuration: alertType)
     super.init(nibName: nil, bundle: nil)
+    self.alertView.delegate = self
     self.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
   }
   
@@ -39,5 +40,35 @@ public final class ToDoGardenAlertController: UIViewController {
         self.alertView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
       ]
     )
+  }
+}
+
+extension ToDoGardenAlertController: ToDoGardenAlertViewDelegate {
+  public func didTapCancel() {
+    print("취소 버튼 실행할 코드")
+  }
+  
+  public func didTapDelete() {
+    print("삭제 버튼 실행할 코드")
+  }
+  
+  public func didTapLogout() {
+    print("로그아웃 버튼 실행할 코드")
+  }
+  
+  public func didTapGoHome() {
+    print("홈으로 버튼 실행할 코드")
+  }
+  
+  public func didTapUnsubscribe() {
+    print("탈퇴하기 버튼 실행할 코드")
+  }
+  
+  public func didTapKeepConcentration() {
+    print("집중하기 버튼 실행할 코드")
+  }
+  
+  public func didTapStopConcentration() {
+    print("그만하기 버튼 실행할 코드")
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertController.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertController.swift
@@ -5,7 +5,7 @@
 //  Created by SONG on 5/5/24.
 //
 
-import UIKit.UIViewController
+import UIKit
 
 import ToDoGardenUIConstant
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertController.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertController.swift
@@ -25,6 +25,8 @@ public final class ToDoGardenAlertController: UIViewController {
   
   public override func viewDidLoad() {
     super.viewDidLoad()
+    self.view.backgroundColor = UIColor.toDoGardenBlack.withAlphaComponent(0.2)
+    // TODO: - Constant 논의 이후 변경예정
     self.layout()
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertController.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertController.swift
@@ -1,0 +1,34 @@
+//
+//  ToDoGardenAlertController.swift
+//
+//
+//  Created by SONG on 5/5/24.
+//
+
+import UIKit.UIViewController
+
+import ToDoGardenUIConstant
+
+public final class ToDoGardenAlertController: UIViewController {
+  private var alertView: ToDoGardenAlertView
+  
+  public init(for alertType: ToDoGardenAlertView.Configuration) {
+    self.alertView = ToDoGardenAlertView(configuration: alertType)
+    super.init(nibName: nil, bundle: nil)
+    self.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  public override func viewDidLoad() {
+    super.viewDidLoad()
+    self.layout()
+  }
+  
+  private func layout() {
+    
+  }
+}


### PR DESCRIPTION
## 💡 관련 이슈
- #118 
- depend on #110 
## 🎉 변경 사항
- AlertView를 포함하고있는 ToDoGardenAlertController를 추가하였습니다. 
## 📌 PR Point

### 미리보기 
<div style="display: flex;">
    <img src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/69d4cc3a-fb5a-43df-9fe8-e758a078b773" alt="Simulator Screen Recording - iPhone 15 Pro - 2024-05-05 at 15 48 43" style="width: 50%;">
    <img src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/d74013d4-55cc-4c3f-be7f-3b93522e3d73" alt="Simulator Screen Recording - iPhone 15 Pro - 2024-05-05 at 15 48 06" style="width: 50%;">
</div>

______

### 추가 설명 1 

```swift
      let vc1 = ToDoGardenAlertController(for: ToDoGardenAlertView.Configuration.askToLogout)
      let vc2 = ToDoGardenAlertController(for: ToDoGardenAlertView.Configuration.welldone)
```
↑ 위 처럼 간단하게 사용하는 쪽에서 사용가능 합니다. 

________

### 추가 설명 2

```swift
extension ToDoGardenAlertController: ToDoGardenAlertViewDelegate {
  public func didTapCancel() {
    print("취소 버튼 실행할 코드")
  }
  
  public func didTapDelete() {
    print("삭제 버튼 실행할 코드")
  }
  
  public func didTapLogout() {
    print("로그아웃 버튼 실행할 코드")
  }
  
  public func didTapGoHome() {
    print("홈으로 버튼 실행할 코드")
  }
  
  public func didTapUnsubscribe() {
    print("탈퇴하기 버튼 실행할 코드")
  }
  
  public func didTapKeepConcentration() {
    print("집중하기 버튼 실행할 코드")
  }
  
  public func didTapStopConcentration() {
    print("그만하기 버튼 실행할 코드")
  }
}
```

↑ 이후, 프로토콜로 추상화되어 VIP사이클에 들어갔을때 버튼에 대한 이벤트 처리를 Controller에서 할 수 있도록 구현하고 싶었습니다. 
delegate 관련 구현부는 화면단위 개발을 진행할 때 구체화가 되거나 개선이 될 것 같습니다.  이와 관련된 조언이 있다면 해주시면 감사하겠습니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?