### PR TITLE
Row Style Constant RightView 크기 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+Styled+Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+Styled+Row.swift
@@ -35,6 +35,7 @@ public extension Constant.Styled.Row.ListPrimary {
   static let stackEdgeInsets = NSDirectionalEdgeInsets(top: 0, leading: 14, bottom: 0, trailing: 14)
   static let colorViewCornerRadius = CGFloat(12)
   static let colorViewSize = CGSize(width: 24, height: 24)
+  static let rightViewSize = CGSize(width: 24, height: 24)
 }
 
 public extension Constant.Styled.Row.RepeatOtherDays {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #248 

## 🎉 변경 사항
- ListPrimary Row Style Constant에 RightView의 크기 상수값을 추가하였습니다.

|기존 ListPrimary 스타일|다음 PR에서 추가할 확장 버전 스타일|
|--|--|
|<img width="400" alt="스크린샷 2024-06-25 11 41 18" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/83b36d53-8615-44c9-8f65-3a116df58b7a">|<img width="400" alt="스크린샷 2024-06-25 11 41 25" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/4506ee8d-01e2-49e1-b98a-8d5a0860e4b9">|

## 📌 PR Point
- RightView를 추가하는 이유는 투두 수정 화면에서 [그룹 설정](https://www.figma.com/design/JCWKb4OUC4zZhKbUz3JLEP/%ED%88%AC%EB%91%90%EA%B0%80%EB%93%A0(%EA%B7%B8%EB%85%80%EC%84%9D%EB%93%A4)?node-id=133-8506&t=Zrkac1r4z1NrHH16-1)에 필요하기 때문입니다.
- 확장성을 고려하여 Button이 아닌 View로 선언하였습니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?