### PR TITLE
CalendarDataGenerator 객체 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -7,12 +7,20 @@
 
 import Foundation
 
-final class CalendarDataGenerator {
+protocol CalendarDataGeneratable {
+  func fetchWeekdaySymbols() -> [String]
+}
+
+final class CalendarDataGenerator: CalendarDataGeneratable {
   private var calendar: Calendar
 
   init(calendar: Calendar = Calendar(identifier: Calendar.Identifier.gregorian)) {
     self.calendar = calendar
     self.setupLocale()
+  }
+
+  func fetchWeekdaySymbols() -> [String] {
+    return self.calendar.shortWeekdaySymbols
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol CalendarDataGeneratable {
   func fetchWeekdaySymbols() -> [String]
+  func fetchMonthData(from date: Date, add value: Int) -> MonthData?
 }
 
 final class CalendarDataGenerator: CalendarDataGeneratable {
@@ -21,6 +22,21 @@ final class CalendarDataGenerator: CalendarDataGeneratable {
 
   func fetchWeekdaySymbols() -> [String] {
     return self.calendar.shortWeekdaySymbols
+  }
+
+  func fetchMonthData(from date: Date, add value: Int) -> MonthData? {
+    guard let monthToFetch = self.calendar.date(
+      byAdding: Calendar.Component.month,
+      value: value,
+      to: date
+    )
+    else { return nil }
+
+    let firstDayOfMonth = self.getFirstDayOfMonth(from: monthToFetch)
+    guard let dates = self.getMonthDates(from: firstDayOfMonth)
+    else { return nil }
+
+    return MonthData(firstDayOfMonth: firstDayOfMonth, dates: dates)
   }
 }
 
@@ -49,6 +65,22 @@ extension CalendarDataGenerator {
     else { return date }
 
     return firstDay
+  }
+
+  private func getMonthDates(from firstDay: Date) -> [MonthData.Day]? {
+    let firstDayOfMonth = firstDay
+    let previousMonthDays = self.getPreviousMonthDays(from: firstDayOfMonth)
+    let nextMonthDays = self.getNextMonthDays(from: firstDayOfMonth)
+    let currentMonthDays = self.getCurrentMonthDays(from: firstDayOfMonth)
+    guard currentMonthDays.isEmpty == false
+    else { return nil }
+
+    let totalMonthDays = previousMonthDays + currentMonthDays + nextMonthDays
+    let weekdaySymbolsCount = self.calendar.weekdaySymbols.count
+    guard totalMonthDays.count % weekdaySymbolsCount == 0
+    else { return nil }
+
+    return totalMonthDays
   }
 
   private func getPreviousMonthDays(from firstDay: Date) -> [MonthData.Day] {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -11,7 +11,6 @@ protocol CalendarDataGeneratable {
   func fetchWeekdaySymbols() -> [String]
   func fetchMonthData(from date: Date, add value: Int) -> MonthData?
   func compareMonth(date1: Date, with date2: Date) -> ComparisonResult
-  func formatToStartTime(for date: Date) -> Date
 }
 
 final class CalendarDataGenerator: CalendarDataGeneratable {
@@ -48,10 +47,6 @@ final class CalendarDataGenerator: CalendarDataGeneratable {
     )
 
     return comparisonResult
-  }
-
-  func formatToStartTime(for date: Date) -> Date {
-    return self.calendar.startOfDay(for: date)
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -31,6 +31,7 @@ final class CalendarDataGenerator: CalendarDataGeneratable {
       to: date
     )
     else { throw CalendarDataError.invalidInput }
+
     let firstDayOfMonth = self.calendar.firstDayOfMonth(from: monthToFetch)
     let dates = try self.monthDays(from: firstDayOfMonth)
     
@@ -92,9 +93,7 @@ extension CalendarDataGenerator {
       switch self {
       case .previous:
         let weekdayCount = calendar.weekdayCount(day)
-        let isFirstDayOfWeek = weekdayCount == 1
-        guard isFirstDayOfWeek else { throw CalendarDataError.failToGenerateData }
-        let startDay = -weekdayCount + 1
+        let startDay = weekdayCount == 1 ? 0 : -weekdayCount + 1
         return (startDay..<0, day)
       case .current:
         let firstDayOfNextMonth = try calendar.dayOfNextMonth(day)
@@ -104,10 +103,8 @@ extension CalendarDataGenerator {
       case .next:
         let firstDayOfNextMonth = try calendar.dayOfNextMonth(day)
         let weekday = calendar.weekdayCount(firstDayOfNextMonth)
-        let isFirstDayOfWeek = weekday == 1
-        guard isFirstDayOfWeek else { throw CalendarDataError.failToGenerateData }
         let weekdayCount = calendar.shortWeekdaySymbols.count
-        let lastDayValue = weekdayCount - weekday + 1
+        let lastDayValue = weekday == 1 ? 0 : weekdayCount - weekday + 1
         return (0..<lastDayValue, firstDayOfNextMonth)
       }
     }
@@ -136,6 +133,7 @@ private extension Calendar {
       to: day
     )
     guard let date else { throw CalendarDataError.unexpected }
+
     return date
   }
   
@@ -147,6 +145,7 @@ private extension Calendar {
     guard
       let date = self.date(byAdding: Component.day, value: -1, to: day)
     else { throw CalendarDataError.unexpected }
+
     return date
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -35,4 +35,45 @@ extension CalendarDataGenerator {
       self.calendar.locale = Locale.autoupdatingCurrent
     }
   }
+
+  private func getFirstDayOfMonth(from date: Date) -> Date {
+    let dateComponents = self.calendar.dateComponents(
+      [
+        Calendar.Component.year,
+        Calendar.Component.month
+      ],
+      from: date
+    )
+
+    guard let firstDay = self.calendar.date(from: dateComponents)
+    else { return date }
+
+    return firstDay
+  }
+
+  private func getPreviousMonthDays(from firstDay: Date) -> [MonthData.Day] {
+    let weekdayCount = self.calendar.component(Calendar.Component.weekday, from: firstDay)
+    guard weekdayCount != 1 else { return [] }
+
+    let startDay = -weekdayCount + 1
+    let dateRange = (startDay..<0)
+    let previousMonthDays = self.getMonthDataDays(for: dateRange, from: firstDay)
+
+    return previousMonthDays
+  }
+
+  private func getMonthDataDays(
+    for dateRange: Range<Int>,
+    from firstDay: Date
+  ) -> [MonthData.Day] {
+    return dateRange.map { value in
+      let dayOfNextMonth = self.calendar.date(
+        byAdding: Calendar.Component.day,
+        value: value,
+        to: firstDay
+      ) ?? Date()
+
+      return MonthData.Day(date: dayOfNextMonth, isThisMonth: false)
+    }
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -1,0 +1,30 @@
+//
+//  CalendarDataGenerator.swift
+//
+//
+//  Created by Wood on 5/7/24.
+//
+
+import Foundation
+
+final class CalendarDataGenerator {
+  private var calendar: Calendar
+
+  init(calendar: Calendar = Calendar(identifier: Calendar.Identifier.gregorian)) {
+    self.calendar = calendar
+    self.setupLocale()
+  }
+}
+
+// MARK: Private Functions
+
+extension CalendarDataGenerator {
+  private func setupLocale() {
+    if let userPreferredIdentifier = Locale.preferredLanguages.first {
+      let userLocale = Locale(identifier: userPreferredIdentifier)
+      self.calendar.locale = userLocale
+    } else {
+      self.calendar.locale = Locale.autoupdatingCurrent
+    }
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol CalendarDataGeneratable {
   func fetchWeekdaySymbols() -> [String]
-  func fetchMonthData(from date: Date, add value: Int) -> MonthData?
+  func fetchMonthData(from date: Date, add value: Int) throws -> MonthData
   func compareMonth(date1: Date, with date2: Date) -> ComparisonResult
 }
 
@@ -24,17 +24,17 @@ final class CalendarDataGenerator: CalendarDataGeneratable {
     return self.calendar.shortWeekdaySymbols
   }
 
-  func fetchMonthData(from date: Date, add value: Int) -> MonthData? {
+  func fetchMonthData(from date: Date, add value: Int) throws -> MonthData {
     guard let monthToFetch = self.calendar.date(
       byAdding: Calendar.Component.month,
       value: value,
       to: date
     )
-    else { return nil }
+    else { throw CalendarDataError.invalidInput }
 
     let firstDayOfMonth = self.getFirstDayOfMonth(from: monthToFetch)
     guard let dates = self.getMonthDates(from: firstDayOfMonth)
-    else { return nil }
+    else { throw CalendarDataError.failToGenerateData }
 
     return MonthData(firstDayOfMonth: firstDayOfMonth, dates: dates)
   }
@@ -73,12 +73,10 @@ extension CalendarDataGenerator {
     let previousMonthDays = self.getPreviousMonthDays(from: firstDayOfMonth)
     let nextMonthDays = self.getNextMonthDays(from: firstDayOfMonth)
     let currentMonthDays = self.getCurrentMonthDays(from: firstDayOfMonth)
-    guard currentMonthDays.isEmpty == false
-    else { return nil }
-
     let totalMonthDays = previousMonthDays + currentMonthDays + nextMonthDays
-    let weekdaySymbolsCount = self.calendar.weekdaySymbols.count
-    guard totalMonthDays.count % weekdaySymbolsCount == 0
+
+    let dayCountOfWeek = self.calendar.shortWeekdaySymbols.count
+    guard totalMonthDays.count % dayCountOfWeek == 0
     else { return nil }
 
     return totalMonthDays
@@ -86,7 +84,8 @@ extension CalendarDataGenerator {
 
   private func getPreviousMonthDays(from firstDay: Date) -> [MonthData.Day] {
     let weekdayCount = self.calendar.component(Calendar.Component.weekday, from: firstDay)
-    guard weekdayCount != 1 else { return [] }
+    let isFirstDayOfWeek = weekdayCount == 1
+    guard isFirstDayOfWeek else { return [] }
 
     let startDay = -weekdayCount + 1
     let dateRange = (startDay..<0)
@@ -126,7 +125,8 @@ extension CalendarDataGenerator {
     else { return [] }
 
     let weekday = self.calendar.component(Calendar.Component.weekday, from: firstDayOfNextMonth)
-    guard weekday != 1 else { return [] }
+    let isFirstDayOfWeek = weekday == 1
+    guard isFirstDayOfWeek else { return [] }
 
     let weekdayCount = self.calendar.shortWeekdaySymbols.count
     let lastDayValue = weekdayCount - weekday + 1
@@ -150,4 +150,9 @@ extension CalendarDataGenerator {
       return MonthData.Day(date: dayOfNextMonth, isThisMonth: false)
     }
   }
+}
+
+enum CalendarDataError: Error {
+  case invalidInput
+  case failToGenerateData
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -62,6 +62,28 @@ extension CalendarDataGenerator {
     return previousMonthDays
   }
 
+  private func getCurrentMonthDays(from firstDay: Date) -> [MonthData.Day] {
+    guard let firstDayOfNextMonth = self.calendar.date(
+      byAdding: Calendar.Component.month,
+      value: 1,
+      to: firstDay
+    )
+    else { return [] }
+
+    guard let lastDayOfCurrentMonth = self.calendar.date(
+      byAdding: Calendar.Component.day,
+      value: -1,
+      to: firstDayOfNextMonth
+    )
+    else { return [] }
+
+    let lastDayNumber = self.calendar.component(Calendar.Component.day, from: lastDayOfCurrentMonth)
+    let dateRange = (0..<lastDayNumber)
+    let currentMonthDays = self.getMonthDataDays(for: dateRange, from: firstDay)
+
+    return currentMonthDays
+  }
+
   private func getMonthDataDays(
     for dateRange: Range<Int>,
     from firstDay: Date

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -15,15 +15,15 @@ protocol CalendarDataGeneratable {
 
 final class CalendarDataGenerator: CalendarDataGeneratable {
   private let calendar: Calendar
-
+  
   init(calendar: Calendar) {
     self.calendar = calendar
   }
-
+  
   func fetchWeekdaySymbols() -> [String] {
     return self.calendar.shortWeekdaySymbols
   }
-
+  
   func fetchMonthData(from date: Date, add value: Int) throws -> MonthData {
     guard let monthToFetch = self.calendar.date(
       byAdding: Calendar.Component.month,
@@ -31,21 +31,19 @@ final class CalendarDataGenerator: CalendarDataGeneratable {
       to: date
     )
     else { throw CalendarDataError.invalidInput }
-
-    let firstDayOfMonth = self.getFirstDayOfMonth(from: monthToFetch)
-    guard let dates = self.getMonthDates(from: firstDayOfMonth)
-    else { throw CalendarDataError.failToGenerateData }
-
+    let firstDayOfMonth = self.calendar.firstDayOfMonth(from: monthToFetch)
+    let dates = try self.monthDays(from: firstDayOfMonth)
+    
     return MonthData(firstDayOfMonth: firstDayOfMonth, dates: dates)
   }
-
+  
   func compareMonth(date1: Date, with date2: Date) -> ComparisonResult {
     let comparisonResult = self.calendar.compare(
       date1,
       to: date2,
       toGranularity: Calendar.Component.month
     )
-
+    
     return comparisonResult
   }
 }
@@ -53,89 +51,20 @@ final class CalendarDataGenerator: CalendarDataGeneratable {
 // MARK: Private Functions
 
 extension CalendarDataGenerator {
-  private func getFirstDayOfMonth(from date: Date) -> Date {
-    let dateComponents = self.calendar.dateComponents(
-      [
-        Calendar.Component.year,
-        Calendar.Component.month
-      ],
-      from: date
-    )
-
-    guard let firstDay = self.calendar.date(from: dateComponents)
-    else { return date }
-
-    return firstDay
-  }
-
-  private func getMonthDates(from firstDay: Date) -> [MonthData.Day]? {
-    let firstDayOfMonth = firstDay
-    let previousMonthDays = self.getPreviousMonthDays(from: firstDayOfMonth)
-    let nextMonthDays = self.getNextMonthDays(from: firstDayOfMonth)
-    let currentMonthDays = self.getCurrentMonthDays(from: firstDayOfMonth)
-    let totalMonthDays = previousMonthDays + currentMonthDays + nextMonthDays
-
+  private func monthDays(from day: Date) throws -> [MonthData.Day] {
+    let totalMonthDays = try MonthPosition.allCases
+      .map { position in
+        let params = try position.monthDayParams(day, calendar: self.calendar)
+        return self.getMonthDataDays(for: params.range, from: params.firstDay)
+      }
+      .reduce(into: [MonthData.Day](), +=)
     let dayCountOfWeek = self.calendar.shortWeekdaySymbols.count
     guard totalMonthDays.count % dayCountOfWeek == 0
-    else { return nil }
-
+    else { throw CalendarDataError.failToGenerateData }
+    
     return totalMonthDays
   }
-
-  private func getPreviousMonthDays(from firstDay: Date) -> [MonthData.Day] {
-    let weekdayCount = self.calendar.component(Calendar.Component.weekday, from: firstDay)
-    let isFirstDayOfWeek = weekdayCount == 1
-    guard isFirstDayOfWeek else { return [] }
-
-    let startDay = -weekdayCount + 1
-    let dateRange = (startDay..<0)
-    let previousMonthDays = self.getMonthDataDays(for: dateRange, from: firstDay)
-
-    return previousMonthDays
-  }
-
-  private func getCurrentMonthDays(from firstDay: Date) -> [MonthData.Day] {
-    guard let firstDayOfNextMonth = self.calendar.date(
-      byAdding: Calendar.Component.month,
-      value: 1,
-      to: firstDay
-    )
-    else { return [] }
-
-    guard let lastDayOfCurrentMonth = self.calendar.date(
-      byAdding: Calendar.Component.day,
-      value: -1,
-      to: firstDayOfNextMonth
-    )
-    else { return [] }
-
-    let lastDayNumber = self.calendar.component(Calendar.Component.day, from: lastDayOfCurrentMonth)
-    let dateRange = (0..<lastDayNumber)
-    let currentMonthDays = self.getMonthDataDays(for: dateRange, from: firstDay)
-
-    return currentMonthDays
-  }
-
-  private func getNextMonthDays(from firstDay: Date) -> [MonthData.Day] {
-    guard let firstDayOfNextMonth = self.calendar.date(
-      byAdding: Calendar.Component.month,
-      value: 1,
-      to: firstDay
-    )
-    else { return [] }
-
-    let weekday = self.calendar.component(Calendar.Component.weekday, from: firstDayOfNextMonth)
-    let isFirstDayOfWeek = weekday == 1
-    guard isFirstDayOfWeek else { return [] }
-
-    let weekdayCount = self.calendar.shortWeekdaySymbols.count
-    let lastDayValue = weekdayCount - weekday + 1
-    let dateRange = (0..<lastDayValue)
-    let nextMonthDays = self.getMonthDataDays(for: dateRange, from: firstDayOfNextMonth)
-
-    return nextMonthDays
-  }
-
+  
   private func getMonthDataDays(
     for dateRange: Range<Int>,
     from firstDay: Date
@@ -146,13 +75,88 @@ extension CalendarDataGenerator {
         value: value,
         to: firstDay
       ) ?? Date()
-
+      
       return MonthData.Day(date: dayOfNextMonth, isThisMonth: false)
     }
+  }
+}
+
+extension CalendarDataGenerator {
+  typealias MonthDayParmas = (range: Range<Int>, firstDay: Date)
+  enum MonthPosition: CaseIterable {
+    case previous
+    case current
+    case next
+    
+    func monthDayParams(_ day: Date, calendar: Calendar) throws -> MonthDayParmas {
+      switch self {
+      case .previous:
+        let weekdayCount = calendar.weekdayCount(day)
+        let isFirstDayOfWeek = weekdayCount == 1
+        guard isFirstDayOfWeek else { throw CalendarDataError.failToGenerateData }
+        let startDay = -weekdayCount + 1
+        return (startDay..<0, day)
+      case .current:
+        let firstDayOfNextMonth = try calendar.dayOfNextMonth(day)
+        let lastDayOfCurrentMonth = try calendar.lastDayOfMonth(firstDayOfNextMonth)
+        let lastDayNumber = calendar.lastDayNumber(lastDay: lastDayOfCurrentMonth)
+        return (0..<lastDayNumber, day)
+      case .next:
+        let firstDayOfNextMonth = try calendar.dayOfNextMonth(day)
+        let weekday = calendar.weekdayCount(firstDayOfNextMonth)
+        let isFirstDayOfWeek = weekday == 1
+        guard isFirstDayOfWeek else { throw CalendarDataError.failToGenerateData }
+        let weekdayCount = calendar.shortWeekdaySymbols.count
+        let lastDayValue = weekdayCount - weekday + 1
+        return (0..<lastDayValue, firstDayOfNextMonth)
+      }
+    }
+  }
+}
+
+private extension Calendar {
+  func firstDayOfMonth(from date: Date) -> Date {
+    let dateComponents = self.dateComponents(
+      [
+        Calendar.Component.year,
+        Calendar.Component.month
+      ],
+      from: date
+    )
+    guard let firstDay = self.date(from: dateComponents)
+    else { return date }
+    
+    return firstDay
+  }
+  
+  func dayOfNextMonth(_ day: Date) throws -> Date {
+    let date = self.date(
+      byAdding: Component.month,
+      value: 1,
+      to: day
+    )
+    guard let date else { throw CalendarDataError.unexpected }
+    return date
+  }
+  
+  func weekdayCount(_ day: Date) -> Int {
+    self.component(Component.weekday, from: day)
+  }
+  
+  func lastDayOfMonth(_ day: Date) throws -> Date {
+    guard
+      let date = self.date(byAdding: Component.day, value: -1, to: day)
+    else { throw CalendarDataError.unexpected }
+    return date
+  }
+  
+  func lastDayNumber(lastDay: Date) -> Int {
+    component(Component.day, from: lastDay)
   }
 }
 
 enum CalendarDataError: Error {
   case invalidInput
   case failToGenerateData
+  case unexpected
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -11,6 +11,7 @@ protocol CalendarDataGeneratable {
   func fetchWeekdaySymbols() -> [String]
   func fetchMonthData(from date: Date, add value: Int) -> MonthData?
   func compareMonth(date1: Date, with date2: Date) -> ComparisonResult
+  func formatToStartTime(for date: Date) -> Date
 }
 
 final class CalendarDataGenerator: CalendarDataGeneratable {
@@ -48,6 +49,10 @@ final class CalendarDataGenerator: CalendarDataGeneratable {
     )
 
     return comparisonResult
+  }
+
+  func formatToStartTime(for date: Date) -> Date {
+    return self.calendar.startOfDay(for: date)
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -15,11 +15,10 @@ protocol CalendarDataGeneratable {
 }
 
 final class CalendarDataGenerator: CalendarDataGeneratable {
-  private var calendar: Calendar
+  private let calendar: Calendar
 
-  init(calendar: Calendar = Calendar(identifier: Calendar.Identifier.gregorian)) {
+  init(calendar: Calendar) {
     self.calendar = calendar
-    self.setupLocale()
   }
 
   func fetchWeekdaySymbols() -> [String] {
@@ -59,15 +58,6 @@ final class CalendarDataGenerator: CalendarDataGeneratable {
 // MARK: Private Functions
 
 extension CalendarDataGenerator {
-  private func setupLocale() {
-    if let userPreferredIdentifier = Locale.preferredLanguages.first {
-      let userLocale = Locale(identifier: userPreferredIdentifier)
-      self.calendar.locale = userLocale
-    } else {
-      self.calendar.locale = Locale.autoupdatingCurrent
-    }
-  }
-
   private func getFirstDayOfMonth(from date: Date) -> Date {
     let dateComponents = self.calendar.dateComponents(
       [

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -84,6 +84,25 @@ extension CalendarDataGenerator {
     return currentMonthDays
   }
 
+  private func getNextMonthDays(from firstDay: Date) -> [MonthData.Day] {
+    guard let firstDayOfNextMonth = self.calendar.date(
+      byAdding: Calendar.Component.month,
+      value: 1,
+      to: firstDay
+    )
+    else { return [] }
+
+    let weekday = self.calendar.component(Calendar.Component.weekday, from: firstDayOfNextMonth)
+    guard weekday != 1 else { return [] }
+
+    let weekdayCount = self.calendar.shortWeekdaySymbols.count
+    let lastDayValue = weekdayCount - weekday + 1
+    let dateRange = (0..<lastDayValue)
+    let nextMonthDays = self.getMonthDataDays(for: dateRange, from: firstDayOfNextMonth)
+
+    return nextMonthDays
+  }
+
   private func getMonthDataDays(
     for dateRange: Range<Int>,
     from firstDay: Date

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol CalendarDataGeneratable {
   func fetchWeekdaySymbols() -> [String]
   func fetchMonthData(from date: Date, add value: Int) -> MonthData?
+  func compareMonth(date1: Date, with date2: Date) -> ComparisonResult
 }
 
 final class CalendarDataGenerator: CalendarDataGeneratable {
@@ -37,6 +38,16 @@ final class CalendarDataGenerator: CalendarDataGeneratable {
     else { return nil }
 
     return MonthData(firstDayOfMonth: firstDayOfMonth, dates: dates)
+  }
+
+  func compareMonth(date1: Date, with date2: Date) -> ComparisonResult {
+    let comparisonResult = self.calendar.compare(
+      date1,
+      to: date2,
+      toGranularity: Calendar.Component.month
+    )
+
+    return comparisonResult
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/MonthData.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/MonthData.swift
@@ -1,0 +1,18 @@
+//
+//  MonthData.swift
+//
+//
+//  Created by Wood on 5/23/24.
+//
+
+import Foundation
+
+struct MonthData {
+  struct Day {
+    let date: Date
+    let isThisMonth: Bool
+  }
+
+  let firstDayOfMonth: Date
+  let dates: [Day]
+}


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #180 

## 🎉 변경 사항
- CalendarView에서 날짜 정보를 생성할 때 사용하는 CalendarDataGenerator 객체를 추가하였습니다.
- CalendarView 관련 파일이 6개라 구분하기 쉽도록 별도의 폴더를 추가하였습니다.

## 📌 PR Point
### 주요 메서드
1. fetchMonthDates: 새로운 날짜 정보를 생성할 때 사용합니다.
캘린더에서 스크롤시 새로운 날짜 정보를 업데이트 할 때 사용합니다.

2. fetchWeekdaySymbols: 요일 정보를 가져올 때 사용합니다.
ex) 월, 화, ..., 토, 일

3. compareMonth: 날짜 정보를 비교할 때 사용합니다.
캘린더에서 날짜 선택시 비교하여 결과에 따라 스크롤 여부를 결정할 때 사용합니다.

- [관련 기술서](https://www.notion.so/49bf319db5a846689c9dbdc6980f939c?pvs=4#3d44dd010a1c4f18adeee47553b515d0)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?