### PR TITLE
GroupSelectionView 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
@@ -11,15 +11,24 @@ import ToDoGardenUIConstant
 
 final class EditableGroupTableViewDelegate: NSObject {
   private let cellHeight: CGFloat
+  private var editableGroupIndexDictionary: [Int: Int]
   private var tableViewDataSource: UITableViewDiffableDataSource<
     EditableGroupSection,
     EditableGroupItem
   >!
+  private(set) var currentGroupItem: EditableGroupItem?
 
   init(tableView: UITableView, cellHeight: CGFloat) {
     self.cellHeight = cellHeight
+    self.editableGroupIndexDictionary = [:]
     super.init()
     self.setupTableView(tableView)
+  }
+
+  func updateGroup(currentItem: EditableGroupItem, editableItems: [EditableGroupItem]) {
+    self.currentGroupItem = currentItem
+    self.storeEditableGroupIndex(groupItems: editableItems)
+    self.reloadNewEditableGroups(groupItems: editableItems)
   }
 }
 
@@ -66,5 +75,26 @@ extension EditableGroupTableViewDelegate {
       cell.updateUI(groupItem: itemIdentifier)
       return cell
     }
+  }
+
+  private func storeEditableGroupIndex(groupItems: [EditableGroupItem]) {
+    groupItems.enumerated().forEach { (index: Int, item: EditableGroupItem) in
+      let id = item.groupId
+      self.editableGroupIndexDictionary[id] = index
+    }
+  }
+
+  private func reloadNewEditableGroups(groupItems: [EditableGroupItem]) {
+    var snapshot = NSDiffableDataSourceSnapshot<EditableGroupSection, EditableGroupItem>()
+    snapshot.appendSections([.main])
+    let items = groupItems.filter { (item: EditableGroupItem) in
+      if let currentGroupItem = self.currentGroupItem {
+        return item != currentGroupItem
+      }
+
+      return false
+    }
+    snapshot.appendItems(items, toSection: EditableGroupSection.main)
+    self.tableViewDataSource.apply(snapshot, animatingDifferences: true)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
@@ -16,7 +16,11 @@ final class EditableGroupTableViewDelegate: NSObject {
     EditableGroupSection,
     EditableGroupItem
   >!
-  private(set) var currentGroupItem: EditableGroupItem?
+  private(set) var currentGroupItem: EditableGroupItem? {
+    willSet { self.selectedGroupSender?.send(groupItem: newValue) }
+  }
+
+  weak var selectedGroupSender: GroupDataSendable?
 
   init(tableView: UITableView, cellHeight: CGFloat) {
     self.cellHeight = cellHeight

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
@@ -52,6 +52,38 @@ extension EditableGroupTableViewDelegate: UITableViewDelegate {
   func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
     return Constant.GroupSelectionView.Layout.EditableGroupTableViewDelegate.headerViewHeight
   }
+
+  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    guard let newItem = self.tableViewDataSource.itemIdentifier(for: indexPath)
+    else { return }
+
+    let oldItem = self.currentGroupItem
+    self.currentGroupItem = newItem
+
+    var snapshot = insertInCorrectOrder(oldItem: oldItem)
+    snapshot.deleteItems([newItem])
+    self.tableViewDataSource.apply(snapshot, animatingDifferences: true)
+  }
+
+  private func insertInCorrectOrder(oldItem: EditableGroupItem?) ->
+  NSDiffableDataSourceSnapshot<EditableGroupSection, EditableGroupItem> {
+    var snapshot = self.tableViewDataSource.snapshot()
+    guard let oldItem = oldItem
+    else { return snapshot }
+
+    let items = snapshot.itemIdentifiers
+    if let index = self.editableGroupIndexDictionary[oldItem.groupId] {
+      if index == 0 {
+        let beforeItem = items[0]
+        snapshot.insertItems([oldItem], beforeItem: beforeItem)
+      } else {
+        let afterItem = items[index - 1]
+        snapshot.insertItems([oldItem], afterItem: afterItem)
+      }
+    }
+
+    return snapshot
+  }
 }
 
 // MARK: Private Functions

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
@@ -15,5 +15,24 @@ final class EditableGroupTableViewDelegate: NSObject {
   init(tableView: UITableView, cellHeight: CGFloat) {
     self.cellHeight = cellHeight
     super.init()
+    tableView.delegate = self
+  }
+}
+
+// MARK: TableView Delegate Functions
+
+extension EditableGroupTableViewDelegate: UITableViewDelegate {
+  func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    return self.cellHeight
+  }
+
+  func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    let headerView = UIView()
+    headerView.backgroundColor = UIColor.toDoGardenGreenGray
+    return headerView
+  }
+
+  func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    return Constant.GroupSelectionView.Layout.EditableGroupTableViewDelegate.headerViewHeight
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
@@ -11,11 +11,15 @@ import ToDoGardenUIConstant
 
 final class EditableGroupTableViewDelegate: NSObject {
   private let cellHeight: CGFloat
+  private var tableViewDataSource: UITableViewDiffableDataSource<
+    EditableGroupSection,
+    EditableGroupItem
+  >!
 
   init(tableView: UITableView, cellHeight: CGFloat) {
     self.cellHeight = cellHeight
     super.init()
-    tableView.delegate = self
+    self.setupTableView(tableView)
   }
 }
 
@@ -34,5 +38,33 @@ extension EditableGroupTableViewDelegate: UITableViewDelegate {
 
   func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
     return Constant.GroupSelectionView.Layout.EditableGroupTableViewDelegate.headerViewHeight
+  }
+}
+
+// MARK: Private Functions
+
+extension EditableGroupTableViewDelegate {
+  private func setupTableView(_ tableView: UITableView) {
+    tableView.delegate = self
+    self.tableViewDataSource = self.makeDiffableDataSource(tableView: tableView)
+    tableView.dataSource = self.tableViewDataSource
+  }
+
+  private func makeDiffableDataSource(tableView: UITableView) -> UITableViewDiffableDataSource<
+    EditableGroupSection,
+    EditableGroupItem
+  > {
+    return UITableViewDiffableDataSource<
+      EditableGroupSection,
+      EditableGroupItem
+    >(tableView: tableView) { (tableView, indexPath, itemIdentifier) in
+      guard let cell = tableView.dequeueReusableCell(
+        type: EditableGroupTableViewCell.self,
+        for: indexPath
+      ) else { return UITableViewCell() }
+
+      cell.updateUI(groupItem: itemIdentifier)
+      return cell
+    }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
@@ -1,0 +1,19 @@
+//
+//  EditableGroupTableViewDelegate.swift
+//
+//
+//  Created by Wood on 7/9/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+
+final class EditableGroupTableViewDelegate: NSObject {
+  private let cellHeight: CGFloat
+
+  init(tableView: UITableView, cellHeight: CGFloat) {
+    self.cellHeight = cellHeight
+    super.init()
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -254,5 +254,18 @@ extension GroupSelectionView {
 @available(iOS 17.0, *)
 #Preview {
   let groupSelectionView = GroupSelectionView(model: GroupSelectionView.Model.primary)
+  groupSelectionView.updateGroup(
+    current: EditableGroupItem(groupId: 0, groupName: "CS 지식", groupColor: UIColor.brown),
+    editableList: [
+      .init(groupId: 0, groupName: "CS 지식", groupColor: UIColor.brown),
+      .init(groupId: 1, groupName: "영어", groupColor: UIColor.red),
+      .init(groupId: 2, groupName: "국어", groupColor: UIColor.blue),
+      .init(groupId: 3, groupName: "수학", groupColor: UIColor.systemMint),
+      .init(groupId: 4, groupName: "Swift", groupColor: UIColor.toDoGardenYellow),
+      .init(groupId: 5, groupName: "런닝", groupColor: UIColor.toDoGardenGreenDark),
+      .init(groupId: 6, groupName: "지구과학", groupColor: UIColor.systemGreen),
+      .init(groupId: 7, groupName: "물리", groupColor: UIColor.orange)
+    ]
+  )
   return groupSelectionView
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -40,7 +40,14 @@ public final class GroupSelectionView: UIView {
     super.init(frame: CGRect.zero)
     self.setup()
   }
-  
+
+  public func updateGroup(current: EditableGroupItem, editableList: [EditableGroupItem]) {
+    self.editableGroupListTableViewDelegate.updateGroup(
+      currentItem: current,
+      editableItems: editableList
+    )
+  }
+
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -1,0 +1,12 @@
+//
+//  GroupSelectionView.swift
+//
+//
+//  Created by Wood on 7/9/24.
+//
+
+import UIKit
+
+public final class GroupSelectionView: UIView {
+  
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -26,7 +26,8 @@ public final class GroupSelectionView: UIView {
           title: Constant.GroupSelectionView.StringLiteral.defaultGroupName,
           color: UIColor.toDoGardenYellow
         )
-      )
+      ),
+      with: [self.showGroupListButton]
     )
     self.editableGroupListTableView = UITableView()
     self.tableViewHeightConstraint = NSLayoutConstraint()
@@ -215,4 +216,10 @@ extension GroupSelectionView {
       visibleCellCount: Constant.GroupSelectionView.Model.Primary.visibleCellCount
     )
   }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+  let groupSelectionView = GroupSelectionView(model: GroupSelectionView.Model.primary)
+  return groupSelectionView
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -11,10 +11,22 @@ import ToDoGardenUIConstant
 
 public final class GroupSelectionView: UIView {
   private let model: GroupSelectionView.Model
+  private let showGroupListButton: UIButton
+  private let currentGroupRow: Styled.Row
 
   public init(model: GroupSelectionView.Model) {
     self.model = model
+    self.showGroupListButton = UIButton()
+    self.currentGroupRow = Styled.Row(
+      configuration: Styled.Row.Configuration.listPrimary(
+        Styled.Row.Configuration.ListPrimaryModel(
+          title: Constant.GroupSelectionView.StringLiteral.defaultGroupName,
+          color: UIColor.toDoGardenYellow
+        )
+      )
+    )
     super.init(frame: CGRect.zero)
+    self.setup()
   }
   
   @available(*, unavailable)
@@ -22,6 +34,42 @@ public final class GroupSelectionView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
 }
+
+// MARK: Private Functions
+
+extension GroupSelectionView {
+  private func setup() {
+    self.addSubviews()
+    self.setupSubviewsLayout()
+  }
+}
+
+// MARK: About Auto Layout
+
+extension GroupSelectionView {
+  private func addSubviews() {
+    self.addSubview(self.currentGroupRow)
+  }
+
+  private func setupSubviewsLayout() {
+    self.setupCurrentGroupRowLayout()
+  }
+
+  private func setupCurrentGroupRowLayout() {
+    self.currentGroupRow.usingAutolayout()
+
+    NSLayoutConstraint.activate(
+      [
+        self.currentGroupRow.topAnchor.constraint(equalTo: self.topAnchor),
+        self.currentGroupRow.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.currentGroupRow.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        self.currentGroupRow.bottomAnchor.constraint(lessThanOrEqualTo: self.bottomAnchor)
+      ]
+    )
+  }
+}
+
+// MARK: Model
 
 extension GroupSelectionView {
   public struct Model {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -7,6 +7,35 @@
 
 import UIKit
 
+import ToDoGardenUIConstant
+
 public final class GroupSelectionView: UIView {
+  private let model: GroupSelectionView.Model
+
+  public init(model: GroupSelectionView.Model) {
+    self.model = model
+    super.init(frame: CGRect.zero)
+  }
   
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+extension GroupSelectionView {
+  public struct Model {
+    let cellHeight: CGFloat
+    let visibleCellCount: Int
+
+    init(cellHeight: CGFloat, visibleCellCount: Int) {
+      self.cellHeight = cellHeight
+      self.visibleCellCount = visibleCellCount
+    }
+
+    public static let primary = Self(
+      cellHeight: Constant.GroupSelectionView.Model.Primary.cellHeight,
+      visibleCellCount: Constant.GroupSelectionView.Model.Primary.visibleCellCount
+    )
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -53,8 +53,8 @@ public final class GroupSelectionView: UIView {
     )
   }
 
-  public func getCurrentGroup() -> EditableGroupItem? {
-    return self.editableGroupListTableViewDelegate.currentGroupItem
+  public func getCurrentGroupId() -> Int? {
+    return self.editableGroupListTableViewDelegate.currentGroupItem?.groupId
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -54,12 +54,29 @@ public final class GroupSelectionView: UIView {
   }
 }
 
+protocol GroupDataSendable: AnyObject {
+  func send(groupItem: EditableGroupItem?)
+}
+
+extension GroupSelectionView: GroupDataSendable {
+  func send(groupItem: EditableGroupItem?) {
+    guard let groupItem = groupItem
+    else { return }
+
+    let title = groupItem.groupName
+    let color = groupItem.groupColor
+    let model = Styled.Row.Configuration.ListPrimaryModel(title: title, color: color)
+    self.currentGroupRow.groupListModel = model
+  }
+}
+
 // MARK: Private Functions
 
 extension GroupSelectionView {
   private func setup() {
     self.setupShowGroupMenuButton()
     self.setupEditableGroupListTableView()
+    self.setupSelectedGroupSender()
     self.addSubviews()
     self.setupSubviewsLayout()
   }
@@ -114,6 +131,10 @@ extension GroupSelectionView {
       CACornerMask.layerMinXMaxYCorner,
       CACornerMask.layerMaxXMaxYCorner
     ]
+  }
+
+  private func setupSelectedGroupSender() {
+    self.editableGroupListTableViewDelegate.selectedGroupSender = self
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -14,6 +14,7 @@ public final class GroupSelectionView: UIView {
   private let showGroupListButton: UIButton
   private let currentGroupRow: Styled.Row
   private let editableGroupListTableView: UITableView
+  private let editableGroupListTableViewDelegate: EditableGroupTableViewDelegate
   private var tableViewHeightConstraint: NSLayoutConstraint
   private var heightConstraint: NSLayoutConstraint
 
@@ -30,6 +31,10 @@ public final class GroupSelectionView: UIView {
       with: [self.showGroupListButton]
     )
     self.editableGroupListTableView = UITableView()
+    self.editableGroupListTableViewDelegate = EditableGroupTableViewDelegate(
+      tableView: self.editableGroupListTableView,
+      cellHeight: self.model.cellHeight
+    )
     self.tableViewHeightConstraint = NSLayoutConstraint()
     self.heightConstraint = NSLayoutConstraint()
     super.init(frame: CGRect.zero)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -13,6 +13,7 @@ public final class GroupSelectionView: UIView {
   private let model: GroupSelectionView.Model
   private let showGroupListButton: UIButton
   private let currentGroupRow: Styled.Row
+  private let editableGroupListTableView: UITableView
 
   public init(model: GroupSelectionView.Model) {
     self.model = model
@@ -25,6 +26,7 @@ public final class GroupSelectionView: UIView {
         )
       )
     )
+    self.editableGroupListTableView = UITableView()
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -40,6 +42,7 @@ public final class GroupSelectionView: UIView {
 extension GroupSelectionView {
   private func setup() {
     self.setupShowGroupMenuButton()
+    self.setupEditableGroupListTableView()
     self.addSubviews()
     self.setupSubviewsLayout()
   }
@@ -65,6 +68,25 @@ extension GroupSelectionView {
       self.showGroupListButton.transform = transform
     }
   }
+
+  private func setupEditableGroupListTableView() {
+    self.editableGroupListTableView.register(
+      EditableGroupTableViewCell.self,
+      forCellReuseIdentifier: EditableGroupTableViewCell.identifier
+    )
+    self.setupEditableGroupListTableViewUI()
+  }
+
+  private func setupEditableGroupListTableViewUI() {
+    self.editableGroupListTableView.sectionHeaderTopPadding = 0
+    self.editableGroupListTableView.separatorStyle = UITableViewCell.SeparatorStyle.none
+    let layout = Constant.GroupSelectionView.Layout.EditableGroupTableView.Layer.self
+    self.editableGroupListTableView.layer.cornerRadius = layout.cornerRadius
+    self.editableGroupListTableView.layer.maskedCorners = [
+      CACornerMask.layerMinXMaxYCorner,
+      CACornerMask.layerMaxXMaxYCorner
+    ]
+  }
 }
 
 // MARK: About Auto Layout
@@ -76,6 +98,9 @@ extension GroupSelectionView {
 
   private func setupSubviewsLayout() {
     self.setupCurrentGroupRowLayout()
+    let containerView = self.makeGroupListContainerView()
+    self.setupContainerViewLayout(containerView: containerView)
+    self.setupGroupListTableViewLayout(with: containerView)
   }
 
   private func setupCurrentGroupRowLayout() {
@@ -87,6 +112,62 @@ extension GroupSelectionView {
         self.currentGroupRow.leadingAnchor.constraint(equalTo: self.leadingAnchor),
         self.currentGroupRow.trailingAnchor.constraint(equalTo: self.trailingAnchor),
         self.currentGroupRow.bottomAnchor.constraint(lessThanOrEqualTo: self.bottomAnchor)
+      ]
+    )
+  }
+
+  private func makeGroupListContainerView() -> UIView {
+    let containerView = UIView()
+    self.setupShadowLayer(to: containerView)
+    return containerView
+  }
+
+  private func setupShadowLayer(to view: UIView) {
+    let layerConstant = Constant.GroupSelectionView.Layout.TableViewContainer.Layer.self
+    view.layer.shadowOpacity = layerConstant.shadowOpacity
+    view.layer.shadowOffset = layerConstant.shadowOffset
+    view.layer.shadowRadius = layerConstant.shadowRadius
+    view.layer.cornerRadius = layerConstant.cornerRadius
+    view.layer.masksToBounds = false
+    view.layer.maskedCorners = [
+      CACornerMask.layerMinXMaxYCorner,
+      CACornerMask.layerMaxXMaxYCorner
+    ]
+  }
+
+  private func setupContainerViewLayout(containerView: UIView) {
+    self.addSubview(containerView)
+
+    containerView.usingAutolayout()
+    let layout = Constant.GroupSelectionView.Layout.TableViewContainer.self
+    NSLayoutConstraint.activate(
+      [
+        containerView.topAnchor.constraint(
+          equalTo: self.currentGroupRow.bottomAnchor,
+          constant: layout.topMargin
+        ),
+        containerView.leadingAnchor.constraint(
+          equalTo: self.currentGroupRow.leadingAnchor,
+          constant: layout.leadingMargin
+        ),
+        containerView.trailingAnchor.constraint(
+          equalTo: self.currentGroupRow.trailingAnchor,
+          constant: -layout.trailingMargin
+        )
+      ]
+    )
+  }
+
+  private func setupGroupListTableViewLayout(with containerView: UIView) {
+    containerView.addSubview(self.editableGroupListTableView)
+    self.editableGroupListTableView.usingAutolayout()
+
+    NSLayoutConstraint.activate(
+      [
+        self.editableGroupListTableView.topAnchor.constraint(equalTo: containerView.topAnchor),
+        self.editableGroupListTableView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+        self.editableGroupListTableView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+        self.editableGroupListTableView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
       ]
     )
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -41,6 +41,11 @@ public final class GroupSelectionView: UIView {
     self.setup()
   }
 
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
   public func updateGroup(current: EditableGroupItem, editableList: [EditableGroupItem]) {
     self.editableGroupListTableViewDelegate.updateGroup(
       currentItem: current,
@@ -48,9 +53,8 @@ public final class GroupSelectionView: UIView {
     )
   }
 
-  @available(*, unavailable)
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
+  public func getCurrentGroup() -> EditableGroupItem? {
+    return self.editableGroupListTableViewDelegate.currentGroupItem
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -39,8 +39,31 @@ public final class GroupSelectionView: UIView {
 
 extension GroupSelectionView {
   private func setup() {
+    self.setupShowGroupMenuButton()
     self.addSubviews()
     self.setupSubviewsLayout()
+  }
+
+  private func setupShowGroupMenuButton() {
+    self.showGroupListButton.setImage(UIImage.forwardButtonImage, for: UIControl.State.normal)
+    self.showGroupListButton.changesSelectionAsPrimaryAction = true
+    self.showGroupListButton.addAction(self.makeShowEditableGroupButtonAction(), for: UIControl.Event.touchUpInside)
+  }
+
+  private func makeShowEditableGroupButtonAction() -> UIAction {
+    return UIAction { [weak self] _ in
+      guard let self else { return }
+
+      let isSelected = self.showGroupListButton.isSelected
+      self.animateRotatingButton(isSelected: isSelected)
+    }
+  }
+
+  private func animateRotatingButton(isSelected: Bool) {
+    let transform = isSelected ? CGAffineTransform(rotationAngle: CGFloat.pi / 2) : CGAffineTransform.identity
+    UIView.animate(withDuration: Constant.GroupSelectionView.Animation.duration) {
+      self.showGroupListButton.transform = transform
+    }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -14,6 +14,8 @@ public final class GroupSelectionView: UIView {
   private let showGroupListButton: UIButton
   private let currentGroupRow: Styled.Row
   private let editableGroupListTableView: UITableView
+  private var tableViewHeightConstraint: NSLayoutConstraint
+  private var heightConstraint: NSLayoutConstraint
 
   public init(model: GroupSelectionView.Model) {
     self.model = model
@@ -27,6 +29,8 @@ public final class GroupSelectionView: UIView {
       )
     )
     self.editableGroupListTableView = UITableView()
+    self.tableViewHeightConstraint = NSLayoutConstraint()
+    self.heightConstraint = NSLayoutConstraint()
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -59,6 +63,7 @@ extension GroupSelectionView {
 
       let isSelected = self.showGroupListButton.isSelected
       self.animateRotatingButton(isSelected: isSelected)
+      self.animateShowingEditableGroupMenu(isSelected: isSelected)
     }
   }
 
@@ -66,6 +71,16 @@ extension GroupSelectionView {
     let transform = isSelected ? CGAffineTransform(rotationAngle: CGFloat.pi / 2) : CGAffineTransform.identity
     UIView.animate(withDuration: Constant.GroupSelectionView.Animation.duration) {
       self.showGroupListButton.transform = transform
+    }
+  }
+
+  private func animateShowingEditableGroupMenu(isSelected: Bool) {
+    let height = self.model.cellHeight * CGFloat(self.model.visibleCellCount)
+    let heightConstant: CGFloat = isSelected ? height : 0
+    UIView.animate(withDuration: Constant.GroupSelectionView.Animation.duration) {
+      self.heightConstraint.constant = heightConstant + self.model.cellHeight
+      self.tableViewHeightConstraint.constant = heightConstant
+      self.superview?.layoutIfNeeded()
     }
   }
 
@@ -101,6 +116,7 @@ extension GroupSelectionView {
     let containerView = self.makeGroupListContainerView()
     self.setupContainerViewLayout(containerView: containerView)
     self.setupGroupListTableViewLayout(with: containerView)
+    self.setupHeightLayout()
   }
 
   private func setupCurrentGroupRowLayout() {
@@ -137,8 +153,11 @@ extension GroupSelectionView {
 
   private func setupContainerViewLayout(containerView: UIView) {
     self.addSubview(containerView)
-
     containerView.usingAutolayout()
+    self.tableViewHeightConstraint = containerView.heightAnchor.constraint(equalToConstant: 0)
+    self.tableViewHeightConstraint.priority = UILayoutPriority.defaultLow
+    self.tableViewHeightConstraint.isActive = true
+
     let layout = Constant.GroupSelectionView.Layout.TableViewContainer.self
     NSLayoutConstraint.activate(
       [
@@ -170,6 +189,12 @@ extension GroupSelectionView {
         self.editableGroupListTableView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
       ]
     )
+  }
+
+  private func setupHeightLayout() {
+    self.heightConstraint = self.heightAnchor.constraint(equalToConstant: 0)
+    self.heightConstraint.priority = UILayoutPriority.defaultLow
+    self.heightConstraint.isActive = true
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #322 

## 🎉 변경 사항
- 투두 수정화면에서 그룹을 수정할 때 사용되는 GroupSelectionView를 추가하였습니다.

## 📌 PR Point
- 높이 변경 애니메이션을 구현하고자 비교적 프로퍼티를 많이 가지고 있습니다
- `getCurrentGroup` 함수는 사용자가 최종적으로 선택한 그룹의 데이터를 가져오기 위함입니다.

### 그룹 중복 방지
- 선택 가능한 그룹을 보여줄 때, 이미 속한 그룹은 보여지지 않습니다.
- 새로운 그룹을 선택하더라도, `모든 그룹의 순서는 유지`되도록 구현하였습니다.
- ex) 1 번 그룹을 선택 -> 5번 그룹을 선택 -> 1 번 그룹은 다시 최상단에 위치

### 컴포넌트 사용법
``` Swift
let groupSelectionView = GroupSelectionView(model: GroupSelectionView.Model.primary)

// Model을 이용해 보여질 셀 개수와 높이를 커스텀 가능
let groupSelectionView = GroupSelectionView(
    model: GroupSelectionView.Model(cellHeight: 50, visibleCellCount: 6)
)

// 그룹 데이터 업데이트
groupSelectionView.updateGroup(
    // 투두가 현재 속한 그룹
    current: EditableGroupItem(groupId: 0, groupName: "CS 지식", groupColor: UIColor.brown),
    editableList: [
      // 선택 가능한 그룹 목록
    ]
  )
``` 

### 동작 GIF
<img width="300" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/84387335/817ff234-bfd8-459e-8562-76fb6a8eccf3">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?