### PR TITLE
TDUtilityPackage 추가

### DIFF
--- a/ToDo-Garden/TDUtility/.gitignore
+++ b/ToDo-Garden/TDUtility/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/ToDo-Garden/TDUtility/Package.swift
+++ b/ToDo-Garden/TDUtility/Package.swift
@@ -17,9 +17,14 @@ let package = Package(
       name: "TDUtility",
       dependencies: [
         "TDCombineExtension",
+        "TDFoundationExtension"
       ]
     ),
     .target(
       name: "TDCombineExtension"
     ),
+    .target(
+      name: "TDFoundationExtension"
+    )
+  ]
 )

--- a/ToDo-Garden/TDUtility/Package.swift
+++ b/ToDo-Garden/TDUtility/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.10
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+  name: "TDUtility",
+  platforms: [.iOS(.v15)],
+  products: [
+    .library(
+      name: "TDUtility",
+      targets: ["TDUtility"]
+    ),
+  ],
+  targets: [
+    .target(
+      name: "TDUtility",
+    ),
+)

--- a/ToDo-Garden/TDUtility/Package.swift
+++ b/ToDo-Garden/TDUtility/Package.swift
@@ -15,5 +15,11 @@ let package = Package(
   targets: [
     .target(
       name: "TDUtility",
+      dependencies: [
+        "TDCombineExtension",
+      ]
+    ),
+    .target(
+      name: "TDCombineExtension"
     ),
 )

--- a/ToDo-Garden/TDUtility/Sources/TDCombineExtension/nwise.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDCombineExtension/nwise.swift
@@ -1,0 +1,19 @@
+#if canImport(Combine)
+import Combine
+
+public extension Publisher {
+  func nwise(_ size: Int) -> AnyPublisher<[Output], Failure> {
+    assert(size > 1, "n must be greater than 1")
+    
+    return self.scan([]) { acc, item in Array((acc + [item]).suffix(size)) }
+      .filter { $0.count == size }
+      .eraseToAnyPublisher()
+  }
+  
+  func pairwise() -> AnyPublisher<(Output, Output), Failure> {
+    nwise(2)
+      .map { ($0[0], $0[1]) }
+      .eraseToAnyPublisher()
+  }
+}
+#endif

--- a/ToDo-Garden/TDUtility/Sources/TDFoundationExtension/String+Extension.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDFoundationExtension/String+Extension.swift
@@ -1,0 +1,18 @@
+//
+//  String+Extension.swift
+//
+//
+//  Created by SONG on 5/23/24.
+//
+
+import Foundation
+
+public extension String {
+  func applyTextAttributes(attributes: [NSAttributedString.Key: Any]?) -> NSAttributedString {
+    let attributedString = NSAttributedString(
+      string: self,
+      attributes: attributes
+    )
+    return attributedString
+  }
+}

--- a/ToDo-Garden/TDUtility/Sources/TDUtility/TDUtility.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/TDUtility.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/ToDo-Garden/ToDo-Garden.xcodeproj/project.pbxproj
+++ b/ToDo-Garden/ToDo-Garden.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		4F0DF1382B4EABD000097B7D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F0DF1362B4EABD000097B7D /* LaunchScreen.storyboard */; };
 		4F3D03842B8EF89800C495E5 /* ToDoGardenUIComponent in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3D03832B8EF89800C495E5 /* ToDoGardenUIComponent */; };
 		4F3D03862B8EF89800C495E5 /* ToDoGardenUIResource in Frameworks */ = {isa = PBXBuildFile; productRef = 4F3D03852B8EF89800C495E5 /* ToDoGardenUIResource */; };
+		4F577A2D2C2BE05F0006F44F /* TDUtility in Frameworks */ = {isa = PBXBuildFile; productRef = 4F577A2C2C2BE05F0006F44F /* TDUtility */; };
 		4FC8C1092B8336A100BA223E /* ToDoGardenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC8C1082B8336A100BA223E /* ToDoGardenTests.swift */; };
 		4FC8C1512B8C575A00BA223E /* ToDoGardenUIAPI in Frameworks */ = {isa = PBXBuildFile; productRef = 4FC8C1502B8C575A00BA223E /* ToDoGardenUIAPI */; };
 		4FDA5E392B4FF1E4006506ED /* Asset.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4FDA5E382B4FF1E4006506ED /* Asset.xcassets */; };
@@ -35,6 +36,7 @@
 		4F0DF12D2B4EABCE00097B7D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		4F0DF1372B4EABD000097B7D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		4F0DF1392B4EABD000097B7D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4F577A2B2C2BDE300006F44F /* TDUtility */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = TDUtility; sourceTree = "<group>"; };
 		4FC8C1062B8336A100BA223E /* ToDo-GardenTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ToDo-GardenTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4FC8C1082B8336A100BA223E /* ToDoGardenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoGardenTests.swift; sourceTree = "<group>"; };
 		4FC8C10F2B83375500BA223E /* ToDo-GardenTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "ToDo-GardenTestPlan.xctestplan"; sourceTree = "<group>"; };
@@ -51,6 +53,7 @@
 				4FC8C1512B8C575A00BA223E /* ToDoGardenUIAPI in Frameworks */,
 				4F3D03862B8EF89800C495E5 /* ToDoGardenUIResource in Frameworks */,
 				4F3D03842B8EF89800C495E5 /* ToDoGardenUIComponent in Frameworks */,
+				4F577A2D2C2BE05F0006F44F /* TDUtility in Frameworks */,
 				E4F7D3B22B996B1F00324294 /* ToDoGardenUIConstant in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -68,6 +71,7 @@
 		4F0DF11F2B4EABCE00097B7D = {
 			isa = PBXGroup;
 			children = (
+				4F577A2B2C2BDE300006F44F /* TDUtility */,
 				4FC8C14A2B87562600BA223E /* ToDoGardenUI */,
 				4F0DF12A2B4EABCE00097B7D /* ToDo-Garden */,
 				4FC8C1072B8336A100BA223E /* ToDo-GardenTests */,
@@ -159,6 +163,7 @@
 				4F3D03832B8EF89800C495E5 /* ToDoGardenUIComponent */,
 				4F3D03852B8EF89800C495E5 /* ToDoGardenUIResource */,
 				E4F7D3B12B996B1F00324294 /* ToDoGardenUIConstant */,
+				4F577A2C2C2BE05F0006F44F /* TDUtility */,
 			);
 			productName = "ToDo-Garden";
 			productReference = 4F0DF1282B4EABCE00097B7D /* ToDo-Garden.app */;
@@ -529,6 +534,10 @@
 		4F3D03852B8EF89800C495E5 /* ToDoGardenUIResource */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ToDoGardenUIResource;
+		};
+		4F577A2C2C2BE05F0006F44F /* TDUtility */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TDUtility;
 		};
 		4FC8C1502B8C575A00BA223E /* ToDoGardenUIAPI */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #260 
## 🎉 변경 사항
유틸리티 성격의 타입을 가진 패키지를 추가하였습니다.
- [x] FoundationExtension 패키지 추가
- [x] CombineExtension 패키지 추가
- [x] Utility 패키지 추가

## 📌 PR Point
- 기존 ToDoGardenUI 패키지에 있는 FoundationExtension target, CombineExtension target과 동일한 타입을 추가하였습니다.
- 해당 패키지가 추가됨에 따라 ToDoGardenUI 패키지에 있는 Extension을 해당 패키지에 있는 타입으로 마이그레이션 후 기존(ToDoGardenUI)패키지에 있는 타입을 삭제하면 될 것 같습니다.
- 해당 패키지가 모두가 사용할 수 있어야하는 유틸리티 성격의 패키지기에 모두가 같이 사용할 수 있는 Swift version인 `Swift 5.10`을 최소 버전으로 하였습니다.
  - 제가 알기로는 강운과, 제가 `Xcode16` 베타를 사용하고 있고 우드와 울버린이 `Xcode15`를 사용하는 것으로 알고있습니다!!
## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?