### PR TITLE
OnlyTodayButton Style Constant 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+Styled+Button.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+Styled+Button.swift
@@ -1,0 +1,35 @@
+//
+//  Constant+Styled+Button.swift
+//
+//
+//  Created by Wood on 5/12/24.
+//
+
+import Foundation
+
+extension Constant.Styled {
+  public enum Button {}
+}
+
+extension Constant.Styled.Button {
+  public enum OnlyToday {}
+}
+
+// MARK: Only Today
+
+extension Constant.Styled.Button.OnlyToday {
+  public enum Layout {}
+}
+
+extension Constant.Styled.Button.OnlyToday.Layout {
+  public enum ImageView {}
+  public enum TitleLabel {}
+}
+
+extension Constant.Styled.Button.OnlyToday.Layout.ImageView {
+  static let trailingMargin: CGFloat = 12
+}
+
+extension Constant.Styled.Button.OnlyToday.Layout.TitleLabel {
+  static let leadingMargin: CGFloat = 16
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+Styled+Button.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+Styled+Button.swift
@@ -19,6 +19,7 @@ extension Constant.Styled.Button {
 
 extension Constant.Styled.Button.OnlyToday {
   public enum Layout {}
+  public enum StringLiteral {}
 }
 
 extension Constant.Styled.Button.OnlyToday.Layout {
@@ -32,4 +33,8 @@ extension Constant.Styled.Button.OnlyToday.Layout.ImageView {
 
 extension Constant.Styled.Button.OnlyToday.Layout.TitleLabel {
   static let leadingMargin: CGFloat = 16
+}
+
+extension Constant.Styled.Button.OnlyToday.StringLiteral {
+  static let defaultTitle: String = "오늘만 할래요"
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #140 

## 🎉 변경 사항
- OnlyTodayButton 스타일에 사용되는 Constant를 추가하였습니다.

## 📌 PR Point
- 버튼 레이아웃 관련 상수 추가
- 버튼 기본 타이틀 StringLiteral 추가

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?