### PR TITLE
ToDoRepeatSelectionView Constant 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoRepeatSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoRepeatSelectionView.swift
@@ -9,6 +9,7 @@ import Foundation
 
 extension Constant.ToDoRepeatSelectionView {
   public enum Layout {}
+  public enum StringLiteral {}
 }
 
 extension Constant.ToDoRepeatSelectionView.Layout {
@@ -23,4 +24,13 @@ extension Constant.ToDoRepeatSelectionView.Layout.RepetitionLabel {
 
 extension Constant.ToDoRepeatSelectionView.Layout.SelectionImageView {
   public static let trailingMargin: CGFloat = 12.0
+}
+
+extension Constant.ToDoRepeatSelectionView.StringLiteral {
+  public enum RepetitionLabel {}
+}
+
+extension Constant.ToDoRepeatSelectionView.StringLiteral.RepetitionLabel {
+  public static let onlyToday: String = "오늘만 할래요"
+  public static let anotherDay: String = "다른 날도 할래요"
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoRepeatSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoRepeatSelectionView.swift
@@ -1,0 +1,26 @@
+//
+//  Constant+ToDoRepeatSelectionView.swift
+//
+//
+//  Created by Wood on 5/14/24.
+//
+
+import Foundation
+
+extension Constant.ToDoRepeatSelectionView {
+  public enum Layout {}
+}
+
+extension Constant.ToDoRepeatSelectionView.Layout {
+  public enum RepetitionLabel {}
+  public enum SelectionImageView {}
+}
+
+extension Constant.ToDoRepeatSelectionView.Layout.RepetitionLabel {
+  public static let topMargin: CGFloat = 7.5
+  public static let leadingMargin: CGFloat = 16.0
+}
+
+extension Constant.ToDoRepeatSelectionView.Layout.SelectionImageView {
+  public static let trailingMargin: CGFloat = 12.0
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -19,4 +19,5 @@ public enum Constant {
   public enum AlarmTimeView {}
   public enum ColorPickerList {}
   public enum SettingTimeView {}
+  public enum ToDoRepeatSelectionView {}
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #143 

## 🎉 변경 사항
- ToDoRepeatSelectionView에서 사용하는 Constant를 추가하였습니다.

## 📌 PR Point
1. 표시할 Label, ImageView의 레이아웃 관련 상수들을 추가하였습니다.
2. 레이블에 표시할 기본 텍스트 StringLiteral을 추가하였습니다.

아래는 추가할 버튼에 대한 Figma 디자인입니다.

<img width="300" alt="스크린샷 2024-05-16 13 10 55" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/6c6e6cfd-efb8-4075-b1ed-eb33875dd4c8">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?