### PR TITLE
EditToDoSegmentedControl 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/EditToDoSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/EditToDoSegmentedControl.swift
@@ -12,4 +12,46 @@ public final class EditToDoSegmentedControl: UISegmentedControl {
     case notification = 0
     case todo = 1
   }
+  
+  public var editMode: EditMode?
+  
+  public init() {
+    super.init(frame: CGRect.zero)
+    self.setup()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: - Setup
+
+extension EditToDoSegmentedControl {
+  private func setup() {
+    self.setupAction()
+  }
+}
+
+// MARK: - Setup action
+
+extension EditToDoSegmentedControl {
+  private func setupAction() {
+    self.addTarget(
+      self,
+      action: #selector(self.editModeDidChange(_:)),
+      for: UIControl.Event.valueChanged
+    )
+  }
+  
+  @objc private func editModeDidChange(_ sender: UISegmentedControl) {
+    guard let selectedMode = EditMode(rawValue: sender.selectedSegmentIndex)
+    else {
+      self.editMode = nil
+      return
+    }
+    
+    self.editMode = selectedMode
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/EditToDoSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/EditToDoSegmentedControl.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import ToDoGardenUIResource
+
 public final class EditToDoSegmentedControl: UISegmentedControl {
   public enum EditMode: Int {
     case notification = 0
@@ -31,6 +33,7 @@ public final class EditToDoSegmentedControl: UISegmentedControl {
 extension EditToDoSegmentedControl {
   private func setup() {
     self.setupAction()
+    self.setupAppearance()
   }
 }
 
@@ -53,5 +56,31 @@ extension EditToDoSegmentedControl {
     }
     
     self.editMode = selectedMode
+  }
+}
+
+// MARK: - Setup appearance
+
+extension EditToDoSegmentedControl {
+  private func setupAppearance() {
+    let notificationEditImage = UIImage.bellIconImage.withRenderingMode(
+      UIImage.RenderingMode.alwaysOriginal
+    )
+    let toDoEditImage = UIImage.editIconImage.withRenderingMode(
+      UIImage.RenderingMode.alwaysOriginal
+    )
+    self.insertSegment(
+      with: notificationEditImage,
+      at: EditToDoSegmentedControl.EditMode.notification.rawValue,
+      animated: false
+    )
+    self.insertSegment(
+      with: toDoEditImage,
+      at: EditToDoSegmentedControl.EditMode.todo.rawValue,
+      animated: false
+    )
+    self.backgroundColor = UIColor.toDoGardenGreenBackground
+    self.selectedSegmentTintColor = UIColor.white
+    self.selectedSegmentIndex = EditToDoSegmentedControl.EditMode.todo.rawValue
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/EditToDoSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/EditToDoSegmentedControl.swift
@@ -84,3 +84,10 @@ extension EditToDoSegmentedControl {
     self.selectedSegmentIndex = EditToDoSegmentedControl.EditMode.todo.rawValue
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  return EditToDoSegmentedControl()
+}
+#endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/EditToDoSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/EditToDoSegmentedControl.swift
@@ -5,4 +5,11 @@
 //  Created by Noah on 6/3/24.
 //
 
-import Foundation
+import UIKit
+
+public final class EditToDoSegmentedControl: UISegmentedControl {
+  public enum EditMode: Int {
+    case notification = 0
+    case todo = 1
+  }
+}


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #202 
## 🎉 변경 사항
- [x] EditToDoSegmentedControl UI 구현
- [x] EditMode 정의

## 📌 PR Point

|실행화면|
|--|
|<div align="center"><img width="500" alt="Screenshot 2024-05-23 at 1 52 33 PM" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/63908856/8eafdcfe-5c8d-4eb3-8b80-a3b5891bba0b"></div>|

```swift
public enum EditMode: Int {
  case notification = 0
  case todo = 1
}
```
```swift
@objc private func editModeDidChange(_ sender: UISegmentedControl) {
  guard let selectedMode = EditMode(rawValue: sender.selectedSegmentIndex)
  else {
    self.editMode = nil
    return
  }
    
  self.editMode = selectedMode
}
```

SegmentedControl의 값이 변경될 때마다 정의된 editMode가 변경되도록 구현하였습니다.
해당 컴포넌트 사용 시 타겟-액션을 등록하여 값이 변경될 때마다 위 실행화면처럼 변경된 editMode값을 받을 수 있습니다.

```swift
editToDoSegmentedControl.addTarget(self, action: #selector(self.editModeDidChange(_:)), for: UIControl.Event.valueChanged)

@objc func editModeDidChange(_ sender: EditToDoSegmentedControl) {
  sender.editMode
}
```



## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?