### PR TITLE
EditToDoWorker 초 단위 시간 > Date 변환 메서드 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Package.swift
@@ -41,6 +41,12 @@ let package = Package(
         .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
         .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI")
       ]
+    ),
+    .testTarget(
+      name: "EditToDoSceneTests",
+      dependencies: [
+        "EditToDoScene"
+      ]
     )
   ]
 )

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -32,8 +32,6 @@ class EditToDoInteractor: EditToDoDataStore {
 
 extension EditToDoInteractor: EditToDoBusinessLogic {
   func doSomething(request: EditToDo.Something.Request) {
-    self.someWorker.doSomeWork()
-    
     let response = EditToDo.Something.Response()
     self.presenter?.presentSomething(response: response)
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoWorker.swift
@@ -9,7 +9,21 @@ import Foundation
 
 import EditToDoSceneAPI
 
-struct EditToDoWorker: EditToDoWorkable {
-  func doSomeWork() {
+public struct EditToDoWorker: EditToDoWorkable {
+  private var calendar: Calendar
+
+  public init(calendar: Calendar) {
+    self.calendar = calendar
+  }
+
+  public func makeDate(from seconds: Double) -> Date? {
+    guard 0 <= seconds && seconds < 86400
+    else { return nil }
+
+    let secondsToInt = Int(seconds)
+    let hour = secondsToInt / 3600
+    let minute = (secondsToInt % 3600) / 60
+    let dateComponents = DateComponents(hour: hour, minute: minute)
+    return self.calendar.date(from: dateComponents)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneAPI/EditToDoWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneAPI/EditToDoWorkable.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 public protocol EditToDoWorkable {
-  func doSomeWork()
+  func makeDate(from seconds: Double) -> Date?
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Tests/EditToDoSceneTests/EditToDoWorkerTests.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Tests/EditToDoSceneTests/EditToDoWorkerTests.swift
@@ -30,4 +30,13 @@ struct EditToDoWorkerTests {
     #expect(hour == expectedResultHour)
     #expect(minute == expectedResultMinute)
   }
+
+  @Test(
+    "make dates from invalid seconds return nil",
+    arguments: TestData.EditToDoWorkerTests.invalidSeconds
+  ) func test_make_dates_from_invalid_seconds_return_nil(second: Double) throws {
+    let date = self.editToDoWorker.makeDate(from: second)
+
+    #expect(date == nil)
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Tests/EditToDoSceneTests/EditToDoWorkerTests.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Tests/EditToDoSceneTests/EditToDoWorkerTests.swift
@@ -11,5 +11,23 @@ import Testing
 @testable import EditToDoScene
 
 struct EditToDoWorkerTests {
-  
+  private let editToDoWorker = EditToDoWorker(calendar: TestData.defaultCalendar)
+
+  @Test(
+    "make dates from valid seconds",
+    arguments: TestData.EditToDoWorkerTests.seconds
+  ) func test_make_dates_from_valid_seconds(
+    secondData: TestData.EditToDoWorkerTests.SecondData
+  ) throws {
+    let second = secondData.input
+    let expectedResultHour = secondData.hour
+    let expectedResultMinute = secondData.minute
+
+    let date = try #require(self.editToDoWorker.makeDate(from: second))
+    let hour = TestData.defaultCalendar.component(Calendar.Component.hour, from: date)
+    let minute = TestData.defaultCalendar.component(Calendar.Component.minute, from: date)
+
+    #expect(hour == expectedResultHour)
+    #expect(minute == expectedResultMinute)
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Tests/EditToDoSceneTests/EditToDoWorkerTests.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Tests/EditToDoSceneTests/EditToDoWorkerTests.swift
@@ -1,0 +1,15 @@
+//
+//  EditToDoWorkerTests.swift
+//
+//
+//  Created by Wood on 7/16/24.
+//
+
+import Foundation
+import Testing
+
+@testable import EditToDoScene
+
+struct EditToDoWorkerTests {
+  
+}

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Tests/EditToDoSceneTests/TestData.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Tests/EditToDoSceneTests/TestData.swift
@@ -1,0 +1,33 @@
+//
+//  TestData.swift
+//
+//
+//  Created by Wood on 7/16/24.
+//
+
+import Foundation
+
+struct TestData {
+  static let defaultCalendar = Calendar(identifier: Calendar.Identifier.gregorian)
+
+  struct EditToDoWorkerTests {
+    static let seconds = [
+      SecondData(input: 43800, hour: 12, minute: 10),
+      SecondData(input: 10140, hour: 2, minute: 49),
+      SecondData(input: 79200, hour: 22, minute: 0)
+    ]
+
+    static let invalidSeconds = [
+      Double(-1),
+      Double(85501)
+    ]
+  }
+}
+
+extension TestData.EditToDoWorkerTests {
+  struct SecondData {
+    let input: Double
+    let hour: Int
+    let minute: Int
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Tests/EditToDoSceneTests/TestData.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Tests/EditToDoSceneTests/TestData.swift
@@ -18,8 +18,10 @@ struct TestData {
     ]
 
     static let invalidSeconds = [
+      Double(-293),
       Double(-1),
-      Double(85501)
+      Double(86400),
+      Double(100000)
     ]
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #356 

## 🎉 변경 사항
- EditToDoWorker에 Second > Date로 변환하는 메서드를 추가하였습니다.
- EditToDoScene 테스트 타겟을 추가하였습니다.
- EditToDoWorker 테스트 코드를 추가하였습니다.

테스트 코드 및 타겟 등 추가로 인해 File Changed 수가 많습니다.
- 테스트 코드와 Worker를 중점적으로 봐주시면 감사하겠습니다! 

## 📌 PR Point
### Second > Date 변환 메서드의 필요성
- 알림 시간을 설정할 때 SettingTimeView 컴포넌트를 통해 Double 타입인 Second를 전달 받습니다.
- 이후 Worker에서 Second > Date로 변경하고, Presenter에서 DateFormatter로 String으로 변경합니다.
<img width="500" alt="스크린샷 2024-07-16 19 53 34" src="https://github.com/user-attachments/assets/60aa3226-06bd-4d26-af37-d8a6e41f864e">

### 테스트 코드
- Swift Testing을 이용하여 테스트 코드를 작성하였습니다.
- 00:00 ~ 23:59 범위의 초 단위 (Double) 데이터를 제대로 변환하는지 테스트 코드를 작성하였습니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?