### PR TITLE
TimerProgressView 추가 기능 구현

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CircularProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CircularProgressView.swift
@@ -45,6 +45,10 @@ public final class CircularProgressView: UIView {
   func setupProgressLayerStrokeColor(with color: UIColor) {
     self.progressLayer.strokeColor = color.cgColor
   }
+  
+  func setupProgressBackgroundLayerStrokeColor(with color: UIColor) {
+    self.progressBackgroundLayer.strokeColor = color.cgColor
+  }
 }
 
 // MARK: - Setup animation

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CircularProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CircularProgressView.swift
@@ -49,6 +49,11 @@ public final class CircularProgressView: UIView {
   func setupProgressBackgroundLayerStrokeColor(with color: UIColor) {
     self.progressBackgroundLayer.strokeColor = color.cgColor
   }
+  
+  func resetProgress() {
+    self.progressLayer.strokeEnd = 0
+    self.isAnimating = false
+  }
 }
 
 // MARK: - Setup animation

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -120,7 +120,6 @@ extension TimerProgressView {
     let circularPath = self.makeCircularPath(toValue: toValue)
     let animationKeyPath = Constant.TimerProgressView.StringLiteral.Dot.Animation.keyPath
     let animation = CAKeyframeAnimation(keyPath: animationKeyPath)
-    animation.delegate = self
     animation.path = circularPath.cgPath
     animation.duration = duration
     animation.calculationMode = CAAnimationCalculationMode.paced
@@ -148,25 +147,7 @@ extension TimerProgressView {
   }
 }
 
-// MARK: - Conforming to a protocol
 
-extension TimerProgressView: CAAnimationDelegate {
-  public func animationDidStop(_ anim: CAAnimation, finished flag: Bool) {
-    guard let toValue
-    else { return }
-    
-    let startAngle = -(Double.pi / 2)
-    let dotWidth = Constant.TimerProgressView.Layout.Dot.width
-    let dotHeight = Constant.TimerProgressView.Layout.Dot.height
-    let dotRadius = dotWidth / 2
-    let endAngle = (2 * Double.pi) * toValue + startAngle
-    let adjustedAngle = atan2(sin(endAngle), cos(endAngle))
-    let endOfXPosition: CGFloat = self.bounds.midX + (self.bounds.width / 2.0 * cos(adjustedAngle)) - dotRadius
-    let endOfYPosition: CGFloat = self.bounds.midY + (self.bounds.width / 2.0 * sin(adjustedAngle)) - dotRadius
-    self.dot.frame = CGRect(
-      origin: CGPoint(x: endOfXPosition, y: endOfYPosition),
-      size: CGSize(width: dotWidth, height: dotHeight)
-    )
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -56,6 +56,14 @@ public final class TimerProgressView: UIView {
     let background: UIColor
     let dot: UIColor
   }
+  
+  /// TimerProgressView 컴포넌트들의 색상을 설정합니다.
+  /// - Parameter colors: progressLayer, backgroundLayer, dot의 색상을 포함하는 `TimerProgressViewColors` 인스턴스입니다.
+  public func setColors(to colors: TimerProgressViewColors) {
+    self.circularProgressView.setupProgressLayerStrokeColor(with: colors.progress)
+    self.circularProgressView.setupProgressBackgroundLayerStrokeColor(with: colors.background)
+    self.dot.backgroundColor = colors.dot
+  }
 }
 
 // MARK: - Setup views

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -83,6 +83,11 @@ extension TimerProgressView {
     self.dot.layer.cornerRadius = self.dot.frame.width / 2
     self.dot.backgroundColor = dotColor
   }
+  
+  private func resetDot() {
+    self.dot.isHidden = true
+    self.dot.layer.removeAllAnimations()
+  }
 }
 
 // MARK: - Add subviews

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -173,7 +173,7 @@ extension TimerProgressView {
   
   /// 세마포어를 사용하여 작업을 동기화하여 실행하는 헬퍼 메소드입니다.
   /// - Parameter task: 메인 스레드에서 실행할 작업 블록입니다.
-  private func performTaskWithSemaphore(_ task: @escaping () -> Void) {
+  private func performTaskWithSemaphore(_ task: @MainActor @Sendable @escaping () -> Void) {
     DispatchQueue.global().async {
       self.semaphore.wait()
       DispatchQueue.main.async {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -45,10 +45,13 @@ public final class TimerProgressView: UIView {
   /// - Parameters:
   ///   - duration: `TimerInterval` 동안 실행될지 결정하는 파라미터입니다.
   ///   - toValue: TimerProgressView`의 애니메이션이 종료되는 지점을 나타내는 값입니다.
+  /// 해당 메소드는 세마포어를 사용하여 작업이 동시에 실행되는 것을 방지합니다.
   public func startAnimation(duration: TimeInterval, to toValue: Double) {
-    self.toValue = toValue
-    self.addAnimation(duration: duration, to: toValue)
-    self.circularProgressView.startAnimation(duration: duration, from: Float.zero, to: Float(toValue))
+    self.performTaskWithSemaphore {
+      self.toValue = toValue
+      self.addAnimation(duration: duration, to: toValue)
+      self.circularProgressView.startAnimation(duration: duration, from: Float.zero, to: Float(toValue))
+    }
   }
   
   /// TimerProgressView에 사용되는 색상들을 캡슐화한 구조체입니다.

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -65,6 +65,16 @@ public final class TimerProgressView: UIView {
     self.circularProgressView.setupProgressBackgroundLayerStrokeColor(with: colors.background)
     self.dot.backgroundColor = colors.dot
   }
+  
+  /// CircularProgressView의 진행 상태를 초기화하고 점(dot)을 숨깁니다.
+  /// 해당 메소드는 세마포어를 사용하여 작업이 동시에 실행되는 것을 방지합니다.
+  public func resetProgress() {
+    self.performTaskWithSemaphore {
+      self.circularProgressView.resetProgress()
+      self.resetDot()
+      self.toValue = nil
+    }
+  }
 }
 
 // MARK: - Setup views

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -124,6 +124,7 @@ extension TimerProgressView {
     animation.duration = duration
     animation.calculationMode = CAAnimationCalculationMode.paced
     animation.isRemovedOnCompletion = false
+    animation.fillMode = CAMediaTimingFillMode.forwards
     self.dot.isHidden = false
     self.dot.layer.add(animation, forKey: nil)
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -10,6 +10,7 @@ import UIKit
 import ToDoGardenUIConstant
 
 public final class TimerProgressView: UIView {
+  private let semaphore = DispatchSemaphore(value: 1)
   public var isAnimating: Bool {
     self.circularProgressView.isAnimating
   }
@@ -153,7 +154,20 @@ extension TimerProgressView {
   }
 }
 
+// MARK: - Using semaphore
 
+extension TimerProgressView {
+  
+  /// 세마포어를 사용하여 작업을 동기화하여 실행하는 헬퍼 메소드입니다.
+  /// - Parameter task: 메인 스레드에서 실행할 작업 블록입니다.
+  private func performTaskWithSemaphore(_ task: @escaping () -> Void) {
+    DispatchQueue.global().async {
+      self.semaphore.wait()
+      DispatchQueue.main.async {
+        task()
+        self.semaphore.signal()
+      }
+    }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -49,6 +49,13 @@ public final class TimerProgressView: UIView {
     self.addAnimation(duration: duration, to: toValue)
     self.circularProgressView.startAnimation(duration: duration, from: Float.zero, to: Float(toValue))
   }
+  
+  /// TimerProgressView에 사용되는 색상들을 캡슐화한 구조체입니다.
+  public struct TimerProgressViewColors {
+    let progress: UIColor
+    let background: UIColor
+    let dot: UIColor
+  }
 }
 
 // MARK: - Setup views

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TimerProgressView.swift
@@ -55,7 +55,7 @@ public final class TimerProgressView: UIView {
   }
   
   /// TimerProgressView에 사용되는 색상들을 캡슐화한 구조체입니다.
-  public struct TimerProgressViewColors {
+  public struct TimerProgressViewColors: Sendable {
     let progress: UIColor
     let background: UIColor
     let dot: UIColor


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #343 

## 🎉 변경 사항
- @GangWoon 께서 요구해주신 TimerProgressView의 추가 기능을 구현하였습니다.
- [x] 색상 변경 기능 추가
- [x] 애니메이션 도중 초기화 기능 추가 
## 📌 PR Point
아래의 Gif와 같이 애니메이션 도중 초기화하는 기능을 구현하였습니다.
|iPhone SE|
|---|
|<img src="https://github.com/user-attachments/assets/40a30027-a73f-4446-a3f9-8f66a0d7e83c" width="200" />| 

### 아래와 같은 예외사항을 고려하였습니다.

|예외 동작|기대 동작|
|:---:|:---:|
|<img src="https://github.com/user-attachments/assets/a1cb5157-13e6-46dc-8388-f6777db1f20e" width="200" />|<img src="https://github.com/user-attachments/assets/6a9077aa-d7a9-4eaa-91d6-7047d75690a4" width="200" />|

```swift
DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
  timerProgressView.resetProgress()
}

DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
  timerProgressView.startAnimation(duration: 3.0, to: 1.0)
}
```

코드와 같이 동시에 초기화와 애니메이션 시작 메소드를 실행하게 되는 경우, `TimerProgressView` 초기화가 완료되지 않은 채 새로운 애니메이션이 시작하게 되어 

Gif와 같이(예외 동작) 예기치 않은 동작을 하게됩니다.

이를 방지하기 위해 세마포어를 이용해 애니메이션 초기화, 실행 메소드의 작업순서를 동기화하는 메소드를 추가하였습니다.

```swift
private func performTaskWithSemaphore(_ task: @escaping () -> Void) {
    DispatchQueue.global().async {
      self.semaphore.wait()
      DispatchQueue.main.async {
        task()
        self.semaphore.signal()
      }
    }
  }
```

Swift Concurrency를 이용해 동기화 메소드를 구성할 수도 있었지만, @GangWoon 께서 작업하고 계신 `TimerScene`의  기존 코드베이스에 영향을 주지않게 하고자 위와 같이 세마포어를 이용해 구현하였습니다.


TimerScene과 TimerProgerssView의 여러 작업간의 동기화를 위해선 Swift Concurrency로 구현하는 것도 좋을 것 같습니다.
- TimerScene 개발 방향에 맞도록 변경 가능하니, 편하게 말씀주시면 감사하겠습니다 :)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?