### PR TITLE
ToDoGardenTimePicker 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -100,11 +100,57 @@ final private class HighlightedView: UIView {
     super.init(frame: CGRect.zero)
     self.backgroundColor = UIColor.toDoGardenGreenBackground
     self.layer.cornerRadius = configuration.highlightedView.cornerRadius
+    self.buildLabels(with: configuration)
   }
   
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func buildLabels(with constants: Constant.SettingTimeView.TimePicker.DataStore) {
+    self.setupUnitLabel(with: constants.hourUnitLabel.text, leading: constants.hourUnitLabel.leading)
+    self.setupUnitLabel(with: constants.minuteUnitLabel.text, centerX: constants.minuteUnitLabel.leading)
+    
+    guard let secondLabelConstants = constants.secondUnitLabel else {
+      return
+    }
+    
+    self.setupUnitLabel(with: secondLabelConstants.text, trailing: secondLabelConstants.trailing)
+  }
+  
+  private func setupUnitLabel(
+    with text: String,
+    leading: CGFloat? = nil,
+    centerX: CGFloat? = nil,
+    trailing: CGFloat? = nil
+  ) {
+    let label = createLabel(with: text)
+    label.usingAutolayout()
+    self.addSubview(label)
+    
+    if let leading = leading {
+      NSLayoutConstraint.activate([
+        label.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: leading),
+        label.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+      ])
+    } else if let centerX = centerX {
+      NSLayoutConstraint.activate([
+        label.centerXAnchor.constraint(equalTo: self.centerXAnchor, constant: centerX),
+        label.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+      ])
+    } else if let trailing = trailing {
+      NSLayoutConstraint.activate([
+        label.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: trailing),
+        label.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+      ])
+    }
+  }
+  
+  private func createLabel(with text: String) -> UILabel {
+    let label = UILabel()
+    label.attributedText = text.applyTextAttributes()
+    return label
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -15,6 +15,7 @@ final public class ToDoGardenTimePicker: UIPickerView {
   public init(configuration: Constant.SettingTimeView.TimePicker) {
     self.configuration = configuration
     super.init(frame: CGRect.zero)
+    self.dataSource = self
     self.backgroundColor = UIColor.clear
   }
   
@@ -92,6 +93,30 @@ final public class ToDoGardenTimePicker: UIPickerView {
         highlightedView.heightAnchor.constraint(equalToConstant: self.configuration.dataStore.highlightedView.height)
       ]
     )
+  }
+}
+
+extension ToDoGardenTimePicker: UIPickerViewDataSource {
+  public func numberOfComponents(in pickerView: UIPickerView) -> Int {
+    return self.configuration.dataStore.pickerView.numberOfComponents
+  }
+  
+  public func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+    return self.configuration.dataStore.pickerView.numberOfRowsInComponent[component]
+  }
+  
+  public func pickerView(
+    _ pickerView: UIPickerView,
+    viewForRow row: Int,
+    forComponent component: Int,
+    reusing view: UIView?
+  ) -> UIView {
+    let view = UILabel()
+    view.textAlignment = NSTextAlignment.center
+    view.text = String(row)
+    view.font = UIFont.pretendardHeadBold
+    view.textColor = UIColor.toDoGardenGreenDark
+    return view
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -22,4 +22,19 @@ final public class ToDoGardenTimePicker: UIPickerView {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+  
+  override public func layoutSubviews() {
+    super.layoutSubviews()
+    guard !self.subviews.isEmpty else {
+      return
+    }
+    
+    self.subviews[Int.zero].backgroundColor = UIColor.clear
+    
+    guard let lastSubview = self.subviews.last else {
+      return
+    }
+    
+    self.sendSubviewToBack(lastSubview)
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -1,0 +1,25 @@
+//
+//  ToDoGardenTimePicker.swift
+//
+//
+//  Created by SONG on 5/20/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+
+final public class ToDoGardenTimePicker: UIPickerView {
+  private let configuration: Constant.SettingTimeView.TimePicker
+  
+  public init(configuration: Constant.SettingTimeView.TimePicker) {
+    self.configuration = configuration
+    super.init(frame: CGRect.zero)
+    self.backgroundColor = UIColor.clear
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -34,9 +34,9 @@ final public class ToDoGardenTimePicker: UIPickerView {
   }
   
   override public var intrinsicContentSize: CGSize {
-    let width = self.configuration.dataStore.pickerView.width
-    let height = self.configuration.dataStore.pickerView.height
-    return CGSize(width: width, height: height)
+    return self.configuration.dataStore.pickerView.size
+  }
+  
   }
   
   public func selectedTime() -> Date? {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -15,6 +15,7 @@ final public class ToDoGardenTimePicker: UIPickerView {
   public init(configuration: Constant.SettingTimeView.TimePicker) {
     self.configuration = configuration
     super.init(frame: CGRect.zero)
+    self.delegate = self
     self.dataSource = self
     self.backgroundColor = UIColor.clear
   }
@@ -93,6 +94,16 @@ final public class ToDoGardenTimePicker: UIPickerView {
         highlightedView.heightAnchor.constraint(equalToConstant: self.configuration.dataStore.highlightedView.height)
       ]
     )
+  }
+}
+
+extension ToDoGardenTimePicker: UIPickerViewDelegate {
+  public func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+    return self.configuration.dataStore.pickerView.rowHeight
+  }
+  
+  public func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+    return self.configuration.dataStore.pickerView.widthForComponent
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -107,3 +107,16 @@ final private class HighlightedView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
 }
+
+fileprivate extension String {
+  func applyTextAttributes() -> NSAttributedString {
+    let attributedString = NSAttributedString(
+      string: self,
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardHeadBold,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    )
+    return attributedString
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import FoundationExtension
 import ToDoGardenUIConstant
 
 final public class ToDoGardenTimePicker: UIPickerView {
@@ -178,21 +179,12 @@ final private class HighlightedView: UIView {
   
   private func createLabel(with text: String) -> UILabel {
     let label = UILabel()
-    label.attributedText = text.applyTextAttributes()
+    let attributes = [
+      NSAttributedString.Key.font: UIFont.pretendardHeadBold,
+      NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+    ]
+    label.attributedText = text.applyTextAttributes(attributes: attributes)
     return label
-  }
-}
-
-fileprivate extension String {
-  func applyTextAttributes() -> NSAttributedString {
-    let attributedString = NSAttributedString(
-      string: self,
-      attributes: [
-        NSAttributedString.Key.font: UIFont.pretendardHeadBold,
-        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
-      ]
-    )
-    return attributedString
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -37,39 +37,8 @@ final public class ToDoGardenTimePicker: UIPickerView {
     return self.configuration.dataStore.pickerView.size
   }
   
-  }
-  
-  public func selectedTime() -> Date? {
-    let calendar = Calendar.current
-    var dateComponents = calendar.dateComponents(
-      [
-        Calendar.Component.year,
-        Calendar.Component.month,
-        Calendar.Component.day,
-        Calendar.Component.hour,
-        Calendar.Component.minute,
-        Calendar.Component.second
-      ],
-      from: Date()
-    )
-    for component in 0..<self.numberOfComponents {
-      let selectedRow = self.selectedRow(inComponent: component)
-      switch component {
-      case 0:
-        dateComponents.hour? += selectedRow
-      case 1:
-        dateComponents.minute? += selectedRow
-      case 2:
-        dateComponents.second? += selectedRow
-      default: break
-      }
-    }
-    return calendar.date(from: dateComponents)
-  }
-  
   private func addHighlightedView() {
     let highlightedView = HighlightedView(configuration: self.configuration.dataStore)
-    
     self.addSubview(highlightedView)
     
     highlightedView.translatesAutoresizingMaskIntoConstraints = false

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -71,4 +71,39 @@ final public class ToDoGardenTimePicker: UIPickerView {
     }
     return calendar.date(from: dateComponents)
   }
+  
+  private func addHighlightedView() {
+    let highlightedView = HighlightedView(configuration: self.configuration.dataStore)
+    
+    self.addSubview(highlightedView)
+    
+    highlightedView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate(
+      [
+        highlightedView.leadingAnchor.constraint(
+          equalTo: self.leadingAnchor,
+          constant: self.configuration.dataStore.highlightedView.leading
+        ),
+        highlightedView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+        highlightedView.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: self.configuration.dataStore.highlightedView.trailing
+        ),
+        highlightedView.heightAnchor.constraint(equalToConstant: self.configuration.dataStore.highlightedView.height)
+      ]
+    )
+  }
+}
+
+final private class HighlightedView: UIView {
+  init(configuration: Constant.SettingTimeView.TimePicker.DataStore) {
+    super.init(frame: CGRect.zero)
+    self.backgroundColor = UIColor.toDoGardenGreenBackground
+    self.layer.cornerRadius = configuration.highlightedView.cornerRadius
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -11,9 +11,14 @@ import ToDoGardenUIConstant
 
 final public class ToDoGardenTimePicker: UIPickerView {
   private let configuration: Constant.SettingTimeView.TimePicker
+  private let dateBuilder: DateBuilder
   
-  public init(configuration: Constant.SettingTimeView.TimePicker) {
+  public init(
+    configuration: Constant.SettingTimeView.TimePicker,
+    dateBuilder: DateBuilder = DateBuilder()
+  ) {
     self.configuration = configuration
+    self.dateBuilder = dateBuilder
     super.init(frame: CGRect.zero)
     self.delegate = self
     self.dataSource = self
@@ -36,6 +41,14 @@ final public class ToDoGardenTimePicker: UIPickerView {
   
   override public var intrinsicContentSize: CGSize {
     return self.configuration.dataStore.pickerView.size
+  }
+  
+  func calculateDate() -> Date {
+    var components = [Int]()
+    for index in Int.zero..<self.numberOfComponents {
+      components.append(self.selectedRow(inComponent: index))
+    }
+    return self.dateBuilder.buildDate(from: components)
   }
   
   private func hideDefaultHighlightedView() {
@@ -180,5 +193,26 @@ fileprivate extension String {
       ]
     )
     return attributedString
+  }
+}
+
+public class DateBuilder {
+  private let baseDate: Date
+  
+  public init(baseDate: Date = Date()) {
+    self.baseDate = baseDate
+  }
+  
+  public func buildDate(from components: [Int]) -> Date {
+    var dateComponents = DateComponents()
+    dateComponents.hour = components[0]
+    dateComponents.minute = components[1]
+    
+    if components.count > 2 {
+      dateComponents.second = components[2]
+    }
+    
+    let calendar = Calendar.current
+    return calendar.date(byAdding: dateComponents, to: baseDate) ?? baseDate
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -28,17 +28,9 @@ final public class ToDoGardenTimePicker: UIPickerView {
   
   override public func layoutSubviews() {
     super.layoutSubviews()
-    guard !self.subviews.isEmpty else {
-      return
+    if let highlightedView = self.subviews.last(where: { $0 is HighlightedView }) {
+      self.sendSubviewToBack(highlightedView)
     }
-    
-    self.subviews[Int.zero].backgroundColor = UIColor.clear
-    
-    guard let lastSubview = self.subviews.last else {
-      return
-    }
-    
-    self.sendSubviewToBack(lastSubview)
   }
   
   override public var intrinsicContentSize: CGSize {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -18,6 +18,7 @@ final public class ToDoGardenTimePicker: UIPickerView {
     self.delegate = self
     self.dataSource = self
     self.backgroundColor = UIColor.clear
+    self.hideDefaultHighlightedView()
     self.addHighlightedView()
   }
   
@@ -35,6 +36,15 @@ final public class ToDoGardenTimePicker: UIPickerView {
   
   override public var intrinsicContentSize: CGSize {
     return self.configuration.dataStore.pickerView.size
+  }
+  
+  private func hideDefaultHighlightedView() {
+    self.layoutIfNeeded()
+    guard let defaultHighlightedView = self.subviews.last else {
+      return
+    }
+    
+    defaultHighlightedView.isHidden = true
   }
   
   private func addHighlightedView() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -43,4 +43,32 @@ final public class ToDoGardenTimePicker: UIPickerView {
     let height = self.configuration.dataStore.pickerView.height
     return CGSize(width: width, height: height)
   }
+  
+  public func selectedTime() -> Date? {
+    let calendar = Calendar.current
+    var dateComponents = calendar.dateComponents(
+      [
+        Calendar.Component.year,
+        Calendar.Component.month,
+        Calendar.Component.day,
+        Calendar.Component.hour,
+        Calendar.Component.minute,
+        Calendar.Component.second
+      ],
+      from: Date()
+    )
+    for component in 0..<self.numberOfComponents {
+      let selectedRow = self.selectedRow(inComponent: component)
+      switch component {
+      case 0:
+        dateComponents.hour? += selectedRow
+      case 1:
+        dateComponents.minute? += selectedRow
+      case 2:
+        dateComponents.second? += selectedRow
+      default: break
+      }
+    }
+    return calendar.date(from: dateComponents)
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -18,6 +18,7 @@ final public class ToDoGardenTimePicker: UIPickerView {
     self.delegate = self
     self.dataSource = self
     self.backgroundColor = UIColor.clear
+    self.addHighlightedView()
   }
   
   @available(*, unavailable)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -37,4 +37,10 @@ final public class ToDoGardenTimePicker: UIPickerView {
     
     self.sendSubviewToBack(lastSubview)
   }
+  
+  override public var intrinsicContentSize: CGSize {
+    let width = self.configuration.dataStore.pickerView.width
+    let height = self.configuration.dataStore.pickerView.height
+    return CGSize(width: width, height: height)
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -146,42 +146,50 @@ final private class HighlightedView: UIView {
   }
   
   private func buildLabels(with constants: Constant.SettingTimeView.TimePicker.DataStore) {
-    self.setupUnitLabel(with: constants.hourUnitLabel.text, leading: constants.hourUnitLabel.leading)
-    self.setupUnitLabel(with: constants.minuteUnitLabel.text, centerX: constants.minuteUnitLabel.leading)
+    self.setupUnitLabel(
+      with: constants.hourUnitLabel.text,
+      constraint: constants.hourUnitLabel.constraint
+    )
+    self.setupUnitLabel(
+      with: constants.minuteUnitLabel.text,
+      constraint: constants.minuteUnitLabel.constraint
+    )
     
     guard let secondLabelConstants = constants.secondUnitLabel else {
       return
     }
     
-    self.setupUnitLabel(with: secondLabelConstants.text, trailing: secondLabelConstants.trailing)
+    self.setupUnitLabel(
+      with: secondLabelConstants.text,
+      constraint: secondLabelConstants.constraint
+    )
   }
   
   private func setupUnitLabel(
     with text: String,
-    leading: CGFloat? = nil,
-    centerX: CGFloat? = nil,
-    trailing: CGFloat? = nil
+    constraint: Constant.SettingTimeView.TimePicker.Constraint
   ) {
     let label = createLabel(with: text)
     label.usingAutolayout()
     self.addSubview(label)
+    var layoutConstraints: [NSLayoutConstraint] = []
     
-    if let leading = leading {
-      NSLayoutConstraint.activate([
-        label.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: leading),
-        label.centerYAnchor.constraint(equalTo: self.centerYAnchor)
-      ])
-    } else if let centerX = centerX {
-      NSLayoutConstraint.activate([
-        label.centerXAnchor.constraint(equalTo: self.centerXAnchor, constant: centerX),
-        label.centerYAnchor.constraint(equalTo: self.centerYAnchor)
-      ])
-    } else if let trailing = trailing {
-      NSLayoutConstraint.activate([
-        label.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: trailing),
-        label.centerYAnchor.constraint(equalTo: self.centerYAnchor)
-      ])
+    switch constraint {
+    case .leading(let value):
+      layoutConstraints.append(
+        label.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: value)
+      )
+    case .centerX(let value):
+      layoutConstraints.append(
+        label.centerXAnchor.constraint(equalTo: self.centerXAnchor, constant: value)
+      )
+    case .trailing(let value):
+      layoutConstraints.append(
+        label.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: value)
+      )
     }
+    layoutConstraints.append(label.centerYAnchor.constraint(equalTo: self.centerYAnchor))
+    NSLayoutConstraint.activate(layoutConstraints)
   }
   
   private func createLabel(with text: String) -> UILabel {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #161 
## 🎉 변경 사항
- ToDoGardenTimePicker 를 추가합니다.

## 📌 PR Point

<img width="602" alt="스크린샷 2024-05-20 오후 5 45 24" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/fa78363a-b7ab-464a-8892-acf49e97242a">
<img width="485" alt="스크린샷 2024-05-20 오후 5 51 13" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/533c6706-f588-4fc5-bcc7-361363bb4506">

SettingTimeView 내에서 사용될 ToDoGardenTimePicker입니다.
3가지 케이스를 커버가능하며, 외부에서 선택된 시간에 대해 접근할 수 있도록 만들었습니다. 


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?