### PR TITLE
EditTodoAlarmView 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
@@ -27,11 +27,15 @@ final class EditToDoAlarmView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
 
+  /// 해당 메서드는 서버로 부터 받아온 투두 정보를 바탕으로 알림 스위치를 활성화시키는 메서드입니다.
+  /// 사용자가 기존에 알림을 비활성화 했었을 경우에 호출합니다.
   func enableAlarm() {
     self.alarmSwitch.setOn(true, animated: true)
     self.alarmTimeSettingView.enable()
   }
 
+  /// 해당 메서드는 서버로 부터 받아온 투두 정보를 바탕으로 알림 스위치를 비활성화시키는 메서드입니다.
+  /// 사용자가 기존에 알림을 비활성화 했었을 경우에 호출합니다.
   func disableAlarm() {
     self.alarmSwitch.setOn(false, animated: true)
     self.alarmTimeSettingView.disable()
@@ -53,6 +57,7 @@ extension EditToDoAlarmView {
     self.alarmSwitch.addAction(switchAction, for: UIControl.Event.valueChanged)
   }
 
+  /// 알림 시간 설정 버튼을 눌렀을 때 Modal로 SettingTimeView를 띄우는 액션을 지정하는데 사용됩니다.
   func setupAlarmSettingAction(_ closure: @escaping () -> Void) {
     self.alarmTimeSettingView.addAlarmSettingAction(closure)
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
@@ -27,9 +27,18 @@ final class EditToDoAlarmView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
 
-  func updateAlarm(isOn: Bool, alarmTime: String?) {
-    self.updateAlarmSwitch(isOn: isOn)
-    self.updateAlarmTime(to: alarmTime)
+  func enableAlarm() {
+    self.alarmSwitch.isOn = true
+    self.alarmTimeSettingView.enable()
+  }
+
+  func disableAlarm() {
+    self.alarmSwitch.isOn = false
+    self.alarmTimeSettingView.disable()
+  }
+
+  func updateAlarmTime(_ alarmTime: String) {
+    self.alarmTimeSettingView.updateAlarmTime(with: alarmTime)
   }
 
   func setupAlarmSettingAction(_ closure: @escaping () -> Void) {
@@ -48,22 +57,6 @@ extension EditToDoAlarmView {
 // MARK: Private Functions
 
 extension EditToDoAlarmView {
-  private func updateAlarmSwitch(isOn: Bool) {
-    self.alarmSwitch.isOn = isOn
-    if isOn {
-      self.alarmTimeSettingView.enable()
-    } else {
-      self.alarmTimeSettingView.disable()
-    }
-  }
-
-  private func updateAlarmTime(to alarmTime: String?) {
-    guard let alarmTime = alarmTime
-    else { return }
-
-    self.alarmTimeSettingView.updateAlarmTime(with: alarmTime)
-  }
-
   private func setup() {
     self.setupAlarmLabelUI()
     self.addSubviews()

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
@@ -11,9 +11,11 @@ import ToDoGardenUIComponent
 
 final class EditToDoAlarmView: UIView {
   private let alarmSwitch: ToDoGardenSwitch
+  private let alarmLabel: UILabel
 
   init() {
     self.alarmSwitch = ToDoGardenSwitch(model: ToDoGardenSwitch.Model.primary)
+    self.alarmLabel = UILabel()
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -24,20 +26,33 @@ final class EditToDoAlarmView: UIView {
   }
 }
 
+// MARK: Private Functions
+
 extension EditToDoAlarmView {
   private func setup() {
+    self.setupAlarmLabelUI()
     self.addSubviews()
     self.setupConstraints()
   }
+
+  private func setupAlarmLabelUI() {
+    self.alarmLabel.font = UIFont.pretendardHeadSemiBold
+    let text = EditToDoSceneTheme.StringLiteral.ToDoScheduleView.AlarmLabel.text
+    self.alarmLabel.text = text
+  }
 }
+
+// MARK: Auto Layout
 
 extension EditToDoAlarmView {
   private func addSubviews() {
     self.addSubview(self.alarmSwitch)
+    self.addSubview(self.alarmLabel)
   }
 
   private func setupConstraints() {
     self.setupAlarmSwitchConstraints()
+    self.setupAlarmLabelConstraints()
   }
 
   private func setupAlarmSwitchConstraints() {
@@ -50,6 +65,20 @@ extension EditToDoAlarmView {
           equalTo: self.trailingAnchor,
           constant: -2
         )
+      ]
+    )
+  }
+
+  private func setupAlarmLabelConstraints() {
+    self.alarmLabel.usingAutolayout()
+
+    NSLayoutConstraint.activate(
+      [
+        self.alarmLabel.leadingAnchor.constraint(
+          equalTo: self.leadingAnchor,
+          constant: 4
+        ),
+        self.alarmLabel.centerYAnchor.constraint(equalTo: self.alarmSwitch.centerYAnchor)
       ]
     )
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
@@ -26,11 +26,32 @@ final class EditToDoAlarmView: UIView {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+
+  func updateAlarm(isOn: Bool, alarmTime: String?) {
+    self.updateAlarmSwitch(isOn: isOn)
+    self.updateAlarmTime(to: alarmTime)
+  }
 }
 
 // MARK: Private Functions
 
 extension EditToDoAlarmView {
+  private func updateAlarmSwitch(isOn: Bool) {
+    self.alarmSwitch.isOn = isOn
+    if isOn {
+      self.alarmTimeSettingView.enable()
+    } else {
+      self.alarmTimeSettingView.disable()
+    }
+  }
+
+  private func updateAlarmTime(to alarmTime: String?) {
+    guard let alarmTime = alarmTime
+    else { return }
+
+    self.alarmTimeSettingView.updateAlarmTime(with: alarmTime)
+  }
+
   private func setup() {
     self.setupAlarmLabelUI()
     self.addSubviews()

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
@@ -33,6 +33,14 @@ final class EditToDoAlarmView: UIView {
   }
 }
 
+// MARK: Theme Color
+
+extension EditToDoAlarmView {
+  func updateThemeColor(to newColor: UIColor) {
+    self.alarmLabel.textColor = newColor
+  }
+}
+
 // MARK: Private Functions
 
 extension EditToDoAlarmView {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
@@ -28,12 +28,12 @@ final class EditToDoAlarmView: UIView {
   }
 
   func enableAlarm() {
-    self.alarmSwitch.isOn = true
+    self.alarmSwitch.setOn(true, animated: true)
     self.alarmTimeSettingView.enable()
   }
 
   func disableAlarm() {
-    self.alarmSwitch.isOn = false
+    self.alarmSwitch.setOn(false, animated: true)
     self.alarmTimeSettingView.disable()
   }
 
@@ -142,4 +142,15 @@ extension EditToDoAlarmView {
       ]
     )
   }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+  let view = EditToDoAlarmView()
+  view.setupSwitchAction {
+    print("switch action called")
+  }
+  view.enableAlarm()
+  view.disableAlarm()
+  return view
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
@@ -1,0 +1,56 @@
+//
+//  EditToDoAlarmView.swift
+//
+//
+//  Created by Wood on 7/18/24.
+//
+
+import UIKit
+
+import ToDoGardenUIComponent
+
+final class EditToDoAlarmView: UIView {
+  private let alarmSwitch: ToDoGardenSwitch
+
+  init() {
+    self.alarmSwitch = ToDoGardenSwitch(model: ToDoGardenSwitch.Model.primary)
+    super.init(frame: CGRect.zero)
+    self.setup()
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+extension EditToDoAlarmView {
+  private func setup() {
+    self.addSubviews()
+    self.setupConstraints()
+  }
+}
+
+extension EditToDoAlarmView {
+  private func addSubviews() {
+    self.addSubview(self.alarmSwitch)
+  }
+
+  private func setupConstraints() {
+    self.setupAlarmSwitchConstraints()
+  }
+
+  private func setupAlarmSwitchConstraints() {
+    self.alarmSwitch.usingAutolayout()
+
+    NSLayoutConstraint.activate(
+      [
+        self.alarmSwitch.topAnchor.constraint(equalTo: self.topAnchor),
+        self.alarmSwitch.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: -2
+        )
+      ]
+    )
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
@@ -40,6 +40,18 @@ final class EditToDoAlarmView: UIView {
   func updateAlarmTime(_ alarmTime: String) {
     self.alarmTimeSettingView.updateAlarmTime(with: alarmTime)
   }
+}
+
+// MARK: Set up Subviews Action
+
+extension EditToDoAlarmView {
+  func setupSwitchAction(_ closure: @escaping () -> Void) {
+    let switchAction = UIAction { _ in
+      closure()
+    }
+
+    self.alarmSwitch.addAction(switchAction, for: UIControl.Event.valueChanged)
+  }
 
   func setupAlarmSettingAction(_ closure: @escaping () -> Void) {
     self.alarmTimeSettingView.addAlarmSettingAction(closure)

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
@@ -12,10 +12,12 @@ import ToDoGardenUIComponent
 final class EditToDoAlarmView: UIView {
   private let alarmSwitch: ToDoGardenSwitch
   private let alarmLabel: UILabel
+  private let alarmTimeSettingView: AlarmTimeView
 
   init() {
     self.alarmSwitch = ToDoGardenSwitch(model: ToDoGardenSwitch.Model.primary)
     self.alarmLabel = UILabel()
+    self.alarmTimeSettingView = AlarmTimeView(model: AlarmTimeView.Model.primary)
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -48,11 +50,13 @@ extension EditToDoAlarmView {
   private func addSubviews() {
     self.addSubview(self.alarmSwitch)
     self.addSubview(self.alarmLabel)
+    self.addSubview(self.alarmTimeSettingView)
   }
 
   private func setupConstraints() {
     self.setupAlarmSwitchConstraints()
     self.setupAlarmLabelConstraints()
+    self.setupAlarmTimeSettingViewConstraints()
   }
 
   private func setupAlarmSwitchConstraints() {
@@ -72,13 +76,31 @@ extension EditToDoAlarmView {
   private func setupAlarmLabelConstraints() {
     self.alarmLabel.usingAutolayout()
 
+    let layout = EditToDoViewController.Constant.Layout.EditToDoScheduleView.AlarmLabel.self
     NSLayoutConstraint.activate(
       [
         self.alarmLabel.leadingAnchor.constraint(
           equalTo: self.leadingAnchor,
-          constant: 4
+          constant: layout.leadingMargin
         ),
         self.alarmLabel.centerYAnchor.constraint(equalTo: self.alarmSwitch.centerYAnchor)
+      ]
+    )
+  }
+
+  private func setupAlarmTimeSettingViewConstraints() {
+    self.alarmTimeSettingView.usingAutolayout()
+
+    let layout = EditToDoViewController.Constant.Layout.EditToDoScheduleView.AlarmTimeSettingView.self
+    NSLayoutConstraint.activate(
+      [
+        self.alarmTimeSettingView.topAnchor.constraint(
+          equalTo: self.alarmSwitch.bottomAnchor,
+          constant: layout.topMargin
+        ),
+        self.alarmTimeSettingView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.alarmTimeSettingView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        self.alarmTimeSettingView.heightAnchor.constraint(equalToConstant: layout.height)
       ]
     )
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
@@ -144,6 +144,7 @@ extension EditToDoAlarmView {
   }
 }
 
+#if DEBUG
 @available(iOS 17.0, *)
 #Preview {
   let view = EditToDoAlarmView()
@@ -154,3 +155,4 @@ extension EditToDoAlarmView {
   view.disableAlarm()
   return view
 }
+#endif

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
@@ -31,6 +31,10 @@ final class EditToDoAlarmView: UIView {
     self.updateAlarmSwitch(isOn: isOn)
     self.updateAlarmTime(to: alarmTime)
   }
+
+  func setupAlarmSettingAction(_ closure: @escaping () -> Void) {
+    self.alarmTimeSettingView.addAlarmSettingAction(closure)
+  }
 }
 
 // MARK: Theme Color

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
@@ -45,6 +45,14 @@ public final class AlarmTimeView: UIView {
   public func updateAlarmTime(with text: String) {
     self.setupAlarmSettingButtonTitle(with: text)
   }
+
+  public func addAlarmSettingAction(_ closure: @escaping () -> Void) {
+    let buttonAction = UIAction { _ in
+      closure()
+    }
+
+    self.alarmSettingButton.addAction(buttonAction, for: UIControl.Event.touchUpInside)
+  }
 }
 
 // MARK: Private Functions

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoRepeatSelectionView.swift
@@ -118,7 +118,6 @@ extension ToDoRepeatSelectionView {
 
 extension ToDoRepeatSelectionView {
   @objc func didTapView() {
-    self.isSelected = !self.isSelected
     self.selectionSender?(self.isSelected)
   }
 }
@@ -208,7 +207,6 @@ extension ToDoRepeatSelectionView {
 @available(iOS 17.0, *)
 #Preview {
   let view = ToDoRepeatSelectionView(model: ToDoRepeatSelectionView.Model.anotherDay)
-
   return view
 }
 #endif


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #362
- related: #344

## 🎉 변경 사항
- [리뷰](https://github.com/ToDo-Garden/ToDo-Garden/pull/344#discussion_r1682260397)를 반영하여 EditToDoScheduleView에서 알림 관련 UI들을 별도의 뷰로 분리했습니다.
- AlarmTimeView를 외부에서 버튼에 액션을 설정할 수 있는 메서드를 추가하였습니다.

## 📌 PR Point
- Constant NameSpace가 안맞는 문제와 매직넘버들이 존재합니다.
- 해당 작업은 ViewController에 UI 추가 작업이 끝난 이후에 새로운 PR에서 한번에 진행하도록 하겠습니다!

### Theme 컬러 변경 호환성
- noah가 구현해준 DynamicUIProperty가 변경되었을 때 호출할 메서드를 구현하였습니다.
``` Swift
  func updateThemeColor(to newColor: UIColor) {
    self.alarmLabel.textColor = newColor
  }
```

### 스위치 동작 X
- 현재 스위치를 눌러도 알람 시간 설정 뷰가 활성화 되지 않습니다.
  - [관련 백로그](https://docs.google.com/spreadsheets/d/17tg1z_x2UiSDCYD5yLnisMQkEVDgYIJNFICO8gTPkK4/edit?gid=917831885#gid=917831885&range=C84)
- 스위치의 상태값을 Interactor에서 가지며, 결과에 따라 UI만 업데이트할 수 있도록 구현하였습니다.

### 스크린샷
<img width="250" alt="스크린샷 2024-07-18 20 08 41" src="https://github.com/user-attachments/assets/aafb971d-faa4-4b94-b185-4ab723ca4b3e">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?