### PR TITLE
DynamicUIProperty 유틸리티 타입 추가

### DIFF
--- a/ToDo-Garden/TDUtility/Sources/TDUtility/DynamicProperty.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/DynamicProperty.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-/// DynamicProperty는 값의 변화를 관리하기 위해 사용하는 프로퍼티 래퍼입니다.
-/// 이 클래스는 값의 변화를 관찰하고 이에 반응해야 하는 상황에서 사용됩니다.
+/// DynamicUIProperty는 UI와 관련된 값의 변화를 관리하기 위해 사용하는 프로퍼티 래퍼입니다.
+/// 이 클래스는 UI 값의 변화를 관찰하고 이에 반응해야 하는 상황에서 사용됩니다.
 ///
 /// # 속성
 ///
@@ -18,19 +18,18 @@ import Foundation
 /// # 사용 예시
 ///
 /// ```swift
-/// @DynamicProperty var myProperty: String = "초기값"
+/// @DynamicUIProperty var textColor: UIColor = UIColor.red
 ///
-/// $myProperty { newValue in
-///     print("값이 \(newValue)로 변경되었습니다.")
+/// $textColor { newColor in
+///   label.textColor = newColor
 /// }
 ///
-/// myProperty = "Hello, World!"
+/// textColor = UIColor.green
 /// ```
 ///
 /// # 참고 사항
 ///
 /// - 만약 changeHandler가 여러 개여야 한다면, 이를 관리할 자료 구조를 추가하거나, 관리 비용이 커질 경우 Combine 등의 다른 프레임워크를 사용하는 것을 고려하려합니다.
-/// - 이 클래스가 동시성 환경에서 사용될 경우, projectedValue 프로퍼티에 @Sendable 속성을 명시해야합니다.
 ///   - 해당 내용은 TODO 주석에 기재하였습니다.
 @MainActor
 @propertyWrapper
@@ -47,7 +46,6 @@ public final class DynamicUIProperty<Value> {
     }
   }
   
-  // TODO: 동시성 환경에서 사용될 경우 @Sendable attribute 명시
   public var projectedValue: (@MainActor @Sendable @escaping (Value) -> Void) -> Void {
     return { [weak self] newHandler in
       guard let self else { return }

--- a/ToDo-Garden/TDUtility/Sources/TDUtility/DynamicProperty.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/DynamicProperty.swift
@@ -1,0 +1,37 @@
+//
+//  DynamicProperty.swift
+//  TDUtility
+//
+//  Created by Noah on 7/15/24.
+//
+
+import Foundation
+
+@propertyWrapper
+public final class DynamicProperty<Value> {
+  private var value: Value
+  // TODO: changeHandler가 여러개가 되어야 할 경우 관리 자료구조 추가 혹은 관리 비용이 커질 경우 Combine등 다른 프레임워크 고려
+  private var changeHandler: ((Value) -> Void)?
+  
+  public var wrappedValue: Value {
+    get { self.value }
+    set {
+      self.value = newValue
+      self.changeHandler?(newValue)
+    }
+  }
+  
+  // TODO: 동시성 환경에서 사용될 경우 @Sendable attribute 명시
+  public var projectedValue: (@escaping (Value) -> Void) -> Void {
+    return { [weak self] newHandler in
+      guard let self else { return }
+      
+      self.changeHandler = newHandler
+      newHandler(self.value)
+    }
+  }
+  
+  public init(wrappedValue: Value) {
+    self.value = wrappedValue
+  }
+}

--- a/ToDo-Garden/TDUtility/Sources/TDUtility/DynamicProperty.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/DynamicProperty.swift
@@ -33,7 +33,7 @@ import Foundation
 /// - 이 클래스가 동시성 환경에서 사용될 경우, projectedValue 프로퍼티에 @Sendable 속성을 명시해야합니다.
 ///   - 해당 내용은 TODO 주석에 기재하였습니다.
 @propertyWrapper
-public final class DynamicProperty<Value> {
+public final class DynamicUIProperty<Value> {
   private var value: Value
   // TODO: changeHandler가 여러개가 되어야 할 경우 관리 자료구조 추가 혹은 관리 비용이 커질 경우 Combine등 다른 프레임워크 고려
   private var changeHandler: ((Value) -> Void)?

--- a/ToDo-Garden/TDUtility/Sources/TDUtility/DynamicProperty.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/DynamicProperty.swift
@@ -7,6 +7,31 @@
 
 import Foundation
 
+/// DynamicProperty는 값의 변화를 관리하기 위해 사용하는 프로퍼티 래퍼입니다.
+/// 이 클래스는 값의 변화를 관찰하고 이에 반응해야 하는 상황에서 사용됩니다.
+///
+/// # 속성
+///
+/// - wrappedValue: 관리되는 값입니다. 이 값을 설정하면 chnageHandler가 호출됩니다.
+/// - projectedValue: changeHandler를 설정할 수 있는 클로저입니다. 이 핸들러는 wrappedValue가 업데이트될 때마다 호출되며, 핸들러가 설정될 때 즉시 현재 값으로 호출됩니다.
+///
+/// # 사용 예시
+///
+/// ```swift
+/// @DynamicProperty var myProperty: String = "초기값"
+///
+/// $myProperty { newValue in
+///     print("값이 \(newValue)로 변경되었습니다.")
+/// }
+///
+/// myProperty = "Hello, World!"
+/// ```
+///
+/// # 참고 사항
+///
+/// - 만약 changeHandler가 여러 개여야 한다면, 이를 관리할 자료 구조를 추가하거나, 관리 비용이 커질 경우 Combine 등의 다른 프레임워크를 사용하는 것을 고려하려합니다.
+/// - 이 클래스가 동시성 환경에서 사용될 경우, projectedValue 프로퍼티에 @Sendable 속성을 명시해야합니다.
+///   - 해당 내용은 TODO 주석에 기재하였습니다.
 @propertyWrapper
 public final class DynamicProperty<Value> {
   private var value: Value

--- a/ToDo-Garden/TDUtility/Sources/TDUtility/DynamicProperty.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/DynamicProperty.swift
@@ -32,6 +32,7 @@ import Foundation
 /// - 만약 changeHandler가 여러 개여야 한다면, 이를 관리할 자료 구조를 추가하거나, 관리 비용이 커질 경우 Combine 등의 다른 프레임워크를 사용하는 것을 고려하려합니다.
 /// - 이 클래스가 동시성 환경에서 사용될 경우, projectedValue 프로퍼티에 @Sendable 속성을 명시해야합니다.
 ///   - 해당 내용은 TODO 주석에 기재하였습니다.
+@MainActor
 @propertyWrapper
 public final class DynamicUIProperty<Value> {
   private var value: Value

--- a/ToDo-Garden/TDUtility/Sources/TDUtility/DynamicProperty.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/DynamicProperty.swift
@@ -37,7 +37,7 @@ import Foundation
 public final class DynamicUIProperty<Value> {
   private var value: Value
   // TODO: changeHandler가 여러개가 되어야 할 경우 관리 자료구조 추가 혹은 관리 비용이 커질 경우 Combine등 다른 프레임워크 고려
-  private var changeHandler: ((Value) -> Void)?
+  private var changeHandler: (@MainActor @Sendable (Value) -> Void)?
   
   public var wrappedValue: Value {
     get { self.value }
@@ -48,7 +48,7 @@ public final class DynamicUIProperty<Value> {
   }
   
   // TODO: 동시성 환경에서 사용될 경우 @Sendable attribute 명시
-  public var projectedValue: (@escaping (Value) -> Void) -> Void {
+  public var projectedValue: (@MainActor @Sendable @escaping (Value) -> Void) -> Void {
     return { [weak self] newHandler in
       guard let self else { return }
       

--- a/ToDo-Garden/TDUtility/Tests/TDUtilityTests/DynamicPropertyTests.swift
+++ b/ToDo-Garden/TDUtility/Tests/TDUtilityTests/DynamicPropertyTests.swift
@@ -18,4 +18,24 @@ struct DynamicPropertyTests {
     intValue = 2
     #expect(_intValue.wrappedValue == 2)
   }
+  
+  @Test("값 변경 테스트")
+  func valueChange() async {
+    // Given
+    let expectedValue = 2
+    let initialValue = 10
+    @DynamicProperty var intValue = initialValue
+    
+    await confirmation(expectedCount: 2) { confirmation in
+      _intValue.projectedValue { value in
+        // Then
+        if value == initialValue || value == expectedValue {
+          #expect(true)
+        }
+        confirmation()
+      }
+      // When
+      intValue = expectedValue
+    }
+  }
 }

--- a/ToDo-Garden/TDUtility/Tests/TDUtilityTests/DynamicPropertyTests.swift
+++ b/ToDo-Garden/TDUtility/Tests/TDUtilityTests/DynamicPropertyTests.swift
@@ -7,12 +7,14 @@
 
 @testable import TDUtility
 import Testing
+import Foundation
 
 @Suite("DynamicPropertyTests")
+@MainActor
 struct DynamicPropertyTests {
   @Test("초기화 테스트")
   private func initialization() {
-    @DynamicProperty var intValue = 1
+    @DynamicUIProperty var intValue = 1
     #expect(_intValue.wrappedValue == 1)
     
     intValue = 2
@@ -24,18 +26,15 @@ struct DynamicPropertyTests {
     // Given
     let expectedValue = 2
     let initialValue = 10
-    @DynamicProperty var intValue = initialValue
+    @DynamicUIProperty var intValue = initialValue
     
-    await confirmation(expectedCount: 2) { confirmation in
-      _intValue.projectedValue { value in
-        // Then
-        if value == initialValue || value == expectedValue {
-          #expect(true)
-        }
-        confirmation()
+    _intValue.projectedValue { value in
+      // Then
+      if value == initialValue || value == expectedValue {
+        #expect(true)
       }
-      // When
-      intValue = expectedValue
     }
+    // When
+    intValue = expectedValue
   }
 }

--- a/ToDo-Garden/TDUtility/Tests/TDUtilityTests/DynamicPropertyTests.swift
+++ b/ToDo-Garden/TDUtility/Tests/TDUtilityTests/DynamicPropertyTests.swift
@@ -7,7 +7,6 @@
 
 @testable import TDUtility
 import Testing
-import Foundation
 
 @Suite("DynamicPropertyTests")
 @MainActor

--- a/ToDo-Garden/TDUtility/Tests/TDUtilityTests/DynamicPropertyTests.swift
+++ b/ToDo-Garden/TDUtility/Tests/TDUtilityTests/DynamicPropertyTests.swift
@@ -1,0 +1,21 @@
+//
+//  DynamicPropertyTests.swift
+//  TDUtility
+//
+//  Created by Noah on 7/15/24.
+//
+
+@testable import TDUtility
+import Testing
+
+@Suite("DynamicPropertyTests")
+struct DynamicPropertyTests {
+  @Test("초기화 테스트")
+  private func initialization() {
+    @DynamicProperty var intValue = 1
+    #expect(_intValue.wrappedValue == 1)
+    
+    intValue = 2
+    #expect(_intValue.wrappedValue == 2)
+  }
+}


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #350 
## 🎉 변경 사항
@wood0203 의 [코드리뷰](https://github.com/ToDo-Garden/ToDo-Garden/pull/346#discussion_r1677265864)를 받던 중 런타임에 동적으로 변하는 UI의 값들을 관리하기 위한 일반화된 타입이 있으면 좋을 것 같아 이에 대한 작업을 진행하였습니다.

- [x] DynamicUIProperty 타입 추가
- [x] 테스트 코드 추가

## 📌 PR Point
 DynamicUIProperty는 UI와 관련된 값의 변화를 관리하기 위해 사용하는 프로퍼티 래퍼입니다.

현재 저희가 View 레이어에서 `label.textColor = UIColor.red` 와 같이 동적으로 변하는 UI와 관련된 값을 직접적으로 사용하지 않고, 중간에 Theme 레이어를 둠으로써 변경에 쉽게 대응하려 하고 있습니다.

따라서 변할 수 있는 UI의 업데이트에 반응하기 위해 해당 타입을 구현하였습니다.

Combine으로도 구현할 수 있지만, 아직 팀에서 Combine 사용에 대한 합의가 없었으며, 학습에 대한 비용이 있을 수도 있어 propertyWrapper를 이용해 구현하였습니다.

#### 사용 예시
 ```swift

/// Theme property
@DynamicUIProperty var textColor: UIColor = UIColor.red

theme.$textColor { newColor in
  label.textColor = newColor
}

textColor = UIColor.green
```

해당 UI와 관련된 속성과 업데이트를 다룰 것이므로 changeHandler 클로저가 메인스레드에서 실행되어야 합니다.
따라서 속성과 별개로 클로저가 실행되어야 하는 환경에 대한 특성을 명시하였습니다.

`public var projectedValue: (@MainActor @Sendable @escaping (Value) -> Void) -> Void`
`private var changeHandler: (@MainActor @Sendable (Value) -> Void)?`

현재는 단일 changeHandler를 사용하고 있지만,changeHandler가 여러 개여야 한다면, 이를 관리할 자료 구조를 추가하거나, 관리 비용이 커질 경우 Combine 등의 다른 프레임워크를 사용하는 것을 고려하려합니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?