### PR TITLE
Refactor CountDownSequence to simplify time interval calculations

### DIFF
--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorker.swift
@@ -17,7 +17,6 @@ extension TimerSceneWorker {
 }
 
 public struct CountDownSequence: AsyncSequence {
-  public typealias Element = Double
   let endTime: TimeInterval
   let timeInterval: UInt64
   
@@ -29,24 +28,40 @@ public struct CountDownSequence: AsyncSequence {
   public func makeAsyncIterator() -> AsyncIterator {
     AsyncIterator(endTime: endTime, timeInterval: timeInterval)
   }
+  
   public struct AsyncIterator: AsyncIteratorProtocol {
     private var endTime: TimeInterval
     private let timeInterval: UInt64
-    private var isFirst: Bool = true
     
-    init(
-      endTime: TimeInterval,
-      timeInterval: UInt64
-    ) {
+    private var targetTime: TimeInterval
+    private var timeCorrection: TimeInterval
+    
+    init(endTime: TimeInterval, timeInterval: UInt64) {
       self.endTime = endTime
       self.timeInterval = timeInterval
+      self.targetTime = Date().timeIntervalSince1970
+      self.timeCorrection = 0
     }
     
     public mutating func next() async throws -> Double? {
       guard self.endTime > 0 else { return nil }
-      try await Task.sleep(nanoseconds: timeInterval)
-      self.endTime -= 1
+      self.targetTime += 1.0
+      try await self.sleepForCorrectTime()
+      self.endTime -= 1.0
+      
       return self.endTime
+    }
+    
+    private mutating func sleepForCorrectTime() async throws {
+      let current = Date().timeIntervalSince1970
+      let sleepTime = self.targetTime - current + self.timeCorrection
+      if sleepTime > 0 {
+        try await Task.sleep(nanoseconds: UInt64(sleepTime * Double(self.timeInterval)))
+        self.timeCorrection = 0
+      } else {
+        try Task.checkCancellation()
+        self.timeCorrection = sleepTime
+      }
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorker.swift
@@ -30,10 +30,18 @@ public struct CountDownSequence: AsyncSequence {
   }
   
   public struct AsyncIterator: AsyncIteratorProtocol {
+    ///
+    ///   endTime: CountDownSequnce의 생성자를 통해 초기화 되는 값
+    ///   ex: 10초 카운트 시퀀스의 경우 endTime이 10으로 초기화 된다.
     private var endTime: TimeInterval
     private let timeInterval: UInt64
-    
+    ///
+    ///   targetTime: AsyncIterator가 초기화 될 때 생성되며, 값이 방출될 때 마다( == next 함수가 호출될 때 마다)
+    ///   1초씩 증가함으로 써 보정 값하고 비교할 수 있는 수치.
     private var targetTime: TimeInterval
+    ///
+    ///   timeCorrection: sleepForCorrectTime 함수 내부에 sleepTime이 음수가 발생할 경우를 대비해서 만든 값
+    ///   다음 주기의 시간 값까지 초과 시킨 경우 sleepTime이 음수가 나옵니다.
     private var timeCorrection: TimeInterval
     
     init(endTime: TimeInterval, timeInterval: UInt64) {
@@ -56,12 +64,17 @@ public struct CountDownSequence: AsyncSequence {
       let current = Date().timeIntervalSince1970
       let sleepTime = self.targetTime - current + self.timeCorrection
       if sleepTime > 0 {
-        try await Task.sleep(nanoseconds: UInt64(sleepTime * Double(self.timeInterval)))
-        self.timeCorrection = 0
+        let nanoseconds = UInt64(sleepTime * Double(self.timeInterval))
+        try await Task.sleep(nanoseconds: nanoseconds)
+        self.resetTimeCorrenction()
       } else {
         try Task.checkCancellation()
         self.timeCorrection = sleepTime
       }
+    }
+    
+    private mutating func resetTimeCorrenction() {
+      self.timeCorrection = 0
     }
   }
 }


### PR DESCRIPTION
@noah0316  @wood0203  @HG-SONG 
다들 궁금해하셨던 이슈여서 태그겁니다.

## 💡 관련 이슈
closed:#295 

## 🎉 변경 사항
- 시간 보정값 추가

## 📌 PR Point
시간초가 증가할 수록 점점 격차가 커지게 되면 1초 이상 차이가 나는 상황이 존재하는 걸 발견했습니다.
애니메이션을 실행 시키는 시간과 뷰를 업데이트 하느랴 딜레이가 발생하는 상황에서 벌어지는 시간 차이였습니다.

이를 해결하기 위해 시간 보정값을 추가해서 비교 후 보정 값 만큼 기다린 후 값을 방출시키도록 수정했습니다.

해당 결과 보정 값을 추가하기 전 40초를 기다리게 됐을 때 1초 이상 차이가 발생했지만 수정 후 0.1ns의 차이정도만 존재하도록 수정했습니다.

테스트 코드는 한번에 작성하도록 하겠습니다.
## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?