### PR TITLE
햅틱 피드백 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/HapticFeedbackable.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/HapticFeedbackable.swift
@@ -1,8 +1,12 @@
 //
 //  HapticFeedbackable.swift
-//  
+//
 //
 //  Created by Noah on 6/5/24.
 //
 
-import Foundation
+import class UIKit.UIImpactFeedbackGenerator
+
+public protocol HapticFeedbackable {
+  func triggerHapticFeedback(style: UIImpactFeedbackGenerator.FeedbackStyle)
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/HapticFeedbackable.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/HapticFeedbackable.swift
@@ -1,0 +1,8 @@
+//
+//  HapticFeedbackable.swift
+//  
+//
+//  Created by Noah on 6/5/24.
+//
+
+import Foundation

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/HapticFeedbackable.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/HapticFeedbackable.swift
@@ -6,11 +6,13 @@
 //
 
 import class UIKit.UIImpactFeedbackGenerator
+import class UIKit.UINotificationFeedbackGenerator
 import class UIKit.UISelectionFeedbackGenerator
 
 public enum HapticFeedbackType {
   case impact(style: UIImpactFeedbackGenerator.FeedbackStyle)
   case selection
+  case notification(type: UINotificationFeedbackGenerator.FeedbackType)
 }
 
 public protocol HapticFeedbackable {
@@ -30,6 +32,9 @@ extension HapticFeedbackable {
     case HapticFeedbackType.selection:
       let generator = UISelectionFeedbackGenerator()
       generator.selectionChanged()
+    case HapticFeedbackType.notification(let feedbackType):
+      let generator = UINotificationFeedbackGenerator()
+      generator.notificationOccurred(feedbackType)
     }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/HapticFeedbackable.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/HapticFeedbackable.swift
@@ -10,3 +10,12 @@ import class UIKit.UIImpactFeedbackGenerator
 public protocol HapticFeedbackable {
   func triggerHapticFeedback(style: UIImpactFeedbackGenerator.FeedbackStyle)
 }
+
+extension HapticFeedbackable {
+  public func triggerHapticFeedback(
+    style: UIImpactFeedbackGenerator.FeedbackStyle = UIImpactFeedbackGenerator.FeedbackStyle.medium
+  ) {
+    let generator = UIImpactFeedbackGenerator(style: style)
+    generator.impactOccurred()
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/HapticFeedbackable.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/HapticFeedbackable.swift
@@ -6,16 +6,30 @@
 //
 
 import class UIKit.UIImpactFeedbackGenerator
+import class UIKit.UISelectionFeedbackGenerator
+
+public enum HapticFeedbackType {
+  case impact(style: UIImpactFeedbackGenerator.FeedbackStyle)
+  case selection
+}
 
 public protocol HapticFeedbackable {
-  func triggerHapticFeedback(style: UIImpactFeedbackGenerator.FeedbackStyle)
+  func triggerHapticFeedback(type: HapticFeedbackType)
 }
 
 extension HapticFeedbackable {
   public func triggerHapticFeedback(
-    style: UIImpactFeedbackGenerator.FeedbackStyle = UIImpactFeedbackGenerator.FeedbackStyle.medium
+    type: HapticFeedbackType = HapticFeedbackType.impact(
+      style: UIImpactFeedbackGenerator.FeedbackStyle.medium
+    )
   ) {
-    let generator = UIImpactFeedbackGenerator(style: style)
-    generator.impactOccurred()
+    switch type {
+    case HapticFeedbackType.impact(let style):
+      let generator = UIImpactFeedbackGenerator(style: style)
+      generator.impactOccurred()
+    case HapticFeedbackType.selection:
+      let generator = UISelectionFeedbackGenerator()
+      generator.selectionChanged()
+    }
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #208 

## 🎉 변경 사항
- [x] HapticFeedbackable 프로토콜 정의
- [x] HapticFeedbackable 프로토콜 확장(기본구현 정의)

## 📌 PR Point
햅틱 피드백을 사용할 수 있는 능력을 나타내는 프로토콜을 추가하였습니다.

```swift
public enum HapticFeedbackType {
  case impact(style: UIImpactFeedbackGenerator.FeedbackStyle)
  case selection
  case notification(type: UINotificationFeedbackGenerator.FeedbackType)
}
```
열거형인 햅틱 피드백 타입을 통해 사용하려고 하는 상황에 맞는 햅틱 피드백 타입을 파라미터로한 함수 인터페이스를 정의하였습니다.

```swift
public protocol HapticFeedbackable {
  func triggerHapticFeedback(type: HapticFeedbackType)
}
```

프로토콜 확장을 통해 기본 구현을 정의하였습니다.

```swift
triggerHapticFeedback(type: .impact(style: .light))
triggerHapticFeedback(type: .selection)
triggerHapticFeedback(type: .notification(type: .success))
```

기본 구현을 통해 햅틱 피드백을 사용하려고 하는 타입에서 해당 프로토콜을 채택 후 프로토콜 확장을 이용할 수 있습니다.

impact case의 style은 UIKit의 Feedback Style입니다.

아래는 진동 세기의 순서대로 나열한 FeedbackStyle입니다:

- `soft`: 매우 가벼운 진동 (iOS 13 이상에서 사용 가능)
- `light`: 가벼운 진동
- `medium`: 중간 정도의 진동
- `heavy`: 강한 진동
- `rigid`: 매우 강한 진동 (iOS 13 이상에서 사용 가능)

notification case의 type은 UIkit의 FeedbackType입니다.

- `success`: 작업이 성공적으로 완료되었음을 나타내는 햅틱 피드백ㅇ비니다.
- `warning`: 주의가 필요함을 나타내는 햅틱 피드백입니다.
- `error`: 오류가 발생했음을 나타내는 햅틱 피드백입니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?