### PR TITLE
GroupSelectionView 컴포넌트 Constant 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
@@ -21,7 +21,16 @@ extension Constant.GroupSelectionView.Layout {
 }
 
 extension Constant.GroupSelectionView.Layout.TableViewContainer {
+  public enum Layer {}
+
   public static let topMargin: CGFloat = 6
   public static let leadingMargin: CGFloat = 10
   public static let trailingMargin: CGFloat = 5
+}
+
+extension Constant.GroupSelectionView.Layout.TableViewContainer.Layer {
+  public static let shadowOpacity: Float = 0.15
+  public static let shadowOffset = CGSize(width: 0, height: 2)
+  public static let shadowRadius: CGFloat = 4
+  public static let cornerRadius: CGFloat = 9
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
@@ -19,6 +19,7 @@ extension Constant.GroupSelectionView.Animation {
 extension Constant.GroupSelectionView.Layout {
   public enum TableViewContainer {}
   public enum EditableGroupTableView {}
+  public enum EditableGroupTableViewCell {}
 }
 
 extension Constant.GroupSelectionView.Layout.TableViewContainer {
@@ -39,5 +40,11 @@ extension Constant.GroupSelectionView.Layout.TableViewContainer.Layer {
 extension Constant.GroupSelectionView.Layout.EditableGroupTableView {
   public enum Layer {
     public static let cornerRadius: CGFloat = 9
+  }
+}
+
+extension Constant.GroupSelectionView.Layout.EditableGroupTableViewCell {
+  public enum SeparatorView {
+    public static let width: CGFloat = 1.0
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
@@ -9,8 +9,19 @@ import Foundation
 
 extension Constant.GroupSelectionView {
   public enum Animation {}
+  public enum Layout {}
 }
 
 extension Constant.GroupSelectionView.Animation {
   public static let duration: CGFloat = 0.2
+}
+
+extension Constant.GroupSelectionView.Layout {
+  public enum TableViewContainer {}
+}
+
+extension Constant.GroupSelectionView.Layout.TableViewContainer {
+  public static let topMargin: CGFloat = 6
+  public static let leadingMargin: CGFloat = 10
+  public static let trailingMargin: CGFloat = 5
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
@@ -7,4 +7,10 @@
 
 import Foundation
 
-extension Constant.GroupSelectionView {}
+extension Constant.GroupSelectionView {
+  public enum Animation {}
+}
+
+extension Constant.GroupSelectionView.Animation {
+  public static let duration: CGFloat = 0.2
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
@@ -18,6 +18,7 @@ extension Constant.GroupSelectionView.Animation {
 
 extension Constant.GroupSelectionView.Layout {
   public enum TableViewContainer {}
+  public enum EditableGroupTableView {}
 }
 
 extension Constant.GroupSelectionView.Layout.TableViewContainer {
@@ -33,4 +34,10 @@ extension Constant.GroupSelectionView.Layout.TableViewContainer.Layer {
   public static let shadowOffset = CGSize(width: 0, height: 2)
   public static let shadowRadius: CGFloat = 4
   public static let cornerRadius: CGFloat = 9
+}
+
+extension Constant.GroupSelectionView.Layout.EditableGroupTableView {
+  public enum Layer {
+    public static let cornerRadius: CGFloat = 9
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
@@ -20,6 +20,7 @@ extension Constant.GroupSelectionView.Layout {
   public enum TableViewContainer {}
   public enum EditableGroupTableView {}
   public enum EditableGroupTableViewCell {}
+  public enum EditableGroupTableViewDelegate {}
 }
 
 extension Constant.GroupSelectionView.Layout.TableViewContainer {
@@ -47,4 +48,8 @@ extension Constant.GroupSelectionView.Layout.EditableGroupTableViewCell {
   public enum SeparatorView {
     public static let width: CGFloat = 1.0
   }
+}
+
+extension Constant.GroupSelectionView.Layout.EditableGroupTableViewDelegate {
+  public static let headerViewHeight: CGFloat = 2.0
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
@@ -11,6 +11,7 @@ extension Constant.GroupSelectionView {
   public enum Animation {}
   public enum Layout {}
   public enum Model {}
+  public enum StringLiteral {}
 }
 
 extension Constant.GroupSelectionView.Animation {
@@ -60,4 +61,8 @@ extension Constant.GroupSelectionView.Model {
     public static let cellHeight: CGFloat = 45
     public static let visibleCellCount = 3
   }
+}
+
+extension Constant.GroupSelectionView.StringLiteral {
+  public static let defaultGroupName = "그룹 1"
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
@@ -1,0 +1,10 @@
+//
+//  Constant+GroupSelectionView.swift
+//
+//
+//  Created by Wood on 7/3/24.
+//
+
+import Foundation
+
+extension Constant.GroupSelectionView {}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
@@ -10,6 +10,7 @@ import Foundation
 extension Constant.GroupSelectionView {
   public enum Animation {}
   public enum Layout {}
+  public enum Model {}
 }
 
 extension Constant.GroupSelectionView.Animation {
@@ -52,4 +53,11 @@ extension Constant.GroupSelectionView.Layout.EditableGroupTableViewCell {
 
 extension Constant.GroupSelectionView.Layout.EditableGroupTableViewDelegate {
   public static let headerViewHeight: CGFloat = 2.0
+}
+
+extension Constant.GroupSelectionView.Model {
+  public enum Primary {
+    public static let cellHeight: CGFloat = 45
+    public static let visibleCellCount = 3
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -34,4 +34,5 @@ public enum Constant {
   public enum PomodoroLevelCollectionView { }
   public enum PomodoroRecordCollectionView { }
   public enum GardenView { }
+  public enum GroupSelectionView { }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #290 

## 🎉 변경 사항
- 투두 수정화면에서 그룹을 선택할 때 사용하는 컴포넌트의 Constant를 추가하였습니다.

## 📌 PR Point
- 화살표 버튼을 눌렀을 때, TableView가 펼쳐지는 애니메이션의 Duration을 추가하였습니다.

### Model
GroupSelectionView를 생성할 때, Model을 주입하여 커스텀합니다.
1. 보여질 TableViewCell의 Count
2. TableViewCell의 Height

### Container
Container 객체는 TableView를 포함하는 UIView 입니다.
- 버튼을 눌렀을 때, TableView 높이가 동적으로 변경될 수 있도록 컨테이너 역할을 합니다.
- Layer에 테두리 UI를 보여질 수 있도록 상수를 추가하였습니다.

### 참고용 이미지
- GroupSelectionView 컴포넌트에 대한 이미지입니다.
<img width="400" alt="스크린샷 2024-07-03 21 10 22" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/01167828-7af6-4c71-a510-81c694afbd14">



## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?