### PR TITLE
ExecuteOnce property wrapper 추가

### DIFF
--- a/ToDo-Garden/TDUtility/Package.swift
+++ b/ToDo-Garden/TDUtility/Package.swift
@@ -25,6 +25,10 @@ let package = Package(
     ),
     .target(
       name: "TDFoundationExtension"
+    ),
+    .testTarget(
+      name: "TDUtilityTests",
+      dependencies: ["TDUtility"]
     )
   ]
 )

--- a/ToDo-Garden/TDUtility/Sources/TDUtility/ExecuteOnce.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/ExecuteOnce.swift
@@ -1,0 +1,33 @@
+//
+//  ExecuteOnce.swift
+//
+//
+//  Created by Noah on 6/25/24.
+//
+
+import Foundation
+
+@propertyWrapper
+public struct ExecuteOnce {
+  private var hasExecute = false
+  private var action: (() -> Void)?
+  
+  public init() { }
+  
+  public var wrappedValue: (() -> Void)? {
+    mutating get {
+      guard self.hasExecute == false
+      else { return nil }
+      
+      return self.action
+    }
+    set {
+      guard self.hasExecute == false
+      else { return }
+      
+      self.action = newValue
+      self.hasExecute = true
+      self.action?()
+    }
+  }
+}

--- a/ToDo-Garden/TDUtility/Sources/TDUtility/TDUtility.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/TDUtility.swift
@@ -1,2 +1,0 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book

--- a/ToDo-Garden/TDUtility/Tests/TDUtilityTests/ExecuteOnceTests.swift
+++ b/ToDo-Garden/TDUtility/Tests/TDUtilityTests/ExecuteOnceTests.swift
@@ -1,0 +1,26 @@
+@testable import TDUtility
+import Testing
+
+@Suite("ExecuteOnceTests")
+struct ExecuteOnceTests {
+  
+  @Test("when action is set multiple times then it executes once")
+  private func whenActionIsSetMultipleTimes_thenItExecutesOnlyOnce() {
+    var executionCount = 0
+    @ExecuteOnce var action: (() -> Void)?
+    
+    action = {
+      executionCount += 1
+    }
+    #expect(executionCount == 1)
+    
+    action = {
+      executionCount += 1
+    }
+    #expect(
+      executionCount == 1,
+      "한번만 실행되어야합니다."
+    )
+  }
+  
+}

--- a/ToDo-Garden/TDUtility/Tests/TDUtilityTests/ExecuteOnceTests.swift
+++ b/ToDo-Garden/TDUtility/Tests/TDUtilityTests/ExecuteOnceTests.swift
@@ -23,7 +23,7 @@ struct ExecuteOnceTests {
     )
   }
   
-  @Test("when action execute multiple times then it executes only once")
+  @Test("when action executed multiple times then it executes only once")
   private func whenActionExecuteMultipleTimes_thenItExecutesOnlyOnce() {
     var executionCount = 0
     @ExecuteOnce var action: (() -> Void)?

--- a/ToDo-Garden/TDUtility/Tests/TDUtilityTests/ExecuteOnceTests.swift
+++ b/ToDo-Garden/TDUtility/Tests/TDUtilityTests/ExecuteOnceTests.swift
@@ -23,4 +23,24 @@ struct ExecuteOnceTests {
     )
   }
   
+  @Test("when action execute multiple times then it executes only once")
+  private func whenActionExecuteMultipleTimes_thenItExecutesOnlyOnce() {
+    var executionCount = 0
+    @ExecuteOnce var action: (() -> Void)?
+    
+    action?()
+    
+    action = {
+      executionCount += 1
+    }
+    #expect(executionCount == 1)
+    
+    action?()
+    action?()
+    action?()
+    #expect(
+      executionCount == 1,
+      "한번만 실행되어야합니다."
+    )
+  }
 }

--- a/ToDo-Garden/ToDo-GardenTests/ToDo-GardenTestPlan.xctestplan
+++ b/ToDo-Garden/ToDo-GardenTests/ToDo-GardenTestPlan.xctestplan
@@ -18,6 +18,13 @@
         "identifier" : "4FC8C1052B8336A100BA223E",
         "name" : "ToDo-GardenTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:TDUtility",
+        "identifier" : "TDUtilityTests",
+        "name" : "TDUtilityTests"
+      }
     }
   ],
   "version" : 1


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #263 

## 🎉 변경 사항
- [x] Property wrapper 추가
- [x] 추가한 property wrapper에 대한 테스트 추가
## 📌 PR Point
기존 플래그 변수의 관리포인트를 줄이고자 할당된 action 단위를 한번만 실행되도록 보장하는 property wrapper를 추가하였습니다.
layout subviews와 같은 곳(View의 layout 결정 시점 이후) 외에도 동작의 단위가 한번만 실행되어야하는 곳에서 사용할 수 있습니다.

- 기존

```swift
  private var isLayoutSubViewsCalled = false 
  
  override func layoutSubviews() {
    super.layoutSubviews()
    if self.isLayoutSubViewsCalled == false {
      self.setupCornerRadius()
      self.isLayoutSubViewsCalled = true
    }
  }
```

- 적용 후
```swift
  @ExecuteOnce private var setup: (() -> Void)?

  override func layoutSubviews() {
    super.layoutSubviews()
    self.setup = {
      self.setupCornerRadius()
    }
  }
```

- 해당 유틸리티 코드는 여러 곳에서 사용될 것이 예상되기에 테스트코드로 결과(여러번 호출 시에도 한번만 실행되는 것)를 검증하였습니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?