### PR TITLE
GardenView 모델 구현 및 테스트

### DIFF
--- a/ToDo-Garden/ToDo-GardenTests/ToDo-GardenTestPlan.xctestplan
+++ b/ToDo-Garden/ToDo-GardenTests/ToDo-GardenTestPlan.xctestplan
@@ -14,16 +14,23 @@
   "testTargets" : [
     {
       "target" : {
-        "containerPath" : "container:ToDo-Garden.xcodeproj",
-        "identifier" : "4FC8C1052B8336A100BA223E",
-        "name" : "ToDo-GardenTests"
+        "containerPath" : "container:",
+        "identifier" : "ToDoGardenUITests",
+        "name" : "ToDoGardenUITests"
       }
     },
     {
       "target" : {
-        "containerPath" : "container:TDUtility",
+        "containerPath" : "container:..\/TDUtility",
         "identifier" : "TDUtilityTests",
         "name" : "TDUtilityTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/ToDo-Garden.xcodeproj",
+        "identifier" : "4FC8C1052B8336A100BA223E",
+        "name" : "ToDo-GardenTests"
       }
     }
   ],

--- a/ToDo-Garden/ToDoGardenUI/Package.swift
+++ b/ToDo-Garden/ToDoGardenUI/Package.swift
@@ -50,5 +50,9 @@ let package = Package(
     .target(name: "ToDoGardenUIConstant"),
     .target(name: "CombineExtension"),
     .target(name: "FoundationExtension")
+    .testTarget(
+      name: "ToDoGardenUITests",
+      dependencies: ["ToDoGardenUIComponent"]
+    )
   ]
 )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroLevel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroLevel.swift
@@ -1,0 +1,16 @@
+//
+//  PomodoroLevel.swift
+//
+//
+//  PomodoroLevel by Noah on 6/12/24.
+//
+
+import class UIKit.UIColor
+
+enum PomodoroLevel {
+  case none
+  case low
+  case middle
+  case high
+  case perfect
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroLevelCellItem.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroLevelCellItem.swift
@@ -1,0 +1,22 @@
+//
+//  PomodoroLevelCellItem.swift
+//
+//
+//  Created by Noah on 6/6/24.
+//
+
+import UIKit
+
+/// CollectionView DataSource의 Item으로 사용될 객체입니다.
+struct PomodoroLevelCellItem: Hashable {
+  private let id = UUID()
+  let pomodoroLevel: PomodoroLevel
+  
+  init(pomodoroLevel: PomodoroLevel) {
+    self.pomodoroLevel = pomodoroLevel
+  }
+  
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(self.id)
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecord.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecord.swift
@@ -1,0 +1,18 @@
+//
+//  PomodoroRecord.swift
+//
+//
+//  Created by Noah on 6/13/24.
+//
+
+import Foundation
+
+public struct PomodoroRecord {
+  let date: Date
+  let pomodoroCount: Int
+  
+  public init(date: Date, pomodoroCount: Int) {
+    self.date = date
+    self.pomodoroCount = pomodoroCount
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecordCellItem.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecordCellItem.swift
@@ -21,4 +21,41 @@ struct PomodoroRecordCellItem: Hashable {
   func hash(into hasher: inout Hasher) {
     hasher.combine(self.id)
   }
+  
+  /// 그룹화된 `PomodoroRecordCellItem` 배열을 반환합니다.
+  /// - Parameters:
+  ///   - pomodoroDates: Pomodoro 세션이 실행된 날짜 배열
+  ///   - pomodoroLevels: 각 날짜에 해당하는 Pomodoro 레벨 배열
+  /// - Returns: 일주일 단위로 그룹화된 `PomodoroRecordCellItem` 배열을 반환합니다. 날짜와 레벨 배열의 크기가 다르면 `nil`을 반환합니다.
+  static func groupedPomodoroRecordCellItem(
+    pomodoroDates: [Date],
+    pomodoroLevels: [PomodoroLevel]
+  ) -> [PomodoroRecordCellItem]? {
+    guard pomodoroDates.count == pomodoroLevels.count
+    else { return nil }
+    
+    var pomodoroRecordCellItems: [PomodoroRecordCellItem] = []
+    
+    let combined = zip(pomodoroDates, pomodoroLevels)
+    
+    var currentBatchDates: [Date] = []
+    var currentBatchLevels: [PomodoroLevel] = []
+    
+    let daysOfWeek = 7
+    
+    for (date, level) in combined {
+      currentBatchDates.append(date)
+      currentBatchLevels.append(level)
+      
+      if currentBatchDates.count == daysOfWeek {
+        let recordItem = PomodoroRecordCellItem(dates: currentBatchDates, pomodoroLevels: currentBatchLevels)
+        pomodoroRecordCellItems.append(recordItem)
+        
+        currentBatchDates.removeAll()
+        currentBatchLevels.removeAll()
+      }
+    }
+    
+    return pomodoroRecordCellItems
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecordCellItem.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecordCellItem.swift
@@ -22,6 +22,28 @@ struct PomodoroRecordCellItem: Hashable {
     hasher.combine(self.id)
   }
   
+  /// 인스턴스의 날짜 목록에서 해당 월의 첫 번째 날짜를 포매팅된 문자열로 반환합니다.
+  ///
+  /// `PomodoroRecordCellItem`인스턴스의 `dates`를 Set으로 변환한 후 순회하며 각 날짜의 해당 월 첫 번째 날짜가 배열에 포함되어 있는지 확인합니다.
+  /// 배열의 `contains(_:)` 메서드는 O(n) Set의 `contains(_:)`는 O(1)이므로, Set으로 변환하였습니다.
+  /// 만약 그러한 날짜를 찾으면, 이 날짜를 "M/d" 형식의 문자열로 변환하여 반환합니다. 해당 날짜를 찾지 못하면 `nil`을 반환합니다.
+  ///
+  /// - Returns: "M/d" 형식의 문자열로 표현된 해당 월의 첫 번째 날짜, 해당 날짜를 찾지 못한 경우 `nil`을 반환합니다.
+  func formattedFirstDayOfMonth() -> String? {
+    let dateFormatStyle = Date.FormatStyle()
+      .month(Date.FormatStyle.Symbol.Month.defaultDigits)
+      .day(Date.FormatStyle.Symbol.Day.defaultDigits)
+    let dateSet = Set(self.dates)
+    
+    for date in self.dates {
+      if let firstDayOfMonth = self.firstDayOfMonth(from: date), dateSet.contains(firstDayOfMonth) {
+        return firstDayOfMonth.formatted(dateFormatStyle)
+      }
+    }
+    
+    return nil
+  }
+  
   /// 그룹화된 `PomodoroRecordCellItem` 배열을 반환합니다.
   /// - Parameters:
   ///   - pomodoroDates: Pomodoro 세션이 실행된 날짜 배열
@@ -57,5 +79,27 @@ struct PomodoroRecordCellItem: Hashable {
     }
     
     return pomodoroRecordCellItems
+  }
+}
+
+extension PomodoroRecordCellItem {
+  /// 주어진 날짜의 해당 월의 첫 번째 날짜를 반환합니다.
+  ///
+  /// 주어진 날짜에서 연도와 월을 추출하고, 해당 월의 첫 번째 날을 나타내는 날짜를 반환합니다.
+  ///
+  /// - Parameter date: 기준이 되는 날짜.
+  /// - Returns: 해당 월의 첫 번째 날짜, 생성할 수 없는 경우 `nil`을 반환합니다.
+  private func firstDayOfMonth(from date: Date) -> Date? {
+    let calendar = Calendar.current
+    var components = calendar.dateComponents(
+      [
+        Calendar.Component.year,
+        Calendar.Component.month
+      ],
+      from: date
+    )
+    components.day = 1
+    
+    return calendar.date(from: components)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecordCellItem.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecordCellItem.swift
@@ -1,0 +1,24 @@
+//
+//  PomodoroRecordCellItem.swift
+//
+//
+//  Created by Noah on 6/8/24.
+//
+
+import Foundation
+
+/// CollectionView DataSource의 Item으로 사용될 객체입니다.
+struct PomodoroRecordCellItem: Hashable {
+  private let id = UUID()
+  private let dates: [Date]
+  let pomodoroLevels: [PomodoroLevel]
+  
+  init(dates: [Date], pomodoroLevels: [PomodoroLevel]) {
+    self.dates = dates
+    self.pomodoroLevels = pomodoroLevels
+  }
+  
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(self.id)
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecordCollection.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecordCollection.swift
@@ -24,6 +24,11 @@ public struct PomodoroRecordCollection {
   func normalizedPomodoroLevels() -> [PomodoroLevel] {
     return self.pomodoroRecords.map { self.normalizedPomodoroLevel(for: $0.pomodoroCount) }
   }
+  
+  func pomodoroDates() -> [Date] {
+    return self.pomodoroRecords.map { $0.date }
+  }
+}
 
 extension PomodoroRecordCollection {
   /// `count`에 따라 `none`~`perfect` 단계에 해당하는 `PomodoroLevel`로 정규화합니다.

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecordCollection.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecordCollection.swift
@@ -1,0 +1,21 @@
+//
+//  PomodoroRecordCollection.swift
+//
+//
+//  Created by Noah on 6/26/24.
+//
+
+import Foundation
+
+/// PomodoroRecord 객체를 저장하는 first class collection입니다.
+public struct PomodoroRecordCollection {
+  private var pomodoroRecords: [PomodoroRecord]
+  private var maxPomodoroCount: Int?
+  
+  public init(pomodoroRecords: [PomodoroRecord] = [PomodoroRecord]()) {
+    self.pomodoroRecords = pomodoroRecords
+    self.maxPomodoroCount = self.pomodoroRecords.max { lhs, rhs in
+      lhs.pomodoroCount < rhs.pomodoroCount
+    }?.pomodoroCount
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecordCollection.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecordCollection.swift
@@ -18,4 +18,34 @@ public struct PomodoroRecordCollection {
       lhs.pomodoroCount < rhs.pomodoroCount
     }?.pomodoroCount
   }
+  
+  /// 뽀모도로 횟수에 따라 정규화된 PomodoroLevel의 배열을 반환하는 메서드입니다.
+  /// - Returns: 뽀모도로 횟수에 따라 정규화된 PomodoroLevel의 배열을 반환합니다.
+  func normalizedPomodoroLevels() -> [PomodoroLevel] {
+    return self.pomodoroRecords.map { self.normalizedPomodoroLevel(for: $0.pomodoroCount) }
+  }
+
+extension PomodoroRecordCollection {
+  /// `count`에 따라 `none`~`perfect` 단계에 해당하는 `PomodoroLevel`로 정규화합니다.
+  /// - Parameter count: Pomodoro를 수행한 횟수를 받습니다.
+  /// - Returns: `count`에 따라 정규화된 `PomodoroLevel` 타입을 반환합니다.
+  private func normalizedPomodoroLevel(for count: Int) -> PomodoroLevel {
+    guard count != 0,
+      let maxPomodoroCount = self.maxPomodoroCount
+    else { return PomodoroLevel.none }
+    
+    let levels: [PomodoroLevel] = [PomodoroLevel.low, PomodoroLevel.middle, PomodoroLevel.high, PomodoroLevel.perfect]
+    let step: Float = Float(maxPomodoroCount) / Float((levels.count - 1))
+    let levelIndex = min(Int(Float(count) / Float(step)), levels.count - 1)
+    
+    if levelIndex > 3 {
+      return PomodoroLevel.perfect
+    }
+    
+    if levelIndex < 0 {
+      return PomodoroLevel.none
+    }
+    
+    return levels[levelIndex]
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Tests/GardenViewTests/PomodoroRecordCellItemTests.swift
+++ b/ToDo-Garden/ToDoGardenUI/Tests/GardenViewTests/PomodoroRecordCellItemTests.swift
@@ -1,0 +1,15 @@
+//
+//  PomodoroRecordCellItemTests.swift
+//
+//
+//  Created by Noah on 6/27/24.
+//
+
+@testable import ToDoGardenUIComponent
+
+import Foundation
+import Testing
+
+extension Tag {
+  @Tag static let gardenView: Self
+}

--- a/ToDo-Garden/ToDoGardenUI/Tests/GardenViewTests/PomodoroRecordCellItemTests.swift
+++ b/ToDo-Garden/ToDoGardenUI/Tests/GardenViewTests/PomodoroRecordCellItemTests.swift
@@ -13,3 +13,56 @@ import Testing
 extension Tag {
   @Tag static let gardenView: Self
 }
+
+@Suite(.tags(.gardenView))
+struct PomodoroRecordCellItemTests {
+  @Test(arguments: [
+    (
+      dates: [
+        "2023/05/31",
+        "2023/06/01",
+        "2023/06/02"
+      ],
+      expected: "6/1"
+    ),
+    (
+      dates: [
+        "2023/07/31",
+        "2023/08/01",
+        "2023/08/02"
+      ],
+      expected: "8/1"
+    ),
+    (
+      dates: [
+        "2023/09/02",
+        "2023/09/03"
+      ],
+      expected: nil
+    )
+  ])
+  // swiftlint:disable identifier_name
+  private func 첫번째날이_배열에_포함되었을경우_올바른_값을_반환하는가(
+    dates: [String],
+    expected: String?
+  ) {
+    // Given
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy/MM/dd"
+    let dateObjects = dates.compactMap { dateFormatter.date(from: $0) }
+    let item = PomodoroRecordCellItem(
+      dates: dateObjects,
+      pomodoroLevels: Array(repeating: PomodoroLevel.high, count: dates.count)
+    )
+    
+    // When
+    let result = item.formattedFirstDayOfMonth()
+    
+    // Then
+    #expect(
+      result == expected,
+      "포맷된 날짜가 올바르지 않습니다. 기대값: \(expected ?? "nil"), 실제값: \(result ?? "nil")"
+    )
+  }
+  // swiftlint:enable identifier_name
+}


### PR DESCRIPTION
## 💡 관련 이슈
- related: #213

## 🎉 변경 사항
- 140일치의 뽀모도로 기록을 시각화하는 GardenView를 구성하기 위해 필요한 모델을 추가하였습니다.
- 테스트 코드를 통해 검증이 필요한 로직의 최종 결과값을 검증하였습니다.

## 📌 PR Point
|GardenView 모델 구조도|
|--|
|<img width="1032" alt="Screenshot 2024-06-27 at 9 12 26 PM" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/63908856/402428f2-dd3c-44d3-87a9-3c651c2d295b">|

- UI레이어에서 뷰를 그릴 때 데이터 모델에 직접 접근하지 않고, 데이터 소스에서 사용할 타입을 만들어 해당 타입에(suffix: CellItem)뷰에서 필요한 로직을(포매팅 등등..) 추가하였습니다.
- 또한 Data model 영역에서 Presentation logic, UI 영역을 알거나, 참조를 하지 않도록 구현하였습니다.

## 🏙️ First class collection 사용
`GardenView`에서는 140일치의 `PomodoroRecord`를(1일에 1개) 다뤄야합니다.
또한 140일치의 데이터를 다루는 여러 로직이 추가될 것으로 예상됩니다.
예) `PomodoroRecord`의 `count`에 따른 정규화된 `PomodoroLevel`을 반환하는 로직

따라서 `PomodoroRecord`를 담는 배열을 사용하는 것 보다 `PomodoroRecord`비즈니스에 종속적인 자료구조를 구현하는게 관련 로직을 응집력있게 다룰 수 있을 것이라 판단하여 배열을 wrapping하는 일급 컬렉션 `PomodoroRecordCollection`을 구현하였습니다.

> 참고: https://jojoldu.tistory.com/412


## 📊 데이터 정규화

|기존 정책|
|--|
|<img width="285" alt="Screenshot 2024-06-27 at 8 52 42 PM" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/63908856/64034ea6-41c6-4aee-9605-180564698260">|

기존 기획에서는 지정된 뽀모도로의 횟수에 따라 색을 다르게 표시하도록 하는 것이었습니다.
하지만, 5개 이상을 매일매일 하는 사용자의 경우 동기부여 및 사용자경험에 좋지 않을 것이라 판단하여,

140일치의 데이터의 최댓값을 기반으로 하여 횟수에 따라 정규화된 `PomodoroLevel`을 반환하도록 로직을 구현하여
사용자는 자신의 최대결과에 따라 다양한 색을 해당 뷰에서 볼 수 있도록 하였습니다.

> 함께 고민해주고 검증을 도와주신 @HG-SONG 감사드립니다!

```swift
  /// `count`에 따라 `none`~`perfect` 단계에 해당하는 `PomodoroLevel`로 정규화합니다.
  /// - Parameter count: Pomodoro를 수행한 횟수를 받습니다.
  /// - Returns: `count`에 따라 정규화된 `PomodoroLevel` 타입을 반환합니다.
  private func normalizedPomodoroLevel(for count: Int) -> PomodoroLevel {
    guard count != 0,
      let maxPomodoroCount = self.maxPomodoroCount
    else { return PomodoroLevel.none }
    
    let levels: [PomodoroLevel] = [PomodoroLevel.low, PomodoroLevel.middle, PomodoroLevel.high, PomodoroLevel.perfect]
    let step: Float = Float(maxPomodoroCount) / Float((levels.count - 1))
    let levelIndex = min(Int(Float(count) / Float(step)), levels.count - 1)
    
    if levelIndex > 3 {
      return PomodoroLevel.perfect
    }
    
    if levelIndex < 0 {
      return PomodoroLevel.none
    }
    
    return levels[levelIndex]
  }
```

## ✅ 테스트
|GardenView|
|--|
|<img width="305" alt="Screenshot 2024-06-27 at 9 00 45 PM" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/63908856/45f9cdad-e2f5-4448-855f-5e336d59410f">|

GardenView에서는 일주일치의 데이터 중 **첫째 달을 포함**하고 있으면, 해당 행 하단에 해당 달의 **첫째 날을 표시**해주어야하는 요구사항을 가지고 있습니다

해당 요구사항이 뷰를 표시하는데 있어 검증이 필요한 로직이라 판단하여 관련 테스트 코드를 작성하여 로직을 검증하였습니다.
테스트 내성을 지키기 위해 중간 **구현사항**을 **테스트**하는 것보다 **최종 결과값**을 **테스트**하는 것이 효율적이라 판단하였습니다.


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?