### PR TITLE
Row Style ListPrimary 확장

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
@@ -57,6 +57,8 @@ extension Styled {
     private func build(with views: [UIView]) {
       let stack = UIStackView(frame: CGRect.zero)
       switch self.configuration {
+      case let Configuration.listPrimary(listPrimaryModel):
+        self.buildListPrimaryStyle(stack: stack, model: listPrimaryModel, views: views)
       case let Configuration.repeatOtherDays(repeatOtherDaysModel):
         self.buildRepeatOtherDaysStyle(stack: stack, model: repeatOtherDaysModel, views: views)
       default: break

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
@@ -122,9 +122,23 @@ extension Styled.Row {
 
 @available(iOS 17.0, *)
 #Preview {
+  let stack = UIStackView()
+  stack.axis = .vertical
+  stack.spacing = 20
+
   let row = Styled.Row(
     configuration: .listPrimary(.init(title: "영어독해", color: .red))
   )
-  
-  return row
+  stack.addArrangedSubview(row)
+
+  let button = UIButton()
+  button.setImage(UIImage.forwardButtonImage, for: UIControl.State.normal)
+
+  let row2 = Styled.Row(
+    configuration: .listPrimary(.init(title: "영어독해", color: .toDoGardenYellow)),
+    with: [button]
+  )
+  stack.addArrangedSubview(row2)
+
+  return stack
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ListPrimary.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ListPrimary.swift
@@ -3,7 +3,11 @@ import UIKit
 import ToDoGardenUIConstant
 
 extension Styled.Row {
-  func buildListPrimaryStyle(stack: UIStackView, model: Configuration.ListPrimaryModel) {
+  func buildListPrimaryStyle(
+    stack: UIStackView,
+    model: Configuration.ListPrimaryModel,
+    views: [UIView]? = nil
+  ) {
     stack.alignment = UIStackView.Alignment.center
     self.buildStack(
       stack: stack,

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ListPrimary.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ListPrimary.swift
@@ -18,6 +18,7 @@ extension Styled.Row {
     stack.addArrangedSubview(label)
     stack.addSpacing()
     self.buildColorView(stack: stack, color: model.color)
+    self.buildRightView(stack: stack, views: views)
   }
   
   private func buildColorView(stack: UIStackView, color: UIColor) {
@@ -30,5 +31,19 @@ extension Styled.Row {
       colorView.heightAnchor.constraint(equalToConstant: Constant.Styled.Row.ListPrimary.colorViewSize.height)
     ])
     stack.addArrangedSubview(colorView)
+  }
+
+  private func buildRightView(stack: UIStackView, views: [UIView]? = nil) {
+    guard let rightView = views?.first
+    else { return }
+
+    rightView.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        rightView.widthAnchor.constraint(equalToConstant: Constant.Styled.Row.ListPrimary.rightViewSize.width),
+        rightView.widthAnchor.constraint(equalToConstant: Constant.Styled.Row.ListPrimary.rightViewSize.height)
+      ]
+    )
+    stack.addArrangedSubview(rightView)
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #250 

## 🎉 변경 사항
- ListPrimary Row Style의 우측에 뷰를 추가할 수 있도록 확장하였습니다.

|기존 ListPrimary 스타일|확장한 ListPrimary 스타일|
|--|--|
|<img width="300" alt="스크린샷 2024-06-25 11 41 18" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/83b36d53-8615-44c9-8f65-3a116df58b7a">|<img width="300" alt="스크린샷 2024-06-25 11 41 25" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/7cafaef7-5779-4beb-991e-254486294338">|

## 📌 PR Point
- 확장성을 고려하여 추가할 객체의 타입이 Button이지만, View로 타입을 명시하였습니다.
- 투두 수정화면에서 [그룹 수정](https://www.figma.com/design/JCWKb4OUC4zZhKbUz3JLEP/%ED%88%AC%EB%91%90%EA%B0%80%EB%93%A0(%EA%B7%B8%EB%85%80%EC%84%9D%EB%93%A4)?node-id=133-8506&t=Zrkac1r4z1NrHH16-1) 화면에 필요하여 확장하였습니다.
- 생성할 때는 다음과 같이 생성합니다.
```swift
  let button = UIButton()

  let row2 = Styled.Row(
    configuration: .listPrimary(.init(title: "영어독해", color: .toDoGardenYellow)),
    with: [button]
  )
``` 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?