### PR TITLE
EditToDoScene Constant 수정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController+Constant.swift
@@ -77,3 +77,19 @@ extension EditToDoViewController.Constant.Layout.EditToDoScheduleView {
     static let height: CGFloat = 53
   }
 }
+
+extension EditToDoViewController.Constant.Layout.EditToDoScheduleView.EditToDoRepetitionView {
+  enum RepetitionLabel {
+    static let leadingMargin: CGFloat = 3
+  }
+
+  enum RepeatOnlyTodayButton {
+    static let topMargin: CGFloat = 11
+  }
+
+  enum RepeatOtherDaysView {
+    static let topMargin: CGFloat = 11
+  }
+
+  static let topMargin: CGFloat = 49
+}

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController+Constant.swift
@@ -9,6 +9,8 @@ extension EditToDoViewController.Constant {
 }
 
 extension EditToDoViewController.Constant.Layout {
+  enum EditToDoView {}
+
   enum CompleteEditingButton {
     static let bottomMargin: CGFloat = 13
   }
@@ -25,36 +27,6 @@ extension EditToDoViewController.Constant.Layout {
     static let leadingMargin: CGFloat = 12
     static let trailingMargin: CGFloat = 19
     static let bottomMargin: CGFloat = 150
-  }
-
-  enum EditToDoView {
-    enum ToDoNameTextField {
-      static let leadingMargin: CGFloat = 15.5
-      static let trailingMargin: CGFloat = 15.5
-      static let height: CGFloat = 23.5
-    }
-
-    enum GroupLabel {
-      static let topMargin: CGFloat = 61
-      static let leadingMargin: CGFloat = 19
-    }
-
-    enum EditGroupRow {
-      static let bottomMargin: CGFloat = 18
-    }
-
-    enum DeleteToDoButton {
-      static let cornerRadius: CGFloat = 10
-      static let topMargin: CGFloat = 28
-      static let leadingMargin: CGFloat = 13
-      static let trailingMargin: CGFloat = 6
-      static let height: CGFloat = 44
-    }
-
-    static let topMargin: CGFloat = 30
-    static let leadingMargin: CGFloat = 12
-    static let trailingMargin: CGFloat = 19
-    static let bottomMargin: CGFloat = 296
   }
 
   enum ToDoScheduleView {
@@ -80,5 +52,32 @@ extension EditToDoViewController.Constant.Layout {
     static let leadingMargin: CGFloat = 30
     static let traillingMargin: CGFloat = 30
     static let bottomMargin: CGFloat = 150
+  }
+}
+
+extension EditToDoViewController.Constant.Layout.EditToDoView {
+  enum ToDoNameTextInputView {
+    static let topMargin: CGFloat = 16.5
+    static let leadingMargin: CGFloat = 15.5
+    static let trailingMargin: CGFloat = 15.5
+    static let height: CGFloat = 23.5
+  }
+
+  enum GroupLabel {
+    static let topMargin: CGFloat = 61
+    static let leadingMargin: CGFloat = 19
+  }
+
+  enum EditGroupRow {
+    static let bottomMargin: CGFloat = 18
+  }
+
+  enum DeleteToDoButton {
+    static let titleLeadingMargin: CGFloat = 14
+    static let cornerRadius: CGFloat = 10
+    static let topMargin: CGFloat = 28
+    static let leadingMargin: CGFloat = 13
+    static let trailingMargin: CGFloat = 6
+    static let height: CGFloat = 44
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController+Constant.swift
@@ -10,6 +10,7 @@ extension EditToDoViewController.Constant {
 
 extension EditToDoViewController.Constant.Layout {
   enum EditToDoView {}
+  enum EditToDoScheduleView {}
 
   enum CompleteEditingButton {
     static let bottomMargin: CGFloat = 13
@@ -26,31 +27,6 @@ extension EditToDoViewController.Constant.Layout {
     static let topMargin: CGFloat = 30
     static let leadingMargin: CGFloat = 12
     static let trailingMargin: CGFloat = 19
-    static let bottomMargin: CGFloat = 150
-  }
-
-  enum ToDoScheduleView {
-    enum AlarmTimeSettingView {
-      static let topMargin: CGFloat = 7
-      static let height: CGFloat = 53
-    }
-
-    enum RepetitionLabel {
-      static let topMargin: CGFloat = 50
-      static let leadingMargin: CGFloat = 3
-    }
-
-    enum RepeatOnlyTodayButton {
-      static let topMargin: CGFloat = 10
-    }
-
-    enum RepeatOtherDaysView {
-      static let topMargin: CGFloat = 11
-    }
-
-    static let topMargin: CGFloat = 40
-    static let leadingMargin: CGFloat = 30
-    static let traillingMargin: CGFloat = 30
     static let bottomMargin: CGFloat = 150
   }
 }
@@ -79,5 +55,25 @@ extension EditToDoViewController.Constant.Layout.EditToDoView {
     static let leadingMargin: CGFloat = 13
     static let trailingMargin: CGFloat = 6
     static let height: CGFloat = 44
+  }
+}
+
+extension EditToDoViewController.Constant.Layout.EditToDoScheduleView {
+  enum EditToDoRepetitionView {}
+
+  enum AlarmSwitch {
+    static let topMargin: CGFloat = 10
+    static let trailingMargin: CGFloat = 20
+  }
+
+  enum AlarmLabel {
+    static let leadingMargin: CGFloat = 4
+  }
+
+  enum AlarmTimeSettingView {
+    static let topMargin: CGFloat = 7
+    static let leadingMargin: CGFloat = 18
+    static let trailingMargin: CGFloat = 11
+    static let height: CGFloat = 53
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController+Constant.swift
@@ -20,6 +20,13 @@ extension EditToDoViewController.Constant.Layout {
     static let height: CGFloat = 49
   }
 
+  enum EditModeScrollView {
+    static let topMargin: CGFloat = 30
+    static let leadingMargin: CGFloat = 12
+    static let trailingMargin: CGFloat = 19
+    static let bottomMargin: CGFloat = 150
+  }
+
   enum EditToDoView {
     enum ToDoNameTextField {
       static let leadingMargin: CGFloat = 15.5


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #278 

## 🎉 변경 사항
- EditToDoScene Constant를 수정하였습니다.

## 📌 PR Point
기존 파일에 선언하지 않았던 Component들에 대한 Constant를 추가하였습니다.
추가된 컴포넌트 목록은 다음과 같습니다.
1. EditModeScrollView: 수정 화면에서 모드 전환시 스크롤할 때 사용 (알림 설정 화면 / 수정 화면)
2. EditToDoRepetitionView: 반복과 관련된 뷰들을 담는 컨테이너 객체

|수정 전(ToDoScheduleView)|수정 후|
|--|--|
|<img width="250" alt="스크린샷 2024-06-12 20 20 54" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/6bfa7859-e51f-472f-a5b4-4418c8a51e8a">|<img width="250" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/7060e4ab-9592-4bc5-96ac-2f1511c99bb7">|

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?