### PR TITLE
ManageGroupTableview 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/ManageGroupTableViewAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/ManageGroupTableViewAPI.swift
@@ -1,0 +1,12 @@
+//
+//  ManageGroupTableViewAPI.swift
+//  
+//
+//  Created by SONG on 6/21/24.
+//
+
+import Foundation
+
+public protocol ManageGroupTableViewAPI {
+  func setEditingMode(_ editing: Bool, animated: Bool)
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableView.swift
@@ -1,0 +1,47 @@
+//
+//  GroupListTableView.swift
+//
+//
+//  Created by SONG on 6/13/24.
+//
+
+import UIKit
+
+import ToDoGardenUIAPI
+import ToDoGardenUIConstant
+
+public final class ManageGroupTableView: UITableView, ManageGroupTableViewAPI {
+  
+  override init(frame: CGRect, style: UITableView.Style) {
+    super.init(frame: frame, style: style)
+    self.commonInit()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder aDecoder: NSCoder) {
+    fatalError()
+  }
+  
+  public override var intrinsicContentSize: CGSize {
+    let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+    let screenWidth = windowScene?.screen.bounds.width ?? 1.0
+    let screenHeight = windowScene?.screen.bounds.height ?? 1.0
+    let widthInset = Constant.ManageGroupListTableView.widthInset
+    let heightInset = Constant.ManageGroupListTableView.heightInset
+    
+    return CGSize(
+      width: screenWidth + widthInset,
+      height: screenHeight + heightInset
+    )
+  }
+}
+
+extension ManageGroupTableView {
+  private func commonInit() {
+    self.register(type: ManageGroupTableViewCell.self)
+    self.backgroundColor = UIColor.clear
+    self.separatorStyle = UITableViewCell.SeparatorStyle.none
+    self.allowsSelectionDuringEditing = true
+    self.dragInteractionEnabled = true
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableView.swift
@@ -34,6 +34,34 @@ public final class ManageGroupTableView: UITableView, ManageGroupTableViewAPI {
       height: screenHeight + heightInset
     )
   }
+  
+  public func setEditingMode(_ editing: Bool, animated: Bool) {
+    self.setEditing(editing, animated: animated)
+    if editing {
+      self.enterEditingMode()
+    } else {
+      self.leaveEditingMode()
+    }
+    
+    Task {
+      try await Task.sleep(nanoseconds: Constant.ManageGroupListTableView.sleepTime)
+      self.reloadSectionExceptFooterCell()
+    }
+  }
+  
+  private func enterEditingMode() {
+    guard let visibleCells = self.visibleCells as? [ManageGroupTableViewCell] else {
+      return
+    }
+    visibleCells.forEach { $0.enterEditingMode() }
+  }
+  
+  private func leaveEditingMode() {
+    guard let visibleCells = self.visibleCells as? [ManageGroupTableViewCell] else {
+      return
+    }
+    visibleCells.forEach { $0.leaveEditingMode() }
+  } 
 }
 
 extension ManageGroupTableView {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableView.swift
@@ -72,4 +72,19 @@ extension ManageGroupTableView {
     self.allowsSelectionDuringEditing = true
     self.dragInteractionEnabled = true
   }
+  
+  private func reloadSectionExceptFooterCell() {
+    let section = Int.zero
+    let numberOfRows = self.numberOfRows(inSection: section)
+    guard numberOfRows > 1 else {
+      return
+    }
+    
+    var indexPaths: [IndexPath] = []
+    for row in Int.zero..<(numberOfRows - 1) {
+      indexPaths.append(IndexPath(row: row, section: section))
+    }
+    
+    self.reloadRows(at: indexPaths, with: UITableView.RowAnimation.none)
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableView.swift
@@ -24,8 +24,8 @@ public final class ManageGroupTableView: UITableView, ManageGroupTableViewAPI {
   
   public override var intrinsicContentSize: CGSize {
     let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-    let screenWidth = windowScene?.screen.bounds.width ?? 1.0
-    let screenHeight = windowScene?.screen.bounds.height ?? 1.0
+    let screenWidth = windowScene?.screen.bounds.width ?? CGFloat.zero
+    let screenHeight = windowScene?.screen.bounds.height ?? CGFloat.zero
     let widthInset = Constant.ManageGroupListTableView.widthInset
     let heightInset = Constant.ManageGroupListTableView.heightInset
     

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableView.swift
@@ -23,6 +23,7 @@ public final class ManageGroupTableView: UITableView, ManageGroupTableViewAPI {
   }
   
   public override var intrinsicContentSize: CGSize {
+    // TODO: - 윈도우 접근하지 않는 방법 고려
     let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
     let screenWidth = windowScene?.screen.bounds.width ?? CGFloat.zero
     let screenHeight = windowScene?.screen.bounds.height ?? CGFloat.zero
@@ -43,6 +44,7 @@ public final class ManageGroupTableView: UITableView, ManageGroupTableViewAPI {
       self.leaveEditingMode()
     }
     
+    // TODO: - 잠재적 문제발생 지점. 애니메이션에 대한 컴플리션으로 수정하기
     Task {
       try await Task.sleep(nanoseconds: Constant.ManageGroupListTableView.sleepTime)
       self.reloadSectionExceptFooterCell()


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #254 
- should be merged after #247 
## 🎉 변경 사항
- ManageGroupTableview 추가 
- ManageGroupTableviewAPI 추가 

## 📌 PR Point
![Simulator Screen Recording - iPhone 15 Pro - 2024-06-25 at 17 04 23](https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/f2137f0c-2aa0-4671-b1ae-749d0dfefc7c)
<gif상단의 파란버튼은 편집모드 진입/탈출용 임시버튼입니다.>
- 인터페이스를 통해 편집 모드로의 진입 / 탈출이 가능한 테이블뷰입니다. 
- 편집모드 진입시, 삭제 버튼이 좌측에서 등장하고, chevron 버튼이 우측에서 등장합니다. 
- 편집모드 탈출시, 등장했던 버튼들이 퇴장합니다. 
- 등장/퇴장 애니메이션이 끝난 뒤, Footer를 제외한 cell을 리로드하여 빠지는 셀없이 모든셀에 대해 일괄적으로 UI업데이트가 진행됩니다. 
- "삭제" / "드래그앤 드롭으로 순서 변경" 등은 delegate에 의해 진행됩니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?