### PR TITLE
PostGroupColorPickerRow 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/PostGroupColorPickerRowAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/PostGroupColorPickerRowAPI.swift
@@ -1,0 +1,13 @@
+//
+//  PostGroupColorPickerRowAPI.swift
+//  
+//
+//  Created by SONG on 7/11/24.
+//
+
+import UIKit.UIColor
+
+public protocol PostGroupColorPickerRowAPI {
+  func getColor() -> UIColor?
+  func updateColor(with color: UIColor)
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PostGroupColorPickerRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PostGroupColorPickerRow.swift
@@ -1,0 +1,110 @@
+//
+//  File.swift
+//
+//
+//  Created by SONG on 7/11/24.
+//
+
+import UIKit
+
+import ToDoGardenUIAPI
+
+final class PostGroupColorPickerRow: UIView, PostGroupColorPickerRowAPI {
+  private var listPrimaryRow: Styled.Row
+  
+  init(color: UIColor) {
+    self.listPrimaryRow = Styled.Row(
+      configuration: Styled.Row.Configuration.listPrimary(
+        Styled.Row.Configuration.ListPrimaryModel(
+          title: "",
+          color: color
+        )
+      )
+    )
+    super.init(frame: CGRect.zero)
+    self.build()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  func getColor() -> UIColor? {
+    return self.listPrimaryRow.groupListModel?.color
+  }
+  
+  func updateColor(with color: UIColor) {
+    self.listPrimaryRow.configuration = Styled.Row.Configuration.listPrimary(
+      Styled.Row.Configuration.ListPrimaryModel(
+        title: "", color: color
+      )
+    )
+  }
+  
+  private func build() {
+    self.buildRow()
+    self.buildTitleLabel()
+  }
+  
+  private func buildRow() {
+    self.addSubview(self.listPrimaryRow)
+    self.listPrimaryRow.usingAutolayout()
+    
+    NSLayoutConstraint.activate(
+      [
+        self.listPrimaryRow.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+        self.listPrimaryRow.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.listPrimaryRow.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+      ]
+    )
+  }
+  
+  private func buildTitleLabel() {
+    let label = UILabel()
+    let text = "컬러"
+    label.attributedText = text.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardHeadSemiBold,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    )
+    label.backgroundColor = UIColor.white
+    self.listPrimaryRow.addSubview(label)
+    label.usingAutolayout()
+    
+    NSLayoutConstraint.activate(
+      [
+        label.centerYAnchor.constraint(equalTo: self.listPrimaryRow.centerYAnchor),
+        label.leadingAnchor.constraint(equalTo: self.listPrimaryRow.leadingAnchor, constant: 15)
+      ]
+    )
+  }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+  let view = PostGroupColorPickerRow(color: .toDoGardenGrassHigh)
+  
+  view.usingAutolayout()
+  NSLayoutConstraint.activate(
+    [
+      view.widthAnchor.constraint(equalToConstant: 300),
+      view.heightAnchor.constraint(equalToConstant: 50)
+    ]
+  )
+  
+  let button = UIButton()
+  button.setImage(UIImage.forwardButtonImage, for: .normal)
+  view.addSubview(button)
+  button.usingAutolayout()
+  
+  NSLayoutConstraint.activate(
+    [
+      button.centerXAnchor.constraint(equalTo: view.trailingAnchor),
+      button.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+    ]
+  )
+  
+  return view
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PostGroupColorPickerRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PostGroupColorPickerRow.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  PostGroupColorPickerRow.swift
 //
 //
 //  Created by SONG on 7/11/24.
@@ -8,6 +8,7 @@
 import UIKit
 
 import ToDoGardenUIAPI
+import ToDoGardenUIConstant
 
 final class PostGroupColorPickerRow: UIView, PostGroupColorPickerRowAPI {
   private var listPrimaryRow: Styled.Row
@@ -62,7 +63,7 @@ final class PostGroupColorPickerRow: UIView, PostGroupColorPickerRowAPI {
   
   private func buildTitleLabel() {
     let label = UILabel()
-    let text = "컬러"
+    let text = Constant.PostGroupColorPickerRow.StringLiteral.title
     label.attributedText = text.applyTextAttributes(
       attributes: [
         NSAttributedString.Key.font: UIFont.pretendardHeadSemiBold,
@@ -76,7 +77,10 @@ final class PostGroupColorPickerRow: UIView, PostGroupColorPickerRowAPI {
     NSLayoutConstraint.activate(
       [
         label.centerYAnchor.constraint(equalTo: self.listPrimaryRow.centerYAnchor),
-        label.leadingAnchor.constraint(equalTo: self.listPrimaryRow.leadingAnchor, constant: 15)
+        label.leadingAnchor.constraint(
+          equalTo: self.listPrimaryRow.leadingAnchor,
+          constant: Constant.PostGroupColorPickerRow.Layout.TitleLabel.leading
+        )
       ]
     )
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PostGroupColorPickerRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PostGroupColorPickerRow.swift
@@ -13,12 +13,12 @@ import ToDoGardenUIConstant
 final class PostGroupColorPickerRow: UIView, PostGroupColorPickerRowAPI {
   private var listPrimaryRow: Styled.Row
   
-  init(color: UIColor) {
+  init() {
     self.listPrimaryRow = Styled.Row(
       configuration: Styled.Row.Configuration.listPrimary(
         Styled.Row.Configuration.ListPrimaryModel(
           title: "",
-          color: color
+          color: UIColor.toDoGardenGray
         )
       )
     )
@@ -88,7 +88,7 @@ final class PostGroupColorPickerRow: UIView, PostGroupColorPickerRowAPI {
 
 @available(iOS 17.0, *)
 #Preview {
-  let view = PostGroupColorPickerRow(color: .toDoGardenGrassHigh)
+  let view = PostGroupColorPickerRow()
   
   view.usingAutolayout()
   NSLayoutConstraint.activate(

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PostGroupColorPickerRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PostGroupColorPickerRow.swift
@@ -10,10 +10,10 @@ import UIKit
 import ToDoGardenUIAPI
 import ToDoGardenUIConstant
 
-final class PostGroupColorPickerRow: UIView, PostGroupColorPickerRowAPI {
+final public class PostGroupColorPickerRow: UIView, PostGroupColorPickerRowAPI {
   private var listPrimaryRow: Styled.Row
   
-  init() {
+  public init() {
     self.listPrimaryRow = Styled.Row(
       configuration: Styled.Row.Configuration.listPrimary(
         Styled.Row.Configuration.ListPrimaryModel(
@@ -31,11 +31,11 @@ final class PostGroupColorPickerRow: UIView, PostGroupColorPickerRowAPI {
     fatalError("init(coder:) has not been implemented")
   }
   
-  func getColor() -> UIColor? {
+  public func getColor() -> UIColor? {
     return self.listPrimaryRow.groupListModel?.color
   }
   
-  func updateColor(with color: UIColor) {
+  public func updateColor(with color: UIColor) {
     self.listPrimaryRow.configuration = Styled.Row.Configuration.listPrimary(
       Styled.Row.Configuration.ListPrimaryModel(
         title: "", color: color

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+PostGroupColorPickerRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+PostGroupColorPickerRow.swift
@@ -1,12 +1,23 @@
 //
-//  File.swift
-//  
+//  Constant+PostGroupColorPickerRow.swift
+//
 //
 //  Created by SONG on 7/11/24.
 //
 
 import Foundation
 
-extension Constant {
-  
+extension Constant.PostGroupColorPickerRow {
+  public enum Layout { }
+  public enum StringLiteral { }
+}
+
+extension Constant.PostGroupColorPickerRow.Layout {
+  public enum TitleLabel {
+    public static let leading: CGFloat = 15.0
+  }
+}
+
+extension Constant.PostGroupColorPickerRow.StringLiteral {
+  public static let title = "컬러"
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+PostGroupColorPickerRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+PostGroupColorPickerRow.swift
@@ -1,0 +1,12 @@
+//
+//  File.swift
+//  
+//
+//  Created by SONG on 7/11/24.
+//
+
+import Foundation
+
+extension Constant {
+  
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -35,4 +35,5 @@ public enum Constant {
   public enum PomodoroRecordCollectionView { }
   public enum GardenView { }
   public enum GroupSelectionView { }
+  public enum PostGroupColorPickerRow { }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #335 
## 🎉 변경 사항
- PostGroupColorPickerRow를 추가합니다.
- PostGroupColorPickerRow Constant를 추가합니다
- PostGroupColorPickerRowAPI를 추가합니다. 

-> 변경된 파일 (4)
`PostGroupColorPickerRow`
`Constant+PostGroupColorPickerRow` 
`Constant`
`PostGroupColorPickerRowAPI` 

## 📌 PR Point
-> 빠른 작업을 위해 한번에 PR합니다. 
-> Styled.Row를 활용하여 PostGroupColorPickerRow를 만들었습니다. 

기존의 Styled.Row의 내부 구현의 변경없이 PostGroupColorPickerRow형태로 확장하고, 인터페이스화 하기보다는 새 컴포넌트를 만들어 작업하였습니다. 

<img width="316" alt="스크린샷 2024-07-11 오후 3 39 23" src="https://github.com/ToDo-Garden/ToDo-Garden/assets/88966578/d4de30d1-b548-4c06-b4fb-d5e0cc17e7ef">

- 우측 버튼은 해당 컴포넌트에 포함되지 않습니다. route와 같은 후속동작의 편의성을 위해 뷰컨트롤러단에서 추가하는 방향으로 갈 예정입니다. 
- 인터페이스를 통해 현재 선택된 컬러를 얻을 수 있습니다. 
- 인터페이스를 통해 컬러를 변경할 수 있습니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?