### PR TITLE
AlarmTimeView Constant 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AlarmTimeView.swift
@@ -1,0 +1,22 @@
+//
+//  Constant+AlarmTimeView.swift
+//  
+//
+//  Created by Wood on 5/7/24.
+//
+
+import Foundation
+
+extension Constant.AlarmTimeView {
+  public enum Layout {}
+}
+
+extension Constant.AlarmTimeView.Layout {
+  public enum TimeLabel {}
+  public enum AlarmSettingButton {}
+}
+
+extension Constant.AlarmTimeView.Layout {
+  public static let borderWidth: CGFloat = 1.0
+  public static let cornerRadius: CGFloat = 15.5
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AlarmTimeView.swift
@@ -9,7 +9,10 @@ import Foundation
 
 extension Constant.AlarmTimeView {
   public enum Layout {}
+  public enum StringLiteral {}
 }
+
+// MARK: Layout
 
 extension Constant.AlarmTimeView.Layout {
   public enum TimeLabel {}
@@ -22,14 +25,12 @@ extension Constant.AlarmTimeView.Layout {
 }
 
 extension Constant.AlarmTimeView.Layout.TimeLabel {
-  public static let defaultText: String = "시간"
   public static let leadingMargin: CGFloat = 22
 }
 
 extension Constant.AlarmTimeView.Layout.AlarmSettingButton {
   public enum ContentInsets {}
 
-  public static let defaultTimeText: String = "00:00"
   public static let trailingMargin: CGFloat = 14
 }
 
@@ -38,4 +39,19 @@ extension Constant.AlarmTimeView.Layout.AlarmSettingButton.ContentInsets {
   public static let leading: CGFloat = 10
   public static let bottom: CGFloat = 4
   public static let trailing: CGFloat = 10
+}
+
+// MARK: String Literal
+
+extension Constant.AlarmTimeView.StringLiteral {
+  public enum AlarmSettingButton {}
+  public enum TimeLabel {}
+}
+
+extension Constant.AlarmTimeView.StringLiteral.AlarmSettingButton {
+  public static let defaultTimeText: String = "00:00"
+}
+
+extension Constant.AlarmTimeView.StringLiteral.TimeLabel {
+  public static let defaultText: String = "시간"
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AlarmTimeView.swift
@@ -29,7 +29,7 @@ extension Constant.AlarmTimeView.Layout.TimeLabel {
 extension Constant.AlarmTimeView.Layout.AlarmSettingButton {
   public enum ContentInsets {}
 
-  public static let defaultTimeText: String = "20:00"
+  public static let defaultTimeText: String = "00:00"
   public static let trailingMargin: CGFloat = 14
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AlarmTimeView.swift
@@ -25,3 +25,17 @@ extension Constant.AlarmTimeView.Layout.TimeLabel {
   public static let defaultText: String = "시간"
   public static let leadingMargin: CGFloat = 22
 }
+
+extension Constant.AlarmTimeView.Layout.AlarmSettingButton {
+  public enum ContentInsets {}
+
+  public static let defaultTimeText: String = "20:00"
+  public static let trailingMargin: CGFloat = 14
+}
+
+extension Constant.AlarmTimeView.Layout.AlarmSettingButton.ContentInsets {
+  public static let top: CGFloat = 4
+  public static let leading: CGFloat = 10
+  public static let bottom: CGFloat = 4
+  public static let trailing: CGFloat = 10
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AlarmTimeView.swift
@@ -20,3 +20,8 @@ extension Constant.AlarmTimeView.Layout {
   public static let borderWidth: CGFloat = 1.0
   public static let cornerRadius: CGFloat = 15.5
 }
+
+extension Constant.AlarmTimeView.Layout.TimeLabel {
+  public static let defaultText: String = "시간"
+  public static let leadingMargin: CGFloat = 22
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -16,4 +16,5 @@ public enum Constant {
   public enum GardenSummaryView {}
   public enum GroupNameLabel {}
   public enum Styled {}
+  public enum AlarmTimeView {}
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #130 

## 🎉 변경 사항
- ToDoGardenUIConstant 타겟에 AlarmTimeView의 Constant를 추가하였습니다.

## 📌 PR Point
### 1. TimeLabel Constant
"시간" 이라는 텍스트를 나타내는 레이블입니다.
- StringLiteral 추가
- 오토 레이아웃 관련 leading 상수 값 추가

### 2. AlarmSettingButton Constant
우측 시간을 설정할 수 있는 버튼으로, 설정된 시간을 텍스트로 보여줍니다.
- 기본 알람 시간 StringLiteral (Figma 디자인에 나와있는 시간)
- 오토레이아웃 및 버튼 텍스트 간격 상수 값 추가

### 추가 논의 사항
- 기본 알람 시간은 Figma 디자인과 동일하게 20:00로 가져가면 될까요?

<img src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/783257c5-9f37-4b9b-b0b2-3bc06dd7f17c" width="315" height="53">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?