### PR TITLE
GardenView UI 구현

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroLevelCollectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroLevelCollectionViewCell.swift
@@ -1,0 +1,32 @@
+//
+//  PomodoroLevelCollectionViewCell.swift
+//
+//
+//  Created by Noah on 6/6/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+import ToDoGardenUIResource
+
+import TDUtility
+
+final class PomodoroLevelCollectionViewCell: UICollectionViewCell {
+  @ExecuteOnce private var setupLayoutIfNeeded: (() -> Void)?
+  
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    self.setupLayoutIfNeeded = {
+      self.setupCornerRadius()
+    }
+  }
+}
+
+extension PomodoroLevelCollectionViewCell {
+  private func setupCornerRadius() {
+    let cornerRadiusRatio = Constant.PomodoroLevelCollectionViewCell.Layout.cornerRadiusRatio
+    self.layer.cornerRadius = self.bounds.width * cornerRadiusRatio
+    self.layer.masksToBounds = true
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroLevelCollectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroLevelCollectionViewCell.swift
@@ -21,6 +21,10 @@ final class PomodoroLevelCollectionViewCell: UICollectionViewCell {
       self.setupCornerRadius()
     }
   }
+  
+  func configure(with pomodoroLevel: PomodoroLevel) {
+    self.backgroundColor = pomodoroLevel.color
+  }
 }
 
 extension PomodoroLevelCollectionViewCell {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroRecordCollectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroRecordCollectionViewCell.swift
@@ -27,4 +27,14 @@ final class PomodoroRecordCollectionViewCell: UICollectionViewCell {
     
     return pomodoroLevelsView
   }()
+  
+  private let contentStackView: UIStackView = {
+    let contentStackView = UIStackView()
+    contentStackView.axis = NSLayoutConstraint.Axis.vertical
+    contentStackView.distribution = UIStackView.Distribution.fill
+    contentStackView.alignment = UIStackView.Alignment.fill
+    contentStackView.spacing = 1
+    
+    return contentStackView
+  }()
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroRecordCollectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroRecordCollectionViewCell.swift
@@ -47,6 +47,11 @@ final class PomodoroRecordCollectionViewCell: UICollectionViewCell {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+  
+  func configure(with pomodoroRecordCellItem: PomodoroRecordCellItem) {
+    self.pomodoroLevelsView.configure(with: pomodoroRecordCellItem.pomodoroLevels)
+    self.configureMonthLabel(with: pomodoroRecordCellItem)
+  }
 }
 
 // MARK: - Setup

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroRecordCollectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroRecordCollectionViewCell.swift
@@ -37,4 +37,52 @@ final class PomodoroRecordCollectionViewCell: UICollectionViewCell {
     
     return contentStackView
   }()
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    self.setup()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: - Setup
+
+extension PomodoroRecordCollectionViewCell {
+  private func setup() {
+    self.addSubviews()
+    self.setupLayoutConstraints()
+  }
+}
+
+// MARK: - Add subviews
+
+extension PomodoroRecordCollectionViewCell {
+  private func addSubviews() {
+    self.contentView.addSubview(self.contentStackView)
+    self.contentStackView.addArrangedSubview(self.pomodoroLevelsView)
+    self.contentStackView.addArrangedSubview(self.firstDayOfMonthLabel)
+  }
+}
+
+// MARK: - Setup layout constraints
+
+extension PomodoroRecordCollectionViewCell {
+  private func setupLayoutConstraints() {
+    self.setupContentsStackViewLayoutConstraints()
+  }
+  
+  private func setupContentsStackViewLayoutConstraints() {
+    self.contentStackView.usingAutolayout()
+    
+    NSLayoutConstraint.activate([
+      self.contentStackView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
+      self.contentStackView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
+      self.contentStackView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor),
+      self.contentStackView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor)
+    ])
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroRecordCollectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroRecordCollectionViewCell.swift
@@ -81,14 +81,7 @@ extension PomodoroRecordCollectionViewCell {
   }
   
   private func setupContentsStackViewLayoutConstraints() {
-    self.contentStackView.usingAutolayout()
-    
-    NSLayoutConstraint.activate([
-      self.contentStackView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
-      self.contentStackView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
-      self.contentStackView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor),
-      self.contentStackView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor)
-    ])
+    self.contentStackView.equalToParent()
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroRecordCollectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroRecordCollectionViewCell.swift
@@ -86,3 +86,17 @@ extension PomodoroRecordCollectionViewCell {
     ])
   }
 }
+
+// MARK: - configure month label
+
+extension PomodoroRecordCollectionViewCell {
+  private func configureMonthLabel(with pomodoroRecordCellItem: PomodoroRecordCellItem) {
+    guard let firstDayOfMonth = pomodoroRecordCellItem.formattedFirstDayOfMonth()
+    else {
+      self.firstDayOfMonthLabel.text = " "
+      return
+    }
+    
+    self.firstDayOfMonthLabel.text = firstDayOfMonth
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroRecordCollectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroRecordCollectionViewCell.swift
@@ -1,0 +1,21 @@
+//
+//  PomodoroRecordCollectionViewCell.swift
+//
+//
+//  Created by Noah on 6/7/24.
+//
+
+import UIKit
+
+import ToDoGardenUIResource
+
+final class PomodoroRecordCollectionViewCell: UICollectionViewCell {
+  private let firstDayOfMonthLabel: UILabel = {
+    let firstDayOfMonthLabel = UILabel()
+    firstDayOfMonthLabel.font = UIFont.pretendardDetailRegular5
+    firstDayOfMonthLabel.textColor = UIColor.black
+    firstDayOfMonthLabel.textAlignment = NSTextAlignment.center
+    
+    return firstDayOfMonthLabel
+  }()
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroRecordCollectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Cell/PomodoroRecordCollectionViewCell.swift
@@ -18,4 +18,13 @@ final class PomodoroRecordCollectionViewCell: UICollectionViewCell {
     
     return firstDayOfMonthLabel
   }()
+  
+  private let pomodoroLevelsView: PomodoroLevelCollectionView = {
+    let pomodoroLevelsView = PomodoroLevelCollectionView()
+    pomodoroLevelsView.showsHorizontalScrollIndicator = false
+    pomodoroLevelsView.showsVerticalScrollIndicator = false
+    pomodoroLevelsView.isScrollEnabled = false
+    
+    return pomodoroLevelsView
+  }()
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/GardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/GardenView.swift
@@ -1,0 +1,106 @@
+//
+//  GardenView.swift
+//
+//
+//  Created by Noah on 6/12/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+import ToDoGardenUIResource
+
+import TDUtility
+
+public final class GardenView: UIView {
+  private let pomodoroRecordCollectionView: PomodoroRecordCollectionView
+  @ExecuteOnce private var setupLayoutIfNeeded: (() -> Void)?
+  
+  public init() {
+    self.pomodoroRecordCollectionView = PomodoroRecordCollectionView()
+    super.init(frame: CGRect.zero)
+    self.setup()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    self.setupLayoutIfNeeded = {
+      self.setupViewAppearance()
+      self.setupLayoutConstraints()
+    }
+  }
+}
+
+// MARK: - Setup
+
+extension GardenView {
+  private func setup() {
+    self.addSubviews()
+  }
+}
+
+extension GardenView {
+  private func addSubviews() {
+    self.addSubview(self.pomodoroRecordCollectionView)
+  }
+}
+
+// MARK: - Setup layout constraints
+
+extension GardenView {
+  private func setupLayoutConstraints() {
+    self.setupPomodoroRecordsCollectionViewLayoutConstraints()
+  }
+  
+  private func setupPomodoroRecordsCollectionViewLayoutConstraints() {
+    self.pomodoroRecordCollectionView.usingAutolayout()
+    let topMarginFraction: CGFloat = Constant.GardenView.Layout.PomodoroRecordCollectionView.topMarginFraction
+    let horizontalMarginFraction: CGFloat =
+    Constant.GardenView.Layout.PomodoroRecordCollectionView.horizontalMarginFraction
+    let bottomMarginFraction: CGFloat = Constant.GardenView.Layout.PomodoroRecordCollectionView.bottomMarginFraction
+    
+    NSLayoutConstraint.activate([
+      self.pomodoroRecordCollectionView.topAnchor.constraint(
+        equalTo: self.topAnchor,
+        constant: self.bounds.height * topMarginFraction
+      ),
+      self.pomodoroRecordCollectionView.leadingAnchor.constraint(
+        equalTo: self.leadingAnchor,
+        constant: self.bounds.width * horizontalMarginFraction
+      ),
+      self.pomodoroRecordCollectionView.trailingAnchor.constraint(
+        equalTo: self.trailingAnchor,
+        constant: -(self.bounds.width * horizontalMarginFraction)
+      ),
+      self.pomodoroRecordCollectionView.bottomAnchor.constraint(
+        equalTo: self.bottomAnchor,
+        constant: -(self.bounds.height * bottomMarginFraction)
+      )
+    ])
+  }
+}
+
+// MARK: - Setup view appearance
+
+extension GardenView {
+  private func setupViewAppearance() {
+    self.roundedCorner()
+    self.setupBorder()
+  }
+  
+  private func roundedCorner() {
+    let cornerRadiusRatio = Constant.GardenView.Layout.cornerRadiusRatio
+    self.layer.cornerRadius = self.bounds.width * (cornerRadiusRatio)
+    self.clipsToBounds = true
+  }
+  
+  private func setupBorder() {
+    self.layer.borderWidth = Constant.GardenView.Layout.borderWidth
+    self.layer.borderColor = UIColor.toDoGardenGreenGray.cgColor
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/GardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/GardenView.swift
@@ -34,6 +34,19 @@ public final class GardenView: UIView {
       self.setupLayoutConstraints()
     }
   }
+  
+  public func configure(with pomodoroRecordCollection: PomodoroRecordCollection) {
+    let pomodoroDates = pomodoroRecordCollection.pomodoroDates()
+    let pomodoroLevels = pomodoroRecordCollection.normalizedPomodoroLevels()
+    
+    guard let groupedPomodoroRecordCellItems = PomodoroRecordCellItem.groupedPomodoroRecordCellItem(
+      pomodoroDates: pomodoroDates,
+      pomodoroLevels: pomodoroLevels
+    )
+    else { return }
+    
+    self.pomodoroRecordCollectionView.configure(with: groupedPomodoroRecordCellItems)
+  }
 }
 
 // MARK: - Setup

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroLevel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroLevel.swift
@@ -13,4 +13,19 @@ enum PomodoroLevel {
   case middle
   case high
   case perfect
+  
+  var color: UIColor {
+    switch self {
+    case PomodoroLevel.none:
+      return UIColor.toDoGardenGrassNone
+    case PomodoroLevel.low:
+      return UIColor.toDoGardenGrassLow
+    case PomodoroLevel.middle:
+      return UIColor.toDoGardenGrassMiddle
+    case PomodoroLevel.high:
+      return UIColor.toDoGardenGrassHigh
+    case PomodoroLevel.perfect:
+      return UIColor.toDoGardenGrassPerfect
+    }
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroLevelCollectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroLevelCollectionView.swift
@@ -11,6 +11,50 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 final class PomodoroLevelCollectionView: UICollectionView {
+  private var pomodoroLevelCollectionViewDataSource: DataSource?
+  
+  init() {
+    self.setup()
+  }
+  
+  @available(*, unavailable)
+  required init(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: - Setup
+
+extension PomodoroLevelCollectionView {
+  private func setup() {
+    self.setupDataSource()
+  }
+  
+  private func setupDataSource() {
+    self.pomodoroLevelCollectionViewDataSource = self.makeDataSource()
+  }
+}
+
+extension PomodoroLevelCollectionView {
+  private func makeDataSource() -> DataSource {
+    let cellRegistration = self.createPomodoroLevelCollectionViewCellRegistration()
+    
+    return DataSource(collectionView: self) { pomodoroLevelsCollectionView, indexPath, pomodoroLevelItem in
+      let pomodoroLevelCollectionViewCell = pomodoroLevelsCollectionView.dequeueConfiguredReusableCell(
+        using: cellRegistration,
+        for: indexPath,
+        item: pomodoroLevelItem.pomodoroLevel
+      )
+      
+      return pomodoroLevelCollectionViewCell
+    }
+  }
+  
+  private func createPomodoroLevelCollectionViewCellRegistration() -> CellRegistration {
+    return CellRegistration { pomodoroLevelCollectionViewCell, _, pomodoroLevel in
+      pomodoroLevelCollectionViewCell.configure(with: pomodoroLevel)
+    }
+  }
 }
 
 extension PomodoroLevelCollectionView {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroLevelCollectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroLevelCollectionView.swift
@@ -25,6 +25,14 @@ final class PomodoroLevelCollectionView: UICollectionView {
   required init(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+  
+  func configure(with pomodoroLevels: [PomodoroLevel]) {
+    var snapshot = Snapshot()
+    snapshot.appendSections([Section.main])
+    let pomodoroLevelCellItems = pomodoroLevels.map { PomodoroLevelCellItem(pomodoroLevel: $0) }
+    snapshot.appendItems(pomodoroLevelCellItems)
+    self.pomodoroLevelCollectionViewDataSource?.apply(snapshot)
+  }
 }
 
 // MARK: - Setup

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroLevelCollectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroLevelCollectionView.swift
@@ -14,6 +14,10 @@ final class PomodoroLevelCollectionView: UICollectionView {
   private var pomodoroLevelCollectionViewDataSource: DataSource?
   
   init() {
+    super.init(
+      frame: CGRect.zero,
+      collectionViewLayout: Self.makePomodoroLevelCollectionViewLayout()
+    )
     self.setup()
   }
   
@@ -32,6 +36,45 @@ extension PomodoroLevelCollectionView {
   
   private func setupDataSource() {
     self.pomodoroLevelCollectionViewDataSource = self.makeDataSource()
+  }
+}
+
+extension PomodoroLevelCollectionView {
+  private static func makePomodoroLevelCollectionViewLayout() -> UICollectionViewCompositionalLayout {
+    let itemSize = Self.makeItemSize()
+    let item = NSCollectionLayoutItem(layoutSize: itemSize)
+    let groupSize = Self.makeGroupSize()
+    let group = NSCollectionLayoutGroup.vertical(
+      layoutSize: groupSize,
+      subitems: [item]
+    )
+    group.interItemSpacing = NSCollectionLayoutSpacing.flexible(
+      Constant.PomodoroLevelCollectionView.Layout.Group.interItemSpacing
+    )
+    let section = NSCollectionLayoutSection(group: group)
+    let layout = UICollectionViewCompositionalLayout(section: section)
+    
+    return layout
+  }
+  
+  private static func makeItemSize() -> NSCollectionLayoutSize {
+    let itemWidthFraction: CGFloat = Constant.PomodoroLevelCollectionView.Layout.Item.widthFraction
+    let itemHeightFraction: CGFloat = Constant.PomodoroLevelCollectionView.Layout.Item.heightFraction
+    
+    return NSCollectionLayoutSize(
+      widthDimension: NSCollectionLayoutDimension.fractionalWidth(itemWidthFraction),
+      heightDimension: NSCollectionLayoutDimension.fractionalWidth(itemHeightFraction)
+    )
+  }
+  
+  private static func makeGroupSize() -> NSCollectionLayoutSize {
+    let groupWidthFraction: CGFloat = Constant.PomodoroLevelCollectionView.Layout.Group.widthFraction
+    let groupHeightFraction: CGFloat = Constant.PomodoroLevelCollectionView.Layout.Group.heightFraction
+    
+    return NSCollectionLayoutSize(
+      widthDimension: NSCollectionLayoutDimension.fractionalWidth(groupWidthFraction),
+      heightDimension: NSCollectionLayoutDimension.fractionalHeight(groupHeightFraction)
+    )
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroLevelCollectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroLevelCollectionView.swift
@@ -1,0 +1,26 @@
+//
+//  PomodoroLevelCollectionView.swift
+//
+//
+//  Created by Noah on 6/6/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+import ToDoGardenUIResource
+
+final class PomodoroLevelCollectionView: UICollectionView {
+}
+
+extension PomodoroLevelCollectionView {
+  private enum Section {
+    case main
+  }
+  private typealias CellRegistration =
+  UICollectionView.CellRegistration<PomodoroLevelCollectionViewCell, PomodoroLevel>
+  private typealias Snapshot =
+  NSDiffableDataSourceSnapshot<PomodoroLevelCollectionView.Section, PomodoroLevelCellItem>
+  private typealias DataSource =
+  UICollectionViewDiffableDataSource<PomodoroLevelCollectionView.Section, PomodoroLevelCellItem>
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroLevelCollectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroLevelCollectionView.swift
@@ -31,7 +31,12 @@ final class PomodoroLevelCollectionView: UICollectionView {
 
 extension PomodoroLevelCollectionView {
   private func setup() {
+    self.setupViewAppearance()
     self.setupDataSource()
+  }
+  
+  private func setupViewAppearance() {
+    self.backgroundColor = UIColor.clear
   }
   
   private func setupDataSource() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroRecordCollectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroRecordCollectionView.swift
@@ -10,6 +10,60 @@ import UIKit
 import ToDoGardenUIConstant
 
 final class PomodoroRecordCollectionView: UICollectionView {
+  
+  init() {
+    super.init(
+      frame: CGRect.zero,
+      collectionViewLayout: Self.makeGardenRecordCollectionViewLayout()
+    )
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: - Setup layout
+
+extension PomodoroRecordCollectionView {
+  private static func makeGardenRecordCollectionViewLayout() -> UICollectionViewCompositionalLayout {
+    let itemSize = Self.makeItemSize()
+    let item = NSCollectionLayoutItem(layoutSize: itemSize)
+    let groupSize = Self.makeGroupSize()
+    var group: NSCollectionLayoutGroup
+    group = NSCollectionLayoutGroup.horizontal(
+      layoutSize: groupSize,
+      subitems: [item]
+    )
+    group.interItemSpacing = NSCollectionLayoutSpacing.flexible(
+      Constant.PomodoroRecordCollectionView.Layout.Group.interItemSpacing
+    )
+    let section = NSCollectionLayoutSection(group: group)
+    let layout = UICollectionViewCompositionalLayout(section: section)
+    
+    return layout
+  }
+  
+  private static func makeItemSize() -> NSCollectionLayoutSize {
+    let itemWidthFraction: CGFloat = Constant.PomodoroRecordCollectionView.Layout.Item.widthFraction
+    let itemHeightFraction: CGFloat = Constant.PomodoroRecordCollectionView.Layout.Item.heightFraction
+    
+    return NSCollectionLayoutSize(
+      widthDimension: NSCollectionLayoutDimension.fractionalWidth(itemWidthFraction),
+      heightDimension: NSCollectionLayoutDimension.fractionalHeight(itemHeightFraction)
+    )
+  }
+  
+  private static func makeGroupSize() -> NSCollectionLayoutSize {
+    let groupWidthFraction: CGFloat = Constant.PomodoroRecordCollectionView.Layout.Group.widthFraction
+    let groupHeightFraction: CGFloat = Constant.PomodoroRecordCollectionView.Layout.Group.heightFraction
+    
+    return NSCollectionLayoutSize(
+      widthDimension: NSCollectionLayoutDimension.fractionalWidth(groupWidthFraction),
+      heightDimension: NSCollectionLayoutDimension.fractionalHeight(groupHeightFraction)
+    )
+  }
 }
 
 extension PomodoroRecordCollectionView {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroRecordCollectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroRecordCollectionView.swift
@@ -1,0 +1,26 @@
+//
+//  PomodoroRecordCollectionView.swift
+//
+//
+//  Created by Noah on 6/8/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+
+final class PomodoroRecordCollectionView: UICollectionView {
+}
+
+extension PomodoroRecordCollectionView {
+  private enum Section {
+    case main
+  }
+  
+  private typealias CellRegistration =
+  UICollectionView.CellRegistration<PomodoroRecordCollectionViewCell, PomodoroRecordCellItem>
+  private typealias Snapshot =
+  NSDiffableDataSourceSnapshot<PomodoroRecordCollectionView.Section, PomodoroRecordCellItem>
+  private typealias DataSource =
+  UICollectionViewDiffableDataSource<PomodoroRecordCollectionView.Section, PomodoroRecordCellItem>
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroRecordCollectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroRecordCollectionView.swift
@@ -10,17 +10,38 @@ import UIKit
 import ToDoGardenUIConstant
 
 final class PomodoroRecordCollectionView: UICollectionView {
+  private var gardenRecordCollectionViewDataSource: DataSource?
   
   init() {
     super.init(
       frame: CGRect.zero,
       collectionViewLayout: Self.makeGardenRecordCollectionViewLayout()
     )
+    self.setup()
   }
   
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+  
+  func configure(with pomodoroRecordCellItems: [PomodoroRecordCellItem]) {
+    var snapshot = Snapshot()
+    snapshot.appendSections([Section.main])
+    snapshot.appendItems(pomodoroRecordCellItems)
+    self.gardenRecordCollectionViewDataSource?.apply(snapshot)
+  }
+}
+
+// MARK: - Setup
+
+extension PomodoroRecordCollectionView {
+  private func setup() {
+    self.setupDataSource()
+  }
+  
+  private func setupDataSource() {
+    self.gardenRecordCollectionViewDataSource = self.makeDataSource()
   }
 }
 
@@ -63,6 +84,30 @@ extension PomodoroRecordCollectionView {
       widthDimension: NSCollectionLayoutDimension.fractionalWidth(groupWidthFraction),
       heightDimension: NSCollectionLayoutDimension.fractionalHeight(groupHeightFraction)
     )
+  }
+}
+
+// MARK: - Setup data source
+
+extension PomodoroRecordCollectionView {
+  private func makeDataSource() -> DataSource {
+    let pomodoroCollectionViewCellRegistration = self.pomodoroRecordCollectionViewCellRegistration()
+    
+    return DataSource(collectionView: self) { pomodoroRecordCollectionView, indexPath, pomodoroRecordItem in
+      let pomodoroRecordCollectionViewCell = pomodoroRecordCollectionView.dequeueConfiguredReusableCell(
+        using: pomodoroCollectionViewCellRegistration,
+        for: indexPath,
+        item: pomodoroRecordItem
+      )
+      
+      return pomodoroRecordCollectionViewCell
+    }
+  }
+  
+  private func pomodoroRecordCollectionViewCellRegistration() -> CellRegistration {
+    return CellRegistration { pomodoroRecordCollectionViewCell, _, pomodoroRecordItem in
+      pomodoroRecordCollectionViewCell.configure(with: pomodoroRecordItem)
+    }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroRecordCollectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/PomodoroRecordCollectionView.swift
@@ -37,7 +37,15 @@ final class PomodoroRecordCollectionView: UICollectionView {
 
 extension PomodoroRecordCollectionView {
   private func setup() {
+    self.setupViewAppearance()
     self.setupDataSource()
+  }
+  
+  private func setupViewAppearance() {
+    self.backgroundColor = UIColor.clear
+    self.showsVerticalScrollIndicator = false
+    self.showsHorizontalScrollIndicator = false
+    self.isScrollEnabled = false
   }
   
   private func setupDataSource() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenView.swift
@@ -20,5 +20,5 @@ extension Constant.GardenView.Layout {
 extension Constant.GardenView.Layout.PomodoroRecordCollectionView {
   public static let topMarginFraction: CGFloat = 18.21 / 119.0
   public static let horizontalMarginFraction: CGFloat = 19.0 / 332.0
-  public static let bottomMMarginFraction: CGFloat = 9.48 / 119.0
+  public static let bottomMarginFraction: CGFloat = 9.48 / 119.0
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIFont+ToDoGarden.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIFont+ToDoGarden.swift
@@ -69,6 +69,11 @@ extension UIFont {
 		name: PretendardFont.light.name,
 		size: 12
 	) ?? UIFont.systemFont(ofSize: 12, weight: .light)
+  
+  public static let pretendardDetailRegular5: UIFont = UIFont(
+    name: PretendardFont.regular.name,
+    size: 5
+  ) ?? UIFont.systemFont(ofSize: 5, weight: .regular)
 }
 
 public enum PretendardFont: String, CaseIterable {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #213 
- related: #272 
## 🎉 변경 사항
- 140일치의 뽀모도로 기록을 시각화하는 GardenView UI를 구현하였습니다.
- 모델부분에 사용되는 코드는 #272 PR에서 로직의 최종 결과값을 테스트 코드를 통해 검증하였습니다.

## 📌 PR Point
|GardenView Component |
|--|
|![image](https://github.com/ToDo-Garden/ToDo-Garden/assets/63908856/c5b51dda-55b5-4aa8-8dea-4d9b91fdb29c)|

**주요 컴포넌트**
- `GardenView`: 140일치 뽀모도로 기록을 표현 및 데이터를 입력하는 인터페이스
- `PomodoroRecordCollectionView`: 140일치 뽀모도로 기록을 표현
- `PomodoroRecordCollectionViewCell`: 7일간의 뽀모도로 기록 표현 및 달의 첫째날을 포함하는 경우 label에 데이터 표시
- `PomodoroLevelCollectionView`: 7일간의 뽀모도로 기록 표현
- `PomodoroLevelCollectionViewCell`: 하루(1일) 뽀모도로 기록을 1~5단계의 배경색으로 표현

## 📸 실행 스크린샷
|iPhone SE 3rd Simulator |
|--|
|<img width="372" alt="Screenshot 2024-07-01 at 5 36 47 PM" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/63908856/ce819c75-7110-4228-99c6-8422a8a7b887">|




## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?