### PR TITLE
SettingTimeView 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -1,0 +1,47 @@
+//
+//  SettingTimeView.swift
+//
+//
+//  Created by SONG on 5/30/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+
+public class SettingTimeView: UIView {
+  private var configuration: Configuration
+  private let timepicker: ToDoGardenTimePicker
+
+  public init(with button: UIButton, for configuration: Configuration) {
+    self.configuration = configuration
+    self.timepicker = ToDoGardenTimePicker(configuration: self.configuration.dataStore.timePicker)
+    super.init(frame: CGRect.zero)
+    self.build(with: button)
+  }
+  
+  @available(*, unavailable)
+  public required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+extension SettingTimeView {
+  private func build(with button: UIButton) {
+    
+  }
+}
+
+extension SettingTimeView {
+  public struct Configuration {
+    let dataStore: Constant.SettingTimeView.DataStore
+    
+    init(dataStore: Constant.SettingTimeView.DataStore) {
+      self.dataStore = dataStore
+    }
+  }
+}
+
+extension SettingTimeView.Configuration {
+
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import ToDoGardenUIConstant
+import ToDoGardenUIResource
 
 public class SettingTimeView: UIView {
   private var configuration: Configuration
@@ -39,7 +40,27 @@ public class SettingTimeView: UIView {
 
 extension SettingTimeView {
   private func build(with button: UIButton) {
+    self.buildTitleLabel()
     
+  }
+  
+  private func buildTitleLabel() {
+    let titleLabel = UILabel()
+    titleLabel.text = self.configuration.dataStore.title.text
+    titleLabel.font = UIFont.pretendardHeadBold
+    titleLabel.textColor = UIColor.toDoGardenBlack
+    self.addSubview(titleLabel)
+    
+    titleLabel.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        titleLabel.topAnchor.constraint(
+          equalTo: self.topAnchor,
+          constant: self.configuration.dataStore.title.topMargin
+        ),
+        titleLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+      ]
+    )
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -83,7 +83,7 @@ extension SettingTimeView {
   private func buildButton(with button: UIButton) {
     self.addSubview(button)
     
-    button.translatesAutoresizingMaskIntoConstraints = false
+    button.usingAutolayout()
     NSLayoutConstraint.activate(
       [
         button.bottomAnchor.constraint(

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -91,5 +91,16 @@ extension SettingTimeView {
 }
 
 extension SettingTimeView.Configuration {
-
+  public static let focusTimeSetting: Self = SettingTimeView.Configuration.init(
+    dataStore: Constant.SettingTimeView.focusTimeSetting
+  )
+  
+  public static let breakTimeSetting: Self = SettingTimeView.Configuration.init(
+    dataStore: Constant.SettingTimeView.breakTimeSetting
+  )
+  
+  public static let alarmTimeSetting: Self =
+  SettingTimeView.Configuration.init(
+    dataStore: Constant.SettingTimeView.alarmTimeSetting
+  )
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -41,6 +41,7 @@ public class SettingTimeView: UIView {
 extension SettingTimeView {
   private func build(with button: UIButton) {
     self.buildTitleLabel()
+    self.buildTimePicker()
     
   }
   
@@ -59,6 +60,21 @@ extension SettingTimeView {
           constant: self.configuration.dataStore.title.topMargin
         ),
         titleLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+      ]
+    )
+  }
+  
+  private func buildTimePicker() {
+    self.addSubview(self.timepicker)
+    
+    self.timepicker.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        self.timepicker.topAnchor.constraint(
+          equalTo: self.topAnchor,
+          constant: self.configuration.dataStore.timePicker.dataStore.pickerView.topMargin
+        ),
+        self.timepicker.centerXAnchor.constraint(equalTo: self.centerXAnchor, constant: -3)
       ]
     )
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -24,6 +24,12 @@ public class SettingTimeView: UIView {
   public required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+  
+  override public var intrinsicContentSize: CGSize {
+    let screenWidth = UIScreen.main.bounds.width
+    let screenHeight = UIScreen.main.bounds.height
+    return CGSize.init(width: screenWidth, height: screenHeight / 2)
+  }
 }
 
 extension SettingTimeView {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -42,7 +42,7 @@ extension SettingTimeView {
   private func build(with button: UIButton) {
     self.buildTitleLabel()
     self.buildTimePicker()
-    
+    self.buildButton(with: button)
   }
   
   private func buildTitleLabel() {
@@ -75,6 +75,21 @@ extension SettingTimeView {
           constant: self.configuration.dataStore.timePicker.dataStore.pickerView.topMargin
         ),
         self.timepicker.centerXAnchor.constraint(equalTo: self.centerXAnchor, constant: -3)
+      ]
+    )
+  }
+  
+  private func buildButton(with button: UIButton) {
+    self.addSubview(button)
+    
+    button.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate(
+      [
+        button.bottomAnchor.constraint(
+          equalTo: self.bottomAnchor,
+          constant: self.configuration.dataStore.button.bottomMargin
+        ),
+        button.centerXAnchor.constraint(equalTo: self.centerXAnchor)
       ]
     )
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -27,8 +27,9 @@ public class SettingTimeView: UIView {
   }
   
   override public var intrinsicContentSize: CGSize {
-    let screenWidth = UIScreen.main.bounds.width
-    let screenHeight = UIScreen.main.bounds.height
+    let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+    let screenWidth = windowScene?.screen.bounds.width ?? 1.0
+    let screenHeight = windowScene?.screen.bounds.height ?? 1.0
     return CGSize.init(width: screenWidth, height: screenHeight / 2)
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -104,3 +104,19 @@ extension SettingTimeView.Configuration {
     dataStore: Constant.SettingTimeView.alarmTimeSetting
   )
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let button = ToDoGardenBoxButton(title: "asdasd", buttonType: .primaryRoundRectButton)
+  
+  let view = SettingTimeView(with: button, for: .breakTimeSetting)
+  
+  let action = UIAction { _ in
+    view.calculateDate { date in print(date) }
+  }
+  
+  button.addAction(action, for: .touchUpInside)
+  return view
+}
+#endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -12,7 +12,7 @@ import ToDoGardenUIConstant
 public class SettingTimeView: UIView {
   private var configuration: Configuration
   private let timepicker: ToDoGardenTimePicker
-
+  
   public init(with button: UIButton, for configuration: Configuration) {
     self.configuration = configuration
     self.timepicker = ToDoGardenTimePicker(configuration: self.configuration.dataStore.timePicker)
@@ -29,6 +29,11 @@ public class SettingTimeView: UIView {
     let screenWidth = UIScreen.main.bounds.width
     let screenHeight = UIScreen.main.bounds.height
     return CGSize.init(width: screenWidth, height: screenHeight / 2)
+  }
+  
+  public func calculateDate(completion: @escaping (Date) -> Void) {
+    let calculatedDate = self.timepicker.calculateDate()
+    completion(calculatedDate)
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #191 
## 🎉 변경 사항
- SettingTimeView를 추가하였습니다. 
## 📌 PR Point

![스크린샷 2024-05-31 오후 1 34 24](https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/14eaf681-3166-42c9-b62b-f34481e91df2)
 - ↑ 하프 모달위에 올라갈 VIew입니다. 
 
 ```swift
let button = UIButton()

let view = SettingTimeView(with: button, for: .breakTimeSetting)

let view = SettingTimeView(with: button, for: .alarmTimeSetting)

let view = SettingTimeView(with: button, for: .focusTimeSetting)
 ```
 - ↑ 3가지 타입이 있으며, 위와 같이 생성 가능합니다. 
 
  ```swift
let settingTimeview = SettingTimeView(with: button, for: .breakTimeSetting)

  let someAction = UIAction { _ in
    settingTimeview.calculateDate { date in someRequest(date) }
  }

button.addAction(someAction, for: .touchUpInside)
 ```
 - ↑ calculateDate() 를 이용하여 호출하는 쪽에서 `현재시각`에 `선택된 시각`을 더한 Date값을 전달받을 수 있습니다. 
 - 반환되는 `date : Date` 는 국제 표준시간대 기준이며, 한국시간과 9시간 차이가 납니다. 이 부분은 요청 명세가 나오면 수정될 수 있겠습니다. 


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?