### PR TITLE
EditToDoView 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/.swiftpm/xcode/xcshareddata/xcschemes/EditToDoScene.xcscheme
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/.swiftpm/xcode/xcshareddata/xcschemes/EditToDoScene.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EditToDoScene"
+               BuildableName = "EditToDoScene"
+               BlueprintName = "EditToDoScene"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EditToDoScene"
+            BuildableName = "EditToDoScene"
+            BlueprintName = "EditToDoScene"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Package.swift
@@ -38,7 +38,8 @@ let package = Package(
       dependencies: [
         "EditToDoSceneAPI",
         "EditToDoSceneEntity",
-        .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
+        .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI"),
+        // .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
         .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI")
       ]
     )

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -95,6 +95,7 @@ extension EditToDoView: UIGestureRecognizerDelegate {
 
   private func setupTapGestureDelegate() {
     let tapGestureRecognizer = UITapGestureRecognizer()
+    self.addGestureRecognizer(tapGestureRecognizer)
     tapGestureRecognizer.delegate = self
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -175,6 +175,7 @@ extension EditToDoView {
     self.addSubview(self.deleteToDoButton)
     self.setupTitleLabelLayout(of: self.deleteToDoButton)
     self.deleteToDoButton.translatesAutoresizingMaskIntoConstraints = false
+    self.sendSubviewToBack(self.deleteToDoButton)
 
     let layout = EditToDoViewController.Constant.Layout.EditToDoView.DeleteToDoButton.self
     NSLayoutConstraint.activate(
@@ -226,3 +227,31 @@ extension EditToDoView {
     }
   }
 }
+
+// MARK: Preview를 확인하기 위해 Package.swift 파일에서 UIComponent 의존성을 추가해주세요.
+//  import ToDoGardenUIComponent
+//  @available(iOS 17.0, *)
+//  #Preview {
+//    let scheduleView = EditToDoView(
+//      toDoNameInputView: TextInputView(model: TextInputView.Model.toDoName),
+//      groupSelectionView: GroupSelectionView(model: GroupSelectionView.Model.primary)
+//    )
+//    scheduleView.updateGroup(
+//      current: EditToDoView.GroupItem(groupId: 002, groupName: "영어", groupColor: UIColor.toDoGardenRed),
+//      editableGroupList: [
+//        EditToDoView.GroupItem(groupId: 001, groupName: "CS 지식", groupColor: UIColor.toDoGardenBrown),
+//        EditToDoView.GroupItem(groupId: 002, groupName: "영어", groupColor: UIColor.toDoGardenRed),
+//        EditToDoView.GroupItem(groupId: 003, groupName: "국어", groupColor: UIColor.toDoGardenBlue),
+//        EditToDoView.GroupItem(groupId: 004, groupName: "수학", groupColor: UIColor.toDoGardenMint),
+//        EditToDoView.GroupItem(groupId: 005, groupName: "Swift", groupColor: UIColor.toDoGardenYellow),
+//        EditToDoView.GroupItem(groupId: 006, groupName: "런닝", groupColor: UIColor.toDoGardenPurple),
+//        EditToDoView.GroupItem(groupId: 007, groupName: "지구과학", groupColor: UIColor.toDoGardenGreenDark),
+//        EditToDoView.GroupItem(groupId: 008, groupName: "물리", groupColor: UIColor.toDoGardenOrange)
+//      ]
+//    )
+//    scheduleView.translatesAutoresizingMaskIntoConstraints = false
+//    scheduleView.widthAnchor.constraint(equalToConstant: 400).isActive = true
+//    scheduleView.heightAnchor.constraint(equalToConstant: 600).isActive = true
+//
+//    return scheduleView
+//  }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -7,13 +7,59 @@
 
 import UIKit
 
+import ToDoGardenUIAPI
+
 final class EditToDoView: UIView {
-  init() {
+  private let toDoNameInputView: TextInputViewAPI
+
+  init(textInputView: TextInputViewAPI) {
+    self.toDoNameInputView = textInputView
     super.init(frame: CGRect.zero)
+    self.setup()
   }
 
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: Private Functions
+
+extension EditToDoView {
+  private func setup() {
+    self.setupSubviewsLayout()
+  }
+}
+
+// MARK: About Layout
+
+extension EditToDoView {
+  private func setupSubviewsLayout() {
+    self.setupToDoNameInputViewLayout()
+  }
+
+  private func setupToDoNameInputViewLayout() {
+    self.addSubview(self.toDoNameInputView)
+    self.toDoNameInputView.translatesAutoresizingMaskIntoConstraints = false
+
+    let layout = EditToDoViewController.Constant.Layout.EditToDoView.ToDoNameTextInputView.self
+    NSLayoutConstraint.activate(
+      [
+        self.toDoNameInputView.topAnchor.constraint(
+          equalTo: self.topAnchor,
+          constant: layout.topMargin
+        ),
+        self.toDoNameInputView.leadingAnchor.constraint(
+          equalTo: self.leadingAnchor,
+          constant: layout.leadingMargin
+        ),
+        self.toDoNameInputView.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: -layout.trailingMargin
+        ),
+        self.toDoNameInputView.heightAnchor.constraint(equalToConstant: layout.height)
+      ]
+    )
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -30,6 +30,14 @@ extension EditToDoView {
   private func setup() {
     self.setupSubviewsLayout()
   }
+
+  private func makeGroupLabel() -> UILabel {
+    let groupLabel = UILabel()
+    groupLabel.font = UIFont.pretendardHeadSemiBold
+    groupLabel.textColor = EditToDoSceneTheme.mainColor
+    groupLabel.text = EditToDoSceneTheme.StringLiteral.EditToDoView.GroupLabel.text
+    return groupLabel
+  }
 }
 
 // MARK: About Layout
@@ -37,6 +45,7 @@ extension EditToDoView {
 extension EditToDoView {
   private func setupSubviewsLayout() {
     self.setupToDoNameInputViewLayout()
+    self.setupGroupLabelLayout(label: self.makeGroupLabel())
   }
 
   private func setupToDoNameInputViewLayout() {
@@ -59,6 +68,25 @@ extension EditToDoView {
           constant: -layout.trailingMargin
         ),
         self.toDoNameInputView.heightAnchor.constraint(equalToConstant: layout.height)
+      ]
+    )
+  }
+
+  private func setupGroupLabelLayout(label: UILabel) {
+    self.addSubview(label)
+    label.usingAutolayout()
+
+    let layout = EditToDoViewController.Constant.Layout.EditToDoView.GroupLabel.self
+    NSLayoutConstraint.activate(
+      [
+        label.topAnchor.constraint(
+          equalTo: self.toDoNameInputView.bottomAnchor,
+          constant: layout.topMargin
+        ),
+        label.leadingAnchor.constraint(
+          equalTo: self.leadingAnchor,
+          constant: layout.leadingMargin
+        )
       ]
     )
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -11,9 +11,11 @@ import ToDoGardenUIAPI
 
 final class EditToDoView: UIView {
   private let toDoNameInputView: TextInputViewAPI
+  private let groupSelectionView: GroupSelectionViewAPI
 
-  init(textInputView: TextInputViewAPI) {
-    self.toDoNameInputView = textInputView
+  init(toDoNameInputView: TextInputViewAPI, groupSelectionView: GroupSelectionViewAPI) {
+    self.toDoNameInputView = toDoNameInputView
+    self.groupSelectionView = groupSelectionView
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -45,7 +47,9 @@ extension EditToDoView {
 extension EditToDoView {
   private func setupSubviewsLayout() {
     self.setupToDoNameInputViewLayout()
-    self.setupGroupLabelLayout(label: self.makeGroupLabel())
+    let groupLabel = self.makeGroupLabel()
+    self.setupGroupLabelLayout(label: groupLabel)
+    self.setupGroupSelectionViewLayout(with: groupLabel)
   }
 
   private func setupToDoNameInputViewLayout() {
@@ -74,7 +78,7 @@ extension EditToDoView {
 
   private func setupGroupLabelLayout(label: UILabel) {
     self.addSubview(label)
-    label.usingAutolayout()
+    label.translatesAutoresizingMaskIntoConstraints = false
 
     let layout = EditToDoViewController.Constant.Layout.EditToDoView.GroupLabel.self
     NSLayoutConstraint.activate(
@@ -87,6 +91,22 @@ extension EditToDoView {
           equalTo: self.leadingAnchor,
           constant: layout.leadingMargin
         )
+      ]
+    )
+  }
+
+  private func setupGroupSelectionViewLayout(with label: UILabel) {
+    self.addSubview(self.groupSelectionView)
+    self.groupSelectionView.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate(
+      [
+        self.groupSelectionView.topAnchor.constraint(
+          equalTo: label.bottomAnchor,
+          constant: 10
+        ),
+        self.groupSelectionView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.groupSelectionView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
       ]
     )
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -14,6 +14,8 @@ final class EditToDoView: UIView {
   private let groupSelectionView: GroupSelectionViewAPI
   private let deleteToDoButton: UIButton
 
+  weak var delegate: EditToDoView.EditToDoViewDelegate?
+
   init(toDoNameInputView: TextInputViewAPI, groupSelectionView: GroupSelectionViewAPI) {
     self.toDoNameInputView = toDoNameInputView
     self.groupSelectionView = groupSelectionView
@@ -48,11 +50,21 @@ final class EditToDoView: UIView {
   }
 }
 
+// MARK: EditToDoView Delegate Functions
+
+extension EditToDoView {
+  /// EditToDoViewController가 채택할 Delegate 프로토콜입니다.
+  /// EditToDoView의 Subview들에서 발생한 이벤트들을 전달하는 역할을 합니다.
+  protocol EditToDoViewDelegate: AnyObject {
+    func didSelectDeleteToDoButton()
+  }
+}
+
 // MARK: Private Functions
 
 extension EditToDoView {
   private func setup() {
-    self.setupDeleteToDoButtonUI()
+    self.setupDeleteToDoButton()
     self.setupSubviewsLayout()
   }
 
@@ -64,7 +76,7 @@ extension EditToDoView {
     return groupLabel
   }
 
-  private func setupDeleteToDoButtonUI() {
+  private func setupDeleteToDoButton() {
     self.deleteToDoButton.backgroundColor = UIColor.toDoGardenGreenBackground
     let cornerRadius = EditToDoViewController.Constant.Layout.EditToDoView.DeleteToDoButton.cornerRadius
     self.deleteToDoButton.layer.cornerRadius = cornerRadius
@@ -77,6 +89,15 @@ extension EditToDoView {
       ]
     )
     self.deleteToDoButton.setAttributedTitle(title, for: UIControl.State.normal)
+    self.setupDeleteToDoButtonAction()
+  }
+
+  private func setupDeleteToDoButtonAction() {
+    let deleteToDoAction = UIAction { _ in
+      self.delegate?.didSelectDeleteToDoButton()
+    }
+
+    self.deleteToDoButton.addAction(deleteToDoAction, for: UIControl.Event.touchUpInside)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -1,0 +1,19 @@
+//
+//  EditToDoView.swift
+//
+//
+//  Created by Wood on 7/22/24.
+//
+
+import UIKit
+
+final class EditToDoView: UIView {
+  init() {
+    super.init(frame: CGRect.zero)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -12,10 +12,12 @@ import ToDoGardenUIAPI
 final class EditToDoView: UIView {
   private let toDoNameInputView: TextInputViewAPI
   private let groupSelectionView: GroupSelectionViewAPI
+  private let deleteToDoButton: UIButton
 
   init(toDoNameInputView: TextInputViewAPI, groupSelectionView: GroupSelectionViewAPI) {
     self.toDoNameInputView = toDoNameInputView
     self.groupSelectionView = groupSelectionView
+    self.deleteToDoButton = UIButton()
     super.init(frame: CGRect.zero)
     self.setup()
   }
@@ -24,12 +26,17 @@ final class EditToDoView: UIView {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+
+  func updateToDoName(_ name: String) {
+    self.toDoNameInputView.setBeginEditing(with: name)
+  }
 }
 
 // MARK: Private Functions
 
 extension EditToDoView {
   private func setup() {
+    self.setupDeleteToDoButtonUI()
     self.setupSubviewsLayout()
   }
 
@@ -39,6 +46,21 @@ extension EditToDoView {
     groupLabel.textColor = EditToDoSceneTheme.mainColor
     groupLabel.text = EditToDoSceneTheme.StringLiteral.EditToDoView.GroupLabel.text
     return groupLabel
+  }
+
+  private func setupDeleteToDoButtonUI() {
+    self.deleteToDoButton.backgroundColor = UIColor.toDoGardenGreenBackground
+    let cornerRadius = EditToDoViewController.Constant.Layout.EditToDoView.DeleteToDoButton.cornerRadius
+    self.deleteToDoButton.layer.cornerRadius = cornerRadius
+    self.deleteToDoButton.setTitleColor(UIColor.toDoGardenEditButtonRed, for: UIControl.State.normal)
+    let title = NSAttributedString(
+      string: EditToDoSceneTheme.StringLiteral.EditToDoView.DeleteToDoButton.title,
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardHeadSemiBold,
+        NSAttributedString.Key.strokeColor: UIColor.toDoGardenEditButtonRed
+      ]
+    )
+    self.deleteToDoButton.setAttributedTitle(title, for: UIControl.State.normal)
   }
 }
 
@@ -50,6 +72,7 @@ extension EditToDoView {
     let groupLabel = self.makeGroupLabel()
     self.setupGroupLabelLayout(label: groupLabel)
     self.setupGroupSelectionViewLayout(with: groupLabel)
+    self.setupDeleteToDoButtonLayout()
   }
 
   private func setupToDoNameInputViewLayout() {
@@ -107,6 +130,49 @@ extension EditToDoView {
         ),
         self.groupSelectionView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
         self.groupSelectionView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+      ]
+    )
+  }
+
+  private func setupDeleteToDoButtonLayout() {
+    self.addSubview(self.deleteToDoButton)
+    self.setupTitleLabelLayout(of: self.deleteToDoButton)
+    self.deleteToDoButton.translatesAutoresizingMaskIntoConstraints = false
+
+    let layout = EditToDoViewController.Constant.Layout.EditToDoView.DeleteToDoButton.self
+    NSLayoutConstraint.activate(
+      [
+        self.deleteToDoButton.topAnchor.constraint(
+          equalTo: self.groupSelectionView.topAnchor,
+          constant: 59
+        ),
+        self.deleteToDoButton.leadingAnchor.constraint(
+          equalTo: self.leadingAnchor,
+          constant: layout.leadingMargin
+        ),
+        self.deleteToDoButton.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: -layout.trailingMargin
+        ),
+        self.deleteToDoButton.heightAnchor.constraint(equalToConstant: layout.height)
+      ]
+    )
+  }
+
+  private func setupTitleLabelLayout(of button: UIButton) {
+    button.titleLabel?.translatesAutoresizingMaskIntoConstraints = false
+
+    guard let titleLabel = button.titleLabel
+    else { return }
+
+    let layout = EditToDoViewController.Constant.Layout.EditToDoView.DeleteToDoButton.self
+    NSLayoutConstraint.activate(
+      [
+        titleLabel.leadingAnchor.constraint(
+          equalTo: self.deleteToDoButton.leadingAnchor,
+          constant: layout.titleLeadingMargin
+        ),
+        titleLabel.centerYAnchor.constraint(equalTo: self.deleteToDoButton.centerYAnchor)
       ]
     )
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -60,11 +60,52 @@ extension EditToDoView {
   }
 }
 
+// MARK: GroupSelectionView Delegate Functions
+
+extension EditToDoView: GroupSelectionViewDelegate {
+  func didSelectGroup(color: UIColor) {
+    self.toDoNameInputView.changeBottomLine(color: color)
+  }
+
+  private func setupGroupSelectionViewDelegate() {
+    self.groupSelectionView.delegate = self
+  }
+}
+
+// MARK: Tap Gesture Functions
+
+extension EditToDoView: UIGestureRecognizerDelegate {
+  func gestureRecognizer(
+    _ gestureRecognizer: UIGestureRecognizer,
+    shouldReceive touch: UITouch
+  ) -> Bool {
+    self.inActiveNameEditModeWhenTouchEmptySpace(touch)
+  }
+
+  private func inActiveNameEditModeWhenTouchEmptySpace(_ touch: UITouch) -> Bool {
+    guard touch.view == self
+    else { return false }
+
+    if self.toDoNameInputView.isFirstResponder {
+      self.toDoNameInputView.resignFirstResponder()
+    }
+
+    return true
+  }
+
+  private func setupTapGestureDelegate() {
+    let tapGestureRecognizer = UITapGestureRecognizer()
+    tapGestureRecognizer.delegate = self
+  }
+}
+
 // MARK: Private Functions
 
 extension EditToDoView {
   private func setup() {
     self.setupDeleteToDoButton()
+    self.setupGroupSelectionViewDelegate()
+    self.setupTapGestureDelegate()
     self.setupSubviewsLayout()
   }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -30,6 +30,22 @@ final class EditToDoView: UIView {
   func updateToDoName(_ name: String) {
     self.toDoNameInputView.setBeginEditing(with: name)
   }
+
+  func updateGroup(
+    current: EditToDoView.GroupItem,
+    editableGroupList: [EditToDoView.GroupItem]
+  ) {
+    self.toDoNameInputView.changeBottomLine(color: current.groupColor)
+    self.groupSelectionView.updateGroup(current: current, editableList: editableGroupList)
+  }
+
+  func getCurrentGroupId() -> Int? {
+    return self.groupSelectionView.getCurrentGroupId()
+  }
+
+  func getEditingText() -> String? {
+    return self.toDoNameInputView.getEditingText()
+  }
 }
 
 // MARK: Private Functions
@@ -175,5 +191,17 @@ extension EditToDoView {
         titleLabel.centerYAnchor.constraint(equalTo: self.deleteToDoButton.centerYAnchor)
       ]
     )
+  }
+}
+
+extension EditToDoView {
+  struct GroupItem: GroupSelectionViewItemAPI {
+    let groupId: Int
+    let groupName: String
+    let groupColor: UIColor
+
+    static func < (lhs: EditToDoView.GroupItem, rhs: EditToDoView.GroupItem) -> Bool {
+      lhs.groupId > rhs.groupId
+    }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/GroupSelectionViewAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/GroupSelectionViewAPI.swift
@@ -14,9 +14,15 @@ public protocol GroupSelectionViewItemAPI: Hashable, Comparable {
 }
 
 public protocol GroupSelectionViewAPI: UIView {
+  var delegate: GroupSelectionViewDelegate? { get set }
+
   func updateGroup(
     current: any GroupSelectionViewItemAPI,
     editableList: [any GroupSelectionViewItemAPI]
   )
   func getCurrentGroupId() -> Int?
+}
+
+public protocol GroupSelectionViewDelegate: AnyObject {
+  func didSelectGroup(color: UIColor)
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -19,6 +19,8 @@ public final class GroupSelectionView: UIView, GroupSelectionViewAPI {
   private var tableViewHeightConstraint: NSLayoutConstraint
   private var heightConstraint: NSLayoutConstraint
 
+  public weak var delegate: GroupSelectionViewDelegate?
+
   public init(model: GroupSelectionView.Model) {
     self.model = model
     self.showGroupListButton = UIButton()
@@ -75,6 +77,7 @@ extension GroupSelectionView: GroupDataSendable {
     let color = groupItem.groupColor
     let model = Styled.Row.Configuration.ListPrimaryModel(title: title, color: color)
     self.currentGroupRow.groupListModel = model
+    self.delegate?.didSelectGroup(color: color)
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -23,6 +23,10 @@ public final class TextInputView: UIView, TextInputViewAPI {
     return CGSize(width: 0, height: self.height)
   }
 
+  public override var isFirstResponder: Bool {
+    return self.inputTextField.isFirstResponder
+  }
+
   public init(model: Model) {
     self.model = model
     self.inputTextField = Styled.TextField(

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -45,6 +45,11 @@ public final class TextInputView: UIView, TextInputViewAPI {
     fatalError("init(coder:) has not been implemented")
   }
 
+  public override func resignFirstResponder() -> Bool {
+    super.resignFirstResponder()
+    return self.inputTextField.resignFirstResponder()
+  }
+
   public func changeBottomLine(color: UIColor) {
     self.inputTextField.mainColor = color
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #371 

## 🎉 변경 사항
- 투두 수정 화면에 사용되는 컴포넌트들을 담는 컨테이너 객체를 추가하였습니다.

## 📌 PR Point
### Delegate
- 하위 뷰들의 이벤트를 입력받아 상위 객체에 전달하는 델리게이트 객체입니다.
- `didSelectedDeleteToDoButton()` 메서드를 호출하여 투두 삭제 VIP 사이클을 트리거합니다.

<img width="450" alt="스크린샷 2024-07-23 15 01 51" src="https://github.com/user-attachments/assets/7f68894d-5a35-40e6-bfb2-35f136c6487c">

### getEditingText, getCurrentGroupId 메서드의 필요성
- 사용자가 완료 버튼을 누르면 (완료 버튼은 ViewCOntroller에서 구현할 예정) VIP Cycle을 실행합니다.
- `getEditingText`, `getCurrentGroupId`을 이용해 사용자가 입력한 데이터를 가져와 수정 요청에 사용합니다. 
<img width="450" alt="스크린샷 2024-07-23 15 01 48" src="https://github.com/user-attachments/assets/f9aafdf0-b0ea-4d48-bea6-c5985695c644">

### Preview
울버린이 사용하셨던 방식인, Preview를 보여줄 떄만 Component 의존성을 추가하도록 구현하였습니다.
- Preview를 사용하기 위해 주석을 해제하고, Package.swift에서 UIComponent 의존성을 추가해줘야 합니다.

사소한 UX 적인 요소들을 추가하였습니다.
- 텍스트 필드 입력상태에서 빈 공간 클릭시 resignFirstResponder 호출
- 사용자가 그룹 선택시 즉시 TextField 하단 색상 변경

<img width="200" src="https://github.com/user-attachments/assets/db3a9417-1a42-409b-8e78-4f39f4f57054">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?