### PR TITLE
SettingTimeView 수정

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -21,6 +21,7 @@ public class SettingTimeView: UIView {
     self.button = button
     super.init(frame: CGRect.zero)
     self.build()
+    self.backgroundColor = .white
   }
   
   @available(*, unavailable)
@@ -54,6 +55,9 @@ extension SettingTimeView {
   
   private func buildTitleLabel() {
     let titleLabel = UILabel()
+    let multiplier = Constant.SettingTimeView.Layout.titleTopMarginMultiplier
+    let topMargin = self.intrinsicContentSize.height / multiplier
+    
     titleLabel.text = self.configuration.dataStore.title.text
     titleLabel.font = UIFont.pretendardHeadBold
     titleLabel.textColor = UIColor.toDoGardenBlack
@@ -64,7 +68,7 @@ extension SettingTimeView {
       [
         titleLabel.topAnchor.constraint(
           equalTo: self.topAnchor,
-          constant: self.configuration.dataStore.title.topMargin
+          constant: topMargin
         ),
         titleLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor)
       ]
@@ -72,6 +76,8 @@ extension SettingTimeView {
   }
   
   private func buildTimePicker() {
+    let multiplier = Constant.SettingTimeView.Layout.timePickertopMarginMultiplier
+    let topMargin = self.intrinsicContentSize.height / multiplier
     self.timepicker.delegate = self
     self.timepicker.dataSource = self
     self.timepicker.setInitialSelection()
@@ -82,7 +88,7 @@ extension SettingTimeView {
       [
         self.timepicker.topAnchor.constraint(
           equalTo: self.topAnchor,
-          constant: self.configuration.dataStore.timePicker.dataStore.pickerView.topMargin
+          constant: topMargin
         ),
         self.timepicker.centerXAnchor.constraint(equalTo: self.centerXAnchor, constant: -3)
       ]
@@ -91,17 +97,24 @@ extension SettingTimeView {
   
   private func buildButton() {
     self.addSubview(self.button)
-    
     self.button.usingAutolayout()
-    NSLayoutConstraint.activate(
-      [
-        self.button.bottomAnchor.constraint(
-          equalTo: self.bottomAnchor,
-          constant: self.configuration.dataStore.button.bottomMargin
-        ),
-        self.button.centerXAnchor.constraint(equalTo: self.centerXAnchor)
-      ]
-    )
+    
+    let dummyView = UIView()
+    dummyView.usingAutolayout()
+    self.addSubview(dummyView)
+    let dummyTopAnchorConstant = Constant.SettingTimeView.Layout.dummyViewTopWeight
+    
+    NSLayoutConstraint.activate([
+      dummyView.topAnchor.constraint(
+        equalTo: self.timepicker.bottomAnchor,
+        constant: dummyTopAnchorConstant
+      ),
+      dummyView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+      dummyView.widthAnchor.constraint(equalToConstant: CGFloat.zero),
+      dummyView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+      self.button.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+      self.button.centerYAnchor.constraint(equalTo: dummyView.centerYAnchor)
+    ])
   }
 }
 
@@ -133,7 +146,7 @@ extension SettingTimeView.Configuration {
 extension SettingTimeView: UIPickerViewDelegate {
   private var timePickerConstant: Constant.SettingTimeView.TimePicker.DataStore {
     return self.configuration.dataStore.timePicker.dataStore
-    }
+  }
   
   public func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
     return self.timePickerConstant.pickerView.rowHeight

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SettingTimeView.swift
@@ -16,9 +16,10 @@ extension Constant.SettingTimeView {
     static let alarmTimeTitle: String = "시간 설정"
   }
   
-  private enum Layout {
-    static let titleTopMargin: CGFloat = 44.0
-    static let buttonBottomMargin: CGFloat = -50.0
+  public enum Layout {
+    public static let titleTopMarginMultiplier: CGFloat = 11.63
+    public static let timePickertopMarginMultiplier: CGFloat = 5.85
+    public static let dummyViewTopWeight: CGFloat = -20
   }
 }
 
@@ -26,11 +27,9 @@ extension Constant.SettingTimeView {
   public struct DataStore {
     public let title: Title
     public let timePicker: TimePicker
-    public let button: Button
   }
   
   public struct Title {
-    public let topMargin: CGFloat
     public let text: String
   }
   
@@ -116,7 +115,7 @@ extension Constant.SettingTimeView {
             constraint: Constraint.centerX(15.0)
           ),
           secondUnitLabel: UnitLabel(
-            text: StringLiteral.minute,
+            text: StringLiteral.second,
             constraint: Constraint.trailing(-7.0)
           ),
           pickerView: PickerView(
@@ -133,7 +132,6 @@ extension Constant.SettingTimeView {
   }
   
   public struct Button {
-    public let bottomMargin: CGFloat
   }
 }
 
@@ -183,20 +181,17 @@ extension Constant.SettingTimeView.TimePicker {
 
 extension Constant.SettingTimeView {
   public static let focusTimeSetting = DataStore.init(
-    title: Title(topMargin: Layout.titleTopMargin, text: StringLiteral.focusTimeTitle),
-    timePicker: TimePicker.focusTime,
-    button: Button(bottomMargin: Layout.buttonBottomMargin)
+    title: Title(text: StringLiteral.focusTimeTitle),
+    timePicker: TimePicker.focusTime
   )
   
   public static let breakTimeSetting = DataStore.init(
-    title: Title(topMargin: Layout.titleTopMargin, text: StringLiteral.breakTimeTitle),
-    timePicker: TimePicker.breakTime,
-    button: Button(bottomMargin: Layout.buttonBottomMargin)
+    title: Title(text: StringLiteral.breakTimeTitle),
+    timePicker: TimePicker.breakTime
   )
   
   public static let alarmTimeSetting = DataStore.init(
-    title: Title(topMargin: Layout.titleTopMargin, text: StringLiteral.alarmTimeTitle),
-    timePicker: TimePicker.alarmTime,
-    button: Button(bottomMargin: Layout.buttonBottomMargin)
+    title: Title(text: StringLiteral.alarmTimeTitle),
+    timePicker: TimePicker.alarmTime
   )
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #364 
## 🎉 변경 사항
- 화면 크기에 비례하여 동적으로 동작하는 레이아웃 설정 
- 휴식시간설정에서 timePicker가 `시분분`을 표시하던 점 `시분초`로 수정 

## 📌 PR Point

<img width="250" alt="스크린샷 2024-07-18 오후 10 41 04" src="https://github.com/user-attachments/assets/6cac119f-f7f2-4efc-8005-c34917fe7603">

- ↑ 빨간 화살표로 표시된 여백이 화면 크기에 비례하여 커지고 작아집니다. 
- 모든 뷰의 위치를 자연스럽게 배치하기 위해 1번과 2번으로 표시된 여백은 어느 기종에서도 동일한 크기를 가지게끔 설정하였습니다. 

________

<img width="471" alt="스크린샷 2024-07-18 오후 10 45 22" src="https://github.com/user-attachments/assets/fe726eef-35cd-4f87-9993-9c8286799f5c">

- 일차적으로, 버튼의 CenterY 를 
`TimePicker의 bottom`과 `SettingTimeView의 bottom`의 중간지점에 배치시켰습니다만, 버튼이 아랫쪽으로 아래쪽으로 치우친 부자연스러운 배치로 표시되어서, 기준점을 아래와 같이 변경하였습니다. 
- `TimePicker의 bottom - 20` 과 `SettingTimeView 의 bottom` 의 중간지점에 버튼을 배치하면 자연스러운 느낌이었고, `TimePicker의 bottom - 20` 과 `SettingTimeView 의 bottom` 의 중간지점을 찾을 마땅한 방법이 없었던 관계로 투명하고, 높이만 갖고있는 `dummyView`를 생성하여 레이아웃 계산에 이용하였습니다. 
- `dummyView` 의 centerY에 버튼을 배치합니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?