### PR TITLE
ToDoRepeatSelectionView 수정

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -40,6 +40,11 @@ public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
   public func updateDate(startDate: String, endDate: String) {
     self.viewModel.updateDate(startDate: startDate, endDate: endDate)
   }
+
+  override func updateUI(isSelected: Bool) {
+    super.updateUI(isSelected: isSelected)
+    self.updateBackgroundColor()
+  }
 }
 
 // MARK: - Private functions
@@ -80,7 +85,6 @@ extension RepeatOtherDaysView {
   private func setupButtonActions() {
     let ringToggleAction = UIAction { [weak self] _ in
       self?.viewModel.ringToggleButtonTapped()
-      self?.updateBackgroundColor()
     }
     
     let dateButtonAction = UIAction { [weak self] _ in
@@ -89,7 +93,6 @@ extension RepeatOtherDaysView {
       }
       
       self?.viewModel.dateButtonSetValueChanged(isSelected: isDateButtonSelected)
-      self?.updateBackgroundColor()
     }
     
     self.ringToggleButton.addAction(ringToggleAction, for: UIControl.Event.touchUpInside)
@@ -204,7 +207,6 @@ extension RepeatOtherDaysView {
 
       self.updateViewModelWhenSelected()
       self.updateUI()
-      self.updateBackgroundColor()
     }
     
     self.viewModel.ringToggleButton.isSelected.bind { [weak self] isSelected in
@@ -220,7 +222,6 @@ extension RepeatOtherDaysView {
       if isSelected == true {
         self?.viewModel.ringToggleButton.isSelected.value = false
       }
-      self?.updateBackgroundColor()
     }
   }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -200,8 +200,11 @@ extension RepeatOtherDaysView {
   
   private func bindSelectionStates() {
     self.viewModel.isSelected.bind { [weak self] _ in
-      self?.updateUI()
-      self?.updateBackgroundColor()
+      guard let self else { return }
+
+      self.updateViewModelWhenSelected()
+      self.updateUI()
+      self.updateBackgroundColor()
     }
     
     self.viewModel.ringToggleButton.isSelected.bind { [weak self] isSelected in
@@ -220,7 +223,13 @@ extension RepeatOtherDaysView {
       self?.updateBackgroundColor()
     }
   }
-  
+
+  private func updateViewModelWhenSelected() {
+    if self.viewModel.isSelected.value {
+      self.viewModel.toggleSelection()
+    }
+  }
+
   private func bindVisibilityStates() {
     self.viewModel.divider.isHidden.bind { [weak self] isHidden in
       self?.dividerView.isHidden = isHidden

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysView.swift
@@ -22,6 +22,7 @@ public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
   override var isSelected: Bool {
     willSet {
       self.viewModel.isSelected.value = newValue
+      self.animateAppearance(isSelected: newValue)
     }
   }
   
@@ -34,16 +35,6 @@ public final class RepeatOtherDaysView: ToDoRepeatSelectionView {
     self.dateButtonSet = DateButtonSet()
     super.init(model: ToDoRepeatSelectionView.Model.anotherDay)
     self.setup()
-  }
-  
-  override public func setSelected() {
-    self.viewModel.toggleSelection()
-    self.animateAppear()
-  }
-  
-  override public func setDeSelected() {
-    super.setDeSelected()
-    self.animateDisappear()
   }
   
   public func updateDate(startDate: String, endDate: String) {
@@ -309,6 +300,14 @@ extension RepeatOtherDaysView {
 
 // MARK: - About animation
 extension RepeatOtherDaysView {
+  private func animateAppearance(isSelected: Bool) {
+    if isSelected {
+      self.animateAppear()
+    } else {
+      self.animateDisappear()
+    }
+  }
+
   private func animateAppear() {
     self.animateLayout()
     UIView.animate(withDuration: Constant.RepeatOtherDaysView.AboutAnimation.duration) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
@@ -18,7 +18,7 @@ public class ToDoRepeatSelectionView: UIView {
   var repetitionLabelTopAchor: NSLayoutConstraint
   var isSelected: Bool {
     willSet {
-      newValue ? self.setSelected() : self.setDeSelected()
+      self.updateUI(isSelected: newValue)
     }
   }
 
@@ -44,17 +44,25 @@ public class ToDoRepeatSelectionView: UIView {
   }
 
   public func setSelected() {
-    self.backgroundColor = UIColor.toDoGardenGreenBackground
-    self.layer.borderColor = UIColor.toDoGardenGreenDark.cgColor
-    self.repetitionLabel.textColor = UIColor.toDoGardenGreenDark
-    self.selectionImageView.isHidden = false
+    self.isSelected = true
   }
 
   public func setDeSelected() {
-    self.backgroundColor = UIColor.clear
-    self.layer.borderColor = UIColor.toDoGardenGray2.cgColor
-    self.repetitionLabel.textColor = UIColor.toDoGardenGray3
-    self.selectionImageView.isHidden = true
+    self.isSelected = false
+  }
+
+  func updateUI(isSelected: Bool) {
+    let backgroundColor = isSelected ? UIColor.toDoGardenGreenBackground : UIColor.clear
+    self.backgroundColor = backgroundColor
+
+    let borderColor = isSelected ? UIColor.toDoGardenGreenDark.cgColor : UIColor.toDoGardenGray2.cgColor
+    self.layer.borderColor = borderColor
+
+    let textColor = isSelected ? UIColor.toDoGardenGreenDark : UIColor.toDoGardenGray3
+    self.repetitionLabel.textColor = textColor
+
+    let isHidden = !isSelected
+    self.selectionImageView.isHidden = isHidden
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
@@ -16,6 +16,7 @@ public class ToDoRepeatSelectionView: UIView {
   var selectionImageView: UIImageView
   var tapGestureRecognizer: UITapGestureRecognizer
   var repetitionLabelTopAchor: NSLayoutConstraint
+  var selectionSender: ((Bool) -> Void)?
   var isSelected: Bool {
     willSet {
       self.updateUI(isSelected: newValue)
@@ -49,6 +50,10 @@ public class ToDoRepeatSelectionView: UIView {
 
   public func setDeSelected() {
     self.isSelected = false
+  }
+
+  public func bindTapGesture(sender: @escaping (Bool) -> Void) {
+    self.selectionSender = sender
   }
 
   func updateUI(isSelected: Bool) {
@@ -107,6 +112,7 @@ extension ToDoRepeatSelectionView {
 extension ToDoRepeatSelectionView {
   @objc func didTapView() {
     self.isSelected = !self.isSelected
+    self.selectionSender?(self.isSelected)
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #267

## 🎉 변경 사항
- ToDoRepeatSelectionView의 UI 업데이트 로직을 수정하였습니다.
- ToDoRepeatSelectionView을 상속받는 객체인 RepeatOtherDaysView에도 변경사항을 반영하였습니다.
- 뷰를 터치했을 때 State를 외부에서 전달받을 수 있도록 기능을 추가하였습니다.

## 📌 PR Point

### 1. UI 업데이트 로직 수정
기존에 선언했던 UI 업데이트 함수(`setSelected / setDeselected`)는 UI만 변경하고 선택 상태를 변경하지 않았습니다.
- 이로 인해 업데이트된 UI와 `isSelecetd` 상태가 불일치하는 경우가 발생

그래서 선택 상태인 `isSelected` 프로퍼티 값에 따라 UI를 업데이트할 수 있도록 수정하였습니다.

### 2. 탭 제스처 바인딩
투두 수정화면에서 반복 설정에 사용되는 `오늘만 할래요`와 `다른날도 할래요` 뷰는 하나만 선택되어야 합니다.
- [뷰 선택 요구사항 백로그](https://docs.google.com/spreadsheets/d/17tg1z_x2UiSDCYD5yLnisMQkEVDgYIJNFICO8gTPkK4/edit?gid=917831885#gid=917831885&range=B84)

이를 위해 탭되었을 때 선택 상태를 외부에서 전달받을 수 있는 클로저를 추가하였습니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?