### PR TITLE
#352: Refactor TimerSceneWork to make it testable

### DIFF
--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneInteractor.swift
@@ -69,6 +69,7 @@ extension TimerSceneInteractor: TimerSceneBusinessLogic {
         let range = TimerScene.CircularProgressRange(1 - (time / seconds))
         self.presenter?.updateTimeState(time, range: range)
       }
+      try Task.checkCancellation()
       self.presenter?.clearPresentState()
       self.updateAndPresentAlertStatus(self.bottomSheetStatus.completionAlertStatus)
     }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneSceneBuilder.swift
@@ -6,9 +6,9 @@ import TimerSceneAPI
 public struct TimerSceneSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
-    let worker: TimerSceneWorker
+    let worker: any TimerSceneWorkable
     
-    public init(worker: TimerSceneWorker) {
+    public init(worker: any TimerSceneWorkable) {
       self.worker = worker
     }
   }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorkable.swift
@@ -2,5 +2,5 @@ import Foundation
 
 @MainActor
 public protocol TimerSceneWorkable: Sendable {
-  var countDownSequence: @Sendable (Double) -> CountDownSequence { get set }
+  var countDownSequence: @Sendable (Double) -> AsyncThrowingStream<Double, any Error> { get set }
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorker.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 public struct TimerSceneWorker: TimerSceneWorkable, Sendable {
-  public var countDownSequence: @Sendable (Double) -> CountDownSequence
+  public var countDownSequence: @Sendable (Double) -> AsyncThrowingStream<Double, any Error>
   
   public init(
-    countDownSequence: @Sendable @escaping (Double) -> CountDownSequence
+    countDownSequence: @Sendable @escaping (Double) -> AsyncThrowingStream<Double, any Error>
   ) {
     self.countDownSequence = countDownSequence
   }
@@ -12,7 +12,23 @@ public struct TimerSceneWorker: TimerSceneWorkable, Sendable {
 
 extension TimerSceneWorker {
   static let live = Self { seconds in
-    return CountDownSequence(endTime: seconds)
+    AsyncThrowingStream { continuation in
+      let task = Task {
+        do {
+          for try await second in CountDownSequence(endTime: seconds) {
+            continuation.yield(second)
+            if second == 0 {
+              continuation.finish()
+            }
+          }
+        } catch {
+          try Task.checkCancellation()
+        }
+      }
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
#352 

## 🎉 변경 사항
타입이 CountDownSequence 경우에, 프로토콜로 상속을 통한 추상화가 필요했습니다.
`protocol CountDownSequenceProtocol: AsyncSequence`
하지만 AsyncStream으로 바꿨을 경우 모킹하는 과정이 훨씬 간단해지는 장점을 얻을 수 있습니다.

추가적으로 작업 라이프 사이클을 체크하는 코드를 추가했습니다.

## 📌 PR Point

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?