### PR TITLE
LightRoundRectButton constant추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+LightRoundRectButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+LightRoundRectButton.swift
@@ -8,7 +8,14 @@
 import UIKit.UIGeometry
 
 extension Constant.LightRoundRectButton {
-  public static let contentsInsets = NSDirectionalEdgeInsets(top: 4, leading: 10, bottom: 4, trailing: 10)
+  public enum Layout {
+    public static let contentsInsets = NSDirectionalEdgeInsets(
+      top: 4,
+      leading: 10,
+      bottom: 4,
+      trailing: 10
+    )
+  }
   
   public enum StringLiteral {
     public static let everyday = "매일"

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+LightRoundRectButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+LightRoundRectButton.swift
@@ -1,0 +1,19 @@
+//
+//  Constant+LightRoundRectButton.swift
+//
+//
+//  Created by SONG on 5/17/24.
+//
+
+import UIKit.UIGeometry
+
+extension Constant.LightRoundRectButton {
+  public static let contentsInsets = NSDirectionalEdgeInsets(top: 4, leading: 10, bottom: 4, trailing: 10)
+  
+  public enum StringLiteral {
+    public static let everyday = "매일"
+    public static let timeSelection = "시간지정"
+    public static let start = "시작"
+    public static let end = "종료"
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -21,4 +21,5 @@ public enum Constant {
   public enum ColorPickerList {}
   public enum SettingTimeView {}
   public enum ToDoRepeatSelectionView {}
+  public enum LightRoundRectButton {}
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #148 
## 🎉 변경 사항
- LightRoundRectButton의 상수를 정의했습니다. 
## 📌 PR Point

<img width="138" alt="스크린샷 2024-05-17 오후 5 13 46" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/f5fc376b-427f-4b5a-9081-d00a4ca5270f">

<img width="298" alt="스크린샷 2024-05-17 오후 5 15 50" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/f9d0d4a3-8810-47d9-b3e8-000ee968c5b9">

- 이놈들 같은 녀석들 같은데, 하나로 통합하는거 어떤가요? 제가 UIButton extension으로 만들어 놨습니다. 
- 일단 LightRoundRectButton로 명명해서 Constant에 선언해놓겠습니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?