### PR TITLE
GroupList Style Row 수정

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
@@ -19,7 +19,22 @@ extension Styled {
         }
       }
     }
-    
+
+    public var groupListModel: Configuration.ListPrimaryModel? {
+      get {
+        if let groupListModel = self.configuration.listPrimaryModel {
+          return groupListModel
+        }
+        return nil
+      }
+      set {
+        if var model = self.configuration.listPrimaryModel, let newValue {
+          model = newValue
+          self.configuration = Configuration.listPrimary(model)
+        }
+      }
+    }
+
     @Published var configuration: Configuration
     var cancellables: Set<AnyCancellable> = []
     

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
@@ -79,6 +79,11 @@ extension Styled.Row.Configuration {
   public struct ListPrimaryModel: Equatable {
     let title: String
     let color: UIColor
+
+    public init(title: String, color: UIColor) {
+      self.title = title
+      self.color = color
+    }
   }
   
   public struct RepeatOtherDaysModel: Equatable {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ListPrimary.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ListPrimary.swift
@@ -19,6 +19,7 @@ extension Styled.Row {
     stack.addSpacing()
     self.buildColorView(stack: stack, color: model.color)
     self.buildRightView(stack: stack, views: views)
+    self.bindingGroupNameState(label: label)
   }
   
   private func buildColorView(stack: UIStackView, color: UIColor) {
@@ -45,5 +46,15 @@ extension Styled.Row {
       ]
     )
     stack.addArrangedSubview(rightView)
+  }
+
+  private func bindingGroupNameState(label: UILabel) {
+    self.$configuration
+      .map(\.listPrimaryModel?.title)
+      .removeDuplicates()
+      .sink { [weak label] title in
+        label?.text = title
+      }
+      .store(in: &cancellables)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ListPrimary.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ListPrimary.swift
@@ -18,22 +18,26 @@ extension Styled.Row {
     stack.addArrangedSubview(label)
     stack.addSpacing()
     let colorView = self.buildColorView(stack: stack, color: model.color)
+    stack.addArrangedSubview(colorView)
+    self.setupColorViewLayout(colorView)
     self.buildRightView(stack: stack, views: views)
     self.bindingGroupNameState(label: label)
     self.bindingGroupColorState(colorView: colorView)
   }
-  
+
   private func buildColorView(stack: UIStackView, color: UIColor) -> UIView {
     let colorView = UIView()
     colorView.backgroundColor = color
     colorView.layer.cornerRadius = Constant.Styled.Row.ListPrimary.colorViewCornerRadius
+    return colorView
+  }
+
+  private func setupColorViewLayout(_ colorView: UIView) {
     colorView.usingAutolayout()
     NSLayoutConstraint.activate([
       colorView.widthAnchor.constraint(equalToConstant: Constant.Styled.Row.ListPrimary.colorViewSize.width),
       colorView.heightAnchor.constraint(equalToConstant: Constant.Styled.Row.ListPrimary.colorViewSize.height)
     ])
-    stack.addArrangedSubview(colorView)
-    return colorView
   }
 
   private func buildRightView(stack: UIStackView, views: [UIView]? = nil) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ListPrimary.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ListPrimary.swift
@@ -17,12 +17,13 @@ extension Styled.Row {
     label.text = model.title
     stack.addArrangedSubview(label)
     stack.addSpacing()
-    self.buildColorView(stack: stack, color: model.color)
+    let colorView = self.buildColorView(stack: stack, color: model.color)
     self.buildRightView(stack: stack, views: views)
     self.bindingGroupNameState(label: label)
+    self.bindingGroupColorState(colorView: colorView)
   }
   
-  private func buildColorView(stack: UIStackView, color: UIColor) {
+  private func buildColorView(stack: UIStackView, color: UIColor) -> UIView {
     let colorView = UIView()
     colorView.backgroundColor = color
     colorView.layer.cornerRadius = Constant.Styled.Row.ListPrimary.colorViewCornerRadius
@@ -32,6 +33,7 @@ extension Styled.Row {
       colorView.heightAnchor.constraint(equalToConstant: Constant.Styled.Row.ListPrimary.colorViewSize.height)
     ])
     stack.addArrangedSubview(colorView)
+    return colorView
   }
 
   private func buildRightView(stack: UIStackView, views: [UIView]? = nil) {
@@ -54,6 +56,16 @@ extension Styled.Row {
       .removeDuplicates()
       .sink { [weak label] title in
         label?.text = title
+      }
+      .store(in: &cancellables)
+  }
+
+  private func bindingGroupColorState(colorView: UIView) {
+    self.$configuration
+      .map(\.listPrimaryModel?.color)
+      .removeDuplicates()
+      .sink { [weak colorView] color in
+        colorView?.backgroundColor = color
       }
       .store(in: &cancellables)
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ListPrimary.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ListPrimary.swift
@@ -20,7 +20,7 @@ extension Styled.Row {
     let colorView = self.buildColorView(stack: stack, color: model.color)
     stack.addArrangedSubview(colorView)
     self.setupColorViewLayout(colorView)
-    self.buildRightView(stack: stack, views: views)
+    self.setupRightViewLayout(stack: stack, views: views)
     self.bindingGroupNameState(label: label)
     self.bindingGroupColorState(colorView: colorView)
   }
@@ -40,7 +40,7 @@ extension Styled.Row {
     ])
   }
 
-  private func buildRightView(stack: UIStackView, views: [UIView]? = nil) {
+  private func setupRightViewLayout(stack: UIStackView, views: [UIView]? = nil) {
     guard let rightView = views?.first
     else { return }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #287

## 🎉 변경 사항
- GroupList Style Row에서 그룹명과 색상을 변경할 수 있도록 수정하였습니다.

## 📌 PR Point
- 외부에서 새로운 ListPrimaryModel을 주입하여 UI를 변경할 수 있도록 수정하였습니다.
- 그룹명을 나타내는 Label과 색상을 나타내는 ColorView를 Model과 바인딩하였습니다.
- 다음은 변경 적용 예시 코드입니다.

``` Swift
let row = Styled.Row(
    configuration: .listPrimary(
      .init(title: "영어독해", color: .red)
    )
)

row.groupListModel = Styled.Row.Configuration.ListPrimaryModel(
    title: "비문학",
    color: UIColor.toDoGardenGreenDark
)
```

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?