### PR TITLE
GroupSelectionView API 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/GroupSelectionViewAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/GroupSelectionViewAPI.swift
@@ -12,3 +12,11 @@ public protocol GroupSelectionViewItemAPI: Hashable, Comparable {
   var groupName: String { get }
   var groupColor: UIColor { get }
 }
+
+public protocol GroupSelectionViewAPI: UIView {
+  func updateGroup(
+    current: any GroupSelectionViewItemAPI,
+    editableList: [any GroupSelectionViewItemAPI]
+  )
+  func getCurrentGroupId() -> Int?
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/GroupSelectionViewAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/GroupSelectionViewAPI.swift
@@ -1,0 +1,14 @@
+//
+//  GroupSelectionViewAPI.swift
+//
+//
+//  Created by Wood on 7/17/24.
+//
+
+import UIKit
+
+public protocol GroupSelectionViewItemAPI: Hashable, Comparable {
+  var groupId: Int { get }
+  var groupName: String { get }
+  var groupColor: UIColor { get }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import ToDoGardenUIAPI
 import ToDoGardenUIConstant
 
 final class EditableGroupTableViewDelegate: NSObject {
@@ -29,10 +30,14 @@ final class EditableGroupTableViewDelegate: NSObject {
     self.setupTableView(tableView)
   }
 
-  func updateGroup(currentItem: EditableGroupItem, editableItems: [EditableGroupItem]) {
-    self.currentGroupItem = currentItem
-    self.storeEditableGroupIndex(groupItems: editableItems)
-    self.reloadNewEditableGroups(groupItems: editableItems)
+  func updateGroup(
+    currentItem: any GroupSelectionViewItemAPI,
+    editableItems: [any GroupSelectionViewItemAPI]
+  ) {
+    self.updateCurrentGroup(item: currentItem)
+    let groupItems = self.makeEditableGroupItems(items: editableItems)
+    self.storeEditableGroupIndex(groupItems: groupItems)
+    self.reloadNewEditableGroups(groupItems: groupItems)
   }
 }
 
@@ -89,6 +94,27 @@ extension EditableGroupTableViewDelegate: UITableViewDelegate {
 // MARK: Private Functions
 
 extension EditableGroupTableViewDelegate {
+  private func updateCurrentGroup(item: any GroupSelectionViewItemAPI) {
+    let currentItem = EditableGroupItem(
+      groupId: item.groupId,
+      groupName: item.groupName,
+      groupColor: item.groupColor
+    )
+    self.currentGroupItem = currentItem
+  }
+
+  private func makeEditableGroupItems(
+    items: [any GroupSelectionViewItemAPI]
+  ) -> [EditableGroupItem] {
+    return items.map { (item: any GroupSelectionViewItemAPI) in
+      return EditableGroupItem(
+        groupId: item.groupId,
+        groupName: item.groupName,
+        groupColor: item.groupColor
+      )
+    }
+  }
+
   private func setupTableView(_ tableView: UITableView) {
     tableView.delegate = self
     self.tableViewDataSource = self.makeDiffableDataSource(tableView: tableView)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupSection+Item.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupSection+Item.swift
@@ -13,20 +13,26 @@ enum EditableGroupSection {
   case main
 }
 
-struct EditableGroupItem: GroupSelectionViewItemAPI {
-  let groupId: Int
-  let groupName: String
-  let groupColor: UIColor
+public struct EditableGroupItem: GroupSelectionViewItemAPI {
+  public let groupId: Int
+  public let groupName: String
+  public let groupColor: UIColor
+
+  public init(groupId: Int, groupName: String, groupColor: UIColor) {
+    self.groupId = groupId
+    self.groupName = groupName
+    self.groupColor = groupColor
+  }
 }
 
 extension EditableGroupItem: Hashable {
-  func hash(into hasher: inout Hasher) {
+  public func hash(into hasher: inout Hasher) {
     hasher.combine(self.groupId)
   }
 }
 
 extension EditableGroupItem: Comparable {
-  static func < (lhs: EditableGroupItem, rhs: EditableGroupItem) -> Bool {
+  public static func < (lhs: EditableGroupItem, rhs: EditableGroupItem) -> Bool {
     return lhs.groupId > rhs.groupId
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupSection+Item.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupSection+Item.swift
@@ -13,7 +13,7 @@ enum EditableGroupSection {
   case main
 }
 
-public struct EditableGroupItem: GroupSelectionViewItemAPI {
+public struct EditableGroupItem {
   public let groupId: Int
   public let groupName: String
   public let groupColor: UIColor

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupSection+Item.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupSection+Item.swift
@@ -7,34 +7,26 @@
 
 import UIKit.UIColor
 
+import ToDoGardenUIAPI
+
 enum EditableGroupSection {
   case main
 }
 
-public struct EditableGroupItem {
+struct EditableGroupItem: GroupSelectionViewItemAPI {
   let groupId: Int
   let groupName: String
   let groupColor: UIColor
-
-  public init(
-    groupId: Int,
-    groupName: String,
-    groupColor: UIColor
-  ) {
-    self.groupId = groupId
-    self.groupName = groupName
-    self.groupColor = groupColor
-  }
 }
 
 extension EditableGroupItem: Hashable {
-  public func hash(into hasher: inout Hasher) {
+  func hash(into hasher: inout Hasher) {
     hasher.combine(self.groupId)
   }
 }
 
 extension EditableGroupItem: Comparable {
-  public static func < (lhs: EditableGroupItem, rhs: EditableGroupItem) -> Bool {
+  static func < (lhs: EditableGroupItem, rhs: EditableGroupItem) -> Bool {
     return lhs.groupId > rhs.groupId
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -7,9 +7,10 @@
 
 import UIKit
 
+import ToDoGardenUIAPI
 import ToDoGardenUIConstant
 
-public final class GroupSelectionView: UIView {
+public final class GroupSelectionView: UIView, GroupSelectionViewAPI {
   private let model: GroupSelectionView.Model
   private let showGroupListButton: UIButton
   private let currentGroupRow: Styled.Row
@@ -46,7 +47,10 @@ public final class GroupSelectionView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
 
-  public func updateGroup(current: EditableGroupItem, editableList: [EditableGroupItem]) {
+  public func updateGroup(
+    current: any GroupSelectionViewItemAPI,
+    editableList: [any GroupSelectionViewItemAPI]
+  ) {
     self.editableGroupListTableViewDelegate.updateGroup(
       currentItem: current,
       editableItems: editableList

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -265,14 +265,14 @@ extension GroupSelectionView {
   groupSelectionView.updateGroup(
     current: EditableGroupItem(groupId: 0, groupName: "CS 지식", groupColor: UIColor.brown),
     editableList: [
-      .init(groupId: 0, groupName: "CS 지식", groupColor: UIColor.brown),
-      .init(groupId: 1, groupName: "영어", groupColor: UIColor.red),
-      .init(groupId: 2, groupName: "국어", groupColor: UIColor.blue),
-      .init(groupId: 3, groupName: "수학", groupColor: UIColor.systemMint),
-      .init(groupId: 4, groupName: "Swift", groupColor: UIColor.toDoGardenYellow),
-      .init(groupId: 5, groupName: "런닝", groupColor: UIColor.toDoGardenGreenDark),
-      .init(groupId: 6, groupName: "지구과학", groupColor: UIColor.systemGreen),
-      .init(groupId: 7, groupName: "물리", groupColor: UIColor.orange)
+      EditableGroupItem(groupId: 0, groupName: "CS 지식", groupColor: UIColor.brown),
+      EditableGroupItem(groupId: 1, groupName: "영어", groupColor: UIColor.red),
+      EditableGroupItem(groupId: 2, groupName: "국어", groupColor: UIColor.blue),
+      EditableGroupItem(groupId: 3, groupName: "수학", groupColor: UIColor.systemMint),
+      EditableGroupItem(groupId: 4, groupName: "Swift", groupColor: UIColor.toDoGardenYellow),
+      EditableGroupItem(groupId: 5, groupName: "런닝", groupColor: UIColor.toDoGardenGreenDark),
+      EditableGroupItem(groupId: 6, groupName: "지구과학", groupColor: UIColor.systemGreen),
+      EditableGroupItem(groupId: 7, groupName: "물리", groupColor: UIColor.orange)
     ]
   )
   return groupSelectionView

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -259,21 +259,24 @@ extension GroupSelectionView {
   }
 }
 
+/// 그룹 정보를 업데이트하는 GroupSelectionViewItemAPI의 구체타입이 선언되어 있지 않습니다.
+/// Preview로 동작을 확인하고 싶으시다면 EditableGroupItem에 GroupSelectionViewItemAPI 프로토콜을 채택 후
+/// 주석을 코드로 변환해주세요
 @available(iOS 17.0, *)
 #Preview {
   let groupSelectionView = GroupSelectionView(model: GroupSelectionView.Model.primary)
-  groupSelectionView.updateGroup(
-    current: EditableGroupItem(groupId: 0, groupName: "CS 지식", groupColor: UIColor.brown),
-    editableList: [
-      EditableGroupItem(groupId: 0, groupName: "CS 지식", groupColor: UIColor.brown),
-      EditableGroupItem(groupId: 1, groupName: "영어", groupColor: UIColor.red),
-      EditableGroupItem(groupId: 2, groupName: "국어", groupColor: UIColor.blue),
-      EditableGroupItem(groupId: 3, groupName: "수학", groupColor: UIColor.systemMint),
-      EditableGroupItem(groupId: 4, groupName: "Swift", groupColor: UIColor.toDoGardenYellow),
-      EditableGroupItem(groupId: 5, groupName: "런닝", groupColor: UIColor.toDoGardenGreenDark),
-      EditableGroupItem(groupId: 6, groupName: "지구과학", groupColor: UIColor.systemGreen),
-      EditableGroupItem(groupId: 7, groupName: "물리", groupColor: UIColor.orange)
-    ]
-  )
+//  groupSelectionView.updateGroup(
+//    current: EditableGroupItem(groupId: 0, groupName: "CS 지식", groupColor: UIColor.brown),
+//    editableList: [
+//      EditableGroupItem(groupId: 0, groupName: "CS 지식", groupColor: UIColor.brown),
+//      EditableGroupItem(groupId: 1, groupName: "영어", groupColor: UIColor.red),
+//      EditableGroupItem(groupId: 2, groupName: "국어", groupColor: UIColor.blue),
+//      EditableGroupItem(groupId: 3, groupName: "수학", groupColor: UIColor.systemMint),
+//      EditableGroupItem(groupId: 4, groupName: "Swift", groupColor: UIColor.toDoGardenYellow),
+//      EditableGroupItem(groupId: 5, groupName: "런닝", groupColor: UIColor.toDoGardenGreenDark),
+//      EditableGroupItem(groupId: 6, groupName: "지구과학", groupColor: UIColor.systemGreen),
+//      EditableGroupItem(groupId: 7, groupName: "물리", groupColor: UIColor.orange)
+//    ]
+//  )
   return groupSelectionView
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #359

## 🎉 변경 사항
- GroupSelectionView를 추상화한 API 프로토콜을 추가하였습니다.
- GroupSelectionView에 사용되는 그룹 정보에 대한 Item을 프로토콜로 추상화하였습니다.

## 📌 PR Point
- Scene에서 구현체인 컴포넌트 대신 추상체인 API를 의존하기 위해 구현하였습니다.

### 사용 예시
- 사용하는 측에서 Item의 구체타입을 선언해야 사용이 가능합니다.
``` Swift
import ToDoGardenUIAPI
// GroupSelectionViewItemAPI 구체타입 선언
struct GroupSelectionViewItem: GroupSelectionViewItemAPI {
  let groupId: Int
  let groupName: String
  let groupColor: UIColor
}

let groupSelectionView: GroupSelectionViewAPI = GroupSelectionView(model: .primary)
let item = GroupSelectionViewItem(...) // 현재 그룹 정보
let items = [...] // 수정가능한 그룹 리스트 정보
groupSelectionView.update(current: item, editableList: items)
```

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?