### PR TITLE
TextField Style BottomLine 애니메이션 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/Style/GroupEdit.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/Style/GroupEdit.swift
@@ -23,8 +23,8 @@ extension Styled.TextField {
   }
   
   private func buildBottomLine(color: UIColor) {
-    let line = UIView()
-    line.backgroundColor = color
+    let line = UIProgressView(progressViewStyle: .bar)
+    line.trackTintColor = UIColor.toDoGardenGray1
     self.configuration.groupEditModel.map { model in
       switch model.bottomLineDisplayMode {
       case Configuration.GroupEditModel.DisPlayMode.always:
@@ -46,12 +46,12 @@ extension Styled.TextField {
     self.bottomLine = line
   }
   
-  private func bindingBottomLine(line: UIView) {
+  private func bindingBottomLine(line: UIProgressView) {
     self.$configuration
       .compactMap(\.groupEditModel)
       .removeDuplicates()
       .sink { [weak line] model in
-        line?.backgroundColor = model.mainColor
+        line?.progressTintColor = model.mainColor
       }
       .store(in: &self.cancellables)
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/Style/GroupEdit.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/Style/GroupEdit.swift
@@ -25,15 +25,6 @@ extension Styled.TextField {
   private func buildBottomLine(color: UIColor) {
     let line = UIProgressView(progressViewStyle: .bar)
     line.trackTintColor = UIColor.toDoGardenGray1
-    self.configuration.groupEditModel.map { model in
-      switch model.bottomLineDisplayMode {
-      case Configuration.GroupEditModel.DisPlayMode.always:
-        line.isHidden = false
-      case Configuration.GroupEditModel.DisPlayMode.editing,
-        Configuration.GroupEditModel.DisPlayMode.none:
-        line.isHidden = true
-      }
-    }
     line.usingAutolayout()
     self.addSubview(line)
     NSLayoutConstraint.activate([

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/TextFieldStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/TextFieldStyle.swift
@@ -55,10 +55,8 @@ extension Styled {
         switch model.bottomLineDisplayMode {
         case Configuration.GroupEditModel.DisPlayMode.always,
           Configuration.GroupEditModel.DisPlayMode.editing:
-          self.bottomLine.isHidden = false
           self.animateBottomLineAppearing()
         case Configuration.GroupEditModel.DisPlayMode.none:
-          self.bottomLine.isHidden = true
           self.animateBottomLineAppearing()
         }
       }
@@ -76,11 +74,9 @@ extension Styled {
       configuration.groupEditModel.map { model in
         switch model.bottomLineDisplayMode {
         case Configuration.GroupEditModel.DisPlayMode.always:
-          self.bottomLine.isHidden = false
           self.bottomLine.setProgress(0.0, animated: false)
         case Configuration.GroupEditModel.DisPlayMode.editing,
           Configuration.GroupEditModel.DisPlayMode.none:
-          self.bottomLine.isHidden = true
           self.bottomLine.setProgress(0.0, animated: false)
         }
       }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/TextFieldStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/TextFieldStyle.swift
@@ -55,10 +55,10 @@ extension Styled {
         switch model.bottomLineDisplayMode {
         case Configuration.GroupEditModel.DisPlayMode.always,
           Configuration.GroupEditModel.DisPlayMode.editing:
-          bottomLine.isHidden = false
+          self.bottomLine.isHidden = false
           self.animateBottomLineAppearing()
         case Configuration.GroupEditModel.DisPlayMode.none:
-          bottomLine.isHidden = true
+          self.bottomLine.isHidden = true
           self.animateBottomLineAppearing()
         }
       }
@@ -76,10 +76,12 @@ extension Styled {
       configuration.groupEditModel.map { model in
         switch model.bottomLineDisplayMode {
         case Configuration.GroupEditModel.DisPlayMode.always:
-          bottomLine.isHidden = false
+          self.bottomLine.isHidden = false
+          self.bottomLine.setProgress(0.0, animated: false)
         case Configuration.GroupEditModel.DisPlayMode.editing,
           Configuration.GroupEditModel.DisPlayMode.none:
-          bottomLine.isHidden = true
+          self.bottomLine.isHidden = true
+          self.bottomLine.setProgress(0.0, animated: false)
         }
       }
       return super.resignFirstResponder()

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/TextFieldStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/TextFieldStyle.swift
@@ -1,6 +1,8 @@
 import Combine
 import UIKit
 
+import ToDoGardenUIConstant
+
 private typealias ViewMode = UIKit.UITextField.ViewMode
 
 extension Styled {
@@ -54,13 +56,22 @@ extension Styled {
         case Configuration.GroupEditModel.DisPlayMode.always,
           Configuration.GroupEditModel.DisPlayMode.editing:
           bottomLine.isHidden = false
+          self.animateBottomLineAppearing()
         case Configuration.GroupEditModel.DisPlayMode.none:
           bottomLine.isHidden = true
+          self.animateBottomLineAppearing()
         }
       }
       return super.becomeFirstResponder()
     }
-    
+
+    private func animateBottomLineAppearing() {
+      let duration = Constant.Styled.TextField.GroupEdit.BottomLineAnimation.duration
+      UIView.animate(withDuration: duration) {
+        self.bottomLine.setProgress(1.0, animated: true)
+      }
+    }
+
     public override func resignFirstResponder() -> Bool {
       configuration.groupEditModel.map { model in
         switch model.bottomLineDisplayMode {
@@ -73,7 +84,7 @@ extension Styled {
       }
       return super.resignFirstResponder()
     }
-    
+
     private func buildLeftImageMargin(_ rect: CGRect) -> CGRect {
       let containedRect = self.configuration.primaryModel
         .map { model in

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/TextFieldStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/TextFieldStyle.swift
@@ -21,7 +21,7 @@ extension Styled {
     }
     
     @Published var configuration: Configuration
-    var bottomLine: UIView!
+    var bottomLine: UIProgressView!
     var cancellables: Set<AnyCancellable> = []
     
     public init(configuration: Configuration) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+Styled+TextField.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+Styled+TextField.swift
@@ -22,3 +22,11 @@ public extension Constant.Styled.TextField.Primary.Standard {
 public extension Constant.Styled.TextField.GroupEdit {
   static let bottomLineHeight = CGFloat(1)
 }
+
+public extension Constant.Styled.TextField.GroupEdit {
+  enum BottomLineAnimation { }
+}
+
+public extension Constant.Styled.TextField.GroupEdit.BottomLineAnimation {
+  static let duration: CGFloat = 0.2
+}


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #237 

## 🎉 변경 사항
- TextField Style에 BottomLine 색상이 변경되는 애니메이션을 추가하였습니다.

## 📌 PR Point
- **GroupEditModel** Style에만 애니메이션을 적용하였습니다.
- TextField의 BottomLine이 보이도록 기본 색상을 Gray로 수정하였습니다.
- BottomLine을 UIView > UIProgressView로 수정하였습니다.

|수정 전|애니메이션 적용 후|
|--|--|
|<img width="250" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/947bed04-0545-4514-bb34-b987741bcc92">|<img width="250" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/ba3213df-265d-4795-a760-afae17d66f0b">|

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?