### PR TITLE
CalendarView 버그 수정

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarCollectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarCollectionViewCell.swift
@@ -9,9 +9,10 @@ import UIKit
 
 import ToDoGardenUIConstant
 
-final class CalendarCollectionViewCell: UICollectionViewCell {
+final class CalendarCollectionViewCell: UICollectionViewCell, ReusableIdentifier {
   private var toDoExistenceView: UIView
   private var dayLabel: UILabel
+  private var isThisMonth: Bool
 
   override var isSelected: Bool {
     willSet {
@@ -26,6 +27,7 @@ final class CalendarCollectionViewCell: UICollectionViewCell {
   override init(frame: CGRect) {
     self.toDoExistenceView = UIView()
     self.dayLabel = UILabel()
+    self.isThisMonth = true
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -37,12 +39,17 @@ final class CalendarCollectionViewCell: UICollectionViewCell {
 
   override func prepareForReuse() {
     super.prepareForReuse()
+    self.isThisMonth = true
     self.deSelected()
   }
 
-  func update(dayString: String, isThisMonth: Bool) {
+  func updateText(with dayString: String) {
     self.dayLabel.text = dayString
+  }
+
+  func updateTextColor(with isThisMonth: Bool) {
     if isThisMonth == false {
+      self.isThisMonth = false
       self.dayLabel.textColor = UIColor.toDoGardenGreenGray
     }
   }
@@ -58,7 +65,8 @@ extension CalendarCollectionViewCell {
 
   private func deSelected() {
     self.backgroundColor = UIColor.toDoGardenWhite
-    self.dayLabel.textColor = UIColor.toDoGardenGreenDark
+    let textColor = self.isThisMonth ? UIColor.toDoGardenGreenDark : UIColor.toDoGardenGreenGray
+    self.dayLabel.textColor = textColor
   }
 
   private func setup() {
@@ -125,5 +133,3 @@ extension CalendarCollectionViewCell {
     ])
   }
 }
-
-extension CalendarCollectionViewCell: ReusableIdentifier {}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarSection+Item.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarSection+Item.swift
@@ -1,0 +1,34 @@
+//
+//  CalendarSection+Item.swift
+//  
+//
+//  Created by Wood on 6/17/24.
+//
+
+import Foundation
+
+struct CalendarSection: Hashable {
+  let firstDay: Date
+
+  static func == (lhs: CalendarSection, rhs: CalendarSection) -> Bool {
+    return lhs.firstDay == rhs.firstDay
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(self.firstDay)
+  }
+}
+
+struct CalendarItem: Hashable {
+  let date: Date
+  let isThisMonth: Bool
+
+  static func == (lhs: CalendarItem, rhs: CalendarItem) -> Bool {
+    return lhs.date == rhs.date && lhs.isThisMonth == rhs.isThisMonth
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(self.date)
+    hasher.combine(self.isThisMonth)
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView+setupCollectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView+setupCollectionView.swift
@@ -21,7 +21,7 @@ extension CalendarView {
     )
   }
 
-  func makeCollectionViewLayout(with collectionViewModel: CalendarView.Model.CollectionView)
+  func makeCollectionViewLayout(with collectionViewModel: CalendarView.Model.CollectionViewLayout)
   -> UICollectionViewCompositionalLayout {
     let item = self.makeItem(with: collectionViewModel.itemSize)
     let group = self.makeGroup(by: item, with: collectionViewModel.itemSpacing)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
@@ -30,7 +30,10 @@ public final class CalendarView: UIView {
     self.weekdaySymbolStackView = UIStackView()
     self.dateCollectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewLayout())
     self.heightConstraint = NSLayoutConstraint()
-    self.calendarViewDelegate = CalendarViewSingleSelectionDelegate(collectionView: self.dateCollectionView)
+    self.calendarViewDelegate = CalendarViewSingleSelectionDelegate(
+      collectionView: self.dateCollectionView,
+      collectionViewLayoutModel: model.collectionViewLayout
+    )
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -138,7 +141,7 @@ extension CalendarView {
 
   private func setupDateCollectionView() {
     self.configureCollectionView(self.dateCollectionView)
-    self.dateCollectionView.collectionViewLayout = self.makeCollectionViewLayout(with: self.model.collectionView)
+    self.dateCollectionView.collectionViewLayout = self.makeCollectionViewLayout(with: self.model.collectionViewLayout)
   }
 }
 
@@ -281,12 +284,12 @@ extension CalendarView {
   public struct Model {
     let borderWidth: CGFloat
     let cornerRadius: CGFloat
-    let collectionView: Model.CollectionView
+    let collectionViewLayout: Model.CollectionViewLayout
 
     public static let primary = Self(
       borderWidth: Constant.CalendarView.Model.Primary.borderWidth,
       cornerRadius: Constant.CalendarView.Model.Primary.cornerRadius,
-      collectionView: CollectionView(
+      collectionViewLayout: CollectionViewLayout(
         itemSize: Constant.CalendarView.Model.Primary.itemSize,
         itemSpacing: Constant.CalendarView.Model.Primary.itemSpacing,
         lineSpacing: Constant.CalendarView.Model.Primary.lineSpacing
@@ -296,7 +299,7 @@ extension CalendarView {
 }
 
 extension CalendarView.Model {
-  public struct CollectionView {
+  public struct CollectionViewLayout {
     let itemSize: CGSize
     let itemSpacing: CGFloat
     let lineSpacing: CGFloat

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
@@ -85,11 +85,12 @@ extension CalendarView: CalendarScrollSendable {
   }
 
   private func updateCollectionViewHeight() {
+    self.superview?.layoutIfNeeded()
     let duration = Constant.CalendarView.Animation.duration
     UIView.animate(withDuration: duration) {
       let collectionViewHeight = self.calendarViewDelegate.getCollectionViewHeight()
       self.heightConstraint.constant = collectionViewHeight
-      self.layoutIfNeeded()
+      self.superview?.layoutIfNeeded()
     }
   }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
@@ -74,7 +74,7 @@ extension CalendarView {
 
 // MARK: ScrollDirection Sender Delegate
 
-protocol CalendarScrollSendable {
+protocol CalendarScrollSendable: AnyObject {
   func didScroll()
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
@@ -52,10 +52,6 @@ public final class CalendarView: UIView {
 // MARK: Private Functions
 
 extension CalendarView {
-  private func setup() {
-    self.setupUI()
-  }
-
   private func scrollToCurrentMonth() {
     if self.isLayoutSubviewsCalled == false {
       self.calendarViewDelegate.scrollCalendar(
@@ -64,6 +60,15 @@ extension CalendarView {
       )
       self.isLayoutSubviewsCalled = true
     }
+  }
+
+  private func setup() {
+    self.setupUI()
+    self.setupCollectionViewScrollDelegate()
+  }
+
+  private func setupCollectionViewScrollDelegate() {
+    self.calendarViewDelegate.scrollDelegate = self
   }
 }
 
@@ -75,7 +80,17 @@ protocol CalendarScrollSendable {
 
 extension CalendarView: CalendarScrollSendable {
   func didScroll() {
+    self.updateCollectionViewHeight()
     self.updateMonthLabelText()
+  }
+
+  private func updateCollectionViewHeight() {
+    let duration = Constant.CalendarView.Animation.duration
+    UIView.animate(withDuration: duration) {
+      let collectionViewHeight = self.calendarViewDelegate.getCollectionViewHeight()
+      self.heightConstraint.constant = collectionViewHeight
+      self.layoutIfNeeded()
+    }
   }
 
   private func updateMonthLabelText() {
@@ -142,6 +157,7 @@ extension CalendarView {
   private func setupDateCollectionView() {
     self.configureCollectionView(self.dateCollectionView)
     self.dateCollectionView.collectionViewLayout = self.makeCollectionViewLayout(with: self.model.collectionViewLayout)
+    self.dateCollectionView.delegate = self.calendarViewDelegate
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate+makeDiffableDataSource.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate+makeDiffableDataSource.swift
@@ -1,5 +1,5 @@
 //
-//  CalendarCollectionViewDelegate+DiffableDataSource.swift
+//  CalendarViewSingleSelectionDelegate+DiffableDataSource.swift
 //
 //
 //  Created by Wood on 5/27/24.
@@ -8,42 +8,60 @@
 import UIKit
 
 extension CalendarViewSingleSelectionDelegate {
-  func makeDiffableDataSource(
-    _ collectionView: UICollectionView,
-    with dateFormatter: DateFormatter
-  )
+  func makeDiffableDataSource()
   -> UICollectionViewDiffableDataSource<CalendarSection, CalendarItem> {
     return UICollectionViewDiffableDataSource<
       CalendarSection,
       CalendarItem
-    >(collectionView: collectionView) { (_, _, _) in
-      return UICollectionViewCell()
+    >(collectionView: self.collectionView) { (collectionView, indexPath, dayItem) in
+      guard let cell = collectionView.dequeueReusableCell(
+        withReuseIdentifier: CalendarCollectionViewCell.identifier,
+        for: indexPath
+      ) as? CalendarCollectionViewCell
+      else { return UICollectionViewCell() }
+
+      let dayString = self.makeDayString(from: dayItem.date)
+      let isThisMonth = dayItem.isThisMonth
+      cell.update(dayString: dayString, isThisMonth: isThisMonth)
+      self.updateCellToSelected(with: self.selectedItem)
+
+      return cell
     }
   }
-}
 
-struct CalendarSection: Hashable {
-  let firstDay: Date
+  private func makeDayString(from date: Date) -> String {
+    let formattedDateString = self.dateFormatter.string(from: date).split(separator: " ")
+    guard let dayString = formattedDateString.last
+    else { return "" }
 
-  static func == (lhs: CalendarSection, rhs: CalendarSection) -> Bool {
-    return lhs.firstDay == rhs.firstDay
+    return String(dayString)
   }
 
-  func hash(into hasher: inout Hasher) {
-    hasher.combine(self.firstDay)
+  private func updateCellToSelected(with item: CalendarItem?) {
+    guard let selectedItem = item
+    else { return }
+
+    guard let indexPath = self.getIndexPath(of: selectedItem)
+    else { return }
+
+    self.collectionView.selectItem(
+      at: indexPath,
+      animated: true,
+      scrollPosition: []
+    )
   }
-}
 
-struct CalendarItem: Hashable {
-  let date: Date
-  let isThisMonth: Bool
+  private func getIndexPath(of item: CalendarItem) -> IndexPath? {
+    let snapshot = self.collectionViewDataSource.snapshot()
+    let section = snapshot.sectionIdentifiers[self.currentIndexPath.section]
+    let indexOfItem = snapshot.itemIdentifiers(inSection: section).firstIndex { (calendarItem: CalendarItem) in
+      return item.date == calendarItem.date
+    }
 
-  static func == (lhs: CalendarItem, rhs: CalendarItem) -> Bool {
-    return lhs.date == rhs.date && lhs.isThisMonth == rhs.isThisMonth
-  }
-
-  func hash(into hasher: inout Hasher) {
-    hasher.combine(self.date)
-    hasher.combine(self.isThisMonth)
+    if let itemIndex = indexOfItem {
+      return IndexPath(item: itemIndex, section: self.currentIndexPath.section)
+    } else {
+      return nil
+    }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate+makeDiffableDataSource.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewDelegate+makeDiffableDataSource.swift
@@ -21,8 +21,9 @@ extension CalendarViewSingleSelectionDelegate {
       else { return UICollectionViewCell() }
 
       let dayString = self.makeDayString(from: dayItem.date)
+      cell.updateText(with: dayString)
       let isThisMonth = dayItem.isThisMonth
-      cell.update(dayString: dayString, isThisMonth: isThisMonth)
+      cell.updateTextColor(with: isThisMonth)
       self.updateCellToSelected(with: self.selectedItem)
 
       return cell

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
@@ -9,8 +9,11 @@ import UIKit
 
 import ToDoGardenUIConstant
 
-protocol CalendarViewControllable where Self: NSObject {
+protocol CalendarViewControllable: UICollectionViewDelegate {
+  var scrollDelegate: CalendarScrollSendable? { get set }
+
   func fetchWeekdaySymbols() -> [String]
+  func getCollectionViewHeight() -> CGFloat
   func scrollCalendar(to scrollDirection: CalendarScrollDirection, animated: Bool)
   func getDateString() -> String
 }
@@ -18,12 +21,16 @@ protocol CalendarViewControllable where Self: NSObject {
 class CalendarViewSingleSelectionDelegate: NSObject {
   private let calendarDataGenerator: CalendarDataGeneratable
   private let collectionViewLayoutModel: CalendarView.Model.CollectionViewLayout
+  
   private(set) var collectionViewDataSource: UICollectionViewDiffableDataSource<CalendarSection, CalendarItem>!
   private(set) var currentIndexPath: IndexPath
   private(set) var selectedItem: CalendarItem?
   private var initialContentOffset: CGPoint
+  
   let collectionView: UICollectionView
   let dateFormatter: DateFormatter
+
+  var scrollDelegate: CalendarScrollSendable?
 
   init(
     collectionView: UICollectionView,
@@ -57,6 +64,14 @@ extension CalendarViewSingleSelectionDelegate: CalendarViewControllable {
       animated: animated
     )
     self.reloadAllSnapshot()
+    self.scrollDelegate?.didScroll()
+  }
+
+  func getCollectionViewHeight() -> CGFloat {
+    let snapshot = self.collectionViewDataSource.snapshot()
+    let currentSection = snapshot.sectionIdentifiers[self.currentIndexPath.section]
+    let itemCount = snapshot.itemIdentifiers(inSection: currentSection).count
+    return self.calculateHeight(items: itemCount)
   }
 
   func getDateString() -> String {
@@ -78,6 +93,18 @@ extension CalendarViewSingleSelectionDelegate {
     } else {
       self.dateFormatter.locale = Locale.autoupdatingCurrent
     }
+
+    self.dateFormatter.dateFormat = Constant.CalendarView.StringLiteral.dateFormat
+  }
+
+  private func calculateHeight(items count: Int) -> CGFloat {
+    let numberOfRows = CGFloat(count / 7)
+    let totalItemHeight = self.collectionViewLayoutModel.itemSize.height * numberOfRows
+    let totalInsets = self.collectionViewLayoutModel.lineSpacing * (numberOfRows - 1)
+    let collectionViewHeight = totalItemHeight + totalInsets
+    let defaultHeight: CGFloat = Constant.CalendarView.Layout.CollectionView.defaultHeight
+
+    return defaultHeight + collectionViewHeight
   }
 }
 
@@ -215,6 +242,7 @@ extension CalendarViewSingleSelectionDelegate: UICollectionViewDelegate {
     ) else { return }
 
     self.currentIndexPath.section += scrollDirection.rawValue
+    self.scrollDelegate?.didScroll()
   }
 
   private func calculateScrollDireciton(

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
@@ -279,42 +279,28 @@ extension CalendarViewSingleSelectionDelegate {
     guard let selectedNewItem = self.collectionViewDataSource.itemIdentifier(for: indexPath)
     else { return }
 
-    let comparisonResult = self.validateIsSameMonth(selectedItem: selectedNewItem, section: indexPath)
-    guard comparisonResult != ComparisonResult.orderedSame
-    else {
-      self.selectedItem = selectedNewItem
-      return
-    }
+    guard let scrollDirection = getScrollDirection(selectedItem: selectedNewItem, section: indexPath)
+    else { return }
 
-    let scrollDirection = comparisonResult == ComparisonResult.orderedAscending ?
-    CalendarScrollDirection.left : CalendarScrollDirection.right
     self.scrollCalendar(to: scrollDirection, animated: true)
-    self.setSelected(to: selectedNewItem)
     self.selectedItem = selectedNewItem
   }
 
-  private func validateIsSameMonth(selectedItem: CalendarItem, section indexPath: IndexPath) -> ComparisonResult {
-    guard let date = self.collectionViewDataSource.sectionIdentifier(for: indexPath.section)?.firstDay
-    else { return ComparisonResult.orderedSame }
+  private func getScrollDirection(
+    selectedItem: CalendarItem,
+    section indexPath: IndexPath
+  ) -> CalendarScrollDirection? {
+    guard let currentDate = self.collectionViewDataSource.sectionIdentifier(for: indexPath.section)?.firstDay
+    else { return nil }
 
-    return self.calendarDataGenerator.compareMonth(from: selectedItem.date, with: date)
-  }
-
-  private func setSelected(to item: CalendarItem) {
-    let snapshot = self.collectionViewDataSource.snapshot()
-    let section = snapshot.sectionIdentifiers[self.currentIndexPath.section]
-    let indexOfItem = snapshot.itemIdentifiers(inSection: section).firstIndex { (calendarItem: CalendarItem) in
-      return item.date == calendarItem.date
+    let comparisonResult = self.calendarDataGenerator.compareMonth(from: selectedItem.date, with: currentDate)
+    guard comparisonResult != ComparisonResult.orderedSame
+    else {
+      self.selectedItem = selectedItem
+      return nil
     }
 
-    if let itemIndex = indexOfItem {
-      let itemIndexPath = IndexPath(item: itemIndex, section: self.currentIndexPath.section)
-      self.collectionView.selectItem(
-        at: itemIndexPath,
-        animated: true,
-        scrollPosition: []
-      )
-    }
+    return comparisonResult == ComparisonResult.orderedAscending ? .left : .right
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
@@ -63,7 +63,6 @@ extension CalendarViewSingleSelectionDelegate: CalendarViewControllable {
       at: UICollectionView.ScrollPosition.left,
       animated: animated
     )
-    self.reloadAllSnapshot()
     self.scrollDelegate?.didScroll()
   }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
@@ -17,14 +17,13 @@ protocol CalendarViewControllable where Self: NSObject {
 
 class CalendarViewSingleSelectionDelegate: NSObject {
   private let calendarDataGenerator: CalendarDataGeneratable
-  private let dateFormatter: DateFormatter
-
   private let collectionViewLayoutModel: CalendarView.Model.CollectionViewLayout
-  private let collectionView: UICollectionView
-  private var collectionViewDataSource: UICollectionViewDiffableDataSource<CalendarSection, CalendarItem>!
-  private var currentIndexPath: IndexPath
+  private(set) var collectionViewDataSource: UICollectionViewDiffableDataSource<CalendarSection, CalendarItem>!
+  private(set) var currentIndexPath: IndexPath
+  private(set) var selectedItem: CalendarItem?
   private var initialContentOffset: CGPoint
-  private var selectedItem: CalendarItem?
+  let collectionView: UICollectionView
+  let dateFormatter: DateFormatter
 
   init(
     collectionView: UICollectionView,
@@ -86,7 +85,7 @@ extension CalendarViewSingleSelectionDelegate {
 
 extension CalendarViewSingleSelectionDelegate {
   private func setupCollectionViewDataSource() {
-    self.collectionViewDataSource = self.makeDiffableDataSource(self.collectionView, with: self.dateFormatter)
+    self.collectionViewDataSource = self.makeDiffableDataSource()
     self.collectionView.dataSource = self.collectionViewDataSource
   }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
@@ -30,7 +30,7 @@ class CalendarViewSingleSelectionDelegate: NSObject {
   let collectionView: UICollectionView
   let dateFormatter: DateFormatter
 
-  var scrollDelegate: CalendarScrollSendable?
+  weak var scrollDelegate: CalendarScrollSendable?
 
   init(
     collectionView: UICollectionView,

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
@@ -16,18 +16,23 @@ protocol CalendarViewControllable where Self: NSObject {
 }
 
 class CalendarViewSingleSelectionDelegate: NSObject {
-  private var calendarDataGenerator: CalendarDataGeneratable
-  private var dateFormatter: DateFormatter
+  private let calendarDataGenerator: CalendarDataGeneratable
+  private let dateFormatter: DateFormatter
 
-  private var collectionView: UICollectionView
+  private let collectionViewLayoutModel: CalendarView.Model.CollectionViewLayout
+  private let collectionView: UICollectionView
   private var collectionViewDataSource: UICollectionViewDiffableDataSource<CalendarSection, CalendarItem>!
   private var currentIndexPath: IndexPath
   private var initialContentOffset: CGPoint
   private var selectedItem: CalendarItem?
 
-  init(collectionView: UICollectionView) {
+  init(
+    collectionView: UICollectionView,
+    collectionViewLayoutModel: CalendarView.Model.CollectionViewLayout
+  ) {
     self.calendarDataGenerator = CalendarDataGenerator(calendar: Calendar.localeUpdated)
     self.dateFormatter = DateFormatter()
+    self.collectionViewLayoutModel = collectionViewLayoutModel
     self.collectionView = collectionView
     self.currentIndexPath = IndexPath(item: 0, section: 3)
     self.initialContentOffset = CGPoint()

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+CalendarView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+CalendarView.swift
@@ -15,7 +15,7 @@ extension Constant.CalendarView {
 }
 
 extension Constant.CalendarView.Animation {
-  public static let duration: CGFloat = 0.1
+  public static let duration: CGFloat = 0.3
 }
 
 extension Constant.CalendarView.Layout {
@@ -47,7 +47,7 @@ extension Constant.CalendarView.Layout {
     public static let leadingMargin: CGFloat = 13
     public static let trailingMargin: CGFloat = 10
     public static let bottomMargin: CGFloat = 11
-    public static let defaultHeight: CGFloat = 98
+    public static let defaultHeight: CGFloat = 102
   }
 
   public enum CollectionViewCell {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #234 

## 🎉 변경 사항
- 이전 PR #200 에서 언급되었던 CalendarView 사용시 발생하는 버그들을 해결하였습니다.

## 📌 PR Point
### 1. 3개월 단위 날짜 업데이트시 끊김 현상
- 원인은 스크롤 애니메이션이 끝나기 전에 데이터를 업데이트했기 때문입니다.
- 스크롤 애니메이션이 끝난 뒤에 날짜를 업데이트하도록 수정하였습니다. 
- (GIF를 첨부하려 했으나, 끊기는것 처럼 보여서 [동영상 링크](https://www.notion.so/7bfb71ed164345c6a28e289783e846f1?pvs=4#f21b178a43014b5ca2c9ce29c939af5f)를 남깁니다)

### 2. topAnchor 레이아웃 변경 문제
- 캘린더 스크롤시 높이가 변경되는 애니메이션과 함께 topAnchor가 깨지는 현상이 있었습니다.
- 애니메이션이 동작할 때 top은 고정, bottom이 변화되도록 수정하였습니다.
- (GIF 특성상 스크롤이 끊기는 것 처럼 보이지만, 실제로는 그렇지 않습니다.)

|수정 전|수정 후|
|--|--|
|<img width="200" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/f11492e1-05f1-498f-9d65-3894e25fa946">|<img width="200" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/96d3c304-675a-41f3-aec3-3d9f7cadd845">|

### 3. 날짜 선택 후 색상 변경되지 않는 문제
- 다음달 날짜 선택 후 새로운 셀 선택시 날짜의 색상이 회색이 아닌 초록색으로 나오는 버그를 해결하였습니다.
- 수정 전은 @HG-SONG 께서 리뷰에 올려주셨던 GIF이기에 CalendarView 이외에 일부 UI가 다릅니다.

|수정 전|수정 후|
|--|--|
|<img width="200" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/e3fd158f-e39b-4d6b-bcf2-d95371bc31da">|<img width="200" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/7c54711c-4477-4bac-a43b-500a815e17bf">|

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?