### PR TITLE
AlarmTimeView 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
@@ -1,0 +1,22 @@
+//
+//  AlarmTimeView.swift
+//
+//
+//  Created by Wood on 5/10/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+import ToDoGardenUIResource
+
+public final class AlarmTimeView: UIView {
+  public init() {
+    super.init(frame: CGRect.zero)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
@@ -11,12 +11,40 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 public final class AlarmTimeView: UIView {
-  public init() {
+  private var model: AlarmTimeView.Model
+
+  public init(model: AlarmTimeView.Model) {
+    self.model = model
     super.init(frame: CGRect.zero)
   }
 
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: Model
+
+extension AlarmTimeView {
+  public struct Model {
+    let labelText: String
+    let alarmTime: String
+    let borderWidth: CGFloat
+    let cornerRadius: CGFloat
+    let contentInsets: NSDirectionalEdgeInsets
+
+    public static let primary = Self(
+      labelText: Constant.AlarmTimeView.StringLiteral.TimeLabel.defaultText,
+      alarmTime: Constant.AlarmTimeView.StringLiteral.AlarmSettingButton.defaultTimeText,
+      borderWidth: Constant.AlarmTimeView.Layout.borderWidth,
+      cornerRadius: Constant.AlarmTimeView.Layout.cornerRadius,
+      contentInsets: NSDirectionalEdgeInsets(
+        top: Constant.AlarmTimeView.Layout.AlarmSettingButton.ContentInsets.top,
+        leading: Constant.AlarmTimeView.Layout.AlarmSettingButton.ContentInsets.leading,
+        bottom: Constant.AlarmTimeView.Layout.AlarmSettingButton.ContentInsets.bottom,
+        trailing: Constant.AlarmTimeView.Layout.AlarmSettingButton.ContentInsets.trailing
+      )
+    )
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
@@ -27,6 +27,20 @@ public final class AlarmTimeView: UIView {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+
+  public func enable() {
+    self.isUserInteractionEnabled = true
+    self.timeLabel.textColor = UIColor.toDoGardenGreenDark
+    self.alarmSettingButton.isEnabled = true
+    self.layer.borderColor = UIColor.toDoGardenGreenDark.cgColor
+  }
+
+  public func disable() {
+    self.isUserInteractionEnabled = false
+    self.timeLabel.textColor = UIColor.toDoGardenGray3
+    self.alarmSettingButton.isEnabled = false
+    self.layer.borderColor = UIColor.toDoGardenGray2.cgColor
+  }
 }
 
 // MARK: Private Functions

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
@@ -157,3 +157,14 @@ extension AlarmTimeView {
     )
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let alarmTimeView = AlarmTimeView(model: AlarmTimeView.Model.primary)
+  alarmTimeView.usingAutolayout()
+  alarmTimeView.widthAnchor.constraint(equalToConstant: 315).isActive = true
+  alarmTimeView.heightAnchor.constraint(equalToConstant: 53).isActive = true
+  return alarmTimeView
+}
+#endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
@@ -41,6 +41,10 @@ public final class AlarmTimeView: UIView {
     self.alarmSettingButton.isEnabled = false
     self.layer.borderColor = UIColor.toDoGardenGray2.cgColor
   }
+
+  public func updateAlarmTime(with text: String) {
+    self.setupAlarmSettingButtonTitle(with: text)
+  }
 }
 
 // MARK: Private Functions

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
@@ -12,15 +12,80 @@ import ToDoGardenUIResource
 
 public final class AlarmTimeView: UIView {
   private var model: AlarmTimeView.Model
+  private var timeLabel: UILabel
+  private var alarmSettingButton: UIButton
 
   public init(model: AlarmTimeView.Model) {
     self.model = model
+    self.timeLabel = UILabel()
+    self.alarmSettingButton = UIButton()
     super.init(frame: CGRect.zero)
+    self.setup()
   }
 
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: Private Functions
+
+extension AlarmTimeView {
+  private func setup() {
+    self.setupBorder()
+    self.setupTimeLabel()
+    self.setupAlarmSettingButton()
+  }
+
+  private func setupBorder() {
+    self.layer.cornerRadius = self.model.cornerRadius
+    self.layer.borderWidth = self.model.borderWidth
+    self.layer.borderColor = UIColor.toDoGardenGreenDark.cgColor
+  }
+
+  private func setupTimeLabel() {
+    self.timeLabel.text = self.model.labelText
+    self.timeLabel.font = UIFont.pretendardBodySemiBold
+    self.timeLabel.textColor = UIColor.toDoGardenGreenDark
+  }
+
+  private func setupAlarmSettingButton() {
+    self.setupAlarmSettingButtonConfiguration()
+    self.setupAlarmSettingButtonUpdateHandler()
+    self.setupAlarmSettingButtonTitle(with: self.model.alarmTime)
+  }
+
+  private func setupAlarmSettingButtonConfiguration() {
+    var configuration = UIButton.Configuration.filled()
+    configuration.contentInsets = model.contentInsets
+    configuration.baseBackgroundColor = UIColor.toDoGardenGreenBackground
+    self.alarmSettingButton.configuration = configuration
+  }
+
+  private func setupAlarmSettingButtonUpdateHandler() {
+    self.alarmSettingButton.configurationUpdateHandler = { button in
+      switch button.state {
+      case UIControl.State.normal:
+        button.configuration?.attributedTitle?.foregroundColor = UIColor.toDoGardenGreenDark
+        button.configuration?.baseBackgroundColor = UIColor.toDoGardenGreenBackground
+      case UIControl.State.disabled:
+        button.configuration?.attributedTitle?.foregroundColor = UIColor.toDoGardenGray3
+      default:
+        break
+      }
+    }
+  }
+
+  private func setupAlarmSettingButtonTitle(with text: String) {
+    let attributes = AttributeContainer(
+      [
+        NSAttributedString.Key.font: UIFont.pretendardBodyMedium,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    )
+    let attributedTitle = AttributedString(text, attributes: attributes)
+    self.alarmSettingButton.configuration?.attributedTitle = attributedTitle
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
@@ -36,6 +36,8 @@ extension AlarmTimeView {
     self.setupBorder()
     self.setupTimeLabel()
     self.setupAlarmSettingButton()
+    self.addSubviews()
+    self.setupSubviewsLayout()
   }
 
   private func setupBorder() {
@@ -86,6 +88,48 @@ extension AlarmTimeView {
     )
     let attributedTitle = AttributedString(text, attributes: attributes)
     self.alarmSettingButton.configuration?.attributedTitle = attributedTitle
+  }
+}
+
+// MARK: Auto Layout
+
+extension AlarmTimeView {
+  private func addSubviews() {
+    self.addSubview(self.timeLabel)
+    self.addSubview(self.alarmSettingButton)
+  }
+
+  private func setupSubviewsLayout() {
+    self.setupTimeLabelLayout()
+    self.setupAlarmSettingButtonLayout()
+  }
+
+  private func setupTimeLabelLayout() {
+    self.timeLabel.usingAutolayout()
+
+    NSLayoutConstraint.activate(
+      [
+        self.timeLabel.leadingAnchor.constraint(
+          equalTo: self.leadingAnchor,
+          constant: Constant.AlarmTimeView.Layout.TimeLabel.leadingMargin
+        ),
+        self.timeLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+      ]
+    )
+  }
+
+  private func setupAlarmSettingButtonLayout() {
+    self.alarmSettingButton.usingAutolayout()
+
+    NSLayoutConstraint.activate(
+      [
+        self.alarmSettingButton.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: -Constant.AlarmTimeView.Layout.AlarmSettingButton.trailingMargin
+        ),
+        self.alarmSettingButton.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+      ]
+    )
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #132

## 🎉 변경 사항
- 투두 수정 화면에서 알림 시간을 설정할 때 사용하는 AlarmTimeView를 추가하였습니다.

## 📌 PR Point
Figma 디자인에 따라 스위치를 이용해 활성 / 비활성화 상태로 바꿀 수 있도록 enable / disable 메서드를 구현하였습니다.
<img width="249" alt="스크린샷 2024-05-10 20 33 24" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/7e8bb7cb-eaa3-4fa1-8af2-d25b38f21b16">

|enable|disable|
|--|--|
|<img width="300" height="650" alt="스크린샷 2024-05-10 20 29 45" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/7a5965a7-c41b-4423-aefe-af89ede186d1">|<img width="300" height="650" alt="스크린샷 2024-05-10 20 30 06" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/ac891fc4-b4ba-45c9-8bc9-41faf6449f21">|

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?