### PR TITLE
TimerProgressView dot 초기 UI 설정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
@@ -151,7 +151,7 @@ extension TimerSceneViewController: TimerSceneDisplayLogic {
   func updateTimeLabel(duration: Double, time: String, isFirst: Bool) {
     if !timerProgressView.isAnimating, isFirst {
       self.timerProgressView
-        .startAnimation(duration: duration, from: 0, to: 1)
+        .startAnimation(duration: duration, to: 1)
     }
     self.timeLabel.text = time
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -43,12 +43,11 @@ public final class TimerProgressView: UIView {
   /// 타이머 애니메이션을 시작하는 메소드입니다.
   /// - Parameters:
   ///   - duration: `TimerInterval` 동안 실행될지 결정하는 파라미터입니다.
-  ///   - from: `TimerProgressView`의 애니메이션이 시작되는 지점을 나타내는 값입니다.
-  ///   - value: TimerProgressView`의 애니메이션이 종료되는 지점을 나타내는 값입니다.
-  public func startAnimation(duration: TimeInterval, from: Double, to value: Double) {
-    self.toValue = value
-    self.addAnimation(duration: duration, from: from, to: value)
-    self.circularProgressView.startAnimation(duration: duration, from: Float(from), to: Float(value))
+  ///   - toValue: TimerProgressView`의 애니메이션이 종료되는 지점을 나타내는 값입니다.
+  public func startAnimation(duration: TimeInterval, to toValue: Double) {
+    self.toValue = toValue
+    self.addAnimation(duration: duration, to: toValue)
+    self.circularProgressView.startAnimation(duration: duration, from: Float.zero, to: Float(toValue))
   }
 }
 
@@ -102,8 +101,8 @@ extension TimerProgressView {
 // MARK: - Setup animation
 
 extension TimerProgressView {
-  private func addAnimation(duration: TimeInterval, from: Double, to value: Double) {
-    let circularPath = self.makeCircularPath(fromValue: from, toValue: value)
+  private func addAnimation(duration: TimeInterval, to toValue: Double) {
+    let circularPath = self.makeCircularPath(toValue: toValue)
     let animationKeyPath = Constant.TimerProgressView.StringLiteral.Dot.Animation.keyPath
     let animation = CAKeyframeAnimation(keyPath: animationKeyPath)
     animation.delegate = self
@@ -115,7 +114,7 @@ extension TimerProgressView {
     self.dot.layer.add(animation, forKey: nil)
   }
   
-  private func makeCircularPath(fromValue: Double, toValue: Double) -> UIBezierPath {
+  private func makeCircularPath(toValue: Double) -> UIBezierPath {
     self.layoutIfNeeded()
     let startAngle = -(Double.pi / 2)
     let endAngle = (2 * Double.pi)
@@ -125,7 +124,7 @@ extension TimerProgressView {
     let circularPath = UIBezierPath(
       arcCenter: arcCenter,
       radius: radius,
-      startAngle: startAngle + (2 * Double.pi) * fromValue,
+      startAngle: startAngle,
       endAngle: endAngle * toValue + startAngle,
       clockwise: true
     )
@@ -167,7 +166,7 @@ extension TimerProgressView: CAAnimationDelegate {
     ),
     dotColor: UIColor.toDoGardenGreenDark
   )
-  timerProgressView.startAnimation(duration: 10.0, from: 0.3, to: 0.7)
+  timerProgressView.startAnimation(duration: 10.0, to: 0.7)
   
   return timerProgressView
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -14,7 +14,16 @@ public final class TimerProgressView: UIView {
     self.circularProgressView.isAnimating
   }
   private let circularProgressView: CircularProgressView
-  private let dot: UIView
+  private let dot: UIView = {
+    let dotWidth = Constant.TimerProgressView.Layout.Dot.width
+    let dotHeight = Constant.TimerProgressView.Layout.Dot.height
+    let dot = UIView(
+      frame: CGRect(x: 0, y: 0, width: dotWidth, height: dotHeight)
+    )
+    dot.isHidden = true
+    
+    return dot
+  }()
   private var toValue: Double?
   
   public init(
@@ -22,11 +31,6 @@ public final class TimerProgressView: UIView {
     dotColor: UIColor
   ) {
     self.circularProgressView = circularProgressView
-    let dotWidth = Constant.TimerProgressView.Layout.Dot.width
-    let dotHeight = Constant.TimerProgressView.Layout.Dot.height
-    self.dot = UIView(
-      frame: CGRect(x: 0, y: 0, width: dotWidth, height: dotHeight)
-    )
     super.init(frame: CGRect.zero)
     self.setupViews(with: dotColor)
   }
@@ -107,7 +111,7 @@ extension TimerProgressView {
     animation.duration = duration
     animation.calculationMode = CAAnimationCalculationMode.paced
     animation.isRemovedOnCompletion = false
-    
+    self.dot.isHidden = false
     self.dot.layer.add(animation, forKey: nil)
   }
   


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #291 

## 🎉 변경 사항
|TimerProgressView|
|--|
|<img width="300" alt="Screenshot 2024-05-23 at 1 52 33 PM" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/63908856/e3a11bdc-e69a-4291-aee8-f7def4714358">|

dot의 isHidden 속성을 [디자인 기획의도](https://www.figma.com/design/JCWKb4OUC4zZhKbUz3JLEP?node-id=66-3443#860877970)에 맞게 타이머 애니메이션이 시작될 경우 보이도록 설정해주었습니다.

## 📌 PR Point
- 기획의도상 사용하지 않는 `startAnimation(duration:from:to:)`의 from argument를 제거하였습니다.

|iPhone SE 3rd Simulator |
|--|
|<img width="372" alt="Screenshot 2024-07-01 at 5 36 47 PM" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/63908856/081d05c6-7c3f-4955-9479-0d323c3b7b1d">|



## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?