### PR TITLE
ToDoGardenSwitch Thumb 크기 수정

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenSwitch.swift
@@ -7,16 +7,17 @@
 
 import UIKit.UISwitch
 
+import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 public final class ToDoGardenSwitch: UISwitch {
-  public init() {
-    super.init(frame: .zero)
+  public init(model: Model) {
+    super.init(frame: CGRect.zero)
     self.setupOnTintColor()
   }
   
   public convenience init(isOn: Bool) {
-    self.init()
+    self.init(model: .primary)
     self.isOn = isOn
   }
   
@@ -41,5 +42,19 @@ extension ToDoGardenSwitch {
   private func setupOffTintColor() {
     let offBackgroundView = self.subviews.first?.subviews.first
     offBackgroundView?.backgroundColor = UIColor.toDoGardenGreenGray
+  }
+}
+
+// MARK: Model
+
+extension ToDoGardenSwitch {
+  public struct Model {
+    let thumbScale: CGFloat
+
+    public init(thumbScale: CGFloat) {
+      self.thumbScale = thumbScale
+    }
+
+    public static let primary = Self(thumbScale: Constant.ToDoGardenSwitch.Layout.thumbScale)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenSwitch.swift
@@ -14,6 +14,7 @@ public final class ToDoGardenSwitch: UISwitch {
   public init(model: Model) {
     super.init(frame: CGRect.zero)
     self.setupOnTintColor()
+    self.setupThumbScale(with: model.thumbScale)
   }
   
   public convenience init(isOn: Bool) {
@@ -42,6 +43,16 @@ extension ToDoGardenSwitch {
   private func setupOffTintColor() {
     let offBackgroundView = self.subviews.first?.subviews.first
     offBackgroundView?.backgroundColor = UIColor.toDoGardenGreenGray
+  }
+
+  private func setupThumbScale(with scale: CGFloat) {
+    let defaultScale: CGFloat = 1.0
+    guard scale != defaultScale
+    else { return }
+
+    if let thumbImageView = self.subviews.first?.subviews.last?.subviews.last as? UIImageView {
+      thumbImageView.transform = CGAffineTransform(scaleX: scale, y: scale)
+    }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenSwitch.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenSwitch.swift
@@ -69,3 +69,12 @@ extension ToDoGardenSwitch {
     public static let primary = Self(thumbScale: Constant.ToDoGardenSwitch.Layout.thumbScale)
   }
 }
+
+// MARK: Preview
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  return ToDoGardenSwitch(model: .primary)
+}
+#endif


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #224 

## 🎉 변경 사항
- ToDoGardenSwitch에 Thumb의 크기를 수정하는 로직을 추가하였습니다.

## 📌 PR Point
- 스위치에 있는 흰색 동그라미인 Thumb의 크기를 Figma 디자인에 맞게 수정하였습니다.
- 수정할 크기를 입력받을 수 있도록 Model 객체를 추가하였습니다.

|수정 전|Figma 디자인|
|--|--|
|<img width="71" alt="스크린샷 2024-06-08 14 04 32" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/c4e3c2c3-d393-4ab7-80e1-9c6b20d1031f">|<img width="71" alt="스크린샷 2024-06-08 14 04 11" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/1f2ca9ac-30db-4a1f-86be-f16b96000e36">|

### 동작
![2024-06-1012 51 22-ezgif com-resize](https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/95c2f58d-9555-4bde-b2a8-940b9d1cc663)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?