### PR TITLE
Feature/#288 timer scene bottom sheet

### DIFF
--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneInteractor.swift
@@ -7,7 +7,7 @@ protocol TimerSceneDataStore {
 
 @MainActor
 protocol TimerSceneBusinessLogic {
-  func controlButtonTapped()
+  func setTimer(for seconds: Double)
 }
 
 @MainActor
@@ -44,11 +44,7 @@ final class TimerSceneInteractor: TimerSceneDataStore {
 
 extension TimerSceneInteractor: TimerSceneBusinessLogic {
   
-  func controlButtonTapped() {
-    guard !self.isFocused else { return }
-    // TODO: Bottom Sheet
-    let seconds = 10.0
-    
+  func setTimer(for seconds: Double) {
     self.isFocused = true
     run {
       self.presenter?.configureTimerSettings(seconds)

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
@@ -93,7 +93,12 @@ public final class TimerSceneViewController: UIViewController, TimerSceneViewCon
       duration: Constant.Layout.SetTimerButton.animationDuration
     )
     let action = UIAction { [weak self] _ in
-      self?.interactor?.controlButtonTapped()
+      let bottom = FocusTimeSettings()
+      bottom.completion = {
+        self?.interactor?.setTimer(for: $0)
+      }
+      bottom.sheetPresentationController?.detents = [.medium()]
+      self?.present(bottom, animated: true)
     }
     button.addAction(action, for: .touchUpInside)
     return button
@@ -159,6 +164,43 @@ extension TimerSceneViewController: TimerSceneDisplayLogic {
   func updateProgressImage(_ image: UIImage) {
     guard self.circularProgressImageView.image != image else { return }
     self.circularProgressImageView.setImageWithZoomTransition(newImage: image)
+  }
+}
+
+extension TimerSceneViewController {
+  private final class FocusTimeSettings: UIViewController {
+    var completion: ((Double) -> Void)?
+    
+    override func viewDidLoad() {
+      view.backgroundColor = UIColor.toDoGardenWhite
+      let stack = UIStackView()
+      stack.axis = .vertical
+      let button = self.buildButton()
+      let settingTimeView = SettingTimeView(with: button, for: .focusTimeSetting)
+      let action = self.builButtonAction(settingTimeView)
+      button.addAction(action, for: .touchUpInside)
+      
+      stack.addArrangedSubview(settingTimeView)
+      view.addSubview(stack)
+      stack.equalToParent()
+    }
+    
+    private func buildButton() -> UIButton {
+      let button = UIButton()
+      button.timerControlButtonDefaultStyle(with: "시작하기")
+      let width = TimerSceneViewController.Constant.Layout.ControlButton.width
+      button.widthAnchor.constraint(equalToConstant: width).isActive = true
+      return button
+    }
+    
+    private func builButtonAction(_ settingTimeView: SettingTimeView) -> UIAction {
+      return UIAction { [weak self, weak settingTimeView]_ in
+        guard let seconds = settingTimeView?.seconds else { return }
+        self?.completion?(seconds)
+        // TODO: - 화면을 제거하는 로직은 외부에서 처리하는게 더 적합합니다.
+        self?.dismiss(animated: true)
+      }
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
@@ -177,7 +177,7 @@ extension TimerSceneViewController {
       stack.axis = .vertical
       let button = self.buildButton()
       let settingTimeView = SettingTimeView(with: button, for: .focusTimeSetting)
-      let action = self.builButtonAction(settingTimeView)
+      let action = self.buildButtonAction(settingTimeView)
       button.addAction(action, for: .touchUpInside)
       
       stack.addArrangedSubview(settingTimeView)
@@ -193,7 +193,7 @@ extension TimerSceneViewController {
       return button
     }
     
-    private func builButtonAction(_ settingTimeView: SettingTimeView) -> UIAction {
+    private func buildButtonAction(_ settingTimeView: SettingTimeView) -> UIAction {
       return UIAction { [weak self, weak settingTimeView]_ in
         guard let seconds = settingTimeView?.seconds else { return }
         self?.completion?(seconds)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -35,6 +35,10 @@ public class SettingTimeView: UIView {
     return CGSize.init(width: screenWidth, height: screenHeight / 2)
   }
   
+  public var seconds: Double {
+    self.timepicker.transformSeconds()
+  }
+  
   public func transformSeconds(completion: @escaping (Double) -> Void) {
     let calculatedDate = self.timepicker.transformSeconds()
     completion(calculatedDate)


### PR DESCRIPTION
## 💡 관련 이슈
#288 

## 🎉 변경 사항
- SettingTimeView
- TimerSceneViewController

## 📌 PR Point
- 집중시간 설정값을 받아오는지
- 바텀시트가 정상적으로 동작하는지

## 기타
- 바텀 시트 크기를 피그마 디자인으로 고정할지에 대한 내용이 정확하지 않습니다. (pro 모델의 경우 피그마 디자인보다 커질 수 있습니다.)
- 바텀 시트가 사라지고 바로 타이머가 시작되는게 아닌 조금의 딜레이가 존재합니다. (심하다고 생각될 경우 이슈를 생성해서 수정하도록 하겠습니다.)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?