### PR TITLE
네비게이션 바 스타일 적용 함수 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/Sources/Application/AppDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/Sources/Application/AppDelegate.swift
@@ -30,6 +30,7 @@ extension AppDelegate {
 extension AppDelegate {
   private func updateNavigationBarApperance() {
     self.updateNavigationBarTitle()
+    self.updateNavigationBackButtonItem()
   }
 
   private func updateNavigationBarTitle() {
@@ -37,5 +38,16 @@ extension AppDelegate {
       NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark,
       NSAttributedString.Key.font: UIFont.pretendardHeadBold
     ]
+  }
+
+  private func updateNavigationBackButtonItem() {
+    UIBarButtonItem.appearance().setBackButtonBackgroundImage(
+      UIImage.backwardButtonImage,
+      for: UIControl.State.normal,
+      barMetrics: UIBarMetrics.default
+    )
+
+    UINavigationBar.appearance().backIndicatorImage = UIImage()
+    UINavigationBar.appearance().backIndicatorTransitionMaskImage = UIImage()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/Sources/Application/AppDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/Sources/Application/AppDelegate.swift
@@ -16,6 +16,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 		didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
 	) -> Bool {
 		self.registerCustomFonts()
+    self.updateNavigationBarApperance()
 		return true
 	}
 }
@@ -24,4 +25,8 @@ extension AppDelegate {
 	private func registerCustomFonts() {
 		PretendardFont.register()
 	}
+}
+
+extension AppDelegate {
+  private func updateNavigationBarApperance() {}
 }

--- a/ToDo-Garden/ToDo-Garden/Sources/Application/AppDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/Sources/Application/AppDelegate.swift
@@ -28,5 +28,14 @@ extension AppDelegate {
 }
 
 extension AppDelegate {
-  private func updateNavigationBarApperance() {}
+  private func updateNavigationBarApperance() {
+    self.updateNavigationBarTitle()
+  }
+
+  private func updateNavigationBarTitle() {
+    UINavigationBar.appearance().titleTextAttributes = [
+      NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark,
+      NSAttributedString.Key.font: UIFont.pretendardHeadBold
+    ]
+  }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #218

## 🎉 변경 사항
- AppDelegate에서 Navigation Bar의 Appearance를 업데이트하는 함수를 추가하였습니다.

## 📌 PR Point

- 네비게이션 바의 backButton과 Title의 UI를 변경합니다.
- 해당 변경사항은 모든 Navigation Bar에서 적용됩니다.
- 앱 실행 이후 한 번만 호출되도록 AppDelegate에서 적용하도록 구현하였습니다.
- 화면 구현때마다 해당 컴포넌트들(backButton, Title)을 업데이트해야 하는 수고를 덜고자 구현하였습니다.

### 실행 이미지

|적용 전|적용 후|
|--|--|
|<img width="300" alt="스크린샷 2024-06-07 21 48 37" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/7c2f2734-7677-499d-89d8-1ce7b9aa088b">|<img width="300" alt="스크린샷 2024-06-07 20 45 23" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/ffe1f523-fe3f-4dd8-a1f7-99b2b6be4df1">|

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?