### PR TITLE
ToDoRepeatSelectionView 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
@@ -15,10 +15,13 @@ public class ToDoRepeatSelectionView: UIView {
   var repetitionLabel: UILabel
   var selectionImageView: UIImageView
 
+  var repetitionLabelTopAchor: NSLayoutConstraint
+
   public init(model: Model) {
     self.model = model
     self.repetitionLabel = UILabel()
     self.selectionImageView = UIImageView()
+    self.repetitionLabelTopAchor = NSLayoutConstraint()
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -36,6 +39,8 @@ extension ToDoRepeatSelectionView {
     self.setupLayer()
     self.setupRepetitionLabel()
     self.setupSelectionImageView()
+    self.addSubviews()
+    self.setupSubviewsLayout()
   }
 
   private func setupLayer() {
@@ -54,6 +59,49 @@ extension ToDoRepeatSelectionView {
 
     let image = self.model.selectedStateImage
     self.selectionImageView.image = image
+  }
+}
+
+// MARK: Set Auto Layout
+
+extension ToDoRepeatSelectionView {
+  private func addSubviews() {
+    self.addSubview(self.repetitionLabel)
+    self.addSubview(self.selectionImageView)
+  }
+
+  private func setupSubviewsLayout() {
+    self.setupLabelLayout()
+    self.setupSelectionImageViewLayout()
+  }
+
+  private func setupLabelLayout() {
+    self.repetitionLabel.usingAutolayout()
+
+    self.repetitionLabelTopAchor = self.repetitionLabel.topAnchor.constraint(
+      equalTo: self.topAnchor,
+      constant: Constant.ToDoRepeatSelectionView.Layout.RepetitionLabel.topMargin
+    )
+    self.repetitionLabelTopAchor.isActive = true
+
+    self.repetitionLabel.leadingAnchor.constraint(
+      equalTo: self.leadingAnchor,
+      constant: Constant.ToDoRepeatSelectionView.Layout.RepetitionLabel.leadingMargin
+    ).isActive = true
+  }
+
+  private func setupSelectionImageViewLayout() {
+    self.selectionImageView.usingAutolayout()
+
+    NSLayoutConstraint.activate(
+      [
+        self.selectionImageView.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: -Constant.ToDoRepeatSelectionView.Layout.SelectionImageView.trailingMargin
+        ),
+        self.selectionImageView.centerYAnchor.constraint(equalTo: self.repetitionLabel.centerYAnchor)
+      ]
+    )
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
@@ -176,3 +176,16 @@ extension ToDoRepeatSelectionView {
     )
   }
 }
+
+// MARK: Preview
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let view = ToDoRepeatSelectionView(model: ToDoRepeatSelectionView.Model.anotherDay)
+  view.usingAutolayout()
+  view.widthAnchor.constraint(equalToConstant: 315).isActive = true
+  view.heightAnchor.constraint(equalToConstant: 31).isActive = true
+  return view
+}
+#endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
@@ -16,11 +16,25 @@ public class ToDoRepeatSelectionView: UIView {
   public init(model: Model) {
     self.model = model
     super.init(frame: CGRect.zero)
+    self.setup()
   }
 
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: Private Functions
+
+extension ToDoRepeatSelectionView {
+  private func setup() {
+    self.setupLayer()
+  }
+
+  private func setupLayer() {
+    self.layer.borderWidth = self.model.borderWidth
+    self.layer.cornerRadius = self.model.cornerRadius
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
@@ -14,21 +14,43 @@ public class ToDoRepeatSelectionView: UIView {
   let model: Model
   var repetitionLabel: UILabel
   var selectionImageView: UIImageView
-
+  var tapGestureRecognizer: UITapGestureRecognizer
   var repetitionLabelTopAchor: NSLayoutConstraint
+  var isSelected: Bool {
+    willSet {
+      newValue ? self.setSelected() : self.setDeSelected()
+    }
+  }
 
   public init(model: Model) {
     self.model = model
     self.repetitionLabel = UILabel()
     self.selectionImageView = UIImageView()
+    self.tapGestureRecognizer = UITapGestureRecognizer()
     self.repetitionLabelTopAchor = NSLayoutConstraint()
+    self.isSelected = false
     super.init(frame: CGRect.zero)
     self.setup()
+    self.setDeSelected()
   }
 
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+
+  public func setSelected() {
+    self.backgroundColor = UIColor.toDoGardenGreenBackground
+    self.layer.borderColor = UIColor.toDoGardenGreenDark.cgColor
+    self.repetitionLabel.textColor = UIColor.toDoGardenGreenDark
+    self.selectionImageView.isHidden = false
+  }
+
+  public func setDeSelected() {
+    self.backgroundColor = UIColor.clear
+    self.layer.borderColor = UIColor.toDoGardenGray2.cgColor
+    self.repetitionLabel.textColor = UIColor.toDoGardenGray3
+    self.selectionImageView.isHidden = true
   }
 }
 
@@ -39,6 +61,7 @@ extension ToDoRepeatSelectionView {
     self.setupLayer()
     self.setupRepetitionLabel()
     self.setupSelectionImageView()
+    self.setupTapGestureRecognizer()
     self.addSubviews()
     self.setupSubviewsLayout()
   }
@@ -59,6 +82,19 @@ extension ToDoRepeatSelectionView {
 
     let image = self.model.selectedStateImage
     self.selectionImageView.image = image
+  }
+
+  private func setupTapGestureRecognizer() {
+    self.addGestureRecognizer(self.tapGestureRecognizer)
+    self.tapGestureRecognizer.addTarget(self, action: #selector(self.didTapView))
+  }
+}
+
+// MARK: Tap Gesture Function
+
+extension ToDoRepeatSelectionView {
+  @objc func didTapView() {
+    self.isSelected = !self.isSelected
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
@@ -12,9 +12,11 @@ import ToDoGardenUIResource
 
 public class ToDoRepeatSelectionView: UIView {
   let model: Model
+  var repetitionLabel: UILabel
 
   public init(model: Model) {
     self.model = model
+    self.repetitionLabel = UILabel()
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -35,6 +37,11 @@ extension ToDoRepeatSelectionView {
   private func setupLayer() {
     self.layer.borderWidth = self.model.borderWidth
     self.layer.cornerRadius = self.model.cornerRadius
+  }
+
+  private func setupRepetitionLabel() {
+    self.repetitionLabel.font = UIFont.pretendardBodyMedium
+    self.repetitionLabel.text = self.model.title
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
@@ -7,13 +7,55 @@
 
 import UIKit
 
+import ToDoGardenUIConstant
+import ToDoGardenUIResource
+
 public class ToDoRepeatSelectionView: UIView {
-  public init() {
+  let model: Model
+
+  public init(model: Model) {
+    self.model = model
     super.init(frame: CGRect.zero)
   }
 
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: Model
+
+extension ToDoRepeatSelectionView {
+  public struct Model {
+    let title: String
+    let borderWidth: CGFloat
+    let cornerRadius: CGFloat
+    var selectedStateImage: UIImage?
+
+    public init(
+      title: String,
+      borderWidth: CGFloat,
+      cornerRadius: CGFloat,
+      selectedStateImage: UIImage? = nil
+    ) {
+      self.title = title
+      self.borderWidth = borderWidth
+      self.cornerRadius = cornerRadius
+      self.selectedStateImage = selectedStateImage
+    }
+
+    public static let onlyToday = Self(
+      title: Constant.ToDoRepeatSelectionView.StringLiteral.RepetitionLabel.onlyToday,
+      borderWidth: Constant.ToDoRepeatSelectionView.Layout.borderWidth,
+      cornerRadius: Constant.ToDoRepeatSelectionView.Layout.cornerRadius,
+      selectedStateImage: UIImage.checkmarkImage
+    )
+
+    public static let anotherDay = Self(
+      title: Constant.ToDoRepeatSelectionView.StringLiteral.RepetitionLabel.anotherDay,
+      borderWidth: Constant.ToDoRepeatSelectionView.Layout.borderWidth,
+      cornerRadius: Constant.ToDoRepeatSelectionView.Layout.cornerRadius
+    )
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
@@ -1,0 +1,19 @@
+//
+//  ToDoRepeatSelectionView.swift
+//
+//
+//  Created by Wood on 5/19/24.
+//
+
+import UIKit
+
+public class ToDoRepeatSelectionView: UIView {
+  public init() {
+    super.init(frame: CGRect.zero)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
@@ -13,10 +13,12 @@ import ToDoGardenUIResource
 public class ToDoRepeatSelectionView: UIView {
   let model: Model
   var repetitionLabel: UILabel
+  var selectionImageView: UIImageView
 
   public init(model: Model) {
     self.model = model
     self.repetitionLabel = UILabel()
+    self.selectionImageView = UIImageView()
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -32,6 +34,8 @@ public class ToDoRepeatSelectionView: UIView {
 extension ToDoRepeatSelectionView {
   private func setup() {
     self.setupLayer()
+    self.setupRepetitionLabel()
+    self.setupSelectionImageView()
   }
 
   private func setupLayer() {
@@ -42,6 +46,14 @@ extension ToDoRepeatSelectionView {
   private func setupRepetitionLabel() {
     self.repetitionLabel.font = UIFont.pretendardBodyMedium
     self.repetitionLabel.text = self.model.title
+  }
+
+  private func setupSelectionImageView() {
+    guard self.model.selectedStateImage != nil
+    else { return }
+
+    let image = self.model.selectedStateImage
+    self.selectionImageView.image = image
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #158 

## 🎉 변경 사항
- 투두 반복 여부를 설정할 때 사용하는 ToDoRepeatSelectionView를 구현하였습니다.

## 📌 PR Point
### 1. 상속 가능성
@HG-SONG 께서 다른날도 할래요 컴포넌트 구현시 상속할 수 있도록 구현하였습니다.
또한, 상속 가능성이 있는 프로퍼티와 메서드의 **접근제어자 수준을 internal로 선언**하였습니다.

### 2. TopAnchor 제약 조건
다른날도 할래요 컴포넌트의 경우 선택시 레이아웃 Top 제약조건이 7.5 > 13 으로 변경되어야 합니다.
선택여부에 따라 해당 제약조건의 Constant값을 수정할 수 있도록 변수로 선언하였습니다.

### 화면 스크린 샷
|다른날도 할래요|오늘만 할래요|
|--|--|
|<img width="250" height="541" alt="스크린샷 2024-05-21 13 03 54" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/356c4d50-cb6d-4460-badf-74d1a49c9e3f">|<img width="250" height="541" alt="스크린샷 2024-05-21 13 03 39" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/5613e404-478e-4075-9a3b-68e13fc834df">|


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?