### PR TITLE
PostGroupColorPickerRow default Color 변경

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PostGroupColorPickerRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PostGroupColorPickerRow.swift
@@ -18,7 +18,7 @@ final public class PostGroupColorPickerRow: UIView, PostGroupColorPickerRowAPI {
       configuration: Styled.Row.Configuration.listPrimary(
         Styled.Row.Configuration.ListPrimaryModel(
           title: "",
-          color: UIColor.toDoGardenGray
+          color: UIColor.toDoGardenGrassNone
         )
       )
     )


### PR DESCRIPTION

## 💡 관련 이슈
- closed: #372 

## 🎉 변경 사항
- 색상이 지정되지 않은 경우, 표시할 기본색상을 변경합니다. 

## 📌 PR Point

<img width="557" alt="스크린샷 2024-07-23 오후 3 26 53" src="https://github.com/user-attachments/assets/a4635f71-aa16-42ef-8572-9157c2a8b746">

- 색상미선택 상태에서 표시할 색상이 `toDoGardenGray` 였습니다. 
- 그러나 컬러지정 색상모음에 `toDoGardenGray`가 존재합니다. 
- 유저 입장에서, 색상미선택 상태라서 `toDoGardenGray`가 보이는 건지, `toDoGardenGray`를 선택해서 `toDoGardenGray`가 보이는 건지 구분하지 못합니다. 
- 그래서 색상미선택 상태에서 표시할 색상을 `toDoGardenGrassNone`으로 변경하였습니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?