### PR TITLE
GardenSummaryView 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -1,0 +1,41 @@
+//
+//  GardenSummaryView.swift
+//
+//
+//  Created by SONG on 5/5/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+
+public final class GardenSummaryView: UIView {
+  private let configuration: Configuration
+  
+  public init(configuration: Configuration) {
+    self.configuration = configuration
+    super.init(frame: CGRect.zero)
+    self.build()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func build() {
+    
+  }
+}
+
+extension GardenSummaryView {
+  public struct Configuration {
+    let contents: Constant.GardenSummaryView.ViewState
+    
+    public init(
+      contents: Constant.GardenSummaryView.ViewState
+    ) {
+      self.contents = contents
+    }
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -149,7 +149,7 @@ extension GardenSummaryView {
           height: height
         )
       )
-      self.layout(on: item, with: title)
+      self.setLayoutUnitItem(on: item, with: title)
       unitItems.append(item)
     }
     return unitItems

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -198,3 +198,9 @@ extension GardenSummaryView {
     }
   }
 }
+
+extension GardenSummaryView.Configuration {
+  public static let primary: Self = GardenSummaryView.Configuration.init(
+    contents: Constant.GardenSummaryView.primary
+  )
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -11,6 +11,8 @@ import ToDoGardenUIConstant
 
 public final class GardenSummaryView: UIView {
   private let configuration: Configuration
+  private var averageTimeLabel: UILabel?
+  private var averageCompleteLabel: UILabel?
   
   public init(configuration: Configuration) {
     self.configuration = configuration
@@ -86,7 +88,30 @@ extension GardenSummaryView {
   }
   
   private func buildDescriptions() {
+    let rightMargin = self.configuration.contents.firstUnitItem.decriptionRightMargin
+    let bottomMargin = self.configuration.contents.firstUnitItem.decriptionBottomMargin
+    self.averageTimeLabel = UILabel()
+    self.averageCompleteLabel = UILabel()
     
+    guard let averageTimeLabel = self.averageTimeLabel, let averageCompleteLabel = self.averageCompleteLabel else {
+      return
+    }
+
+    let labels = [averageTimeLabel, averageCompleteLabel]
+    for label in labels {
+      label.font = UIFont.pretendardHeadBold
+      self.addSubview(label)
+      label.textColor = UIColor.toDoGardenGreenDark
+      label.usingAutolayout()
+    }
+    NSLayoutConstraint.activate(
+      [
+        averageTimeLabel.trailingAnchor.constraint(equalTo: self.centerXAnchor, constant: rightMargin),
+        averageTimeLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: bottomMargin),
+        averageCompleteLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: rightMargin),
+        averageCompleteLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: bottomMargin)
+      ]
+    )
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -80,9 +80,9 @@ extension GardenSummaryView {
         stackView.heightAnchor.constraint(equalToConstant: self.configuration.contents.backPlane.height)
       ]
     )
-    var items = self.buildUnitItems()
-    for _ in items {
-      stackView.addArrangedSubview(items.removeFirst())
+    var unitItems = self.buildUnitItems()
+    for unitItem in unitItems {
+      stackView.addArrangedSubview(unitItem)
     }
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -80,14 +80,14 @@ extension GardenSummaryView {
         stackView.heightAnchor.constraint(equalToConstant: self.configuration.contents.backPlane.height)
       ]
     )
-    var items = buildUnitItems()
+    var items = self.buildUnitItems()
     for _ in items {
       stackView.addArrangedSubview(items.removeFirst())
     }
   }
   
   private func buildDivider() {
-    let divider = generateDivider()
+    let divider = self.generateDivider()
     divider.usingAutolayout()
     
     self.addSubview(divider)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -25,6 +25,13 @@ public final class GardenSummaryView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
   
+  public override var intrinsicContentSize: CGSize {
+    return CGSize(
+      width: self.configuration.contents.backPlane.width,
+      height: self.configuration.contents.backPlane.height
+    )
+  }
+  
   private func build() {
     // MARK: - BackgroundColor
     self.backgroundColor = UIColor.toDoGardenWhite

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -49,7 +49,25 @@ extension GardenSummaryView {
   }
   
   private func buildStackView() {
+    let stackView = UIStackView()
+    stackView.axis = NSLayoutConstraint.Axis.horizontal
+    stackView.distribution = UIStackView.Distribution.fillProportionally
+    self.addSubview(stackView)
+    stackView.usingAutolayout()
     
+    NSLayoutConstraint.activate(
+      [
+        stackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+        stackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+        stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        stackView.heightAnchor.constraint(equalToConstant: self.configuration.contents.backPlane.height)
+      ]
+    )
+    var items = buildUnitItems()
+    for _ in items {
+      stackView.addArrangedSubview(items.removeFirst())
+    }
   }
   
   private func buildDivider() {
@@ -58,6 +76,43 @@ extension GardenSummaryView {
   
   private func buildDescriptions() {
     
+  }
+}
+
+extension GardenSummaryView {
+  private func buildUnitItems() -> [UIView] {
+    var unitItems: [UIView] = []
+    let itemConfigurations = [
+      self.configuration.contents.firstUnitItem,
+      self.configuration.contents.secondUnitItem
+    ]
+    
+    let width = Int(self.configuration.contents.backPlane.width) / itemConfigurations.count
+    let height = Int(self.configuration.contents.backPlane.height)
+    
+    for itemConfiguration in itemConfigurations {
+      let title = generateLabel(text: itemConfiguration.title)
+      
+      let item = UIView(
+        frame: CGRect(
+          x: Int.zero,
+          y: Int.zero,
+          width: width,
+          height: height
+        )
+      )
+      self.layout(on: item, with: title)
+      unitItems.append(item)
+    }
+    return unitItems
+  }
+  
+  private func generateLabel(text: String) -> UILabel {
+    let label = UILabel()
+    label.text = text
+    label.font = UIFont.pretendardBodySemiBold
+    label.textColor = UIColor.toDoGardenGreenDark
+    return label
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -43,7 +43,9 @@ public final class GardenSummaryView: UIView {
 
 extension GardenSummaryView {
   private func setupLayer() {
-
+    self.layer.cornerRadius = self.configuration.contents.backPlane.cornerRadius
+    self.layer.borderColor = UIColor.toDoGardenGreenGray.cgColor
+    self.layer.borderWidth = self.configuration.contents.backPlane.borderWidth
   }
   
   private func buildStackView() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -11,11 +11,13 @@ import ToDoGardenUIConstant
 
 public final class GardenSummaryView: UIView {
   private let configuration: Configuration
-  private var averageTimeLabel: UILabel?
-  private var averageCompleteLabel: UILabel?
+  private let averageTimeLabel: UILabel
+  private let averageCompleteLabel: UILabel
   
   public init(configuration: Configuration) {
     self.configuration = configuration
+    self.averageTimeLabel = UILabel()
+    self.averageCompleteLabel = UILabel()
     super.init(frame: CGRect.zero)
     self.build()
   }
@@ -33,8 +35,8 @@ public final class GardenSummaryView: UIView {
   }
   
   public func update(timeText: String, completionsText: String) {
-    self.averageTimeLabel?.text = timeText
-    self.averageCompleteLabel?.text = completionsText
+    self.averageTimeLabel.text = timeText
+    self.averageCompleteLabel.text = completionsText
   }
   
   private func build() {
@@ -102,14 +104,8 @@ extension GardenSummaryView {
   private func buildDescriptions() {
     let rightMargin = self.configuration.contents.firstUnitItem.decriptionRightMargin
     let bottomMargin = self.configuration.contents.firstUnitItem.decriptionBottomMargin
-    self.averageTimeLabel = UILabel()
-    self.averageCompleteLabel = UILabel()
-    
-    guard let averageTimeLabel = self.averageTimeLabel, let averageCompleteLabel = self.averageCompleteLabel else {
-      return
-    }
 
-    let labels = [averageTimeLabel, averageCompleteLabel]
+    let labels = [self.averageTimeLabel, self.averageCompleteLabel]
     for label in labels {
       label.font = UIFont.pretendardHeadBold
       self.addSubview(label)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -204,3 +204,12 @@ extension GardenSummaryView.Configuration {
     contents: Constant.GardenSummaryView.primary
   )
 }
+
+// #if DEBUG
+// @available(iOS 17.0, *)
+// #Preview {
+//   let view = GardenSummaryView(configuration: GardenSummaryView.Configuration.primary)
+//   view.update(timeText: "111시간 11분", completionsText: "222개")
+//   return view
+// }
+// #endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -71,7 +71,18 @@ extension GardenSummaryView {
   }
   
   private func buildDivider() {
+    let divider = generateDivider()
+    divider.usingAutolayout()
     
+    self.addSubview(divider)
+    NSLayoutConstraint.activate(
+      [
+        divider.widthAnchor.constraint(equalToConstant: self.configuration.contents.line.width),
+        divider.heightAnchor.constraint(equalToConstant: self.configuration.contents.line.height),
+        divider.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+        divider.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+      ]
+    )
   }
   
   private func buildDescriptions() {
@@ -113,6 +124,12 @@ extension GardenSummaryView {
     label.font = UIFont.pretendardBodySemiBold
     label.textColor = UIColor.toDoGardenGreenDark
     return label
+  }
+  
+  private func generateDivider() -> UIView {
+    let divider = UIView()
+    divider.backgroundColor = UIColor.toDoGardenGreenGray
+    return divider
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -168,6 +168,23 @@ extension GardenSummaryView {
     divider.backgroundColor = UIColor.toDoGardenGreenGray
     return divider
   }
+  
+  private func setLayoutUnitItem(on unitItem: UIView, with title: UILabel) {
+    unitItem.addSubview(title)
+    title.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        title.leadingAnchor.constraint(
+          equalTo: unitItem.leadingAnchor,
+          constant: self.configuration.contents.firstUnitItem.titleLeftMargin
+        ),
+        title.topAnchor.constraint(
+          equalTo: unitItem.topAnchor,
+          constant: self.configuration.contents.firstUnitItem.titleTopMargin
+        )
+      ]
+    )
+  }
 }
 
 extension GardenSummaryView {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -32,6 +32,11 @@ public final class GardenSummaryView: UIView {
     )
   }
   
+  public func update(timeText: String, completionsText: String) {
+    self.averageTimeLabel?.text = timeText
+    self.averageCompleteLabel?.text = completionsText
+  }
+  
   private func build() {
     // MARK: - BackgroundColor
     self.backgroundColor = UIColor.toDoGardenWhite

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenSummaryView.swift
@@ -24,6 +24,37 @@ public final class GardenSummaryView: UIView {
   }
   
   private func build() {
+    // MARK: - BackgroundColor
+    self.backgroundColor = UIColor.toDoGardenWhite
+    
+    // MARK: - layer
+    self.setupLayer()
+    
+    // MARK: - StackView
+    self.buildStackView()
+    
+    // MARK: - Divider
+    self.buildDivider()
+    
+    // MARK: - Descriptions
+    self.buildDescriptions()
+  }
+}
+
+extension GardenSummaryView {
+  private func setupLayer() {
+
+  }
+  
+  private func buildStackView() {
+    
+  }
+  
+  private func buildDivider() {
+    
+  }
+  
+  private func buildDescriptions() {
     
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #120 
- depend on #112 
## 🎉 변경 사항
- GardenSummaryView 를 추가하였습니다. 
## 📌 PR Point

### 미리보기 
<img width="259" alt="스크린샷 2024-05-06 오후 1 08 49" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/f398984a-5cbc-450a-b995-70749cf4de76">

### 이야기 나누고 싶은 점  
<img width="225" alt="스크린샷 2024-05-06 오후 1 12 25" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/33d4dda7-bf3e-4784-b9f7-b3c71dd23ee8">

```swift
  private var averageTimeLabel: UILabel
  private var averageCompleteLabel: UILabel
```

↑ 지속적으로 바뀌는 이 두 녀석을 GardenSummaryView가 직접 업데이트 해야 한다는 점입니다. 일단, 그 이유는 아래와 같습니다. 개선이 필요할까요?
- `상태가 업데이트 될 때마다 기존의 뷰를 제거하고 뷰를 새로 그려주는 방식` vs `뷰를 가지고 있고 수동으로 text만 업데이트하는 방식`
- `뷰를 가지고 있고 수동으로 text만 업데이트하는 방식` 이 지금 케이스에서 퍼포먼스 적으로 더 좋아보임 
- 컴바인을 쓰기엔, 컴바인에 대해 얕게 알고 있다. 


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?