### PR TITLE
CalendarDataGenerator 수정

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -56,7 +56,7 @@ extension CalendarDataGenerator {
     let totalMonthDays = try MonthPosition.allCases
       .map { position in
         let params = try position.monthDayParams(day, calendar: self.calendar)
-        let isThisMonth = position == MonthPosition.current ? true : false
+        let isThisMonth = position == MonthPosition.current
         return self.getMonthDataDays(for: params.range, from: params.firstDay, isThisMonth: isThisMonth)
       }
       .reduce(into: [MonthData.Day](), +=)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol CalendarDataGeneratable {
   func fetchWeekdaySymbols() -> [String]
   func fetchMonthData(from date: Date, add value: Int) throws -> MonthData
-  func compareMonth(date1: Date, with date2: Date) -> ComparisonResult
+  func compareMonth(from date: Date, with another: Date) -> ComparisonResult
 }
 
 final class CalendarDataGenerator: CalendarDataGeneratable {
@@ -31,17 +31,17 @@ final class CalendarDataGenerator: CalendarDataGeneratable {
       to: date
     )
     else { throw CalendarDataError.invalidInput }
-
+    
     let firstDayOfMonth = self.calendar.firstDayOfMonth(from: monthToFetch)
     let dates = try self.monthDays(from: firstDayOfMonth)
     
     return MonthData(firstDayOfMonth: firstDayOfMonth, dates: dates)
   }
   
-  func compareMonth(date1: Date, with date2: Date) -> ComparisonResult {
+  func compareMonth(from date: Date, with another: Date) -> ComparisonResult {
     let comparisonResult = self.calendar.compare(
-      date1,
-      to: date2,
+      date,
+      to: another,
       toGranularity: Calendar.Component.month
     )
     

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarDataGenerator.swift
@@ -56,7 +56,8 @@ extension CalendarDataGenerator {
     let totalMonthDays = try MonthPosition.allCases
       .map { position in
         let params = try position.monthDayParams(day, calendar: self.calendar)
-        return self.getMonthDataDays(for: params.range, from: params.firstDay)
+        let isThisMonth = position == MonthPosition.current ? true : false
+        return self.getMonthDataDays(for: params.range, from: params.firstDay, isThisMonth: isThisMonth)
       }
       .reduce(into: [MonthData.Day](), +=)
     let dayCountOfWeek = self.calendar.shortWeekdaySymbols.count
@@ -68,7 +69,8 @@ extension CalendarDataGenerator {
   
   private func getMonthDataDays(
     for dateRange: Range<Int>,
-    from firstDay: Date
+    from firstDay: Date,
+    isThisMonth: Bool
   ) -> [MonthData.Day] {
     return dateRange.map { value in
       let dayOfNextMonth = self.calendar.date(
@@ -77,7 +79,7 @@ extension CalendarDataGenerator {
         to: firstDay
       ) ?? Date()
       
-      return MonthData.Day(date: dayOfNextMonth, isThisMonth: false)
+      return MonthData.Day(date: dayOfNextMonth, isThisMonth: isThisMonth)
     }
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #189

## 🎉 변경 사항
- CalendarDataGenerator의 날짜 생성 로직을 수정하였습니다.

## 📌 PR Point
### 1. 월 비교 로직 파라미터 네이밍 수정
두 Date 객체를 입력받아 같은 달인지 비교하는 
compareMonth 메서드의 파라미터명을 더 명확하게 수정하였습니다.

### 2. 날짜 생성 로직 수정
- 한 달에 대한 데이터를 생성할 때, 날짜가 같은달에 속하는지 여부를 입력하도록 수정하였습니다.
```swift
private func monthDays(from day: Date) throws -> [MonthData.Day] {
  let totalMonthDays = try MonthPosition.allCases
      .map { position in
        let params = try position.monthDayParams(day, calendar: self.calendar)

        // 변경 전
        let isThisMonth = true

        // 변경 후 -> 이번달이 아니면 false를 할당
        let isThisMonth = position == MonthPosition.current ? true : false
        return self.getMonthDataDays(for: params.range, from: params.firstDay, isThisMonth: isThisMonth)
      }
``` 

- 해당 여부를 토대로 이번달에 속하지 않는 날짜는 textColor를 변경할 때 사용됩니다.
<img width="355" alt="스크린샷 2024-05-28 16 42 03" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/9f6c2c37-a68c-4ed5-9b73-0e8c7a045e0c">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?