### PR TITLE
RepeatOtherDaysView 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -326,5 +326,13 @@ extension RepeatOtherDaysView {
       self.superview?.layoutIfNeeded()
     }
   }
-
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let view = RepeatOtherDaysView(startDate: "1234.12.12", endDate: "4321.32.32")
+
+  return view
+}
+#endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -303,7 +303,16 @@ extension RepeatOtherDaysView {
   }
   
   private func animateDisappear() {
-    
+    UIView.animate(withDuration: Constant.RepeatOtherDaysView.AboutAnimation.duration) {
+      self.innerStackView.alpha = Constant.RepeatOtherDaysView.AboutAnimation.alphaDisappear
+      self.divider.alpha = Constant.RepeatOtherDaysView.AboutAnimation.alphaDisappear
+    } completion: { _ in
+      Task {
+        try await Task.sleep(nanoseconds: Constant.RepeatOtherDaysView.AboutAnimation.delay)
+        self.viewModel.toggleSelection()
+        self.animateLayout()
+      }
+    }
   }
   
   private func animateLayout() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import ToDoGardenUIConstant
+import ToDoGardenUIResource
 
 public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
   public let ringToggleButton: UIButton
@@ -122,6 +123,50 @@ extension RepeatOtherDaysView {
     }
   }
 }
+
+// MARK: - About Updating states
+extension RepeatOtherDaysView {
+  private func updateUI() {
+    self.divider.isHidden = self.viewModel.divider.isHidden.value
+    self.innerStackView.isHidden = self.viewModel.innerStackView.isHidden.value
+    self.updateRepeatOtherDaysViewHeightConstraint(to: self.viewModel.height.value)
+    self.updateTitleConstraint(to: self.viewModel.title.topMargin.value)
+    self.updateInnerStackViewViewHeightConstraint(to: self.viewModel.innerStackView.height.value)
+  }
+  
+  private func updateBackgroundColor() {
+    if self.viewModel.isSelected.value && self.viewModel.ringToggleButton.isSelected.value {
+      self.backgroundColor = UIColor.toDoGardenGreenBackground
+    } else {
+      self.backgroundColor = UIColor.clear
+    }
+  }
+  
+  private func updateRepeatOtherDaysViewHeightConstraint(to height: CGFloat) {
+    if self.heightConstraints.isEmpty {
+      return
+    }
+    
+    guard let repeatOtherDaysViewHeightConstraint = self.heightConstraints.first else {
+      return
+    }
+    repeatOtherDaysViewHeightConstraint.constant = height
+  }
+  
+  private func updateInnerStackViewViewHeightConstraint(to height: CGFloat) {
+    if self.heightConstraints.isEmpty {
+      return
+    }
+    
+    guard let innerStackViewHeightConstraint = self.heightConstraints.last else {
+      return
+    }
+    
+    innerStackViewHeightConstraint.constant = height
+  }
+  
+  private func updateTitleConstraint(to topMargin: CGFloat) {
+    self.repetitionLabelTopAchor.constant = topMargin
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -13,7 +13,7 @@ import ToDoGardenUIResource
 public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
   public let ringToggleButton: UIButton
   public let dateButtonSet: DateButtonSet
-  private let divider: UIView
+  private let dividerView: UIView
   private let innerStackView: UIStackView
   
   private var heightConstraints: [NSLayoutConstraint]
@@ -30,7 +30,7 @@ public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
     self.heightConstraints = []
     self.ringToggleButton = UIButton()
     self.innerStackView = UIStackView()
-    self.divider = UIView()
+    self.dividerView = UIView()
     self.dateButtonSet = DateButtonSet()
     super.init(model: ToDoRepeatSelectionView.Model.anotherDay)
     self.setup()
@@ -127,16 +127,16 @@ extension RepeatOtherDaysView {
   }
   
   private func buildDivider() {
-    self.divider.backgroundColor = UIColor.toDoGardenGreenGray
-    self.divider.usingAutolayout()
-    self.addSubview(self.divider)
+    self.dividerView.backgroundColor = UIColor.toDoGardenGreenGray
+    self.dividerView.usingAutolayout()
+    self.addSubview(self.dividerView)
     let constants = Constant.RepeatOtherDaysView.Layout.self
     NSLayoutConstraint.activate(
       [
-        self.divider.widthAnchor.constraint(equalToConstant: constants.Divider.width),
-        self.divider.heightAnchor.constraint(equalToConstant: constants.Divider.height),
-        self.divider.topAnchor.constraint(equalTo: self.topAnchor, constant: constants.CommonMargin.broad),
-        self.divider.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+        self.dividerView.widthAnchor.constraint(equalToConstant: constants.Divider.width),
+        self.dividerView.heightAnchor.constraint(equalToConstant: constants.Divider.height),
+        self.dividerView.topAnchor.constraint(equalTo: self.topAnchor, constant: constants.CommonMargin.broad),
+        self.dividerView.centerXAnchor.constraint(equalTo: self.centerXAnchor)
       ]
     )
     self.innerStackView.addSpacing(constants.CommonMargin.narrow)
@@ -228,7 +228,7 @@ extension RepeatOtherDaysView {
   
   private func bindVisibilityStates() {
     self.viewModel.divider.isHidden.bind { [weak self] isHidden in
-      self?.divider.isHidden = isHidden
+      self?.dividerView.isHidden = isHidden
     }
     
     self.viewModel.innerStackView.isHidden.bind { [weak self] isHidden in
@@ -256,7 +256,7 @@ extension RepeatOtherDaysView {
 // MARK: - About Updating states
 extension RepeatOtherDaysView {
   private func updateUI() {
-    self.divider.isHidden = self.viewModel.divider.isHidden.value
+    self.dividerView.isHidden = self.viewModel.divider.isHidden.value
     self.innerStackView.isHidden = self.viewModel.innerStackView.isHidden.value
     self.updateRepeatOtherDaysViewHeightConstraint(to: self.viewModel.height.value)
     self.updateTitleConstraint(to: self.viewModel.title.topMargin.value)
@@ -305,14 +305,14 @@ extension RepeatOtherDaysView {
     self.animateLayout()
     UIView.animate(withDuration: Constant.RepeatOtherDaysView.AboutAnimation.duration) {
       self.innerStackView.alpha = Constant.RepeatOtherDaysView.AboutAnimation.alphaAppear
-      self.divider.alpha = Constant.RepeatOtherDaysView.AboutAnimation.alphaAppear
+      self.dividerView.alpha = Constant.RepeatOtherDaysView.AboutAnimation.alphaAppear
     }
   }
   
   private func animateDisappear() {
     UIView.animate(withDuration: Constant.RepeatOtherDaysView.AboutAnimation.duration) {
       self.innerStackView.alpha = Constant.RepeatOtherDaysView.AboutAnimation.alphaDisappear
-      self.divider.alpha = Constant.RepeatOtherDaysView.AboutAnimation.alphaDisappear
+      self.dividerView.alpha = Constant.RepeatOtherDaysView.AboutAnimation.alphaDisappear
     } completion: { _ in
       Task {
         try await Task.sleep(nanoseconds: Constant.RepeatOtherDaysView.AboutAnimation.delay)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -5,10 +5,32 @@
 //  Created by SONG on 5/28/24.
 //
 
-import Foundation
+import UIKit
 
 import ToDoGardenUIConstant
 
 public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
+  public let ringToggleButton: UIButton
+  public let dateButtonSet: DateButtonSet
+  private let divider: UIView
+  private let innerStackView: UIStackView
   
+  private var heightConstraints: [NSLayoutConstraint]
+  private var viewModel: RepeatOtherDaysViewModel
+  
+  public init(startDate: String?, endDate: String?) {
+    self.viewModel = RepeatOtherDaysViewModel(startDate: startDate, endDate: endDate)
+    self.heightConstraints = []
+    self.ringToggleButton = UIButton()
+    self.innerStackView = UIStackView()
+    self.divider = UIView()
+    self.dateButtonSet = DateButtonSet()
+    super.init(model: ToDoRepeatSelectionView.Model.anotherDay)
+    self.setup()
+  }
+}
+
+extension RepeatOtherDaysView {
+  private func setup() {
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -53,6 +53,7 @@ extension RepeatOtherDaysView {
     self.bindViewModel()
     self.usingAutolayout()
     self.setupInitialHeightConstraint()
+    self.applyRingToggleButton()
   }
   
   private func bindViewModel() {
@@ -73,6 +74,10 @@ extension RepeatOtherDaysView {
     for constraint in heightConstraints {
       constraint.isActive = true
     }
+  }
+  
+  private func applyRingToggleButton() {
+    self.ringToggleButton.applyRingToggleStyle()
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -83,7 +83,7 @@ extension RepeatOtherDaysView {
   }
   
   private func applyRingToggleButton() {
-    self.ringToggleButton.applyRingToggleStyle()
+    self.ringToggleButton.applyRingToggleButtonStyle()
   }
   
   private func setupButtonActions() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -55,6 +55,7 @@ extension RepeatOtherDaysView {
     self.setupInitialHeightConstraint()
     self.applyRingToggleButton()
     self.buildStackView()
+    self.setupButtonActions()
   }
   
   private func bindViewModel() {
@@ -79,6 +80,18 @@ extension RepeatOtherDaysView {
   
   private func applyRingToggleButton() {
     self.ringToggleButton.applyRingToggleStyle()
+  }
+  
+  private func setupButtonActions() {
+    self.ringToggleButton.addAction(UIAction { [weak self] _ in
+      self?.viewModel.ringToggleButtonTapped()
+      self?.updateBackgroundColor()
+    }, for: UIControl.Event.touchUpInside)
+    
+    self.dateButtonSet.addAction(UIAction { [weak self] _ in
+      self?.viewModel.dateButtonSetTapped()
+      self?.updateBackgroundColor()
+    }, for: UIControl.Event.touchUpInside)
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -51,6 +51,7 @@ public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
 extension RepeatOtherDaysView {
   private func setup() {
     self.bindViewModel()
+    self.usingAutolayout()
     self.setupInitialHeightConstraint()
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -45,6 +45,10 @@ public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
     super.setDeSelected()
     self.animateDisappear()
   }
+  
+  public func updateDate(startDate: String, endDate: String) {
+    self.viewModel.updateDate(startDate: startDate, endDate: endDate)
+  }
 }
 
 // MARK: - Private functions

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -1,6 +1,6 @@
 //
 //  RepeatOtherDaysView.swift
-//  
+//
 //
 //  Created by SONG on 5/28/24.
 //
@@ -295,10 +295,23 @@ extension RepeatOtherDaysView {
 // MARK: - About animation
 extension RepeatOtherDaysView {
   private func animateAppear() {
-
+    self.animateLayout()
+    UIView.animate(withDuration: Constant.RepeatOtherDaysView.AboutAnimation.duration) {
+      self.innerStackView.alpha = Constant.RepeatOtherDaysView.AboutAnimation.alphaAppear
+      self.divider.alpha = Constant.RepeatOtherDaysView.AboutAnimation.alphaAppear
+    }
   }
   
   private func animateDisappear() {
-
+    
   }
+  
+  private func animateLayout() {
+    UIView.animate(
+      withDuration: Constant.RepeatOtherDaysView.AboutAnimation.duration
+    ) {
+      self.superview?.layoutIfNeeded()
+    }
+  }
+
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -39,6 +39,11 @@ public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
     self.viewModel.toggleSelection()
     self.animateAppear()
   }
+  
+  override public func setDeSelected() {
+    super.setDeSelected()
+    self.animateDisappear()
+  }
 }
 
 // MARK: - Private functions
@@ -50,6 +55,10 @@ extension RepeatOtherDaysView {
 // MARK: - About animation
 extension RepeatOtherDaysView {
   private func animateAppear() {
+
+  }
+  
+  private func animateDisappear() {
 
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -87,15 +87,18 @@ extension RepeatOtherDaysView {
   }
   
   private func setupButtonActions() {
-    self.ringToggleButton.addAction(UIAction { [weak self] _ in
+    let ringToggleAction = UIAction { [weak self] _ in
       self?.viewModel.ringToggleButtonTapped()
       self?.updateBackgroundColor()
-    }, for: UIControl.Event.touchUpInside)
+    }
     
-    self.dateButtonSet.addAction(UIAction { [weak self] _ in
+    let dateButtonAction = UIAction { [weak self] _ in
       self?.viewModel.dateButtonSetTapped()
       self?.updateBackgroundColor()
-    }, for: UIControl.Event.touchUpInside)
+    }
+    
+    self.ringToggleButton.addAction(ringToggleAction, for: UIControl.Event.touchUpInside)
+    self.dateButtonSet.addAction(dateButtonAction, for: UIControl.Event.touchUpInside)
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -49,6 +49,79 @@ public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
 // MARK: - Private functions
 extension RepeatOtherDaysView {
   private func setup() {
+    self.bindViewModel()
+  }
+  
+  private func bindViewModel() {
+    self.bindDateButtons()
+    self.bindSelectionStates()
+    self.bindVisibilityStates()
+    self.bindViewHeights()
+    self.bindMargins()
+  }
+}
+
+// MARK: - About Binding
+extension RepeatOtherDaysView {
+  private func bindDateButtons() {
+    self.viewModel.dateButton.startDate.bind { [weak self] date in
+      self?.dateButtonSet.updateStartDateButton(title: date)
+    }
+    
+    self.viewModel.dateButton.endDate.bind { [weak self] date in
+      self?.dateButtonSet.updateEndDateButton(title: date)
+    }
+  }
+  
+  private func bindSelectionStates() {
+    self.viewModel.isSelected.bind { [weak self] _ in
+      self?.updateUI()
+      self?.updateBackgroundColor()
+    }
+    
+    self.viewModel.ringToggleButton.isSelected.bind { [weak self] isSelected in
+      self?.ringToggleButton.isSelected = isSelected
+      if isSelected == true {
+        self?.dateButtonSet.isSelected = false
+      }
+      self?.updateBackgroundColor()
+    }
+    
+    self.viewModel.dateButton.isSelected.bind { [weak self] isSelected in
+      self?.dateButtonSet.isSelected = isSelected
+      if isSelected == true {
+        self?.ringToggleButton.isSelected = false
+      }
+      self?.updateBackgroundColor()
+    }
+  }
+  
+  private func bindVisibilityStates() {
+    self.viewModel.divider.isHidden.bind { [weak self] isHidden in
+      self?.divider.isHidden = isHidden
+    }
+    
+    self.viewModel.innerStackView.isHidden.bind { [weak self] isHidden in
+      self?.innerStackView.isHidden = isHidden
+    }
+  }
+  
+  private func bindViewHeights() {
+    self.viewModel.height.bind { [weak self] height in
+      self?.updateRepeatOtherDaysViewHeightConstraint(to: height)
+    }
+    
+    self.viewModel.innerStackView.height.bind { [weak self] height in
+      self?.updateInnerStackViewViewHeightConstraint(to: height)
+    }
+  }
+  
+  private func bindMargins() {
+    self.viewModel.title.topMargin.bind { [weak self] margin in
+      self?.updateTitleConstraint(to: margin)
+    }
+  }
+}
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -1,0 +1,14 @@
+//
+//  RepeatOtherDaysView.swift
+//  
+//
+//  Created by SONG on 5/28/24.
+//
+
+import Foundation
+
+import ToDoGardenUIConstant
+
+public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
+  
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -54,6 +54,7 @@ extension RepeatOtherDaysView {
     self.usingAutolayout()
     self.setupInitialHeightConstraint()
     self.applyRingToggleButton()
+    self.buildStackView()
   }
   
   private func bindViewModel() {
@@ -78,6 +79,95 @@ extension RepeatOtherDaysView {
   
   private func applyRingToggleButton() {
     self.ringToggleButton.applyRingToggleStyle()
+  }
+}
+
+// MARK: - About Building Views
+
+extension RepeatOtherDaysView {
+  private func buildStackView() {
+    self.innerStackView.axis = NSLayoutConstraint.Axis.vertical
+    self.innerStackView.distribution = .fillProportionally
+    self.buildDivider()
+    self.buildRows()
+    self.innerStackView.isUserInteractionEnabled = true
+    self.addSubview(self.innerStackView)
+    self.innerStackView.usingAutolayout()
+    
+    let constants = Constant.RepeatOtherDaysView.Layout.self
+    
+    NSLayoutConstraint.activate(
+      [
+        self.innerStackView.topAnchor.constraint(equalTo: self.topAnchor, constant: constants.CommonMargin.broad),
+        self.innerStackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+        self.innerStackView.widthAnchor.constraint(equalToConstant: constants.InnerStackView.width),
+        self.innerStackView.heightAnchor.constraint(equalToConstant: constants.InnerStackView.height)
+      ]
+    )
+  }
+  
+  private func buildDivider() {
+    self.divider.backgroundColor = UIColor.toDoGardenGreenGray
+    self.divider.usingAutolayout()
+    self.addSubview(self.divider)
+    let constants = Constant.RepeatOtherDaysView.Layout.self
+    NSLayoutConstraint.activate(
+      [
+        self.divider.widthAnchor.constraint(equalToConstant: constants.Divider.width),
+        self.divider.heightAnchor.constraint(equalToConstant: constants.Divider.height),
+        self.divider.topAnchor.constraint(equalTo: self.topAnchor, constant: constants.CommonMargin.broad),
+        self.divider.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+      ]
+    )
+    self.innerStackView.addSpacing(constants.CommonMargin.narrow)
+  }
+  
+  private func buildRows() {
+    self.buildToggleRow()
+    self.innerStackView.addSpacing(
+      Constant.RepeatOtherDaysView.Layout.CommonMargin.broad
+    )
+    self.buildDateRow()
+  }
+  
+  private func buildToggleRow() {
+    let row = Styled.Row(
+      configuration: Styled.Row.Configuration.repeatOtherDays(
+        Styled.Row.Configuration.RepeatOtherDaysModel.init(
+          title: Constant.RepeatOtherDaysView.StringLiteral.everyday
+        )
+      ),
+      with: [self.ringToggleButton]
+    )
+    
+    self.innerStackView.addArrangedSubview(row)
+  }
+  
+  private func buildDateRow() {
+    let row = Styled.Row(
+      configuration: Styled.Row.Configuration.repeatOtherDays(
+        Styled.Row.Configuration.RepeatOtherDaysModel.init(
+          title: Constant.RepeatOtherDaysView.StringLiteral.timeSet
+        )
+      ),
+      with: []
+    )
+    let constants = Constant.RepeatOtherDaysView.Layout.self
+    self.innerStackView.insertArrangedSubview(row, at: 2)
+    self.innerStackView.addSubview(self.dateButtonSet)
+    self.dateButtonSet.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        self.dateButtonSet.topAnchor.constraint(
+          equalTo: row.topAnchor,
+          constant: constants.CommonMargin.narrow
+        ),
+        self.dateButtonSet.trailingAnchor.constraint(
+          equalTo: row.trailingAnchor,
+          constant: constants.DateButtonSet.trailing
+        )
+      ]
+    )
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -51,6 +51,7 @@ public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
 extension RepeatOtherDaysView {
   private func setup() {
     self.bindViewModel()
+    self.setupInitialHeightConstraint()
   }
   
   private func bindViewModel() {
@@ -59,6 +60,18 @@ extension RepeatOtherDaysView {
     self.bindVisibilityStates()
     self.bindViewHeights()
     self.bindMargins()
+  }
+  
+  private func setupInitialHeightConstraint() {
+    self.heightConstraints =
+    [
+      self.heightAnchor.constraint(equalToConstant: self.viewModel.height.value),
+      self.innerStackView.heightAnchor.constraint(equalToConstant: self.viewModel.innerStackView.height.value)
+    ]
+    
+    for constraint in heightConstraints {
+      constraint.isActive = true
+    }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -18,6 +18,12 @@ public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
   private var heightConstraints: [NSLayoutConstraint]
   private var viewModel: RepeatOtherDaysViewModel
   
+  override var isSelected: Bool {
+    willSet {
+      viewModel.isSelected.value = newValue
+    }
+  }
+  
   public init(startDate: String?, endDate: String?) {
     self.viewModel = RepeatOtherDaysViewModel(startDate: startDate, endDate: endDate)
     self.heightConstraints = []

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -21,7 +21,7 @@ public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
   
   override var isSelected: Bool {
     willSet {
-      viewModel.isSelected.value = newValue
+      self.viewModel.isSelected.value = newValue
     }
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -34,9 +34,22 @@ public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
     super.init(model: ToDoRepeatSelectionView.Model.anotherDay)
     self.setup()
   }
+  
+  override public func setSelected() {
+    self.viewModel.toggleSelection()
+    self.animateAppear()
+  }
 }
 
+// MARK: - Private functions
 extension RepeatOtherDaysView {
   private func setup() {
+  }
+}
+
+// MARK: - About animation
+extension RepeatOtherDaysView {
+  private func animateAppear() {
+
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
@@ -45,10 +45,30 @@ public final class RepeatOtherDaysViewModel {
     self.height = Observable(Constant.RepeatOtherDaysView.Layout.heightUnselected)
     self.title = TitleState(topMargin: Observable(Constant.ToDoRepeatSelectionView.Layout.RepetitionLabel.topMargin))
   }
+  
+  public func toggleSelection() {
+    self.updateState()
+  }
 }
 
 extension RepeatOtherDaysViewModel {
-  
+  private func updateState() {
+    let constants = Constant.RepeatOtherDaysView.Layout.self
+    
+    if self.isSelected.value {
+      self.divider.isHidden.value = false
+      self.innerStackView.isHidden.value = false
+      self.height.value = constants.heightSelected
+      self.title.topMargin.value = constants.Title.topMargin
+      self.innerStackView.height.value = constants.InnerStackView.height
+    } else {
+      self.divider.isHidden.value = true
+      self.innerStackView.isHidden.value = true
+      self.height.value = constants.heightUnselected
+      self.title.topMargin.value =  Constant.ToDoRepeatSelectionView.Layout.RepetitionLabel.topMargin
+      self.innerStackView.height.value = CGFloat.zero
+    }
+  }
 }
 
 extension RepeatOtherDaysViewModel {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
@@ -49,6 +49,13 @@ final class RepeatOtherDaysViewModel {
   func toggleSelection() {
     self.updateState()
   }
+  
+  func ringToggleButtonTapped() {
+    self.ringToggleButton.isSelected.value.toggle()
+    if self.ringToggleButton.isSelected.value == true {
+      self.dateButton.isSelected.value = false
+    }
+  }
 }
 
 extension RepeatOtherDaysViewModel {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
@@ -10,7 +10,67 @@ import Foundation
 import ToDoGardenUIConstant
 
 public final class RepeatOtherDaysViewModel {
+  private(set) var dateButton: DateButtonState
+  private(set) var ringToggleButton: RingToggleButtonState
+  private(set) var divider: DividerState
+  private(set) var innerStackView: InnerStackViewState
+  private(set) var title: TitleState
   
+  private(set) var isSelected: Observable<Bool>
+  private(set) var height: Observable<CGFloat>
+  
+  init(
+    startDate: String?,
+    endDate: String?
+  ) {
+    let today = RepeatOtherDaysViewModel.currentDateString()
+    
+    self.ringToggleButton = RepeatOtherDaysViewModel.initializeRingToggleButton(
+      startDate: startDate,
+      endDate: endDate
+    )
+    
+    self.dateButton = RepeatOtherDaysViewModel.initializeDateButton(
+      startDate: startDate,
+      endDate: endDate,
+      today: today
+    )
+    
+    self.isSelected = Observable(false)
+    self.divider = DividerState(isHidden: Observable(true))
+    self.innerStackView = InnerStackViewState(
+      isHidden: Observable(true),
+      height: Observable(CGFloat.zero)
+    )
+    self.height = Observable(Constant.RepeatOtherDaysView.Layout.heightUnselected)
+    self.title = TitleState(topMargin: Observable(Constant.ToDoRepeatSelectionView.Layout.RepetitionLabel.topMargin))
+  }
+}
+
+extension RepeatOtherDaysViewModel {
+  
+}
+
+extension RepeatOtherDaysViewModel {
+  private static func currentDateString() -> String {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy.MM.dd"
+    return dateFormatter.string(from: Date())
+  }
+  
+  private static func initializeRingToggleButton(startDate: String?, endDate: String?) -> RingToggleButtonState {
+    let isDateUndecided = (startDate == nil) || (endDate == nil)
+    return RingToggleButtonState(isSelected: Observable(isDateUndecided))
+  }
+  
+  private static func initializeDateButton(startDate: String?, endDate: String?, today: String) -> DateButtonState {
+    let isDateUndecided = (startDate == nil) || (endDate == nil)
+    return DateButtonState(
+      startDate: Observable(startDate ?? today),
+      endDate: Observable(endDate ?? today),
+      isSelected: Observable(!isDateUndecided)
+    )
+  }
 }
 
 extension RepeatOtherDaysViewModel {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
@@ -12,6 +12,32 @@ import ToDoGardenUIConstant
 public final class RepeatOtherDaysViewModel {
   
 }
+
+extension RepeatOtherDaysViewModel {
+  struct DateButtonState {
+    var startDate: Observable<String>
+    var endDate: Observable<String>
+    var isSelected: Observable<Bool>
+  }
+  
+  struct RingToggleButtonState {
+    var isSelected: Observable<Bool>
+  }
+  
+  struct DividerState {
+    var isHidden: Observable<Bool>
+  }
+  
+  struct InnerStackViewState {
+    var isHidden: Observable<Bool>
+    var height: Observable<CGFloat>
+  }
+  
+  struct TitleState {
+    var topMargin: Observable<CGFloat>
+  }
+}
+
 class Observable<T> {
   var value: T {
     didSet {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
@@ -1,0 +1,14 @@
+//
+//  RepeatOtherDaysViewModel.swift
+//
+//
+//  Created by SONG on 5/28/24.
+//
+
+import Foundation
+
+import ToDoGardenUIConstant
+
+public final class RepeatOtherDaysViewModel {
+  
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
@@ -137,10 +137,10 @@ extension RepeatOtherDaysViewModel {
   }
 }
 
-class Observable<T> {
+final class Observable<T> {
   var value: T {
     didSet {
-      listener?(value)
+      self.listener?(value)
     }
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
@@ -12,3 +12,21 @@ import ToDoGardenUIConstant
 public final class RepeatOtherDaysViewModel {
   
 }
+class Observable<T> {
+  var value: T {
+    didSet {
+      listener?(value)
+    }
+  }
+  
+  private var listener: ((T) -> Void)?
+  
+  init(_ value: T) {
+    self.value = value
+  }
+  
+  func bind(_ listener: @escaping (T) -> Void) {
+    self.listener = listener
+    listener(value)
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
@@ -63,6 +63,11 @@ final class RepeatOtherDaysViewModel {
       self.ringToggleButton.isSelected.value = false
     }
   }
+  
+  func updateDate(startDate: String, endDate: String) {
+    self.dateButton.startDate.value = startDate
+    self.dateButton.endDate.value = endDate
+  }
 }
 
 extension RepeatOtherDaysViewModel {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 import ToDoGardenUIConstant
 
-public final class RepeatOtherDaysViewModel {
+final class RepeatOtherDaysViewModel {
   private(set) var dateButton: DateButtonState
   private(set) var ringToggleButton: RingToggleButtonState
   private(set) var divider: DividerState
@@ -46,7 +46,7 @@ public final class RepeatOtherDaysViewModel {
     self.title = TitleState(topMargin: Observable(Constant.ToDoRepeatSelectionView.Layout.RepetitionLabel.topMargin))
   }
   
-  public func toggleSelection() {
+  func toggleSelection() {
     self.updateState()
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
@@ -56,6 +56,13 @@ final class RepeatOtherDaysViewModel {
       self.dateButton.isSelected.value = false
     }
   }
+  
+  func dateButtonSetTapped() {
+    self.dateButton.isSelected.value.toggle()
+    if self.dateButton.isSelected.value == true {
+      self.ringToggleButton.isSelected.value = false
+    }
+  }
 }
 
 extension RepeatOtherDaysViewModel {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #171 
## 🎉 변경 사항
- RepeatOtherDaysView 추가 
- RepeatOtherDaysViewModel 추가 

## 📌 PR Point

### 실행화면
![Simulator Screen Recording - iPhone 15 - 2024-05-30 at 14 51 30](https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/e3123503-9ed9-4c61-a019-167916458397)

- 실제로는 자연스러운 애니메이션이 적용되어 있습니다. 

### 기능설명
![스크린샷 2024-05-30 오후 3 06 55](https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/307a30f2-08cb-4d46-b259-f77952924758)
![스크린샷 2024-05-30 오후 3 07 04](https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/35886ff1-7fb2-4d45-a81b-bdd0fd07e144)

- 아래와 같이 사용가능합니다. 
```swift
let repeatView = RepeatOtherDaysView(startDate: "2323.23.23", endDate: "9999.99.99") // addSubview이후 x,y 위치 지정 요망

repeatView.dateButtonSet.addAction(someUIAction, for: .touchUpInside) // 모듈 외부에서 시간지정 버튼에대한 액션 할당

repeatView.updateDate(startDate: "9999.99.99", endDate: "0000.00.00") // 모듈 외부에서 날짜 변경
```

### 뷰 바인딩과 테스터블 
RepeatOtherDaysViewModel의 존재 이유는 뷰 바인딩과 테스트코드 작성시 용이함을 목적으로 만들었습니다. 

- 각 버튼의 상태에 따라 다른 요소들의 상태 변경이 많음. -> 테스트코드를 작성해야 할 필요성
- 가변할 수 있는 상태값들을 ViewModel에 모아놓았습니다. 
- 해당 상태들은 `private(set)`을 적용하여 외부에서 직접 접근하여 변경될 수 없고, 항상 RepeatOtherDaysViewModel 내부의 메서드를 거쳐 변경(set)됩니다. 
- RepeatOtherDaysViewModel의 메소드를 실행시키고, 이후 각 상태값을 확인하는 방식의 테스트코드를 작성할 수 있습니다. 


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?