### PR TITLE
PostGroupBottomSheet 추가 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Package.swift
@@ -21,7 +21,8 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(name: "ToDoGardenUI", path: "../ToDoGardenUI")
+    .package(name: "ToDoGardenUI", path: "../ToDoGardenUI"),
+    .package(path: "../TDUtility")
   ],
   targets: [
     .target(
@@ -36,8 +37,12 @@ let package = Package(
     .target(
       name: "PostGroupScene",
       dependencies: [
+        // .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
         "PostGroupSceneAPI",
-        "PostGroupSceneEntity"
+        "PostGroupSceneEntity",
+        .product(name: "TDUtility", package: "TDUtility"),
+        .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI"),
+        .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI")
       ]
     ),
     .testTarget(

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
@@ -85,15 +85,13 @@ extension PostGroupBottomSheet {
     self.setupColorPickerList()
     self.setupBottomButton()
   }
-  
-  private func setupGesture() {
-  }
 
   private func setupBindings() {
   }
   
   private func setupButtonAction() {
   }
+  
   private func setupDimmedView() {
     self.dimmedView.backgroundColor = UIColor.black.withAlphaComponent(Constant.BottomSheet.DimmedView.normalAlpha)
     self.dimmedView.alpha = CGFloat.zero
@@ -252,6 +250,17 @@ extension PostGroupBottomSheet {
         cancelButton.centerYAnchor.constraint(equalTo: navigationBarView.centerYAnchor)
       ]
     )
+  }
+}
+
+extension PostGroupBottomSheet {
+  private func setupGesture() {
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.handleTap))
+    self.dimmedView.addGestureRecognizer(tapGesture)
+  }
+  
+  @objc private func handleTap(_ sender: UITapGestureRecognizer) {
+    self.dismiss(animated: true, completion: nil)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
@@ -46,6 +46,7 @@ final class PostGroupBottomSheet: UIViewController {
   
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
+    self.animatePresenting()
   }
   
   override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
@@ -160,6 +161,20 @@ extension PostGroupBottomSheet {
       self.bottomButton.bottomAnchor.constraint(equalTo: self.bottomSheetView.bottomAnchor, constant: bottomMargin)
     ])
   }
+  
+  private func animatePresenting() {
+    self.dimmedView.alpha = CGFloat.zero
+    self.bottomSheetView.transform = CGAffineTransform(
+      translationX: CGFloat.zero,
+      y: self.bottomSheetHeight
+    )
+    
+    UIView.animate(withDuration: Constant.BottomSheet.Animation.duration) {
+      self.dimmedView.alpha = Constant.BottomSheet.DimmedView.presentingAlpha
+      self.bottomSheetView.transform = CGAffineTransform.identity
+    }
+  }
+  
   private func setupNavigationBar() {
     let navigationBarView = createNavigationBarView()
     let titleLabel = createTitleLabel()

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
@@ -85,12 +85,6 @@ extension PostGroupBottomSheet {
     self.setupColorPickerList()
     self.setupBottomButton()
   }
-
-  private func setupBindings() {
-  }
-  
-  private func setupButtonAction() {
-  }
   
   private func setupDimmedView() {
     self.dimmedView.backgroundColor = UIColor.black.withAlphaComponent(Constant.BottomSheet.DimmedView.normalAlpha)
@@ -261,6 +255,17 @@ extension PostGroupBottomSheet {
   
   @objc private func handleTap(_ sender: UITapGestureRecognizer) {
     self.dismiss(animated: true, completion: nil)
+  }
+  
+  private func setupBindings() {
+    self.colorPickerList.selected
+      .sink { [weak self] selectedIndex in
+        self?.bottomButton.isEnabled = selectedIndex != nil
+      }
+      .store(in: &subscriptions)
+  }
+  
+  private func setupButtonAction() {
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
@@ -280,3 +280,34 @@ extension PostGroupBottomSheet {
 protocol PostGroupBottomSheetDelegate: AnyObject {
   func dismissedBottomSheet(color: UIColor)
 }
+
+// MARK: Preview : PostGroupScene의 Package.swift에 있는 주석처리를 해제해주세요.
+
+// import ToDoGardenUIComponent
+// #if DEBUG
+// @available(iOS 17.0, *)
+// #Preview {
+//  let subject =  CurrentValueSubject<Int?, Never>(nil)
+//  
+//  let colorPickerList = ColorPickerList(colors: [
+//    .toDoGardenBlack,
+//    .toDoGardenBlue,
+//    .toDoGardenBrown,
+//    .toDoGardenEditButtonBlue,
+//    .toDoGardenEditButtonRed,
+//    .toDoGardenEditButtonYellow,
+//    .toDoGardenGrassHigh,
+//    .toDoGardenGrassLow,
+//    .toDoGardenGrassMiddle,
+//    .toDoGardenGray,
+//    .toDoGardenOlive,
+//    .toDoGardenPink
+//  ], itemsPerRow: 6, selected: subject)
+//  
+//  let button = ToDoGardenBoxButton(title: "확인", buttonType: .primaryRoundRectButton)
+//  
+//  let vc = PostGroupBottomSheet(colorPickerList: colorPickerList, bottomButton: button)
+//  
+//  return vc
+// }
+// #endif

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
@@ -167,15 +167,15 @@ extension PostGroupBottomSheet {
   }
   
   private func setupNavigationBar() {
-    let navigationBarView = createNavigationBarView()
-    let titleLabel = createTitleLabel()
-    let cancelButton = createCancelButton()
+    let navigationBarView = self.createNavigationBarView()
+    let titleLabel = self.createTitleLabel()
+    let cancelButton = self.createCancelButton()
     
     navigationBarView.addSubview(titleLabel)
     navigationBarView.addSubview(cancelButton)
-    bottomSheetView.addSubview(navigationBarView)
-    
-    setupConstraints(for: navigationBarView, titleLabel: titleLabel, cancelButton: cancelButton)
+    self.bottomSheetView.addSubview(navigationBarView)
+  
+    self.setupConstraints(for: navigationBarView, titleLabel: titleLabel, cancelButton: cancelButton)
   }
   
   private func createNavigationBarView() -> UIView {
@@ -202,7 +202,7 @@ extension PostGroupBottomSheet {
   }
   
   private func createCancelButton() -> UIButton {
-    let cancelButton = UIButton(type: .system)
+    let cancelButton = UIButton(type: UIButton.ButtonType.system)
     let text = Constant.BottomSheet.StringLiteral.cancel
     
     cancelButton.setAttributedTitle(text.applyTextAttributes(
@@ -269,6 +269,7 @@ extension PostGroupBottomSheet {
       guard let index = self.colorPickerList.selected.value else {
         return
       }
+      
       let color = self.colorPickerList.colors[index]
       self.delegate?.dismissedBottomSheet(color: color)
       self.dismiss(animated: true)

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
@@ -76,6 +76,13 @@ final class PostGroupBottomSheet: UIViewController {
 
 extension PostGroupBottomSheet {
   private func setupView() {
+    self.view.backgroundColor = UIColor.clear
+    self.setupDimmedView()
+    self.setupBottomSheetView()
+    self.setupGrabberView()
+    self.setupNavigationBar()
+    self.setupColorPickerList()
+    self.setupBottomButton()
   }
   
   private func setupGesture() {
@@ -85,6 +92,151 @@ extension PostGroupBottomSheet {
   }
   
   private func setupButtonAction() {
+  }
+  private func setupDimmedView() {
+    self.dimmedView.backgroundColor = UIColor.black.withAlphaComponent(Constant.BottomSheet.DimmedView.normalAlpha)
+    self.dimmedView.alpha = CGFloat.zero
+    self.view.addSubview(self.dimmedView)
+    
+    self.dimmedView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      self.dimmedView.topAnchor.constraint(equalTo: self.view.topAnchor),
+      self.dimmedView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+      self.dimmedView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+      self.dimmedView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
+    ])
+  }
+  
+  private func setupBottomSheetView() {
+    self.bottomSheetView.backgroundColor = UIColor.white
+    self.bottomSheetView.layer.cornerRadius = Constant.BottomSheet.BottomSheetView.cornerRadius
+    self.bottomSheetView.layer.masksToBounds = true
+    self.view.addSubview(self.bottomSheetView)
+    
+    self.bottomSheetView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      self.bottomSheetView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+      self.bottomSheetView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+      self.bottomSheetView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+      self.bottomSheetView.heightAnchor.constraint(equalToConstant: self.bottomSheetHeight)
+    ])
+  }
+  
+  private func setupGrabberView() {
+    self.grabberView.backgroundColor = UIColor.lightGray
+    self.grabberView.layer.cornerRadius = Constant.BottomSheet.GrabberView.cornerRadius
+    self.bottomSheetView.addSubview(self.grabberView)
+    
+    self.grabberView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      self.grabberView.topAnchor.constraint(
+        equalTo: self.bottomSheetView.topAnchor,
+        constant: Constant.BottomSheet.GrabberView.topMargin
+      ),
+      self.grabberView.centerXAnchor.constraint(equalTo: self.bottomSheetView.centerXAnchor),
+      self.grabberView.widthAnchor.constraint(equalToConstant: Constant.BottomSheet.GrabberView.width),
+      self.grabberView.heightAnchor.constraint(equalToConstant: Constant.BottomSheet.GrabberView.height)
+    ])
+  }
+  
+  private func setupColorPickerList() {
+    let topMargin = self.bottomSheetHeight / Constant.BottomSheet.ColorPickerList.multiplier
+    self.bottomSheetView.addSubview(self.colorPickerList)
+    
+    self.colorPickerList.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      self.colorPickerList.topAnchor.constraint(equalTo: self.bottomSheetView.topAnchor, constant: topMargin),
+      self.colorPickerList.centerXAnchor.constraint(equalTo: self.bottomSheetView.centerXAnchor)
+    ])
+  }
+  
+  private func setupBottomButton() {
+    let bottomMargin = self.bottomSheetHeight / Constant.BottomSheet.BottomButton.multiplier
+    self.bottomSheetView.addSubview(self.bottomButton)
+    
+    self.bottomButton.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      self.bottomButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+      self.bottomButton.bottomAnchor.constraint(equalTo: self.bottomSheetView.bottomAnchor, constant: bottomMargin)
+    ])
+  }
+  private func setupNavigationBar() {
+    let navigationBarView = createNavigationBarView()
+    let titleLabel = createTitleLabel()
+    let cancelButton = createCancelButton()
+    
+    navigationBarView.addSubview(titleLabel)
+    navigationBarView.addSubview(cancelButton)
+    bottomSheetView.addSubview(navigationBarView)
+    
+    setupConstraints(for: navigationBarView, titleLabel: titleLabel, cancelButton: cancelButton)
+  }
+  
+  private func createNavigationBarView() -> UIView {
+    let navigationBarView = UIView()
+    navigationBarView.backgroundColor = UIColor.clear
+    navigationBarView.translatesAutoresizingMaskIntoConstraints = false
+    return navigationBarView
+  }
+  
+  private func createTitleLabel() -> UILabel {
+    let titleLabel = UILabel()
+    let titleLabelText = Constant.BottomSheet.StringLiteral.title
+    
+    titleLabel.attributedText = titleLabelText.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardHeadBold,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    )
+    
+    titleLabel.textAlignment = .center
+    titleLabel.translatesAutoresizingMaskIntoConstraints = false
+    return titleLabel
+  }
+  
+  private func createCancelButton() -> UIButton {
+    let cancelButton = UIButton(type: .system)
+    let text = Constant.BottomSheet.StringLiteral.cancel
+    
+    cancelButton.setAttributedTitle(text.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardBodyRegular,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    ), for: UIControl.State.normal)
+    
+    cancelButton.backgroundColor = UIColor.clear
+    cancelButton.addAction(UIAction { _ in self.dismiss(animated: true) }, for: UIControl.Event.touchUpInside)
+    cancelButton.translatesAutoresizingMaskIntoConstraints = false
+    return cancelButton
+  }
+  
+  private func setupConstraints(
+    for navigationBarView: UIView,
+    titleLabel: UILabel,
+    cancelButton: UIButton
+  ) {
+    let topMargin = self.bottomSheetHeight / Constant.BottomSheet.NavigationBar.multiplier
+    NSLayoutConstraint.activate(
+      [
+        navigationBarView.topAnchor.constraint(equalTo: bottomSheetView.topAnchor, constant: topMargin),
+        navigationBarView.leadingAnchor.constraint(equalTo: bottomSheetView.leadingAnchor),
+        navigationBarView.trailingAnchor.constraint(equalTo: bottomSheetView.trailingAnchor),
+        navigationBarView.heightAnchor.constraint(
+          equalToConstant: Constant.BottomSheet.NavigationBar.height
+        ),
+        
+        titleLabel.centerXAnchor.constraint(equalTo: navigationBarView.centerXAnchor),
+        titleLabel.centerYAnchor.constraint(equalTo: navigationBarView.centerYAnchor),
+        
+        cancelButton.trailingAnchor.constraint(
+          equalTo: navigationBarView.trailingAnchor,
+          constant: Constant.BottomSheet.NavigationBar.trailingMargin
+        ),
+        cancelButton.centerYAnchor.constraint(equalTo: navigationBarView.centerYAnchor)
+      ]
+    )
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
@@ -1,0 +1,93 @@
+import Combine
+import UIKit
+
+import TDFoundationExtension
+import ToDoGardenUIAPI
+import ToDoGardenUIResource
+
+final class PostGroupBottomSheet: UIViewController {
+  var delegate: PostGroupBottomSheetDelegate?
+  private let dimmedView: UIView
+  private let bottomSheetView: UIView
+  private let grabberView: UIView
+  private let colorPickerList: ColorPickerListAPI
+  private let bottomButton: UIButton
+  
+  private var bottomSheetHeight: CGFloat {
+    return view.bounds.height * Constant.BottomSheet.multiplier
+  }
+  
+  private var subscriptions = Set<AnyCancellable>()
+  
+  init(colorPickerList: ColorPickerListAPI, bottomButton: UIButton) {
+    self.dimmedView = UIView()
+    self.bottomSheetView = UIView()
+    self.grabberView = UIView()
+    self.colorPickerList = colorPickerList
+    self.bottomButton = bottomButton
+    super.init(nibName: nil, bundle: nil)
+    self.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
+    self.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
+    
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.setupView()
+    self.setupGesture()
+    self.setupBindings()
+    self.setupButtonAction()
+  }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+  }
+  
+  override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+    UIView.animate(
+      withDuration: Constant.BottomSheet.Animation.duration,
+      animations: { [weak self] in
+        self?.dimmedView.alpha = CGFloat.zero
+        self?.bottomSheetView.transform = CGAffineTransform(
+          translationX: CGFloat.zero,
+          y: self?.bottomSheetHeight ?? CGFloat.zero
+        )
+      },
+      completion: { _ in
+        super.dismiss(animated: false, completion: completion)
+      }
+    )
+  }
+  
+  func setupCurrentColor(color: UIColor?) {
+    guard let color = color else {
+      return
+    }
+    
+    let index = self.colorPickerList.colors.firstIndex(of: color)
+    self.colorPickerList.selected.send(index)
+  }
+}
+
+extension PostGroupBottomSheet {
+  private func setupView() {
+  }
+  
+  private func setupGesture() {
+  }
+
+  private func setupBindings() {
+  }
+  
+  private func setupButtonAction() {
+  }
+}
+
+protocol PostGroupBottomSheetDelegate: AnyObject {
+  func dismissedBottomSheet(color: UIColor)
+}

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
@@ -6,7 +6,7 @@ import ToDoGardenUIAPI
 import ToDoGardenUIResource
 
 final class PostGroupBottomSheet: UIViewController {
-  var delegate: PostGroupBottomSheetDelegate?
+  weak var delegate: PostGroupBottomSheetDelegate?
   private let dimmedView: UIView
   private let bottomSheetView: UIView
   private let grabberView: UIView

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
@@ -101,6 +101,10 @@ extension PostGroupBottomSheet {
   
   private func setupBottomSheetView() {
     self.bottomSheetView.backgroundColor = UIColor.white
+    self.bottomSheetView.layer.maskedCorners = [
+      CACornerMask.layerMinXMinYCorner,
+      CACornerMask.layerMaxXMinYCorner
+    ]
     self.bottomSheetView.layer.cornerRadius = Constant.BottomSheet.BottomSheetView.cornerRadius
     self.bottomSheetView.layer.masksToBounds = true
     self.view.addSubview(self.bottomSheetView)

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
@@ -266,6 +266,14 @@ extension PostGroupBottomSheet {
   }
   
   private func setupButtonAction() {
+    self.bottomButton.addAction(UIAction { _ in
+      guard let index = self.colorPickerList.selected.value else {
+        return
+      }
+      let color = self.colorPickerList.colors[index]
+      self.delegate?.dismissedBottomSheet(color: color)
+      self.dismiss(animated: true)
+    }, for: UIControl.Event.touchUpInside)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupBottomSheet.swift
@@ -11,7 +11,7 @@ final class PostGroupBottomSheet: UIViewController {
   private let bottomSheetView: UIView
   private let grabberView: UIView
   private let colorPickerList: ColorPickerListAPI
-  private let bottomButton: UIButton
+  private let doneBottomButton: UIButton
   
   private var bottomSheetHeight: CGFloat {
     return view.bounds.height * Constant.BottomSheet.multiplier
@@ -24,11 +24,10 @@ final class PostGroupBottomSheet: UIViewController {
     self.bottomSheetView = UIView()
     self.grabberView = UIView()
     self.colorPickerList = colorPickerList
-    self.bottomButton = bottomButton
+    self.doneBottomButton = bottomButton
     super.init(nibName: nil, bundle: nil)
     self.modalPresentationStyle = UIModalPresentationStyle.overFullScreen
     self.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
-    
   }
   
   @available(*, unavailable)
@@ -145,12 +144,12 @@ extension PostGroupBottomSheet {
   
   private func setupBottomButton() {
     let bottomMargin = self.bottomSheetHeight / Constant.BottomSheet.BottomButton.multiplier
-    self.bottomSheetView.addSubview(self.bottomButton)
+    self.bottomSheetView.addSubview(self.doneBottomButton)
     
-    self.bottomButton.translatesAutoresizingMaskIntoConstraints = false
+    self.doneBottomButton.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
-      self.bottomButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-      self.bottomButton.bottomAnchor.constraint(equalTo: self.bottomSheetView.bottomAnchor, constant: bottomMargin)
+      self.doneBottomButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+      self.doneBottomButton.bottomAnchor.constraint(equalTo: self.bottomSheetView.bottomAnchor, constant: bottomMargin)
     ])
   }
   
@@ -260,13 +259,13 @@ extension PostGroupBottomSheet {
   private func setupBindings() {
     self.colorPickerList.selected
       .sink { [weak self] selectedIndex in
-        self?.bottomButton.isEnabled = selectedIndex != nil
+        self?.doneBottomButton.isEnabled = selectedIndex != nil
       }
-      .store(in: &subscriptions)
+      .store(in: &self.subscriptions)
   }
   
   private func setupButtonAction() {
-    self.bottomButton.addAction(UIAction { _ in
+    self.doneBottomButton.addAction(UIAction { _ in
       guard let index = self.colorPickerList.selected.value else {
         return
       }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneConstants.swift
@@ -1,0 +1,55 @@
+//
+//  PostGroupSceneConstants.swift
+//
+//
+//  Created by SONG on 7/21/24.
+//
+
+import Foundation
+
+enum Constant {
+  enum BottomSheet {
+    static let multiplier: CGFloat = 0.41
+  }
+}
+
+extension Constant.BottomSheet {
+  enum StringLiteral {
+    static let title: String = "컬러지정"
+    static let cancel: String = "취소"
+  }
+  
+  enum DimmedView {
+    static let normalAlpha: CGFloat = 0.5
+    static let presentingAlpha: CGFloat = 1.0
+  }
+  
+  enum BottomSheetView {
+    static let cornerRadius: CGFloat = 16.0
+  }
+  
+  enum GrabberView {
+    static let cornerRadius: CGFloat = 2.5
+    static let topMargin: CGFloat = 8.0
+    static let width: CGFloat = 36.0
+    static let height: CGFloat = 5.0
+  }
+  
+  enum ColorPickerList {
+    static let multiplier: CGFloat = 3.03
+  }
+  
+  enum BottomButton {
+    static let multiplier: CGFloat = -10.0
+  }
+  
+  enum NavigationBar {
+    static let multiplier: CGFloat = 11.64
+    static let height: CGFloat = 44.0
+    static let trailingMargin: CGFloat = -16.0
+  }
+  
+  enum Animation {
+    static let duration: CGFloat = 0.3
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ColorPickerList.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ColorPickerList.swift
@@ -67,8 +67,7 @@ public final class ColorPickerList: UIStackView, ColorPickerListAPI {
     self.selected
       .pairwise()
       .sink { [weak button] old, new in
-        guard let button 
-        else { return }
+        guard let button else { return }
         if index == old, old != new {
           button.isSelected = false
         }
@@ -104,6 +103,7 @@ public final class ColorPickerList: UIStackView, ColorPickerListAPI {
 
 private final class ColorButton: UIButton {
   private var padding: CGFloat
+  private var innerView: UIView!
   
   override var isSelected: Bool {
     didSet {
@@ -130,33 +130,34 @@ private final class ColorButton: UIButton {
   
   fileprivate override func layoutSubviews() {
     super.layoutSubviews()
-    if
-      let configuration,
-      configuration.background.cornerRadius != self.bounds.width / 2 {
-      self.configuration?.background.cornerRadius = self.bounds.width / 2
-    }
-    if self.layer.cornerRadius != self.bounds.width / 2 {
-      self.layer.cornerRadius = self.bounds.width / 2
-    }
+    innerView.layer.cornerRadius = innerView.bounds.width / 2
+    self.layer.cornerRadius = self.bounds.width / 2
   }
   
   private func build(backgroundColor: UIColor, selectedColor: UIColor?) {
-    self.buildConfiguration(backgroundColor)
+    self.innerView = buildInnerView(backgroundColor)
+    self.addSubview(innerView)
+    self.layoutInnerView()
     if let selectedColor {
       self.layer.borderColor = selectedColor.cgColor
     }
   }
   
-  private func buildConfiguration(_ backgroundColor: UIColor) {
-    self.configuration = UIButton.Configuration.filled()
-    self.configuration?.background.backgroundInsets = NSDirectionalEdgeInsets(
-      top: self.padding,
-      leading: self.padding,
-      bottom: self.padding,
-      trailing: self.padding
-    )
-    self.configuration?.background.backgroundColor = backgroundColor
-    self.changesSelectionAsPrimaryAction = true
+  private func buildInnerView(_ backgroundColor: UIColor) -> UIView {
+    let view = UIView()
+    view.isUserInteractionEnabled = false
+    view.backgroundColor = backgroundColor
+    return view
+  }
+  
+  private func layoutInnerView() {
+    self.innerView.usingAutolayout()
+    NSLayoutConstraint.activate([
+      self.innerView.topAnchor.constraint(equalTo: self.topAnchor, constant: self.padding),
+      self.innerView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: self.padding),
+      self.innerView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -self.padding),
+      self.innerView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -self.padding)
+    ])
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #368 
## 🎉 변경 사항
- PostGroupBottomSheet를 추가합니다. 
## 📌 PR Point

### 1) 디바이스 크기에 따라 동적으로 대응되는 레이아웃 
![스크린샷 2024-07-22 오후 3 17 01](https://github.com/user-attachments/assets/b6e08e8f-bf31-4dbe-bfc5-0fe94819b632)

### 2) ColorPickerList 
- case 1) ↓ 색상을 터치하고, `확인` 을 누른 뒤, 정상처리가 되었다면, 다시 PostGroupBottomSheet가 떴을 때, 선택된 색상이 강조됩니다. 

![Simulator Screen Recording - iPhone 15 Pro - 2024-07-22 at 15 15 43](https://github.com/user-attachments/assets/820acdd0-845f-4d91-b41e-e44fb47d0029)

- case 2) ↓  색상을 터치하고, `취소` 를 누른 뒤, 다시 PostGroupBottomSheet가 떴을 때, 선택된 색상이 없는 상황이므로, 강조된 색상이 없습니다. 

![Simulator Screen Recording - iPhone 15 Pro - 2024-07-22 at 15 15 13](https://github.com/user-attachments/assets/a7927a6a-9ac5-45a6-871a-4c11caef8a41)

### 3) Preview를 통해 확인하실 수 있습니다. 
- 지금은 VIP를 거치지 못하기 때문에 의존성 주입이 안되는 관계로, 주석처리 해놓은 상태입니다. 
- PostGroupScene/Package.swift의 주석처리된 부분을 해제하고 프리뷰도 주석처리 해제하면 에러없이 프리뷰 확인가능. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?