### PR TITLE
TextInputView 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -38,6 +38,14 @@ public final class TextInputView: UIView {
   public func changeBottomLine(color: UIColor) {
     self.inputTextField.mainColor = color
   }
+
+  public func setBeginEditing(with text: String) {
+    guard self.inputTextField.isFirstResponder == false
+    else { return }
+
+    self.inputTextField.text = text
+    _ = self.inputTextField.becomeFirstResponder()
+  }
 }
 
 // MARK: Private Functions

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -28,6 +28,7 @@ public final class TextInputView: UIView {
 extension TextInputView {
   private func setup() {
     self.setupPlaceholderLabel()
+    self.setupInputTextFieldDelegate()
     self.addSubviews()
     self.setupSubviewsLayout()
   }
@@ -38,7 +39,15 @@ extension TextInputView {
     self.placeholderLabel.textColor = UIColor.toDoGardenGray2
     self.placeholderLabel.adjustsFontSizeToFitWidth = true
   }
+
+  private func setupInputTextFieldDelegate() {
+    self.inputTextField.delegate = self
+  }
 }
+
+// MARK: TextField Delegate Functions
+
+extension TextInputView: UITextFieldDelegate {}
 
 // MARK: Auto Layout
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -4,9 +4,11 @@ import ToDoGardenUIConstant
 
 public final class TextInputView: UIView {
   private let model: Model
+  private let inputTextField: Styled.TextField
 
   public init(model: Model) {
     self.model = model
+    self.inputTextField = Styled.TextField(configuration: .groupEdit(.standard))
     super.init(frame: CGRect.zero)
   }
 
@@ -15,6 +17,41 @@ public final class TextInputView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
 }
+
+// MARK: Private Functions
+
+extension TextInputView {
+  private func setup() {
+    self.addSubviews()
+    self.setupSubviewsLayout()
+  }
+}
+
+// MARK: Auto Layout
+
+extension TextInputView {
+  private func addSubviews() {
+    self.addSubview(self.inputTextField)
+  }
+
+  private func setupSubviewsLayout() {
+    self.setupInputTextFieldLayout()
+  }
+
+  private func setupInputTextFieldLayout() {
+    self.inputTextField.usingAutolayout()
+
+    NSLayoutConstraint.activate(
+      [
+        self.inputTextField.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.inputTextField.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        self.inputTextField.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+      ]
+    )
+  }
+}
+
+// MARK: Model
 
 extension TextInputView {
   public struct Model {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -182,3 +182,25 @@ extension TextInputView {
     public static let userDescription = Self(inputText: "소개")
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let stackView = UIStackView()
+  stackView.axis = .vertical
+  stackView.spacing = 50
+
+  let toDoNameView = TextInputView(model: .toDoName)
+  stackView.addArrangedSubview(toDoNameView)
+
+  let groupNameView = TextInputView(model: .groupName)
+  groupNameView.changeBottomLine(color: UIColor.toDoGardenYellow)
+  stackView.addArrangedSubview(groupNameView)
+
+  let userIdInputView = TextInputView(model: .userId)
+  userIdInputView.setBeginEditing(with: "우드")
+  stackView.addArrangedSubview(userIdInputView)
+
+  return stackView
+}
+#endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -3,12 +3,33 @@ import UIKit
 import ToDoGardenUIConstant
 
 public final class TextInputView: UIView {
-  public init() {
+  private let model: Model
+
+  public init(model: Model) {
+    self.model = model
     super.init(frame: CGRect.zero)
   }
 
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+extension TextInputView {
+  public struct Model {
+    let inputText: String
+    let shrinkScale: CGFloat
+
+    public init(inputText: String, shrinkScale: CGFloat = 0.8) {
+      self.inputText = inputText
+      self.shrinkScale = shrinkScale
+    }
+
+    public static let toDoName = Self(inputText: "할 일")
+    public static let groupName = Self(inputText: "그룹명")
+    public static let userNickname = Self(inputText: "닉네임")
+    public static let userId = Self(inputText: "아이디")
+    public static let userDescription = Self(inputText: "소개")
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+import ToDoGardenUIConstant
+
+public final class TextInputView: UIView {
+  public init() {
+    super.init(frame: CGRect.zero)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -5,11 +5,14 @@ import ToDoGardenUIConstant
 public final class TextInputView: UIView {
   private let model: Model
   private let inputTextField: Styled.TextField
+  private let placeholderLabel: UILabel
 
   public init(model: Model) {
     self.model = model
     self.inputTextField = Styled.TextField(configuration: .groupEdit(.standard))
+    self.placeholderLabel = UILabel()
     super.init(frame: CGRect.zero)
+    self.setup()
   }
 
   @available(*, unavailable)
@@ -32,10 +35,12 @@ extension TextInputView {
 extension TextInputView {
   private func addSubviews() {
     self.addSubview(self.inputTextField)
+    self.addSubview(self.placeholderLabel)
   }
 
   private func setupSubviewsLayout() {
     self.setupInputTextFieldLayout()
+    self.setupPlaceholderLabelLayout()
   }
 
   private func setupInputTextFieldLayout() {
@@ -46,6 +51,22 @@ extension TextInputView {
         self.inputTextField.leadingAnchor.constraint(equalTo: self.leadingAnchor),
         self.inputTextField.trailingAnchor.constraint(equalTo: self.trailingAnchor),
         self.inputTextField.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+      ]
+    )
+  }
+
+  private func setupPlaceholderLabelLayout() {
+    self.placeholderLabel.usingAutolayout()
+
+    NSLayoutConstraint.activate(
+      [
+        self.placeholderLabel.topAnchor.constraint(equalTo: self.inputTextField.topAnchor),
+        self.placeholderLabel.leadingAnchor.constraint(equalTo: self.inputTextField.leadingAnchor),
+        self.placeholderLabel.trailingAnchor.constraint(lessThanOrEqualTo: self.inputTextField.trailingAnchor),
+        self.placeholderLabel.bottomAnchor.constraint(
+          equalTo: self.inputTextField.bottomAnchor,
+          constant: Constant.TextInputView.Layout.PlaceholderLabel.bottomMargin
+        )
       ]
     )
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -34,6 +34,10 @@ public final class TextInputView: UIView {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+
+  public func changeBottomLine(color: UIColor) {
+    self.inputTextField.mainColor = color
+  }
 }
 
 // MARK: Private Functions
@@ -144,7 +148,7 @@ extension TextInputView {
         self.placeholderLabel.trailingAnchor.constraint(lessThanOrEqualTo: self.inputTextField.trailingAnchor),
         self.placeholderLabel.bottomAnchor.constraint(
           equalTo: self.inputTextField.bottomAnchor,
-          constant: Constant.TextInputView.Layout.PlaceholderLabel.bottomMargin
+          constant: -Constant.TextInputView.Layout.PlaceholderLabel.bottomMargin
         )
       ]
     )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -8,6 +8,19 @@ public final class TextInputView: UIView {
   private let placeholderLabel: UILabel
   private let placeholderText: String
 
+  private var height: CGFloat {
+    let textFieldDefatulLineHeight = Constant.TextInputView.Layout.InputTextField.defaultHeight
+    let textFieldHeight = self.inputTextField.font?.lineHeight ?? textFieldDefatulLineHeight
+
+    let labelDefatulLineHeight = Constant.TextInputView.Layout.PlaceholderLabel.defaultHeight
+    let labelHeight = self.placeholderLabel.font?.lineHeight ?? labelDefatulLineHeight
+    return textFieldHeight + labelHeight + 1
+  }
+
+  public override var intrinsicContentSize: CGSize {
+    return CGSize(width: 0, height: self.height)
+  }
+
   public init(model: Model) {
     self.model = model
     self.inputTextField = Styled.TextField(configuration: .groupEdit(.standard))

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -47,7 +47,26 @@ extension TextInputView {
 
 // MARK: TextField Delegate Functions
 
-extension TextInputView: UITextFieldDelegate {}
+extension TextInputView: UITextFieldDelegate {
+  public func textFieldDidBeginEditing(_ textField: UITextField) {
+    self.updatePlaceholderLabelText(isEditing: true)
+  }
+
+  public func textFieldDidEndEditing(_ textField: UITextField) {
+    guard self.inputTextField.text?.isEmpty == true
+    else { return }
+
+    self.updatePlaceholderLabelText(isEditing: false)
+  }
+
+  private func updatePlaceholderLabelText(isEditing: Bool) {
+    let text = isEditing ? self.model.inputText : self.placeholderText
+    self.placeholderLabel.text = text
+
+    let textColor = isEditing ? UIColor.toDoGardenGreenDark : UIColor.toDoGardenGray2
+    self.placeholderLabel.textColor = textColor
+  }
+}
 
 // MARK: Auto Layout
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -6,11 +6,13 @@ public final class TextInputView: UIView {
   private let model: Model
   private let inputTextField: Styled.TextField
   private let placeholderLabel: UILabel
+  private let placeholderText: String
 
   public init(model: Model) {
     self.model = model
     self.inputTextField = Styled.TextField(configuration: .groupEdit(.standard))
     self.placeholderLabel = UILabel()
+    self.placeholderText = model.inputText + Constant.TextInputView.StringLiteral.placeholderText
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -25,8 +27,16 @@ public final class TextInputView: UIView {
 
 extension TextInputView {
   private func setup() {
+    self.setupPlaceholderLabel()
     self.addSubviews()
     self.setupSubviewsLayout()
+  }
+
+  private func setupPlaceholderLabel() {
+    self.placeholderLabel.font = UIFont.pretendardBodySemiBold15
+    self.placeholderLabel.text = self.placeholderText
+    self.placeholderLabel.textColor = UIColor.toDoGardenGray2
+    self.placeholderLabel.adjustsFontSizeToFitWidth = true
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -23,7 +23,11 @@ public final class TextInputView: UIView {
 
   public init(model: Model) {
     self.model = model
-    self.inputTextField = Styled.TextField(configuration: .groupEdit(.standard))
+    self.inputTextField = Styled.TextField(
+      configuration: Styled.TextField.Configuration.groupEdit(
+        Styled.TextField.Configuration.GroupEditModel.standard
+      )
+    )
     self.placeholderLabel = UILabel()
     self.placeholderText = model.inputText + Constant.TextInputView.StringLiteral.placeholderText
     super.init(frame: CGRect.zero)
@@ -190,14 +194,14 @@ extension TextInputView {
   stackView.axis = .vertical
   stackView.spacing = 50
 
-  let toDoNameView = TextInputView(model: .toDoName)
+  let toDoNameView = TextInputView(model: TextInputView.Model.toDoName)
   stackView.addArrangedSubview(toDoNameView)
 
-  let groupNameView = TextInputView(model: .groupName)
+  let groupNameView = TextInputView(model: TextInputView.Model.groupName)
   groupNameView.changeBottomLine(color: UIColor.toDoGardenYellow)
   stackView.addArrangedSubview(groupNameView)
 
-  let userIdInputView = TextInputView(model: .userId)
+  let userIdInputView = TextInputView(model: TextInputView.Model.userId)
   userIdInputView.setBeginEditing(with: "우드")
   stackView.addArrangedSubview(userIdInputView)
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -50,6 +50,7 @@ extension TextInputView {
 extension TextInputView: UITextFieldDelegate {
   public func textFieldDidBeginEditing(_ textField: UITextField) {
     self.updatePlaceholderLabelText(isEditing: true)
+    self.updatePlaceholderLabelPosition(isEditing: true)
   }
 
   public func textFieldDidEndEditing(_ textField: UITextField) {
@@ -57,6 +58,7 @@ extension TextInputView: UITextFieldDelegate {
     else { return }
 
     self.updatePlaceholderLabelText(isEditing: false)
+    self.updatePlaceholderLabelPosition(isEditing: false)
   }
 
   private func updatePlaceholderLabelText(isEditing: Bool) {
@@ -65,6 +67,32 @@ extension TextInputView: UITextFieldDelegate {
 
     let textColor = isEditing ? UIColor.toDoGardenGreenDark : UIColor.toDoGardenGray2
     self.placeholderLabel.textColor = textColor
+  }
+
+  private func updatePlaceholderLabelPosition(isEditing: Bool) {
+    let transform = self.makePlaceholderLabelTrasnform(isEditing: isEditing, scale: self.model.shrinkScale)
+    if isEditing == false {
+      self.placeholderLabel.transform = transform
+    }
+
+    let duration = Constant.TextInputView.Animation.duration
+    UIView.animate(withDuration: duration, delay: 0.0) {
+      let animationTransform = isEditing ? transform : CGAffineTransform.identity
+      self.placeholderLabel.transform = animationTransform
+    }
+  }
+
+  private func makePlaceholderLabelTrasnform(isEditing: Bool, scale: CGFloat) -> CGAffineTransform {
+    let leadingMargin = -self.placeholderLabel.font.pointSize * (1 - scale)
+    let totalMargin = isEditing ? leadingMargin : leadingMargin * 4
+    let offsetX = self.placeholderLabel.bounds.origin.x + totalMargin
+
+    let labelHeight = -self.placeholderLabel.bounds.height
+    let defaultLineHeight = Constant.TextInputView.Layout.InputTextField.defaultHeight
+    let textFieldLineHeight = self.inputTextField.font?.lineHeight ?? defaultLineHeight
+    let offsetY = labelHeight == 0 ? -textFieldLineHeight : labelHeight
+
+    return CGAffineTransform(translationX: offsetX, y: offsetY).scaledBy(x: scale, y: scale)
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #242 

## 🎉 변경 사항
- 텍스트를 입력받을 때 애니메이션을 실행하는 TextInputView를 추가하였습니다.

## 📌 PR Point
- TextField에 텍스트를 입력할 때, Placeholder의 위치를 위로 이동시키는 애니메이션이 동작합니다.
![GIF speed changer 2024-06-22 21 18 28](https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/17319633-75ce-4ba3-9fdb-2ffa719d2189)


- 다음과 같이 사용이 가능합니다.
``` Swift
  let toDoNameView = TextInputView(model: .toDoName)

  let groupNameView = TextInputView(model: .groupName)
  // BottomLine 색상 변경 메서드
  // 투두 이름 수정시 그룹 색상으로 변경하는데 사용
  groupNameView.changeBottomLine(color: UIColor.toDoGardenYellow)

  let userIdInputView = TextInputView(model: .userId)
  // 수정모드 진입 메서드
  // 기존에 입력된 텍스트 적용
  userIdInputView.setBeginEditing(with: "우드")
```

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?