### PR TITLE
CalendarViewSingleSelectionDelegate 함수 네이밍 수정

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
@@ -266,10 +266,7 @@ extension CalendarViewSingleSelectionDelegate {
     guard let date = self.collectionViewDataSource.sectionIdentifier(for: indexPath.section)?.firstDay
     else { return ComparisonResult.orderedSame }
 
-    return self.calendarDataGenerator.compareMonth(
-      date1: selectedItem.date,
-      with: date
-    )
+    return self.calendarDataGenerator.compareMonth(from: selectedItem.date, with: date)
   }
 
   private func setSelected(to item: CalendarItem) {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #216 

## 🎉 변경 사항
- CalendarDataGenerator의 compareMonth 메서드 변경사항으로 인해 발생하는 
   컴파일 에러코드를 삭제하였습니다.
- 관련 변경사항 PR: #190

- 190번 PR 머지 전 빌드를 돌렸을 때 문제가 없었지만,
  190번 PR 생성당시 Delegate 객체가 Develop에 존재하지 않아서 알아차리지 못하였습니다.

## 📌 PR Point
x

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?