### PR TITLE
ColorPikcerList 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Package.swift
+++ b/ToDo-Garden/ToDoGardenUI/Package.swift
@@ -30,7 +30,8 @@ let package = Package(
 			name: "ToDoGardenUIComponent",
 			dependencies: [
         "ToDoGardenUIResource",
-        "ToDoGardenUIConstant"
+        "ToDoGardenUIConstant",
+        "CombineExtension"
       ]
 		),
 		.target(
@@ -39,6 +40,7 @@ let package = Package(
 				.process("Fonts")
 			]
 		),
-    .target(name: "ToDoGardenUIConstant")
+    .target(name: "ToDoGardenUIConstant"),
+    .target(name: "CombineExtension")
 	]
 )

--- a/ToDo-Garden/ToDoGardenUI/Sources/CombineExtension/nwise.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/CombineExtension/nwise.swift
@@ -1,0 +1,19 @@
+#if canImport(Combine)
+import Combine
+
+public extension Publisher {
+  func nwise(_ size: Int) -> AnyPublisher<[Output], Failure> {
+    assert(size > 1, "n must be greater than 1")
+    
+    return self.scan([]) { acc, item in Array((acc + [item]).suffix(size)) }
+      .filter { $0.count == size }
+      .eraseToAnyPublisher()
+  }
+  
+  func pairwise() -> AnyPublisher<(Output, Output), Failure> {
+    nwise(2)
+      .map { ($0[0], $0[1]) }
+      .eraseToAnyPublisher()
+  }
+}
+#endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ColorPickerList.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ColorPickerList.swift
@@ -1,0 +1,194 @@
+import Combine
+import UIKit
+
+import CombineExtension
+
+public final class ColorPickerList: UIStackView {
+  let colors: [UIColor]
+  public var selected: CurrentValueSubject<Int?, Never>
+  var itemsPerRow: Int
+  private var cancellables: Set<AnyCancellable> = []
+  
+  public init(
+    colors: [UIColor],
+    selected: Int?,
+    itemsPerRow: Int
+  ) {
+    self.colors = colors
+    self.selected = CurrentValueSubject<Int?, Never>(selected)
+    self.itemsPerRow = itemsPerRow
+    super.init(frame: CGRect.zero)
+    build()
+  }
+  
+  public init(
+    colors: [UIColor],
+    selected: CurrentValueSubject<Int?, Never>,
+    itemsPerRow: Int
+  ) {
+    self.colors = colors
+    self.selected = selected
+    self.itemsPerRow = itemsPerRow
+    super.init(frame: CGRect.zero)
+    build()
+  }
+  
+  public required init(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  deinit {
+    cancellables.forEach { $0.cancel() }
+    cancellables.removeAll()
+  }
+  
+  private func build() {
+    self.axis = .vertical
+    self.spacing = 14
+    let colors = colors.splitArray(itemsPerRow)
+    colors
+      .enumerated()
+      .forEach { column, colorList in
+        let subViews = colorList
+          .enumerated()
+          .map { ((column * itemsPerRow) + $0.offset, $0.element) }
+          .map(buildColorButton)
+        let stack = UIStackView(arrangedSubviews: subViews)
+        if subViews.count != itemsPerRow {
+          stack.addArrangedSubview(UIView())
+        }
+        stack.spacing = 14
+        self.addArrangedSubview(stack)
+      }
+  }
+  
+  private func buildColorButton(index: Int, backgroundColor: UIColor) -> UIButton {
+    let button = ColorButton(color: backgroundColor)
+    self.buildColorButtonConfiguration(button, index: index)
+    self.buildColorButtonLayout(button)
+    self.selected
+      .pairwise()
+      .sink { [weak button] old, new in
+        guard let button else { return }
+        if index == old, old != new {
+          button.isSelected = false
+        }
+        if new == index, !button.isSelected {
+          button.isSelected.toggle()
+        }
+      }
+      .store(in: &self.cancellables)
+    
+    return button
+  }
+  
+  private func buildColorButtonConfiguration(_ button: UIButton, index: Int) {
+    let action = UIAction { [weak self] _ in
+      self?.selected.send(index)
+    }
+    button.addAction(action, for: .touchUpInside)
+    if selected.value == index {
+      button.isSelected = true
+    }
+  }
+  
+  private func buildColorButtonLayout(_ button: UIButton) {
+    button.usingAutolayout()
+    NSLayoutConstraint.activate([
+      button.widthAnchor.constraint(equalToConstant: 36),
+      button.heightAnchor.constraint(equalToConstant: 36)
+    ])
+  }
+}
+
+private final class ColorButton: UIButton {
+  private var padding: CGFloat
+  
+  override var isSelected: Bool {
+    didSet {
+      self.layer.borderWidth = isSelected ? 2 : 0
+    }
+  }
+  
+  init(
+    padding: CGFloat = 4,
+    color: UIColor,
+    selectedColor: UIColor? = UIColor.toDoGardenGray
+  ) {
+    self.padding = padding
+    super.init(frame: .zero)
+    self.build(backgroundColor: color, selectedColor: selectedColor)
+  }
+  
+  @available(*, unavailable)
+  fileprivate required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  fileprivate override func layoutSubviews() {
+    super.layoutSubviews()
+    if
+      let configuration,
+      configuration.background.cornerRadius != self.bounds.width / 2 {
+      self.configuration?.background.cornerRadius = self.bounds.width / 2
+    }
+    if self.layer.cornerRadius != self.bounds.width / 2 {
+      self.layer.cornerRadius = self.bounds.width / 2
+    }
+  }
+  
+  private func build(backgroundColor: UIColor, selectedColor: UIColor?) {
+    self.buildConfiguration(backgroundColor)
+    if let selectedColor {
+      self.buildSelectedState(selectedColor: selectedColor)
+    }
+  }
+  
+  private func buildConfiguration(_ backgroundColor: UIColor) {
+    self.configuration = UIButton.Configuration.filled()
+    self.configuration?.background.backgroundInsets = NSDirectionalEdgeInsets(
+      top: self.padding,
+      leading: self.padding,
+      bottom: self.padding,
+      trailing: self.padding
+    )
+    self.configuration?.background.backgroundColor = backgroundColor
+    self.changesSelectionAsPrimaryAction = true
+  }
+  
+  private func buildSelectedState(selectedColor: UIColor) {
+    self.layer.borderColor = selectedColor.cgColor
+    
+    let action = UIAction { [weak self] _ in
+      guard let self else { return }
+      self.layer.borderWidth = self.isSelected ? 2 : 0
+    }
+    self.addAction(action, for: .touchUpInside)
+  }
+}
+
+private extension Array {
+  func splitArray(_ itemsPerRow: Int) -> [[Element]] {
+    var result: [[Element]] = []
+    for index in stride(from: 0, to: self.count, by: itemsPerRow) {
+      let endIndex = Swift.min(index + itemsPerRow, self.count)
+      let row = Array(self[index..<endIndex])
+      result.append(row)
+    }
+    
+    return result
+  }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+  let subject =  CurrentValueSubject<Int?, Never>(nil)
+  let view = ColorPickerList(
+    colors: [UIColor.gray, UIColor.red, UIColor.green, UIColor.blue],
+    selected: subject,
+    itemsPerRow: 4
+  )
+  subject.send(3)
+  
+  return view
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ColorPickerList.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ColorPickerList.swift
@@ -19,7 +19,7 @@ public final class ColorPickerList: UIStackView {
     self.selected = CurrentValueSubject<Int?, Never>(selected)
     self.itemsPerRow = itemsPerRow
     super.init(frame: CGRect.zero)
-    build()
+    self.build()
   }
   
   public init(
@@ -31,9 +31,10 @@ public final class ColorPickerList: UIStackView {
     self.selected = selected
     self.itemsPerRow = itemsPerRow
     super.init(frame: CGRect.zero)
-    build()
+    self.build()
   }
   
+  @available(*, unavailable)
   public required init(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
@@ -41,7 +42,7 @@ public final class ColorPickerList: UIStackView {
   private func build() {
     self.axis = NSLayoutConstraint.Axis.vertical
     self.spacing = Constant.ColorPickerList.spacing
-    let colors = colors.splitArray(itemsPerRow)
+    let colors = self.colors.splitArray(itemsPerRow)
     colors
       .enumerated()
       .forEach { column, colorList in
@@ -65,7 +66,8 @@ public final class ColorPickerList: UIStackView {
     self.selected
       .pairwise()
       .sink { [weak button] old, new in
-        guard let button else { return }
+        guard let button 
+        else { return }
         if index == old, old != new {
           button.isSelected = false
         }
@@ -82,7 +84,7 @@ public final class ColorPickerList: UIStackView {
     let action = UIAction { [weak self] _ in
       self?.selected.send(index)
     }
-    button.addAction(action, for: .touchUpInside)
+    button.addAction(action, for: UIControl.Event.touchUpInside)
     if selected.value == index {
       button.isSelected = true
     }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ColorPickerList.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ColorPickerList.swift
@@ -2,6 +2,7 @@ import Combine
 import UIKit
 
 import CombineExtension
+import ToDoGardenUIConstant
 
 public final class ColorPickerList: UIStackView {
   let colors: [UIColor]
@@ -37,14 +38,9 @@ public final class ColorPickerList: UIStackView {
     fatalError("init(coder:) has not been implemented")
   }
   
-  deinit {
-    cancellables.forEach { $0.cancel() }
-    cancellables.removeAll()
-  }
-  
   private func build() {
-    self.axis = .vertical
-    self.spacing = 14
+    self.axis = NSLayoutConstraint.Axis.vertical
+    self.spacing = Constant.ColorPickerList.spacing
     let colors = colors.splitArray(itemsPerRow)
     colors
       .enumerated()
@@ -57,7 +53,7 @@ public final class ColorPickerList: UIStackView {
         if subViews.count != itemsPerRow {
           stack.addArrangedSubview(UIView())
         }
-        stack.spacing = 14
+        stack.spacing = Constant.ColorPickerList.spacing
         self.addArrangedSubview(stack)
       }
   }
@@ -94,9 +90,11 @@ public final class ColorPickerList: UIStackView {
   
   private func buildColorButtonLayout(_ button: UIButton) {
     button.usingAutolayout()
+    let width = Constant.ColorPickerList.buttonSize.width
+    let height = Constant.ColorPickerList.buttonSize.height
     NSLayoutConstraint.activate([
-      button.widthAnchor.constraint(equalToConstant: 36),
-      button.heightAnchor.constraint(equalToConstant: 36)
+      button.widthAnchor.constraint(equalToConstant: width),
+      button.heightAnchor.constraint(equalToConstant: height)
     ])
   }
 }
@@ -106,12 +104,14 @@ private final class ColorButton: UIButton {
   
   override var isSelected: Bool {
     didSet {
-      self.layer.borderWidth = isSelected ? 2 : 0
+      self.layer.borderWidth = isSelected
+      ? Constant.ColorPickerList.buttonSelectedBorderWidth
+      : Constant.ColorPickerList.buttonNormalBorderWidth
     }
   }
   
   init(
-    padding: CGFloat = 4,
+    padding: CGFloat = Constant.ColorPickerList.buttonPadding,
     color: UIColor,
     selectedColor: UIColor? = UIColor.toDoGardenGray
   ) {
@@ -140,7 +140,7 @@ private final class ColorButton: UIButton {
   private func build(backgroundColor: UIColor, selectedColor: UIColor?) {
     self.buildConfiguration(backgroundColor)
     if let selectedColor {
-      self.buildSelectedState(selectedColor: selectedColor)
+      self.layer.borderColor = selectedColor.cgColor
     }
   }
   
@@ -154,16 +154,6 @@ private final class ColorButton: UIButton {
     )
     self.configuration?.background.backgroundColor = backgroundColor
     self.changesSelectionAsPrimaryAction = true
-  }
-  
-  private func buildSelectedState(selectedColor: UIColor) {
-    self.layer.borderColor = selectedColor.cgColor
-    
-    let action = UIAction { [weak self] _ in
-      guard let self else { return }
-      self.layer.borderWidth = self.isSelected ? 2 : 0
-    }
-    self.addAction(action, for: .touchUpInside)
   }
 }
 
@@ -184,7 +174,11 @@ private extension Array {
 #Preview {
   let subject =  CurrentValueSubject<Int?, Never>(nil)
   let view = ColorPickerList(
-    colors: [UIColor.gray, UIColor.red, UIColor.green, UIColor.blue],
+    colors: [
+      UIColor.gray, UIColor.red, UIColor.green, UIColor.blue,
+      UIColor.gray, UIColor.red, UIColor.green, UIColor.blue,
+      UIColor.gray, UIColor.red, UIColor.green, UIColor.blue
+    ],
     selected: subject,
     itemsPerRow: 4
   )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ColorPickerList.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ColorPickerList.swift
@@ -6,30 +6,30 @@ import ToDoGardenUIConstant
 
 public final class ColorPickerList: UIStackView {
   let colors: [UIColor]
+  let itemsPerRow: Int
   public var selected: CurrentValueSubject<Int?, Never>
-  var itemsPerRow: Int
   private var cancellables: Set<AnyCancellable> = []
   
   public init(
     colors: [UIColor],
-    selected: Int?,
-    itemsPerRow: Int
+    itemsPerRow: Int,
+    selected: Int?
   ) {
     self.colors = colors
-    self.selected = CurrentValueSubject<Int?, Never>(selected)
     self.itemsPerRow = itemsPerRow
+    self.selected = CurrentValueSubject<Int?, Never>(selected)
     super.init(frame: CGRect.zero)
     self.build()
   }
   
   public init(
     colors: [UIColor],
-    selected: CurrentValueSubject<Int?, Never>,
-    itemsPerRow: Int
+    itemsPerRow: Int,
+    selected: CurrentValueSubject<Int?, Never>
   ) {
     self.colors = colors
-    self.selected = selected
     self.itemsPerRow = itemsPerRow
+    self.selected = selected
     super.init(frame: CGRect.zero)
     self.build()
   }
@@ -181,8 +181,8 @@ private extension Array {
       UIColor.gray, UIColor.red, UIColor.green, UIColor.blue,
       UIColor.gray, UIColor.red, UIColor.green, UIColor.blue
     ],
-    selected: subject,
-    itemsPerRow: 4
+    itemsPerRow: 4,
+    selected: subject
   )
   subject.send(3)
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ColorPickerList.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ColorPickerList.swift
@@ -1,0 +1,10 @@
+import struct Foundation.CGFloat
+import struct Foundation.CGSize
+
+public extension Constant.ColorPickerList {
+  static let spacing: CGFloat = 14
+  static let buttonSelectedBorderWidth: CGFloat = 2
+  static let buttonNormalBorderWidth: CGFloat = 0
+  static let buttonPadding: CGFloat = 4
+  static let buttonSize = CGSize(width: 36, height: 36)
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -16,4 +16,5 @@ public enum Constant {
   public enum GardenSummaryView {}
   public enum GroupNameLabel {}
   public enum Styled {}
+  public enum ColorPickerList {}
 }


### PR DESCRIPTION
## 💡 관련 이슈
#121 

## 🎉 변경 사항
- CombineExtension 모듈 추가
- Color Picker List 추가

## 고민했던 점
저희 다른 디자인 중에서도 원형인 뷰들이 존재합니다.
이를 공통적으로 처리할 수 있는 CircularView를 생성할 까 했지만, UIButton과 같이 내부적으로 contents를 갖는 뷰들의 경우 
이를 상속 받아서 처리할 수 없었기 때문에 생성하지 않고 해당 티켓에서만 사용하는 ColorButton을 생성했습니다.
다른 분들은 이 부분에 대해서 어떻게 생각하시나요?

## 📝 셀프체크리스트
- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?