### PR TITLE
CalendarViewSingleSelectionDelegate 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/Calendar+localeUpdated.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/Calendar+localeUpdated.swift
@@ -1,0 +1,21 @@
+//
+//  Calendar+localeUpdated.swift
+//  
+//
+//  Created by Wood on 5/31/24.
+//
+
+import Foundation
+
+extension Calendar {
+  static var localeUpdated: Self {
+    var calendar = Self(identifier: Identifier.gregorian)
+    if let localeIdentifier = Locale.preferredLanguages.first {
+      calendar.locale = Locale(identifier: localeIdentifier)
+    } else {
+      calendar.locale = Locale.autoupdatingCurrent
+    }
+
+    return calendar
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate+makeDiffableDataSource.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate+makeDiffableDataSource.swift
@@ -16,22 +16,8 @@ extension CalendarViewDelegate {
     return UICollectionViewDiffableDataSource<
       CalendarSection,
       CalendarItem
-    >(collectionView: collectionView) { (collectionView, indexPath, dayItem) in
-      guard let cell = collectionView.dequeueReusableCell(
-        withReuseIdentifier: CalendarCollectionViewCell.identifier,
-        for: indexPath
-      ) as? CalendarCollectionViewCell
-      else { return UICollectionViewCell() }
-
-      let date = dayItem.date
-      let formattedDateString = dateFormatter.string(from: date).split(separator: " ")
-      guard let dayString = formattedDateString.last
-      else { return cell }
-
-      let isThisMonth = dayItem.isThisMonth
-      cell.update(dayString: String(dayString), isThisMonth: isThisMonth)
-
-      return cell
+    >(collectionView: collectionView) { (_, _, _) in
+      return UICollectionViewCell()
     }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate+makeDiffableDataSource.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate+makeDiffableDataSource.swift
@@ -1,0 +1,63 @@
+//
+//  CalendarCollectionViewDelegate+DiffableDataSource.swift
+//
+//
+//  Created by Wood on 5/27/24.
+//
+
+import UIKit
+
+extension CalendarViewDelegate {
+  func makeDiffableDataSource(
+    _ collectionView: UICollectionView,
+    with dateFormatter: DateFormatter
+  )
+  -> UICollectionViewDiffableDataSource<CalendarSection, CalendarItem> {
+    return UICollectionViewDiffableDataSource<
+      CalendarSection,
+      CalendarItem
+    >(collectionView: collectionView) { (collectionView, indexPath, dayItem) in
+      guard let cell = collectionView.dequeueReusableCell(
+        withReuseIdentifier: CalendarCollectionViewCell.identifier,
+        for: indexPath
+      ) as? CalendarCollectionViewCell
+      else { return UICollectionViewCell() }
+
+      let date = dayItem.date
+      let formattedDateString = dateFormatter.string(from: date).split(separator: " ")
+      guard let dayString = formattedDateString.last
+      else { return cell }
+
+      let isThisMonth = dayItem.isThisMonth
+      cell.update(dayString: String(dayString), isThisMonth: isThisMonth)
+
+      return cell
+    }
+  }
+}
+
+struct CalendarSection: Hashable {
+  let firstDay: Date
+
+  static func == (lhs: CalendarSection, rhs: CalendarSection) -> Bool {
+    return lhs.firstDay == rhs.firstDay
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(self.firstDay)
+  }
+}
+
+struct CalendarItem: Hashable {
+  let date: Date
+  let isThisMonth: Bool
+
+  static func == (lhs: CalendarItem, rhs: CalendarItem) -> Bool {
+    return lhs.date == rhs.date && lhs.isThisMonth == rhs.isThisMonth
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(self.date)
+    hasher.combine(self.isThisMonth)
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate+makeDiffableDataSource.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate+makeDiffableDataSource.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-extension CalendarViewDelegate {
+extension CalendarViewSingleSelectionDelegate {
   func makeDiffableDataSource(
     _ collectionView: UICollectionView,
     with dateFormatter: DateFormatter

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -20,6 +20,8 @@ final class CalendarViewDelegate: NSObject {
   private var initialContentOffset: CGPoint
   private var selectedItem: CalendarItem?
 
+  var scrollSender: CalendarScrollSender?
+
   init(
     collectionView: UICollectionView,
     collectionViewModel: CalendarView.Model.CollectionView
@@ -48,6 +50,7 @@ final class CalendarViewDelegate: NSObject {
       animated: animated
     )
     self.reloadAllSnapshot()
+    self.scrollSender?.didScroll()
   }
 
   func getCollectionViewHeight() -> CGFloat {
@@ -245,10 +248,12 @@ extension CalendarViewDelegate: UICollectionViewDelegate {
 
   func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
     self.reloadAllSnapshot()
+    self.scrollSender?.didScroll()
   }
 
   func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
     self.reloadAllSnapshot()
+    self.scrollSender?.didScroll()
   }
 }
 
@@ -271,6 +276,7 @@ extension CalendarViewDelegate {
     self.scrollCalendar(to: scrollDirection, animated: true)
     self.setSelected(to: selectedNewItem)
     self.selectedItem = selectedNewItem
+    self.scrollSender?.didScroll()
   }
 
   private func validateIsSameMonth(selectedItem: CalendarItem, section indexPath: IndexPath) -> ComparisonResult {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -102,7 +102,7 @@ extension CalendarViewDelegate {
   private func loadInitialMonthSnapshot() {
     let snapshot = self.collectionViewDataSource.snapshot()
     let dateRange = (-3...3)
-    guard let newSnapshot = try? self.addMonthData(to: snapshot, wit: dateRange, isAppendFirst: false)
+    guard let newSnapshot = try? self.addMonthData(to: snapshot, with: dateRange, isAppendFirst: false)
     else { return }
 
     self.collectionViewDataSource.apply(newSnapshot)
@@ -151,14 +151,14 @@ extension CalendarViewDelegate {
     let isAppendFirst = self.currentIndexPath.section == 0 ? true : false
     return try self.addMonthData(
       to: snapshot,
-      wit: (1...3),
+      with: (1...3),
       isAppendFirst: isAppendFirst
     )
   }
 
   private func addMonthData(
     to snapshot: NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem>,
-    wit dateRange: ClosedRange<Int>,
+    with dateRange: ClosedRange<Int>,
     isAppendFirst: Bool
   ) throws -> NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem> {
     var newSnapshot = snapshot

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -34,6 +34,10 @@ final class CalendarViewDelegate: NSObject {
     self.loadInitialMonthSnapshot()
   }
 
+  func fetchWeekdaySymbols() -> [String] {
+    return self.calendarDataGenerator.fetchWeekdaySymbols()
+  }
+
   func scrollCalendar(to scrollDirection: CalendarScrollDirection, animated: Bool) {
     self.currentIndexPath.section += scrollDirection.rawValue
     self.collectionView.scrollToItem(
@@ -48,6 +52,14 @@ final class CalendarViewDelegate: NSObject {
     let currentSection = snapshot.sectionIdentifiers[self.currentIndexPath.section]
     let itemCount = snapshot.itemIdentifiers(inSection: currentSection).count
     return self.calculateHeight(items: itemCount)
+  }
+
+  func getDateString() -> String {
+    let snapShot = self.collectionViewDataSource.snapshot()
+    let currentSectionDate = snapShot.sectionIdentifiers[self.currentIndexPath.section].firstDay
+    let formattedString = self.dateFormatter.string(from: currentSectionDate).split(separator: " ")
+    let dateString = formattedString[0] + " \(formattedString[1])"
+    return String(dateString)
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -10,18 +10,24 @@ import UIKit
 import ToDoGardenUIConstant
 
 final class CalendarViewDelegate: NSObject {
-  private var collectionView: UICollectionView
-  private var collectionViewDataSource: UICollectionViewDiffableDataSource<CalendarSection, CalendarItem>!
   private var calendarDataGenerator: CalendarDataGeneratable
-  private var currentIndexPath: IndexPath
-  private var collectionViewModel: CalendarView.Model.CollectionView
   private var dateFormatter: DateFormatter
 
-  init(collectionView: UICollectionView) {
-    self.collectionView = collectionView
+  private var collectionView: UICollectionView
+  private var collectionViewDataSource: UICollectionViewDiffableDataSource<CalendarSection, CalendarItem>!
+  private var currentIndexPath: IndexPath
+  private var collectionViewModel: CalendarView.Model.CollectionView
+  private var initialContentOffset: CGPoint
+
+  init(
+    collectionView: UICollectionView,
+    collectionViewModel: CalendarView.Model.CollectionView
+  ) {
     self.calendarDataGenerator = CalendarDataGenerator(calendar: Calendar.localeUpdated)
-    self.currentIndexPath = IndexPath(item: 0, section: 3)
     self.dateFormatter = DateFormatter()
+    self.collectionView = collectionView
+    self.currentIndexPath = IndexPath(item: 0, section: 3)
+    self.initialContentOffset = CGPoint()
     super.init()
     self.setupDateFormatter()
     self.loadInitialMonthSnapshot()
@@ -94,6 +100,59 @@ extension CalendarViewDelegate {
     }
 
     self.collectionViewDataSource.apply(snapshot)
+  }
+}
+
+// MARK: UIScrollView Deleagate Functions
+
+extension CalendarViewDelegate: UICollectionViewDelegate {
+  func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+    self.initialContentOffset = scrollView.contentOffset
+  }
+
+  func scrollViewWillEndDragging(
+    _ scrollView: UIScrollView,
+    withVelocity velocity: CGPoint,
+    targetContentOffset: UnsafeMutablePointer<CGPoint>
+  ) {
+    let contentOffset = scrollView.contentOffset.x
+    let targetContentOffset = targetContentOffset.pointee.x
+    let velocity = velocity.x
+    let scrollViewWidth = scrollView.frame.width
+
+    guard let scrollDirection = self.calculateScrollDireciton(
+      contentOffset,
+      targetContentOffset,
+      velocity,
+      scrollViewWidth / 2
+    ) else { return }
+
+    self.currentIndexPath.section += scrollDirection.rawValue
+  }
+
+  private func calculateScrollDireciton(
+    _ contentOffset: CGFloat,
+    _ targetContentOffset: CGFloat,
+    _ velocity: CGFloat,
+    _ scrollViewHalfWidth: CGFloat
+  ) -> CalendarScrollDirection? {
+    guard velocity == 0 else {
+      return velocity > 0 ? CalendarScrollDirection.right : CalendarScrollDirection.left
+    }
+
+    let hasScrolledFarEnough = abs(contentOffset - self.initialContentOffset.x) > scrollViewHalfWidth
+    guard hasScrolledFarEnough else {
+      return nil
+    }
+
+    return contentOffset > targetContentOffset ?
+    CalendarScrollDirection.left : CalendarScrollDirection.right
+  }
+
+  func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+  }
+
+  func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -18,6 +18,7 @@ final class CalendarViewDelegate: NSObject {
   private var currentIndexPath: IndexPath
   private var collectionViewModel: CalendarView.Model.CollectionView
   private var initialContentOffset: CGPoint
+  private var selectedItem: CalendarItem?
 
   init(
     collectionView: UICollectionView,
@@ -233,6 +234,55 @@ extension CalendarViewDelegate: UICollectionViewDelegate {
 
   func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
     self.reloadAllSnapshot()
+  }
+}
+
+// MARK: Cell Selection Functions
+
+extension CalendarViewDelegate {
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    guard let selectedNewItem = self.collectionViewDataSource.itemIdentifier(for: indexPath)
+    else { return }
+
+    let comparisonResult = self.validateIsSameMonth(selectedItem: selectedNewItem, section: indexPath)
+    guard comparisonResult != ComparisonResult.orderedSame
+    else {
+      self.selectedItem = selectedNewItem
+      return
+    }
+
+    let scrollDirection = comparisonResult == ComparisonResult.orderedAscending ?
+    CalendarScrollDirection.left : CalendarScrollDirection.right
+    self.scrollCalendar(to: scrollDirection, animated: true)
+    self.setSelected(to: selectedNewItem)
+    self.selectedItem = selectedNewItem
+  }
+
+  private func validateIsSameMonth(selectedItem: CalendarItem, section indexPath: IndexPath) -> ComparisonResult {
+    guard let date = self.collectionViewDataSource.sectionIdentifier(for: indexPath.section)?.firstDay
+    else { return ComparisonResult.orderedSame }
+
+    return self.calendarDataGenerator.compareMonth(
+      date1: selectedItem.date,
+      with: date
+    )
+  }
+
+  private func setSelected(to item: CalendarItem) {
+    let snapshot = self.collectionViewDataSource.snapshot()
+    let section = snapshot.sectionIdentifiers[self.currentIndexPath.section]
+    let indexOfItem = snapshot.itemIdentifiers(inSection: section).firstIndex { (calendarItem: CalendarItem) in
+      return item.date == calendarItem.date
+    }
+
+    if let itemIndex = indexOfItem {
+      let itemIndexPath = IndexPath(item: itemIndex, section: self.currentIndexPath.section)
+      self.collectionView.selectItem(
+        at: itemIndexPath,
+        animated: true,
+        scrollPosition: []
+      )
+    }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -1,0 +1,18 @@
+//
+//  CalendarViewDelegate.swift
+//
+//
+//  Created by Wood on 5/31/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+
+final class CalendarViewDelegate: NSObject {
+  private var collectionView: UICollectionView
+
+  init(collectionView: UICollectionView) {
+    self.collectionView = collectionView
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -12,11 +12,16 @@ import ToDoGardenUIConstant
 final class CalendarViewDelegate: NSObject {
   private var collectionView: UICollectionView
   private var collectionViewDataSource: UICollectionViewDiffableDataSource<CalendarSection, CalendarItem>!
+  private var calendarDataGenerator: CalendarDataGeneratable
   private var dateFormatter: DateFormatter
 
   init(collectionView: UICollectionView) {
     self.collectionView = collectionView
     self.dateFormatter = DateFormatter()
+    self.calendarDataGenerator = CalendarDataGenerator(calendar: Calendar.localeUpdated)
+    super.init()
+    self.setupDateFormatter()
+    self.loadInitialMonthSnapshot()
   }
 }
 
@@ -38,5 +43,27 @@ extension CalendarViewDelegate {
   private func setupCollectionViewDataSource() {
     self.collectionViewDataSource = self.makeDiffableDataSource(self.collectionView, with: self.dateFormatter)
     self.collectionView.dataSource = self.collectionViewDataSource
+  }
+
+  private func loadInitialMonthSnapshot() {
+    var snapshot = self.collectionViewDataSource.snapshot()
+    let currentDate = Date()
+    let dateRange = (-3...3)
+    dateRange.forEach { (addValue: Int) in
+      guard let monthData = try? self.calendarDataGenerator.fetchMonthData(from: currentDate, add: addValue)
+      else { return }
+
+      let section = CalendarSection(firstDay: monthData.firstDayOfMonth)
+      snapshot.appendSections([section])
+
+      let newItems = monthData.dates.map { (day: MonthData.Day) in
+        let date = day.date
+        let isThisMonth = day.isThisMonth
+        return CalendarItem(date: date, isThisMonth: isThisMonth)
+      }
+      snapshot.appendItems(newItems, toSection: section)
+    }
+
+    self.collectionViewDataSource.apply(snapshot)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import ToDoGardenUIConstant
 
-final class CalendarViewDelegate: NSObject {
+class CalendarViewDelegate: NSObject {
   private var calendarDataGenerator: CalendarDataGeneratable
   private var dateFormatter: DateFormatter
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -28,9 +28,11 @@ final class CalendarViewDelegate: NSObject {
     self.dateFormatter = DateFormatter()
     self.collectionView = collectionView
     self.currentIndexPath = IndexPath(item: 0, section: 3)
+    self.collectionViewModel = collectionViewModel
     self.initialContentOffset = CGPoint()
     super.init()
     self.setupDateFormatter()
+    self.setupCollectionViewDataSource()
     self.loadInitialMonthSnapshot()
   }
 
@@ -45,6 +47,7 @@ final class CalendarViewDelegate: NSObject {
       at: UICollectionView.ScrollPosition.left,
       animated: animated
     )
+    self.reloadAllSnapshot()
   }
 
   func getCollectionViewHeight() -> CGFloat {
@@ -94,25 +97,12 @@ extension CalendarViewDelegate {
   }
 
   private func loadInitialMonthSnapshot() {
-    var snapshot = self.collectionViewDataSource.snapshot()
-    let currentDate = Date()
+    let snapshot = self.collectionViewDataSource.snapshot()
     let dateRange = (-3...3)
-    dateRange.forEach { (addValue: Int) in
-      guard let monthData = try? self.calendarDataGenerator.fetchMonthData(from: currentDate, add: addValue)
-      else { return }
+    guard let newSnapshot = try? self.addMonthData(to: snapshot, wit: dateRange, isAppendFirst: false)
+    else { return }
 
-      let section = CalendarSection(firstDay: monthData.firstDayOfMonth)
-      snapshot.appendSections([section])
-
-      let newItems = monthData.dates.map { (day: MonthData.Day) in
-        let date = day.date
-        let isThisMonth = day.isThisMonth
-        return CalendarItem(date: date, isThisMonth: isThisMonth)
-      }
-      snapshot.appendItems(newItems, toSection: section)
-    }
-
-    self.collectionViewDataSource.apply(snapshot)
+    self.collectionViewDataSource.apply(newSnapshot)
   }
 
   private func reloadAllSnapshot() {
@@ -120,13 +110,14 @@ extension CalendarViewDelegate {
     guard self.currentIndexPath.section <= 0 || self.currentIndexPath.section >= lastSection
     else { return }
 
-    let currentSnapshot = self.collectionViewDataSource.snapshot()
-    let scrollDirection: CalendarScrollDirection = self.currentIndexPath.section == 0 ? .left : .right
-    let snapshot1 = self.deleteSections(by: scrollDirection, to: currentSnapshot)
-    let snapshot2 = self.insertNewSection(by: scrollDirection, to: snapshot1)
+    guard let deletedSnapshot = try? self.deleteSections(to: self.collectionViewDataSource.snapshot()),
+    let updatedSnapshot = try? self.insertNewSection(to: deletedSnapshot)
+    else { return }
 
-    self.collectionViewDataSource?.apply(
-      snapshot2,
+    self.currentIndexPath.section = 3
+
+    self.collectionViewDataSource.apply(
+      updatedSnapshot,
       animatingDifferences: false
     ) {
       self.moveToCurrentMonth()
@@ -134,52 +125,64 @@ extension CalendarViewDelegate {
   }
 
   private func deleteSections(
-    by scrollDirection: CalendarScrollDirection,
     to snapshot: NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem>
-  ) -> NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem> {
+  ) throws -> NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem> {
     var newSnapshot = snapshot
 
     for _ in (0...2) {
       let sections = newSnapshot.sectionIdentifiers
-      let sectionToDelete = scrollDirection == CalendarScrollDirection.left ? sections.last : sections.first
-      if let section = sectionToDelete {
-        let itemsToDelete = newSnapshot.itemIdentifiers(inSection: section)
-        newSnapshot.deleteItems(itemsToDelete)
-        newSnapshot.deleteSections([section])
-      }
+      guard let sectionToDelete = self.currentIndexPath.section == 0 ? sections.last : sections.first
+      else { throw CalendarViewDelegateError.snapshotIsNotLoaded }
+
+      let itemsToDelete = newSnapshot.itemIdentifiers(inSection: sectionToDelete)
+      newSnapshot.deleteItems(itemsToDelete)
+      newSnapshot.deleteSections([sectionToDelete])
     }
 
     return newSnapshot
   }
 
   private func insertNewSection(
-    by scrollDirection: CalendarScrollDirection,
     to snapshot: NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem>
-  ) -> NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem> {
+  ) throws -> NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem> {
+    let isAppendFirst = self.currentIndexPath.section == 0 ? true : false
+    return try self.addMonthData(
+      to: snapshot,
+      wit: (1...3),
+      isAppendFirst: isAppendFirst
+    )
+  }
+
+  private func addMonthData(
+    to snapshot: NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem>,
+    wit dateRange: ClosedRange<Int>,
+    isAppendFirst: Bool
+  ) throws -> NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem> {
     var newSnapshot = snapshot
+    let sections = newSnapshot.sectionIdentifiers
+    guard let firstDay = isAppendFirst ? sections.first?.firstDay : sections.last?.firstDay ?? Date()
+    else { throw CalendarViewDelegateError.snapshotIsNotLoaded }
 
-    for _ in (0...2) {
-      let sections = newSnapshot.sectionIdentifiers
-      let section = scrollDirection == .left ? sections.first : sections.last
-      let addValue = scrollDirection == .left ? -1 : 1
-      if let section2 = section {
-        guard let monthData = try? self.calendarDataGenerator.fetchMonthData(from: section2.firstDay, add: addValue)
-        else { continue }
+    for value in dateRange {
+      let addValue = self.currentIndexPath.section == 0 ? -value : value
+      let monthData = try self.calendarDataGenerator.fetchMonthData(from: firstDay, add: addValue)
 
-        let sectionToAppend = CalendarSection(firstDay: monthData.firstDayOfMonth)
-        if scrollDirection == CalendarScrollDirection.left {
-          newSnapshot.insertSections([sectionToAppend], beforeSection: section2)
-        } else {
-          newSnapshot.appendSections([sectionToAppend])
-        }
+      let section = CalendarSection(firstDay: monthData.firstDayOfMonth)
+      if isAppendFirst {
+        guard let beforeSection = newSnapshot.sectionIdentifiers.first
+        else { throw CalendarViewDelegateError.snapshotIsNotLoaded }
 
-        let newItems = monthData.dates.map { (day: MonthData.Day) in
-          let date = day.date
-          let isThisMonth = day.isThisMonth
-          return CalendarItem(date: date, isThisMonth: isThisMonth)
-        }
-        newSnapshot.appendItems(newItems, toSection: sectionToAppend)
+        newSnapshot.insertSections([section], beforeSection: beforeSection)
+      } else {
+        newSnapshot.appendSections([section])
       }
+
+      let items = monthData.dates.map { (day: MonthData.Day) in
+        let date = day.date
+        let isThisMonth = day.isThisMonth
+        return CalendarItem(date: date, isThisMonth: isThisMonth)
+      }
+      newSnapshot.appendItems(items, toSection: section)
     }
 
     return newSnapshot
@@ -302,4 +305,8 @@ enum CalendarScrollDirection: Int {
   case left  = -1
   case current = 0
   case right = 1
+}
+
+enum CalendarViewDelegateError: Error {
+  case snapshotIsNotLoaded
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -102,6 +102,24 @@ extension CalendarViewDelegate {
     self.collectionViewDataSource.apply(snapshot)
   }
 
+  private func reloadAllSnapshot() {
+    let lastSection = self.collectionViewDataSource.snapshot().sectionIdentifiers.count - 1
+    guard self.currentIndexPath.section <= 0 || self.currentIndexPath.section >= lastSection
+    else { return }
+
+    let currentSnapshot = self.collectionViewDataSource.snapshot()
+    let scrollDirection: CalendarScrollDirection = self.currentIndexPath.section == 0 ? .left : .right
+    let snapshot1 = self.deleteSections(by: scrollDirection, to: currentSnapshot)
+    let snapshot2 = self.insertNewSection(by: scrollDirection, to: snapshot1)
+
+    self.collectionViewDataSource?.apply(
+      snapshot2,
+      animatingDifferences: false
+    ) {
+      self.moveToCurrentMonth()
+    }
+  }
+
   private func deleteSections(
     by scrollDirection: CalendarScrollDirection,
     to snapshot: NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem>
@@ -152,6 +170,14 @@ extension CalendarViewDelegate {
     }
 
     return newSnapshot
+  }
+
+  private func moveToCurrentMonth() {
+    let currentMonthOffset = CGPoint(
+      x: self.collectionView.frame.width * 3,
+      y: self.collectionView.bounds.origin.y
+    )
+    self.collectionView.setContentOffset(currentMonthOffset, animated: false)
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -102,6 +102,25 @@ extension CalendarViewDelegate {
     self.collectionViewDataSource.apply(snapshot)
   }
 
+  private func deleteSections(
+    by scrollDirection: CalendarScrollDirection,
+    to snapshot: NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem>
+  ) -> NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem> {
+    var newSnapshot = snapshot
+
+    for _ in (0...2) {
+      let sections = newSnapshot.sectionIdentifiers
+      let sectionToDelete = scrollDirection == CalendarScrollDirection.left ? sections.last : sections.first
+      if let section = sectionToDelete {
+        let itemsToDelete = newSnapshot.itemIdentifiers(inSection: section)
+        newSnapshot.deleteItems(itemsToDelete)
+        newSnapshot.deleteSections([section])
+      }
+    }
+
+    return newSnapshot
+  }
+
   private func insertNewSection(
     by scrollDirection: CalendarScrollDirection,
     to snapshot: NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem>

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -11,8 +11,32 @@ import ToDoGardenUIConstant
 
 final class CalendarViewDelegate: NSObject {
   private var collectionView: UICollectionView
+  private var collectionViewDataSource: UICollectionViewDiffableDataSource<CalendarSection, CalendarItem>!
+  private var dateFormatter: DateFormatter
 
   init(collectionView: UICollectionView) {
     self.collectionView = collectionView
+    self.dateFormatter = DateFormatter()
+  }
+}
+
+extension CalendarViewDelegate {
+  private func setupDateFormatter() {
+    if let userPreferredIdentifier = Locale.preferredLanguages.first {
+      let userLocale = Locale(identifier: userPreferredIdentifier)
+      self.dateFormatter.locale = userLocale
+    } else {
+      self.dateFormatter.locale = Locale.autoupdatingCurrent
+    }
+    self.dateFormatter.dateFormat = Constant.CalendarView.StringLiteral.dateFormat
+  }
+}
+
+// MARK: Diffable DataSource
+
+extension CalendarViewDelegate {
+  private func setupCollectionViewDataSource() {
+    self.collectionViewDataSource = self.makeDiffableDataSource(self.collectionView, with: self.dateFormatter)
+    self.collectionView.dataSource = self.collectionViewDataSource
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -101,6 +101,39 @@ extension CalendarViewDelegate {
 
     self.collectionViewDataSource.apply(snapshot)
   }
+
+  private func insertNewSection(
+    by scrollDirection: CalendarScrollDirection,
+    to snapshot: NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem>
+  ) -> NSDiffableDataSourceSnapshot<CalendarSection, CalendarItem> {
+    var newSnapshot = snapshot
+
+    for _ in (0...2) {
+      let sections = newSnapshot.sectionIdentifiers
+      let section = scrollDirection == .left ? sections.first : sections.last
+      let addValue = scrollDirection == .left ? -1 : 1
+      if let section2 = section {
+        guard let monthData = try? self.calendarDataGenerator.fetchMonthData(from: section2.firstDay, add: addValue)
+        else { continue }
+
+        let sectionToAppend = CalendarSection(firstDay: monthData.firstDayOfMonth)
+        if scrollDirection == CalendarScrollDirection.left {
+          newSnapshot.insertSections([sectionToAppend], beforeSection: section2)
+        } else {
+          newSnapshot.appendSections([sectionToAppend])
+        }
+
+        let newItems = monthData.dates.map { (day: MonthData.Day) in
+          let date = day.date
+          let isThisMonth = day.isThisMonth
+          return CalendarItem(date: date, isThisMonth: isThisMonth)
+        }
+        newSnapshot.appendItems(newItems, toSection: sectionToAppend)
+      }
+    }
+
+    return newSnapshot
+  }
 }
 
 // MARK: UIScrollView Deleagate Functions
@@ -150,9 +183,11 @@ extension CalendarViewDelegate: UICollectionViewDelegate {
   }
 
   func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+    self.reloadAllSnapshot()
   }
 
   func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+    self.reloadAllSnapshot()
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -16,21 +16,14 @@ class CalendarViewDelegate: NSObject {
   private var collectionView: UICollectionView
   private var collectionViewDataSource: UICollectionViewDiffableDataSource<CalendarSection, CalendarItem>!
   private var currentIndexPath: IndexPath
-  private var collectionViewModel: CalendarView.Model.CollectionView
   private var initialContentOffset: CGPoint
   private var selectedItem: CalendarItem?
 
-  var scrollSender: CalendarScrollSender?
-
-  init(
-    collectionView: UICollectionView,
-    collectionViewModel: CalendarView.Model.CollectionView
-  ) {
+  init(collectionView: UICollectionView) {
     self.calendarDataGenerator = CalendarDataGenerator(calendar: Calendar.localeUpdated)
     self.dateFormatter = DateFormatter()
     self.collectionView = collectionView
     self.currentIndexPath = IndexPath(item: 0, section: 3)
-    self.collectionViewModel = collectionViewModel
     self.initialContentOffset = CGPoint()
     super.init()
     self.setupDateFormatter()
@@ -50,14 +43,6 @@ class CalendarViewDelegate: NSObject {
       animated: animated
     )
     self.reloadAllSnapshot()
-    self.scrollSender?.didScroll()
-  }
-
-  func getCollectionViewHeight() -> CGFloat {
-    let snapshot = self.collectionViewDataSource.snapshot()
-    let currentSection = snapshot.sectionIdentifiers[self.currentIndexPath.section]
-    let itemCount = snapshot.itemIdentifiers(inSection: currentSection).count
-    return self.calculateHeight(items: itemCount)
   }
 
   func getDateString() -> String {
@@ -77,17 +62,6 @@ extension CalendarViewDelegate {
     } else {
       self.dateFormatter.locale = Locale.autoupdatingCurrent
     }
-    self.dateFormatter.dateFormat = Constant.CalendarView.StringLiteral.dateFormat
-  }
-
-  private func calculateHeight(items count: Int) -> CGFloat {
-    let numberOfRows = CGFloat(count / 7)
-    let totalItemHeight = self.collectionViewModel.itemSize.height * numberOfRows
-    let totalInsets = self.collectionViewModel.lineSpacing * (numberOfRows - 1)
-    let collectionViewHeight = totalItemHeight + totalInsets
-    let defaultHeight: CGFloat = Constant.CalendarView.Layout.CollectionView.defaultHeight
-
-    return defaultHeight + collectionViewHeight
   }
 }
 
@@ -248,12 +222,10 @@ extension CalendarViewDelegate: UICollectionViewDelegate {
 
   func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
     self.reloadAllSnapshot()
-    self.scrollSender?.didScroll()
   }
 
   func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
     self.reloadAllSnapshot()
-    self.scrollSender?.didScroll()
   }
 }
 
@@ -276,7 +248,6 @@ extension CalendarViewDelegate {
     self.scrollCalendar(to: scrollDirection, animated: true)
     self.setSelected(to: selectedNewItem)
     self.selectedItem = selectedNewItem
-    self.scrollSender?.didScroll()
   }
 
   private func validateIsSameMonth(selectedItem: CalendarItem, section indexPath: IndexPath) -> ComparisonResult {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate.swift
@@ -13,15 +13,34 @@ final class CalendarViewDelegate: NSObject {
   private var collectionView: UICollectionView
   private var collectionViewDataSource: UICollectionViewDiffableDataSource<CalendarSection, CalendarItem>!
   private var calendarDataGenerator: CalendarDataGeneratable
+  private var currentIndexPath: IndexPath
+  private var collectionViewModel: CalendarView.Model.CollectionView
   private var dateFormatter: DateFormatter
 
   init(collectionView: UICollectionView) {
     self.collectionView = collectionView
-    self.dateFormatter = DateFormatter()
     self.calendarDataGenerator = CalendarDataGenerator(calendar: Calendar.localeUpdated)
+    self.currentIndexPath = IndexPath(item: 0, section: 3)
+    self.dateFormatter = DateFormatter()
     super.init()
     self.setupDateFormatter()
     self.loadInitialMonthSnapshot()
+  }
+
+  func scrollCalendar(to scrollDirection: CalendarScrollDirection, animated: Bool) {
+    self.currentIndexPath.section += scrollDirection.rawValue
+    self.collectionView.scrollToItem(
+      at: self.currentIndexPath,
+      at: UICollectionView.ScrollPosition.left,
+      animated: animated
+    )
+  }
+
+  func getCollectionViewHeight() -> CGFloat {
+    let snapshot = self.collectionViewDataSource.snapshot()
+    let currentSection = snapshot.sectionIdentifiers[self.currentIndexPath.section]
+    let itemCount = snapshot.itemIdentifiers(inSection: currentSection).count
+    return self.calculateHeight(items: itemCount)
   }
 }
 
@@ -34,6 +53,16 @@ extension CalendarViewDelegate {
       self.dateFormatter.locale = Locale.autoupdatingCurrent
     }
     self.dateFormatter.dateFormat = Constant.CalendarView.StringLiteral.dateFormat
+  }
+
+  private func calculateHeight(items count: Int) -> CGFloat {
+    let numberOfRows = CGFloat(count / 7)
+    let totalItemHeight = self.collectionViewModel.itemSize.height * numberOfRows
+    let totalInsets = self.collectionViewModel.lineSpacing * (numberOfRows - 1)
+    let collectionViewHeight = totalItemHeight + totalInsets
+    let defaultHeight: CGFloat = Constant.CalendarView.Layout.CollectionView.defaultHeight
+
+    return defaultHeight + collectionViewHeight
   }
 }
 
@@ -66,4 +95,10 @@ extension CalendarViewDelegate {
 
     self.collectionViewDataSource.apply(snapshot)
   }
+}
+
+enum CalendarScrollDirection: Int {
+  case left  = -1
+  case current = 0
+  case right = 1
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import ToDoGardenUIConstant
 
-class CalendarViewDelegate: NSObject {
+class CalendarViewSingleSelectionDelegate: NSObject {
   private var calendarDataGenerator: CalendarDataGeneratable
   private var dateFormatter: DateFormatter
 
@@ -54,7 +54,7 @@ class CalendarViewDelegate: NSObject {
   }
 }
 
-extension CalendarViewDelegate {
+extension CalendarViewSingleSelectionDelegate {
   private func setupDateFormatter() {
     if let userPreferredIdentifier = Locale.preferredLanguages.first {
       let userLocale = Locale(identifier: userPreferredIdentifier)
@@ -67,7 +67,7 @@ extension CalendarViewDelegate {
 
 // MARK: Diffable DataSource
 
-extension CalendarViewDelegate {
+extension CalendarViewSingleSelectionDelegate {
   private func setupCollectionViewDataSource() {
     self.collectionViewDataSource = self.makeDiffableDataSource(self.collectionView, with: self.dateFormatter)
     self.collectionView.dataSource = self.collectionViewDataSource
@@ -176,7 +176,7 @@ extension CalendarViewDelegate {
 
 // MARK: UIScrollView Deleagate Functions
 
-extension CalendarViewDelegate: UICollectionViewDelegate {
+extension CalendarViewSingleSelectionDelegate: UICollectionViewDelegate {
   func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
     self.initialContentOffset = scrollView.contentOffset
   }
@@ -231,7 +231,7 @@ extension CalendarViewDelegate: UICollectionViewDelegate {
 
 // MARK: Cell Selection Functions
 
-extension CalendarViewDelegate {
+extension CalendarViewSingleSelectionDelegate {
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     guard let selectedNewItem = self.collectionViewDataSource.itemIdentifier(for: indexPath)
     else { return }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
@@ -9,6 +9,12 @@ import UIKit
 
 import ToDoGardenUIConstant
 
+protocol CalendarViewControllable where Self: NSObject {
+  func fetchWeekdaySymbols() -> [String]
+  func scrollCalendar(to scrollDirection: CalendarScrollDirection, animated: Bool)
+  func getDateString() -> String
+}
+
 class CalendarViewSingleSelectionDelegate: NSObject {
   private var calendarDataGenerator: CalendarDataGeneratable
   private var dateFormatter: DateFormatter
@@ -30,7 +36,11 @@ class CalendarViewSingleSelectionDelegate: NSObject {
     self.setupCollectionViewDataSource()
     self.loadInitialMonthSnapshot()
   }
+}
 
+// MARK: CalendarViewControllable Protocol
+
+extension CalendarViewSingleSelectionDelegate: CalendarViewControllable {
   func fetchWeekdaySymbols() -> [String] {
     return self.calendarDataGenerator.fetchWeekdaySymbols()
   }
@@ -53,6 +63,8 @@ class CalendarViewSingleSelectionDelegate: NSObject {
     return String(dateString)
   }
 }
+
+// MARK: Private Functions
 
 extension CalendarViewSingleSelectionDelegate {
   private func setupDateFormatter() {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #194

## 🎉 변경 사항
- CalendarView에서 스크롤시 날짜 정보를 업데이트할 때 사용하는 객체를 추가하였습니다.

## 📌 PR Point
CalendarView는 CalendarViewDelegate 객체를 가지고 있으며,
캘린더 스크롤 및 날짜 정보를 업데이트하는 역할을 합니다.

### Diffable DataSource
현재 날짜를 기준으로 -3 ~ +3달에 대한 데이터를 불러옵니다.
한 달은 한 섹션으로 이루어져있습니다.

### 1. 캘린더 스크롤
캘린더를 스크롤했을 때, 맨 첫번째 Month or 맨 마지막 Month로 스크롤하면, 모든 데이터를 업데이트 합니다.
- CalendarView에 스크롤 여부를 알리는 Delegate 변수를 추가하였습니다.
- 해당 변수를 통해 스크롤시 CalendarView에서 날짜 정보와 높이를 수정합니다.

### 2. 캘린더 높이 계산
CalendarView의 높이는 월별 보여줘야하는 주차의 수가 다르므로 동적으로 바뀌어야 합니다.
ex) 5월은 6주를, 6월은 5주의 데이터를 보여주어야 함.

### 3. 날짜 선택
사용자가 이번달이 아닌 날짜를 선택하면 자동으로 스크롤 되도록 구현하였습니다.

### 참고용 기술서
[캘린더 기술서](https://www.notion.so/49bf319db5a846689c9dbdc6980f939c?pvs=4)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?