### PR TITLE
GardenView 색상 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/Assets.xcassets/ToDoGardenGrassHigh.colorset/Contents.json
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/Assets.xcassets/ToDoGardenGrassHigh.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4A",
+          "green" : "0x98",
+          "red" : "0x2F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/Assets.xcassets/ToDoGardenGrassLow.colorset/Contents.json
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/Assets.xcassets/ToDoGardenGrassLow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA2",
+          "green" : "0xE7",
+          "red" : "0x93"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/Assets.xcassets/ToDoGardenGrassMiddle.colorset/Contents.json
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/Assets.xcassets/ToDoGardenGrassMiddle.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5E",
+          "green" : "0xBE",
+          "red" : "0x3E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/Assets.xcassets/ToDoGardenGrassNone.colorset/Contents.json
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/Assets.xcassets/ToDoGardenGrassNone.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEE",
+          "green" : "0xEA",
+          "red" : "0xE8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/Assets.xcassets/ToDoGardenGrassPerfect.colorset/Contents.json
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/Assets.xcassets/ToDoGardenGrassPerfect.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x35",
+          "green" : "0x64",
+          "red" : "0x21"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIColor+ToDoGarden.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIColor+ToDoGarden.swift
@@ -53,4 +53,16 @@ extension UIColor {
   public static let toDoGardenLightRed = UIColor(resource: .toDoGardenLightRed)
   
   public static let toDoGardenWhite = UIColor(resource: .toDoGardenWhite)
+  
+  // MARK: - Garden view
+  
+  public static let toDoGardenGrassNone = UIColor(resource: .toDoGardenGrassNone)
+  
+  public static let toDoGardenGrassLow = UIColor(resource: .toDoGardenGrassLow)
+  
+  public static let toDoGardenGrassMiddle = UIColor(resource: .toDoGardenGrassMiddle)
+  
+  public static let toDoGardenGrassHigh = UIColor(resource: .toDoGardenGrassHigh)
+  
+  public static let toDoGardenGrassPerfect = UIColor(resource: .toDoGardenGrassPerfect)
 }


### PR DESCRIPTION
## 💡 관련 이슈
- relative: #213 
## 🎉 변경 사항
- [x] UIColor 추가

## 📌 PR Point
- GardenView에 필요한 색상 다섯가지를 추가하였습니다.

|색상 표|
|--|
|<img width="400" alt="스크린샷 2024-06-05 16 38 20" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/63908856/81f815a3-8c80-4bfb-99e2-eb7187dfba8d">|


## 📝 셀프체크리스트
- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?