### PR TITLE
GroupNameLabel에 repeatOtherDays 케이스 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupNameLabel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupNameLabel.swift
@@ -98,6 +98,9 @@ extension GroupNameLabel.Configuration {
   public static let primaryConfigration = GroupNameLabel.Configuration.primary(
     PrimaryModel.defaultPrimaryModel
   )
+  public static let repeatOtherDaysConfiguration = GroupNameLabel.Configuration.primary(
+    PrimaryModel.repeatOtherDaysModel
+  )
 }
 
 // MARK: Models
@@ -121,6 +124,19 @@ extension GroupNameLabel.Configuration {
       font: UIFont.pretendardBodyBold,
       textColor: UIColor.toDoGardenGreenDark,
       backgroundColor: UIColor.toDoGardenGreenBackground
+    )
+    
+    static let repeatOtherDaysModel =  GroupNameLabel.Configuration.PrimaryModel(
+      cornerRadius: CGFloat.zero,
+      textPadding: UIEdgeInsets(
+        top: CGFloat.zero,
+        left: CGFloat.zero,
+        bottom: CGFloat.zero,
+        right: CGFloat.zero
+      ),
+      font: UIFont.pretendardBodySemiBold,
+      textColor: UIColor.toDoGardenGreenDark,
+      backgroundColor: UIColor.clear
     )
   }
 }


### PR DESCRIPTION
- repeatOtherDaysButton에 필요한 label을 만들기위해 스태틱 인스턴스를 추가 선언합니다.

## 💡 관련 이슈
- #145 

## 🎉 변경 사항
- repeatOtherDays 케이스를 추가했습니다. 

## 📌 PR Point
- UILabel 의 배경색을 clear로 지정해서 쓸 수 있을 것이라고 생각했지만, Styled.row 내에서 GroupNameLabel를 사용하고 있었기에, 일관성을 맞추기 위한 확장을 하였습니다. 

![스크린샷 2024-05-16 오후 4 20 28](https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/a728801b-543c-44ee-aa8d-8e45f8985f25)

![스크린샷 2024-05-16 오후 4 20 10](https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/a7ee478a-c817-422e-b814-5575d143167c)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?