### PR TITLE
SettingTimeView Constant 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
@@ -14,4 +14,8 @@ extension Constant.SettingTimeView {
     static let notificationTimeTitle: String = "시간 설정"
   }
   
+  private enum Layout {
+    static let titleTopMargin: CGFloat = 44.0
+    static let buttonTopMargin: CGFloat = 335.0
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
@@ -39,13 +39,88 @@ extension Constant.SettingTimeView {
     public var dataStore: TimePicker.DataStore {
       switch self {
       case TimePicker.alarmTime:
-        return TimePicker.DataStore()
+        return TimePicker.DataStore(
+          highlightedView: HighlightedView(
+            leading: 40.0,
+            trailing: -20.0,
+            height: 33.0
+          ),
+          hourUnitLabel: HourUnitLabel(
+            text: Content.hour,
+            leading: 34.0
+          ),
+          minuteUnitLabel: MinuteUnitLabel(
+            text: Content.minute,
+            leading: 15.0
+          ),
+          secondUnitLabel: nil,
+          pickerView: PickerView(
+            topMargin: 95.0,
+            width: 214.0,
+            height: 216.0,
+            rowHeight: 43.0,
+            numberOfComponents: 2,
+            numberOfRowsInComponent: [24, 60]
+          )
+        )
         
       case TimePicker.focusTime:
-        return TimePicker.DataStore()
+        return TimePicker.DataStore(
+          highlightedView: HighlightedView(
+            leading: 40.0,
+            trailing: -20.0,
+            height: 33.0
+          ),
+          hourUnitLabel: HourUnitLabel(
+            text: Content.hour,
+            leading: 34.0
+          ),
+          minuteUnitLabel: MinuteUnitLabel(
+            text: Content.minute,
+            leading: 15.0
+          ),
+          secondUnitLabel: SecondUnitLabel(
+            text: Content.second,
+            leading: -7.0
+          ),
+          pickerView: PickerView(
+            topMargin: 95.0,
+            width: 320.0,
+            height: 216.0,
+            rowHeight: 43.0,
+            numberOfComponents: 3,
+            numberOfRowsInComponent: [24, 60, 60]
+          )
+        )
         
       case TimePicker.breakTime:
-        return TimePicker.DataStore()
+        return TimePicker.DataStore(
+          highlightedView: HighlightedView(
+            leading: 40.0,
+            trailing: -20.0,
+            height: 33.0
+          ),
+          hourUnitLabel: HourUnitLabel(
+            text: Content.hour,
+            leading: 34.0
+          ),
+          minuteUnitLabel: MinuteUnitLabel(
+            text: Content.minute,
+            leading: 15.0
+          ),
+          secondUnitLabel: SecondUnitLabel(
+            text: Content.second,
+            leading: -7.0
+          ),
+          pickerView: PickerView(
+            topMargin: 95.0,
+            width: 320.0,
+            height: 216.0,
+            rowHeight: 43.0,
+            numberOfComponents: 3,
+            numberOfRowsInComponent: [2, 60, 60]
+          )
+        )
       }
     }
   }
@@ -56,5 +131,47 @@ extension Constant.SettingTimeView {
 }
 
 extension Constant.SettingTimeView.TimePicker {
-  public struct DataStore {}
+  private enum Content {
+    static let hour = "시간"
+    static let minute = "분"
+    static let second = "초"
+  }
+  
+  public struct DataStore {
+    public let highlightedView: HighlightedView
+    public let hourUnitLabel: HourUnitLabel
+    public let minuteUnitLabel: MinuteUnitLabel
+    public let secondUnitLabel: SecondUnitLabel?
+    public let pickerView: PickerView
+  }
+  
+  public struct HighlightedView {
+    public let leading: CGFloat
+    public let trailing: CGFloat
+    public let height: CGFloat
+  }
+  
+  public struct HourUnitLabel {
+    public let text: String
+    public let leading: CGFloat
+  }
+  
+  public struct MinuteUnitLabel {
+    public let text: String
+    public let leading: CGFloat
+  }
+  
+  public struct SecondUnitLabel {
+    public let text: String
+    public let leading: CGFloat
+  }
+  
+  public struct PickerView {
+    public let topMargin: CGFloat
+    public let width: CGFloat
+    public let height: CGFloat
+    public let rowHeight: CGFloat
+    public let numberOfComponents: Int
+    public let numberOfRowsInComponent: [Int]
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
@@ -11,7 +11,7 @@ extension Constant.SettingTimeView {
   private enum Content {
     static let focusTimeTitle: String = "집중시간 설정"
     static let breakTimeTitle: String = "휴식시간 설정"
-    static let notificationTimeTitle: String = "시간 설정"
+    static let alarmTimeTitle: String = "시간 설정"
   }
   
   private enum Layout {
@@ -174,4 +174,24 @@ extension Constant.SettingTimeView.TimePicker {
     public let numberOfComponents: Int
     public let numberOfRowsInComponent: [Int]
   }
+}
+
+extension Constant.SettingTimeView {
+  public static let focusTimeSetting = DataStore.init(
+    title: Title(topMargin: Layout.titleTopMargin, text: Content.focusTimeTitle),
+    timePicker: TimePicker.focusTime,
+    button: Button(topMargin: Layout.buttonTopMargin)
+  )
+  
+  public static let breakTimeSetting = DataStore.init(
+    title: Title(topMargin: Layout.titleTopMargin, text: Content.breakTimeTitle),
+    timePicker: TimePicker.breakTime,
+    button: Button(topMargin: Layout.buttonTopMargin)
+  )
+  
+  public static let alarmTimeSetting = DataStore.init(
+    title: Title(topMargin: Layout.titleTopMargin, text: Content.alarmTimeTitle),
+    timePicker: TimePicker.alarmTime,
+    button: Button(topMargin: Layout.buttonTopMargin)
+  )
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Constant.SettingTimeView {
-  private enum Content {
+  private enum StringLiteral {
     static let focusTimeTitle: String = "집중시간 설정"
     static let breakTimeTitle: String = "휴식시간 설정"
     static let alarmTimeTitle: String = "시간 설정"
@@ -26,6 +26,7 @@ extension Constant.SettingTimeView {
     public let timePicker: TimePicker
     public let button: Button
   }
+  
   public struct Title {
     public let topMargin: CGFloat
     public let text: String
@@ -47,11 +48,11 @@ extension Constant.SettingTimeView {
             cornerRadius: 5.0
           ),
           hourUnitLabel: HourUnitLabel(
-            text: Content.hourAlarm,
+            text: StringLiteral.hourAlarm,
             leading: 35.0
           ),
           minuteUnitLabel: MinuteUnitLabel(
-            text: Content.minute,
+            text: StringLiteral.minute,
             leading: 56.0
           ),
           secondUnitLabel: nil,
@@ -75,15 +76,15 @@ extension Constant.SettingTimeView {
             cornerRadius: 5.0
           ),
           hourUnitLabel: HourUnitLabel(
-            text: Content.hourDefault,
+            text: StringLiteral.hourDefault,
             leading: 34.0
           ),
           minuteUnitLabel: MinuteUnitLabel(
-            text: Content.minute,
+            text: StringLiteral.minute,
             leading: 15.0
           ),
           secondUnitLabel: SecondUnitLabel(
-            text: Content.second,
+            text: StringLiteral.second,
             leading: -7.0
           ),
           pickerView: PickerView(
@@ -106,15 +107,15 @@ extension Constant.SettingTimeView {
             cornerRadius: 5.0
           ),
           hourUnitLabel: HourUnitLabel(
-            text: Content.hourDefault,
+            text: StringLiteral.hourDefault,
             leading: 34.0
           ),
           minuteUnitLabel: MinuteUnitLabel(
-            text: Content.minute,
+            text: StringLiteral.minute,
             leading: 15.0
           ),
           secondUnitLabel: SecondUnitLabel(
-            text: Content.second,
+            text: StringLiteral.second,
             leading: -7.0
           ),
           pickerView: PickerView(
@@ -137,7 +138,7 @@ extension Constant.SettingTimeView {
 }
 
 extension Constant.SettingTimeView.TimePicker {
-  private enum Content {
+  private enum StringLiteral {
     static let hourDefault = "시간"
     static let hourAlarm = "시"
     static let minute = "분"
@@ -187,19 +188,19 @@ extension Constant.SettingTimeView.TimePicker {
 
 extension Constant.SettingTimeView {
   public static let focusTimeSetting = DataStore.init(
-    title: Title(topMargin: Layout.titleTopMargin, text: Content.focusTimeTitle),
+    title: Title(topMargin: Layout.titleTopMargin, text: StringLiteral.focusTimeTitle),
     timePicker: TimePicker.focusTime,
     button: Button(bottomMargin: Layout.buttonBottomMargin)
   )
   
   public static let breakTimeSetting = DataStore.init(
-    title: Title(topMargin: Layout.titleTopMargin, text: Content.breakTimeTitle),
+    title: Title(topMargin: Layout.titleTopMargin, text: StringLiteral.breakTimeTitle),
     timePicker: TimePicker.breakTime,
     button: Button(bottomMargin: Layout.buttonBottomMargin)
   )
   
   public static let alarmTimeSetting = DataStore.init(
-    title: Title(topMargin: Layout.titleTopMargin, text: Content.alarmTimeTitle),
+    title: Title(topMargin: Layout.titleTopMargin, text: StringLiteral.alarmTimeTitle),
     timePicker: TimePicker.alarmTime,
     button: Button(bottomMargin: Layout.buttonBottomMargin)
   )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
@@ -16,7 +16,7 @@ extension Constant.SettingTimeView {
   
   private enum Layout {
     static let titleTopMargin: CGFloat = 44.0
-    static let buttonTopMargin: CGFloat = 335.0
+    static let buttonBottomMargin: CGFloat = -16.0
   }
 }
 
@@ -132,7 +132,7 @@ extension Constant.SettingTimeView {
   }
   
   public struct Button {
-    public let topMargin: CGFloat
+    public let bottomMargin: CGFloat
   }
 }
 
@@ -189,18 +189,18 @@ extension Constant.SettingTimeView {
   public static let focusTimeSetting = DataStore.init(
     title: Title(topMargin: Layout.titleTopMargin, text: Content.focusTimeTitle),
     timePicker: TimePicker.focusTime,
-    button: Button(topMargin: Layout.buttonTopMargin)
+    button: Button(bottomMargin: Layout.buttonBottomMargin)
   )
   
   public static let breakTimeSetting = DataStore.init(
     title: Title(topMargin: Layout.titleTopMargin, text: Content.breakTimeTitle),
     timePicker: TimePicker.breakTime,
-    button: Button(topMargin: Layout.buttonTopMargin)
+    button: Button(bottomMargin: Layout.buttonBottomMargin)
   )
   
   public static let alarmTimeSetting = DataStore.init(
     title: Title(topMargin: Layout.titleTopMargin, text: Content.alarmTimeTitle),
     timePicker: TimePicker.alarmTime,
-    button: Button(topMargin: Layout.buttonTopMargin)
+    button: Button(bottomMargin: Layout.buttonBottomMargin)
   )
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  Constant+SettingTimeView.swift
+//
 //
 //  Created by SONG on 5/9/24.
 //

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
@@ -8,5 +8,10 @@
 import Foundation
 
 extension Constant.SettingTimeView {
+  private enum Content {
+    static let focusTimeTitle: String = "집중시간 설정"
+    static let breakTimeTitle: String = "휴식시간 설정"
+    static let notificationTimeTitle: String = "시간 설정"
+  }
   
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
@@ -19,3 +19,42 @@ extension Constant.SettingTimeView {
     static let buttonTopMargin: CGFloat = 335.0
   }
 }
+
+extension Constant.SettingTimeView {
+  public struct DataStore {
+    public let title: Title
+    public let timePicker: TimePicker
+    public let button: Button
+  }
+  public struct Title {
+    public let topMargin: CGFloat
+    public let text: String
+  }
+  
+  public enum TimePicker {
+    case focusTime
+    case breakTime
+    case alarmTime
+    
+    public var dataStore: TimePicker.DataStore {
+      switch self {
+      case TimePicker.alarmTime:
+        return TimePicker.DataStore()
+        
+      case TimePicker.focusTime:
+        return TimePicker.DataStore()
+        
+      case TimePicker.breakTime:
+        return TimePicker.DataStore()
+      }
+    }
+  }
+  
+  public struct Button {
+    public let topMargin: CGFloat
+  }
+}
+
+extension Constant.SettingTimeView.TimePicker {
+  public struct DataStore {}
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
@@ -1,0 +1,12 @@
+//
+//  File.swift
+//  
+//
+//  Created by SONG on 5/9/24.
+//
+
+import Foundation
+
+extension Constant.SettingTimeView {
+  
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
@@ -41,17 +41,18 @@ extension Constant.SettingTimeView {
       case TimePicker.alarmTime:
         return TimePicker.DataStore(
           highlightedView: HighlightedView(
-            leading: 40.0,
-            trailing: -20.0,
-            height: 33.0
+            leading: 42.5,
+            trailing: -27.5,
+            height: 33.0,
+            cornerRadius: 5.0
           ),
           hourUnitLabel: HourUnitLabel(
-            text: Content.hour,
-            leading: 34.0
+            text: Content.hourAlarm,
+            leading: 35.0
           ),
           minuteUnitLabel: MinuteUnitLabel(
             text: Content.minute,
-            leading: 15.0
+            leading: 56.0
           ),
           secondUnitLabel: nil,
           pickerView: PickerView(
@@ -59,6 +60,7 @@ extension Constant.SettingTimeView {
             width: 214.0,
             height: 216.0,
             rowHeight: 43.0,
+            widthForComponent: 80.0,
             numberOfComponents: 2,
             numberOfRowsInComponent: [24, 60]
           )
@@ -67,12 +69,13 @@ extension Constant.SettingTimeView {
       case TimePicker.focusTime:
         return TimePicker.DataStore(
           highlightedView: HighlightedView(
-            leading: 40.0,
-            trailing: -20.0,
-            height: 33.0
+            leading: 45.0,
+            trailing: -27.5,
+            height: 33.0,
+            cornerRadius: 5.0
           ),
           hourUnitLabel: HourUnitLabel(
-            text: Content.hour,
+            text: Content.hourDefault,
             leading: 34.0
           ),
           minuteUnitLabel: MinuteUnitLabel(
@@ -88,6 +91,7 @@ extension Constant.SettingTimeView {
             width: 320.0,
             height: 216.0,
             rowHeight: 43.0,
+            widthForComponent: 90.0,
             numberOfComponents: 3,
             numberOfRowsInComponent: [24, 60, 60]
           )
@@ -96,12 +100,13 @@ extension Constant.SettingTimeView {
       case TimePicker.breakTime:
         return TimePicker.DataStore(
           highlightedView: HighlightedView(
-            leading: 40.0,
-            trailing: -20.0,
-            height: 33.0
+            leading: 45.0,
+            trailing: -27.5,
+            height: 33.0,
+            cornerRadius: 5.0
           ),
           hourUnitLabel: HourUnitLabel(
-            text: Content.hour,
+            text: Content.hourDefault,
             leading: 34.0
           ),
           minuteUnitLabel: MinuteUnitLabel(
@@ -117,6 +122,7 @@ extension Constant.SettingTimeView {
             width: 320.0,
             height: 216.0,
             rowHeight: 43.0,
+            widthForComponent: 90.0,
             numberOfComponents: 3,
             numberOfRowsInComponent: [2, 60, 60]
           )
@@ -132,7 +138,8 @@ extension Constant.SettingTimeView {
 
 extension Constant.SettingTimeView.TimePicker {
   private enum Content {
-    static let hour = "시간"
+    static let hourDefault = "시간"
+    static let hourAlarm = "시"
     static let minute = "분"
     static let second = "초"
   }
@@ -149,6 +156,7 @@ extension Constant.SettingTimeView.TimePicker {
     public let leading: CGFloat
     public let trailing: CGFloat
     public let height: CGFloat
+    public let cornerRadius: CGFloat
   }
   
   public struct HourUnitLabel {
@@ -171,6 +179,7 @@ extension Constant.SettingTimeView.TimePicker {
     public let width: CGFloat
     public let height: CGFloat
     public let rowHeight: CGFloat
+    public let widthForComponent: CGFloat
     public let numberOfComponents: Int
     public let numberOfRowsInComponent: [Int]
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -17,4 +17,5 @@ public enum Constant {
   public enum GroupNameLabel {}
   public enum Styled {}
   public enum ColorPickerList {}
+  public enum SettingTimeView {}
 }


### PR DESCRIPTION
## 💡 관련 이슈
  - #133
## 🎉 변경 사항

- Constant+SettingTimeView.swift 파일을 추가하였습니다. 

## 📌 PR Point

<img width="336" alt="스크린샷 2024-05-09 오후 1 52 35" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/f7e4c232-3a7f-4087-ac62-6196bec06b48">


- ↑ 위 이미지의 설명 기반으로, 컴포넌트 생성에 필요한 Constant들을 카테고리화 하였습니다. 

<img width="867" alt="스크린샷 2024-05-09 오후 4 50 00" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/557f8102-7111-4523-bd9c-15d9c6794ba3">

```swift
let alarmTimepickerView = SettingTimeView(
      with: someUIButton,
      for: SettingTimeView.Configuration.alarmTimeSetting
    )
```

- ↑ 사용하는 쪽에서 이렇게 생성합니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?