### PR TITLE
ToDoGardenSwitch Constant Thumb Scale 값 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenSwitch.swift
@@ -10,3 +10,7 @@ import Foundation
 extension Constant.ToDoGardenSwitch {
   public enum Layout {}
 }
+
+extension Constant.ToDoGardenSwitch.Layout {
+  public static let thumbScale: CGFloat = 0.8
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenSwitch.swift
@@ -1,0 +1,12 @@
+//
+//  Constant+ToDoGardenSwitch.swift
+//
+//
+//  Created by Wood on 6/10/24.
+//
+
+import Foundation
+
+extension Constant.ToDoGardenSwitch {
+  public enum Layout {}
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -26,4 +26,5 @@ public enum Constant {
   public enum TimerProgressView {}
   public enum RepeatOtherDaysView {}
   public enum CalendarView {}
+  public enum ToDoGardenSwitch {}
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #221

## 🎉 변경 사항
- ToDoGardenSwitch Constant 파일을 생성였습니다.
- 스위치의 Thumb Scale 상수 값을 추가하였습니다.

## 📌 PR Point
- 해당 값은 스위치에 있는 흰색 동그라미인 Thumb의 크기를 줄일 때 사용합니다.

|수정 전|Figma 디자인|
|--|--|
|<img width="71" alt="스크린샷 2024-06-08 14 04 32" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/c4e3c2c3-d393-4ab7-80e1-9c6b20d1031f">|<img width="71" alt="스크린샷 2024-06-08 14 04 11" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/1f2ca9ac-30db-4a1f-86be-f16b96000e36">|


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?