### PR TITLE
ColorPickerList 인터페이스 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/ColorPickerListAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/ColorPickerListAPI.swift
@@ -11,5 +11,4 @@ import UIKit.UIColor
 public protocol ColorPickerListAPI {
   var colors: [UIColor] { get }
   var selected: CurrentValueSubject<Int?, Never> { get }
-  init(colors: [UIColor], itemsPerRow: Int, selected: CurrentValueSubject<Int?, Never>)
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/ColorPickerListAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/ColorPickerListAPI.swift
@@ -8,7 +8,7 @@
 import Combine
 import UIKit.UIColor
 
-public protocol ColorPickerListAPI {
+public protocol ColorPickerListAPI: UIView {
   var colors: [UIColor] { get }
   var selected: CurrentValueSubject<Int?, Never> { get }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/ColorPickerListAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/ColorPickerListAPI.swift
@@ -1,0 +1,15 @@
+//
+//  ColorPickerListAPI.swift
+//
+//
+//  Created by SONG on 7/15/24.
+//
+
+import Combine
+import UIKit.UIColor
+
+public protocol ColorPickerListAPI {
+  var colors: [UIColor] { get }
+  var selected: CurrentValueSubject<Int?, Never> { get }
+  init(colors: [UIColor], itemsPerRow: Int, selected: CurrentValueSubject<Int?, Never>)
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ColorPickerList.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ColorPickerList.swift
@@ -2,11 +2,12 @@ import Combine
 import UIKit
 
 import CombineExtension
+import ToDoGardenUIAPI
 import ToDoGardenUIConstant
 
-public final class ColorPickerList: UIStackView {
-  let colors: [UIColor]
+public final class ColorPickerList: UIStackView, ColorPickerListAPI {
   let itemsPerRow: Int
+  public let colors: [UIColor]
   public var selected: CurrentValueSubject<Int?, Never>
   private var cancellables: Set<AnyCancellable> = []
   


### PR DESCRIPTION
## 💡 관련 이슈
- closed : #348 
## 🎉 변경 사항
- ColorPickerListAPI를 추가합니다
## 📌 PR Point
- ColorPickerListAPI를 거쳐서 컴포넌트를 사용하고자 합니다. 
```swift
let index = colorPickerListAPI.selected.value
let selectedColor = colorPickerListAPI.colors[index] 
```
처럼 사용하기 위해 

colorPickerList 의 colors 속성을 public으로 변경하고 싶습니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?