### PR TITLE
TimerProgressView 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -98,6 +98,7 @@ extension TimerProgressView {
     animation.path = circularPath.cgPath
     animation.duration = duration
     animation.calculationMode = CAAnimationCalculationMode.paced
+    animation.isRemovedOnCompletion = false
     
     self.dot.layer.add(animation, forKey: nil)
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -79,10 +79,10 @@ extension TimerProgressView {
     self.circularProgressView.usingAutolayout()
     
     NSLayoutConstraint.activate([
-      self.circularProgressView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-      self.circularProgressView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-      self.circularProgressView.heightAnchor.constraint(equalTo: self.heightAnchor),
-      self.circularProgressView.widthAnchor.constraint(equalTo: self.widthAnchor)
+      self.circularProgressView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.circularProgressView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.circularProgressView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+      self.circularProgressView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
     ])
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -32,6 +32,12 @@ public final class TimerProgressView: UIView {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+  
+  public func startAnimation(duration: TimeInterval, from: Double, to value: Double) {
+    self.toValue = value
+    self.addAnimation(duration: duration, from: from, to: value)
+    self.circularProgressView.startAnimation(duration: duration, from: Float(from), to: Float(value))
+  }
 }
 
 // MARK: - Setup views
@@ -78,5 +84,61 @@ extension TimerProgressView {
       self.circularProgressView.heightAnchor.constraint(equalTo: self.heightAnchor),
       self.circularProgressView.widthAnchor.constraint(equalTo: self.widthAnchor)
     ])
+  }
+}
+
+// MARK: - Setup animation
+
+extension TimerProgressView {
+  private func addAnimation(duration: TimeInterval, from: Double, to value: Double) {
+    let circularPath = self.makeCircularPath(fromValue: from, toValue: value)
+    let animationKeyPath = Constant.TimerProgressView.StringLiteral.Dot.Animation.keyPath
+    let animation = CAKeyframeAnimation(keyPath: animationKeyPath)
+    animation.delegate = self
+    animation.path = circularPath.cgPath
+    animation.duration = duration
+    animation.calculationMode = CAAnimationCalculationMode.paced
+    
+    self.dot.layer.add(animation, forKey: nil)
+  }
+  
+  private func makeCircularPath(fromValue: Double, toValue: Double) -> UIBezierPath {
+    self.layoutIfNeeded()
+    let startAngle = -(Double.pi / 2)
+    let endAngle = (2 * Double.pi)
+    let radius = self.bounds.width / 2
+    let arcCenter = CGPoint(x: self.bounds.midX, y: self.bounds.midY)
+    
+    let circularPath = UIBezierPath(
+      arcCenter: arcCenter,
+      radius: radius,
+      startAngle: startAngle + (2 * Double.pi) * fromValue,
+      endAngle: endAngle * toValue + startAngle,
+      clockwise: true
+    )
+    
+    return circularPath
+  }
+}
+
+// MARK: - Conforming to a protocol
+
+extension TimerProgressView: CAAnimationDelegate {
+  public func animationDidStop(_ anim: CAAnimation, finished flag: Bool) {
+    guard let toValue
+    else { return }
+    
+    let startAngle = -(Double.pi / 2)
+    let dotWidth = Constant.TimerProgressView.Layout.Dot.width
+    let dotHeight = Constant.TimerProgressView.Layout.Dot.height
+    let dotRadius = dotWidth / 2
+    let endAngle = (2 * Double.pi) * toValue + startAngle
+    let adjustedAngle = atan2(sin(endAngle), cos(endAngle))
+    let endOfXPosition: CGFloat = self.center.x + (self.frame.width / 2.0 * cos(adjustedAngle)) - dotRadius
+    let endOfYPosition: CGFloat =  self.center.y + (self.frame.width / 2.0 * sin(adjustedAngle)) - dotRadius
+    self.dot.frame = CGRect(
+      origin: CGPoint(x: endOfXPosition, y: endOfYPosition),
+      size: CGSize(width: dotWidth, height: dotHeight)
+    )
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -134,8 +134,8 @@ extension TimerProgressView: CAAnimationDelegate {
     let dotRadius = dotWidth / 2
     let endAngle = (2 * Double.pi) * toValue + startAngle
     let adjustedAngle = atan2(sin(endAngle), cos(endAngle))
-    let endOfXPosition: CGFloat = self.center.x + (self.frame.width / 2.0 * cos(adjustedAngle)) - dotRadius
-    let endOfYPosition: CGFloat =  self.center.y + (self.frame.width / 2.0 * sin(adjustedAngle)) - dotRadius
+    let endOfXPosition: CGFloat = self.bounds.midX + (self.bounds.width / 2.0 * cos(adjustedAngle)) - dotRadius
+    let endOfYPosition: CGFloat = self.bounds.midY + (self.bounds.width / 2.0 * sin(adjustedAngle)) - dotRadius
     self.dot.frame = CGRect(
       origin: CGPoint(x: endOfXPosition, y: endOfYPosition),
       size: CGSize(width: dotWidth, height: dotHeight)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -142,3 +142,20 @@ extension TimerProgressView: CAAnimationDelegate {
     )
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let timerProgressView = TimerProgressView(
+    circularProgressView: CircularProgressView(
+      progressColor: UIColor.toDoGardenGreenDark,
+      backgroundColor: UIColor.toDoGardenLeaf,
+      lineWidth: 9.0
+    ),
+    dotColor: UIColor.toDoGardenGreenDark
+  )
+  timerProgressView.startAnimation(duration: 10.0, from: 0.3, to: 0.7)
+  
+  return timerProgressView
+}
+#endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -6,3 +6,37 @@
 //
 
 import UIKit
+
+import ToDoGardenUIConstant
+
+public final class TimerProgressView: UIView {
+  private let circularProgressView: CircularProgressView
+  private let dot: UIView
+  private var toValue: Double?
+  
+  public init(
+    circularProgressView: CircularProgressView,
+    dotColor: UIColor
+  ) {
+    self.circularProgressView = circularProgressView
+    let dotWidth = Constant.TimerProgressView.Layout.Dot.width
+    let dotHeight = Constant.TimerProgressView.Layout.Dot.height
+    self.dot = UIView(
+      frame: CGRect(x: 0, y: 0, width: dotWidth, height: dotHeight)
+    )
+    super.init(frame: CGRect.zero)
+    self.setupViews(with: dotColor)
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: - Setup views
+
+extension TimerProgressView {
+  private func setupViews(with dotColor: UIColor) {
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -33,6 +33,11 @@ public final class TimerProgressView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
   
+  /// 타이머 애니메이션을 시작하는 메소드입니다.
+  /// - Parameters:
+  ///   - duration: `TimerInterval` 동안 실행될지 결정하는 파라미터입니다.
+  ///   - from: `TimerProgressView`의 애니메이션이 시작되는 지점을 나타내는 값입니다.
+  ///   - value: TimerProgressView`의 애니메이션이 종료되는 지점을 나타내는 값입니다.
   public func startAnimation(duration: TimeInterval, from: Double, to value: Double) {
     self.toValue = value
     self.addAnimation(duration: duration, from: from, to: value)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -38,5 +38,45 @@ public final class TimerProgressView: UIView {
 
 extension TimerProgressView {
   private func setupViews(with dotColor: UIColor) {
+    self.setupDot(with: dotColor)
+    self.addSubviews()
+    self.setupLayoutConstraints()
+  }
+}
+
+// MARK: - Setup dot
+
+extension TimerProgressView {
+  private func setupDot(with dotColor: UIColor) {
+    self.dot.layer.cornerRadius = self.dot.frame.width / 2
+    self.dot.backgroundColor = dotColor
+  }
+}
+
+// MARK: - Add subviews
+
+extension TimerProgressView {
+  private func addSubviews() {
+    self.addSubview(self.circularProgressView)
+    self.addSubview(self.dot)
+  }
+}
+
+// MARK: - Setup layout constraints
+
+extension TimerProgressView {
+  private func setupLayoutConstraints() {
+    self.setupCircularProgressViewLayoutConstraints()
+  }
+  
+  private func setupCircularProgressViewLayoutConstraints() {
+    self.circularProgressView.usingAutolayout()
+    
+    NSLayoutConstraint.activate([
+      self.circularProgressView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+      self.circularProgressView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+      self.circularProgressView.heightAnchor.constraint(equalTo: self.heightAnchor),
+      self.circularProgressView.widthAnchor.constraint(equalTo: self.widthAnchor)
+    ])
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -1,0 +1,8 @@
+//
+//  TimerProgressView.swift
+//
+//
+//  Created by Noah on 5/23/24.
+//
+
+import UIKit


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #168 

## 🎉 변경 사항
- [x] TimerProgressView 추가
- [x] 애니메이션 구현

## 📌 PR Point

| TimerProgressView 실행 화면	|
|----------------	|
| <img src="https://github.com/ToDo-Garden/ToDo-Garden/assets/63908856/3b34579d-bf06-4bb0-8f09-ed4c0df694d9" width="375px" height="812px"/> |

- 외부에서 설정해주는 레이아웃 제약조건에 따라 TimerProgressView가 설정되도록 하였습니다.
- 아래의 메소드를 통해 애니메이션을 시작할 수 있도록 구현하였습니다.
- 뷰의 애니메이션 경로가 결정되기 위해손 레이아웃이 결정된 뒤에 애니메이션이 실행되어야하기 때문에 `layoutIfNeeded`가  불린 뒤 실행될 수 있도록 구현하였습니다.

```swift
/// 타이머 애니메이션을 시작하는 메소드입니다.
/// - Parameters:
///   - duration: `TimerInterval` 동안 실행될지 결정하는 파라미터입니다.
///   - from: `TimerProgressView`의 애니메이션이 시작되는 지점을 나타내는 값입니다.
///   - value: TimerProgressView`의 애니메이션이 종료되는 지점을 나타내는 값입니다.
func startAnimation(duration:from:to:)
```


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?