### PR TITLE
RepeatOtherDaysView를 위한 Styled.Row 확장 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
@@ -29,6 +29,12 @@ extension Styled {
       self.build()
     }
     
+    public init(configuration: Configuration, with buttons: [UIView]) {
+      self.configutration = configuration
+      super.init(frame: CGRect.zero)
+      self.build(with: buttons)
+    }
+    
     @available(*, unavailable)
     public required init?(coder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
@@ -43,6 +49,17 @@ extension Styled {
         self.buildListPrimaryStyle(stack: stack, model: listPrimaryModel)
       case let Configuration.todoList(todoListModel):
         self.buildTodoListStyle(stack: stack, model: todoListModel)
+      case let Configuration.repeatOtherDays(repeatOtherDaysModel):
+        self.buildRepeatOtherDaysStyle(stack: stack, model: repeatOtherDaysModel, views: nil)
+      }
+    }
+    
+    private func build(with views: [UIView]) {
+      let stack = UIStackView(frame: CGRect.zero)
+      switch self.configutration {
+      case let Configuration.repeatOtherDays(repeatOtherDaysModel):
+        self.buildRepeatOtherDaysStyle(stack: stack, model: repeatOtherDaysModel, views: views)
+      default: break
       }
     }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
@@ -29,10 +29,10 @@ extension Styled {
       self.build()
     }
     
-    public init(configuration: Configuration, with buttons: [UIView]) {
+    public init(configuration: Configuration, with views: [UIView]) {
       self.configutration = configuration
       super.init(frame: CGRect.zero)
-      self.build(with: buttons)
+      self.build(with: views)
     }
     
     @available(*, unavailable)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
@@ -23,10 +23,17 @@ extension Styled.Row {
       }
       return nil
     }
+    var repeatOtherDaysModel: RepeatOtherDaysModel? {
+      if case let Self.repeatOtherDays(model) = self {
+        return model
+      }
+      return nil
+    }
     
     case profile(ProfileModel)
     case listPrimary(ListPrimaryModel)
     case todoList(TodoListModel)
+    case repeatOtherDays(RepeatOtherDaysModel)
   }
 }
 
@@ -72,6 +79,10 @@ extension Styled.Row.Configuration {
   public struct ListPrimaryModel: Equatable {
     let title: String
     let color: UIColor
+  }
+  
+  public struct RepeatOtherDaysModel: Equatable {
+    let title: String
   }
   
   public struct TodoListModel: Equatable {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/RepeatOtherDaysStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/RepeatOtherDaysStyle.swift
@@ -1,0 +1,41 @@
+//
+//  OtherDaysListStyle.swift
+//
+//
+//  Created by SONG on 5/14/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+
+extension Styled.Row {
+  func buildRepeatOtherDaysStyle(stack: UIStackView, model: Configuration.RepeatOtherDaysModel, views: [UIView]?) {
+    stack.alignment = UIStackView.Alignment.center
+    self.buildStack(
+      stack: stack,
+      edgeInsets: Constant.Styled.Row.ListPrimary.stackEdgeInsets
+    )
+    let labelConfiguration = GroupNameLabel.Configuration.self
+    let label = GroupNameLabel(
+      configuration: labelConfiguration.primary(
+        labelConfiguration.PrimaryModel.repeatOtherDaysModel
+      )
+    )
+    label.text = model.title
+    stack.addArrangedSubview(label)
+    stack.addSpacing()
+    self.buildViews(stack: stack, views: views)
+  }
+  
+  func buildViews(stack: UIStackView, views: [UIView]?) {
+    guard let views = views else {
+      return
+    }
+    
+    for view in views {
+      stack.addArrangedSubview(view)
+      stack.addSpacing(Constant.Styled.Row.RepeatOtherDays.stackSpacing)
+    }
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+Styled+Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+Styled+Row.swift
@@ -10,6 +10,7 @@ public extension Constant.Styled.Row {
   enum ToDoList {}
   enum Profile {}
   enum ListPrimary {}
+  enum RepeatOtherDays {}
 }
 
 public extension Constant.Styled.Row.ToDoList {
@@ -34,4 +35,8 @@ public extension Constant.Styled.Row.ListPrimary {
   static let stackEdgeInsets = NSDirectionalEdgeInsets(top: 0, leading: 14, bottom: 0, trailing: 14)
   static let colorViewCornerRadius = CGFloat(12)
   static let colorViewSize = CGSize(width: 24, height: 24)
+}
+
+public extension Constant.Styled.Row.RepeatOtherDays {
+  static let stackSpacing = CGFloat(5.0)
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #142 
## 🎉 변경 사항
- Styled.Row를 이용하여 RepeatOtherDays에 사용될 row형태의 view를 만들 수 있게 확장하였습니다. 
- 이니셜라이저를 추가 정의하고, RepeatOtherDays Row를 만드는 메서드를 추가하였습니다. 
## 📌 PR Point

![스크린샷 2024-05-16 오후 5 08 55](https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/95cce3fa-433f-4531-b4f5-7b9613b16900)

- ↑ 위 이미지처럼, 외부의 view객체를 이니셜라이저를 통해 전달받을 수 있습니다. 

- [UIView] 를 파라미터로 전달받지만, 사실상 [UIButton]을 넣기위한 목적으로 확장하였습니다. 

- RepeatOtherDays에 쓰이는 우측 view객체는 버튼입니다. 컴포넌트 내부에 버튼이 존재하면 기능 구현시 해당 버튼의 동작을 제어하기 까다로울 것이라고 생각합니다. 이니셜라이저를 통해 우측에 배치될 버튼을 제공받는 형태로 구성하고, 컴포넌트 외부에서 해당 버튼에 addAction/addTarget 해주어 버튼터치에 대한 동작을 VIP사이클 내에서 지정하는 방식을 채택하였습니다. 

- 기존 Styled.Row 기능들에 대한 수정사항은 없습니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?