### PR TITLE
DateButtonSet 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
@@ -1,0 +1,38 @@
+//
+//  DateButtonSet.swift
+//
+//
+//  Created by SONG on 5/28/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+
+public class DateButtonSet: UIStackView {
+  public var delegate: DateButtonSetDelegate?
+  private let startDateButton: UIButton
+  private let startLabelButton: UIButton
+  private let endDateButton: UIButton
+  private let endLabelButton: UIButton
+  
+  init() {
+    self.delegate = nil
+    self.startDateButton = UIButton()
+    self.startLabelButton = UIButton()
+    self.endDateButton = UIButton()
+    self.endLabelButton = UIButton()
+    super.init(frame: CGRect.zero)
+    self.isUserInteractionEnabled = true
+    self.axis = NSLayoutConstraint.Axis.vertical
+  }
+  
+  @available(*, unavailable)
+  required init(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+public protocol DateButtonSetDelegate: AnyObject {
+  func dateButtonTapped(isSelected: Bool)
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
@@ -56,7 +56,15 @@ public class DateButtonSet: UIStackView {
   }
   
   private func setupButtonStyle() {
-
+    let contentsInsets = Constant.LightRoundRectButton.Layout.contentsInsetsSecondary
+    let buttonTitle = Constant.LightRoundRectButton.StringLiteral.self
+    self.startDateButton.applyLightRoundRectButtonStyle(title: "")
+    self.startDateButton.configuration?.contentInsets = contentsInsets
+    self.startLabelButton.applyLightRoundRectButtonStyle(title: buttonTitle.start)
+    
+    self.endDateButton.applyLightRoundRectButtonStyle(title: "")
+    self.endDateButton.configuration?.contentInsets = contentsInsets
+    self.endLabelButton.applyLightRoundRectButtonStyle(title: buttonTitle.end)
   }
   
   private func setupButtonInnerStackView(labelButton: UIButton, dateButton: UIButton) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
@@ -16,20 +16,43 @@ public class DateButtonSet: UIStackView {
   private let endDateButton: UIButton
   private let endLabelButton: UIButton
   
+  private var _isSelected: Bool
+  
+  var isSelected: Bool {
+    get {
+      return self._isSelected
+    }
+    set {
+      self._isSelected = newValue
+      self.updateButtonSelectionStates()
+      self.delegate?.dateButtonTapped(isSelected: _isSelected)
+    }
+  }
+  
   init() {
     self.delegate = nil
     self.startDateButton = UIButton()
     self.startLabelButton = UIButton()
     self.endDateButton = UIButton()
     self.endLabelButton = UIButton()
+    self._isSelected = false
+    
     super.init(frame: CGRect.zero)
-    self.isUserInteractionEnabled = true
     self.axis = NSLayoutConstraint.Axis.vertical
   }
   
   @available(*, unavailable)
   required init(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+extension DateButtonSet {
+  private func updateButtonSelectionStates() {
+    startDateButton.isSelected = _isSelected
+    startLabelButton.isSelected = _isSelected
+    endDateButton.isSelected = _isSelected
+    endLabelButton.isSelected = _isSelected
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
@@ -47,7 +47,7 @@ public final class DateButtonSet: UIControl {
   }
   
   override public var intrinsicContentSize: CGSize {
-    return CGSize(width: 140, height: 52)
+    return Constant.RepeatOtherDaysView.Layout.DateButtonSet.size
   }
   
   private func setupButtons() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import FoundationExtension
 import ToDoGardenUIConstant
 
 public class DateButtonSet: UIStackView {
@@ -108,6 +109,16 @@ public class DateButtonSet: UIStackView {
 }
 
 extension DateButtonSet {
+  public func updateStartDateButton(title: String) {
+    let attributedString = attributedButtonTitle(with: title)
+    self.startDateButton.setAttributedTitle(attributedString, for: .normal)
+  }
+  
+  public func updateEndDateButton(title: String) {
+    let attributedString = attributedButtonTitle(with: title)
+    self.endDateButton.setAttributedTitle(attributedString, for: .normal)
+  }
+  
   private func updateButtonSelectionStates() {
     startDateButton.isSelected = _isSelected
     startLabelButton.isSelected = _isSelected
@@ -129,6 +140,15 @@ extension DateButtonSet {
         self.isSelected = false
       }
     }
+  }
+  
+  private func attributedButtonTitle(with title: String) -> NSAttributedString {
+    let attributedString = title.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardBodySemiBold
+      ]
+    )
+    return attributedString
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
@@ -81,7 +81,17 @@ public class DateButtonSet: UIStackView {
   }
   
   private func setupButtonActions() {
-
+    let buttons = [
+      self.startDateButton,
+      self.startLabelButton,
+      self.endDateButton,
+      self.endLabelButton
+    ]
+    buttons.forEach { button in
+      button.addAction(UIAction { [weak self] _ in
+        self?.buttonTapped(button)
+      }, for: UIControl.Event.touchUpInside)
+    }
   }
   
   private func buttonsLayout() {
@@ -95,6 +105,22 @@ extension DateButtonSet {
     startLabelButton.isSelected = _isSelected
     endDateButton.isSelected = _isSelected
     endLabelButton.isSelected = _isSelected
+  }
+  
+  private func buttonTapped(_ sender: UIButton) {
+    if sender.isSelected {
+      self.isSelected = true
+    } else {
+      let isAllSelected = 
+      self.startDateButton.isSelected &&
+      self.startLabelButton.isSelected &&
+      self.endDateButton.isSelected &&
+      self.endLabelButton.isSelected
+      
+      if !isAllSelected {
+        self.isSelected = false
+      }
+    }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
@@ -10,28 +10,26 @@ import UIKit
 import FoundationExtension
 import ToDoGardenUIConstant
 
-public class DateButtonSet: UIStackView {
-  public var delegate: DateButtonSetDelegate?
+public final class DateButtonSet: UIControl {
   private let startDateButton: UIButton
   private let startLabelButton: UIButton
   private let endDateButton: UIButton
   private let endLabelButton: UIButton
+  private let stackView: UIStackView
   
   private var _isSelected: Bool
   
-  var isSelected: Bool {
+  public override var isSelected: Bool {
     get {
       return self._isSelected
     }
     set {
       self._isSelected = newValue
       self.updateButtonSelectionStates()
-      self.delegate?.dateButtonTapped(isSelected: _isSelected)
     }
   }
   
   init() {
-    self.delegate = nil
     self.startDateButton = UIButton()
     self.startLabelButton = UIButton()
     self.endDateButton = UIButton()
@@ -39,7 +37,7 @@ public class DateButtonSet: UIStackView {
     self._isSelected = false
     
     super.init(frame: CGRect.zero)
-    self.axis = NSLayoutConstraint.Axis.vertical
+    self.stackView.axis = NSLayoutConstraint.Axis.vertical
     self.setupButtons()
   }
   
@@ -48,12 +46,17 @@ public class DateButtonSet: UIStackView {
     fatalError("init(coder:) has not been implemented")
   }
   
+  override public var intrinsicContentSize: CGSize {
+    return CGSize(width: 140, height: 52)
+  }
+  
   private func setupButtons() {
     self.setupButtonStyle()
     self.setupButtonInnerStackView(labelButton: self.startLabelButton, dateButton: self.startDateButton)
     self.setupButtonInnerStackView(labelButton: self.endLabelButton, dateButton: self.endDateButton)
     self.setupButtonActions()
     self.buttonsLayout()
+    self.setupStackView()
   }
   
   private func setupButtonStyle() {
@@ -77,8 +80,8 @@ public class DateButtonSet: UIStackView {
     innerStackView.addSpacing(margin)
     innerStackView.addArrangedSubview(dateButton)
     
-    self.addArrangedSubview(innerStackView)
-    self.addSpacing(margin)
+    self.stackView.addArrangedSubview(innerStackView)
+    self.stackView.addSpacing(margin)
   }
   
   private func setupButtonActions() {
@@ -103,6 +106,20 @@ public class DateButtonSet: UIStackView {
       [
         self.startDateButton.widthAnchor.constraint(equalToConstant: buttonWidth),
         self.endDateButton.widthAnchor.constraint(equalToConstant: buttonWidth)
+      ]
+    )
+  }
+  
+  private func setupStackView() {
+    self.stackView.usingAutolayout()
+    self.addSubview(self.stackView)
+
+    self.stackView.axis = .vertical
+    self.stackView.distribution = .fillProportionally
+    NSLayoutConstraint.activate(
+      [
+        self.stackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+        self.stackView.centerYAnchor.constraint(equalTo: self.centerYAnchor)
       ]
     )
   }
@@ -140,6 +157,7 @@ extension DateButtonSet {
         self.isSelected = false
       }
     }
+    self.sendActions(for: .touchUpInside)
   }
   
   private func attributedButtonTitle(with title: String) -> NSAttributedString {
@@ -150,8 +168,4 @@ extension DateButtonSet {
     )
     return attributedString
   }
-}
-
-public protocol DateButtonSetDelegate: AnyObject {
-  func dateButtonTapped(isSelected: Bool)
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
@@ -95,7 +95,15 @@ public class DateButtonSet: UIStackView {
   }
   
   private func buttonsLayout() {
-
+    self.startDateButton.usingAutolayout()
+    self.endDateButton.usingAutolayout()
+    let buttonWidth = Constant.RepeatOtherDaysView.Layout.DateButtonSet.buttonWidth
+    NSLayoutConstraint.activate(
+      [
+        self.startDateButton.widthAnchor.constraint(equalToConstant: buttonWidth),
+        self.endDateButton.widthAnchor.constraint(equalToConstant: buttonWidth)
+      ]
+    )
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
@@ -68,7 +68,16 @@ public class DateButtonSet: UIStackView {
   }
   
   private func setupButtonInnerStackView(labelButton: UIButton, dateButton: UIButton) {
-
+    let margin = Constant.RepeatOtherDaysView.Layout.DateButtonSet.margin
+    let innerStackView = UIStackView()
+    innerStackView.axis = NSLayoutConstraint.Axis.horizontal
+    innerStackView.distribution = UIStackView.Distribution.fillProportionally
+    innerStackView.addArrangedSubview(labelButton)
+    innerStackView.addSpacing(margin)
+    innerStackView.addArrangedSubview(dateButton)
+    
+    self.addArrangedSubview(innerStackView)
+    self.addSpacing(margin)
   }
   
   private func setupButtonActions() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
@@ -39,11 +39,36 @@ public class DateButtonSet: UIStackView {
     
     super.init(frame: CGRect.zero)
     self.axis = NSLayoutConstraint.Axis.vertical
+    self.setupButtons()
   }
   
   @available(*, unavailable)
   required init(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupButtons() {
+    self.setupButtonStyle()
+    self.setupButtonInnerStackView(labelButton: self.startLabelButton, dateButton: self.startDateButton)
+    self.setupButtonInnerStackView(labelButton: self.endLabelButton, dateButton: self.endDateButton)
+    self.setupButtonActions()
+    self.buttonsLayout()
+  }
+  
+  private func setupButtonStyle() {
+
+  }
+  
+  private func setupButtonInnerStackView(labelButton: UIButton, dateButton: UIButton) {
+
+  }
+  
+  private func setupButtonActions() {
+
+  }
+  
+  private func buttonsLayout() {
+
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
@@ -35,7 +35,7 @@ public final class DateButtonSet: UIControl {
     self.endDateButton = UIButton()
     self.endLabelButton = UIButton()
     self._isSelected = false
-    
+    self.stackView = UIStackView()
     super.init(frame: CGRect.zero)
     self.stackView.axis = NSLayoutConstraint.Axis.vertical
     self.setupButtons()

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateButtonSet.swift
@@ -114,8 +114,8 @@ public final class DateButtonSet: UIControl {
     self.stackView.usingAutolayout()
     self.addSubview(self.stackView)
 
-    self.stackView.axis = .vertical
-    self.stackView.distribution = .fillProportionally
+    self.stackView.axis = NSLayoutConstraint.Axis.vertical
+    self.stackView.distribution = UIStackView.Distribution.fillProportionally
     NSLayoutConstraint.activate(
       [
         self.stackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
@@ -128,19 +128,19 @@ public final class DateButtonSet: UIControl {
 extension DateButtonSet {
   public func updateStartDateButton(title: String) {
     let attributedString = attributedButtonTitle(with: title)
-    self.startDateButton.setAttributedTitle(attributedString, for: .normal)
+    self.startDateButton.setAttributedTitle(attributedString, for: UIControl.State.normal)
   }
   
   public func updateEndDateButton(title: String) {
     let attributedString = attributedButtonTitle(with: title)
-    self.endDateButton.setAttributedTitle(attributedString, for: .normal)
+    self.endDateButton.setAttributedTitle(attributedString, for: UIControl.State.normal)
   }
   
   private func updateButtonSelectionStates() {
-    startDateButton.isSelected = _isSelected
-    startLabelButton.isSelected = _isSelected
-    endDateButton.isSelected = _isSelected
-    endLabelButton.isSelected = _isSelected
+    self.startDateButton.isSelected = self._isSelected
+    self.startLabelButton.isSelected = self._isSelected
+    self.endDateButton.isSelected = self._isSelected
+    self.endLabelButton.isSelected = self._isSelected
   }
   
   private func buttonTapped(_ sender: UIButton) {
@@ -157,7 +157,7 @@ extension DateButtonSet {
         self.isSelected = false
       }
     }
-    self.sendActions(for: .touchUpInside)
+    self.sendActions(for: UIControl.Event.touchUpInside)
   }
   
   private func attributedButtonTitle(with title: String) -> NSAttributedString {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #179 
- should be merged after: #177
## 🎉 변경 사항
- DateButtonSet를 추가합니다. 
## 📌 PR Point
![스크린샷 2024-05-28 오후 5 23 35](https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/52c3b468-803b-4b11-9a3f-18ac202447e1)
- 4개의 버튼은 isSelected 를 공유하는 구조입니다. 
   - 하나라도 Selected 상태로 변하면 모두 Selected 상태가 되고, 반대도 마찬가지입니다.
   - 각 버튼의 isSelected 상태는 통일되어 DateButtonSet의 isSelected로 접근가능합니다. 
- RepeatOtherDaysView의 subview로 쓰일 예정입니다. 
- "시작/종료" 는 고정이며, 날짜는 변경가능합니다. 
- UIControl을 상속받아, 외부에서 addAction/Target을 통해 직관적이고 손쉬운 후속동작 구현/ 이벤트 처리가 가능합니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?