### PR TITLE
PostGroupScene(1): 의존성 주입 및 뷰 배치

### DIFF
--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupRouter.swift
@@ -20,9 +20,9 @@ protocol PostGroupDataPassing {
 class PostGroupRouter: PostGroupDataPassing {
   weak var viewController: PostGroupViewController?
   var dataStore: PostGroupDataStore?
-  private let nextSceneBuilder: NextSceneBuildable
+  private let nextSceneBuilder: NextSceneBuildable?
   
-  init(nextSceneBuilder: NextSceneBuildable) {
+  init(nextSceneBuilder: NextSceneBuildable?) {
     self.nextSceneBuilder = nextSceneBuilder
   }
 }
@@ -31,7 +31,9 @@ class PostGroupRouter: PostGroupDataPassing {
 
 extension PostGroupRouter: PostGroupRoutingLogic {
   func routeToSomewhere() {
-    let destinationViewController = self.nextSceneBuilder.build(with: NextScenePayload())
+    guard let destinationViewController = self.nextSceneBuilder?.build(
+      with: NextScenePayload()
+    ) else { return }
     
     self.viewController?.present(destinationViewController, animated: true)
   }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
@@ -56,11 +56,20 @@ extension PostGroupSceneBuilder: PostGroupSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
-  public func build(with payload: PostGroupScenePayloadable) -> PostGroupViewControllable {
-    let someViewController = self.configureVIPCycle(for: PostGroupViewController())
-    self.setPayload(for: someViewController, with: payload)
+  public func build(with payload: PostGroupScenePayloadable?) -> PostGroupViewControllable {
+    let postGroupViewController = self.configureVIPCycle(
+      for: PostGroupViewController(
+        textInputView: self.dependency.textInputView,
+        postGroupColorPickerRow: self.dependency.colorRow,
+        colorPickerList: self.dependency.colorPickerList,
+        colorPickButton: self.dependency.colorPickButton,
+        bottomButton: self.dependency.bottomButton,
+        modalBottomButton: self.dependency.modalBottomButton
+      )
+    )
+    self.setPayload(for: postGroupViewController, with: payload)
     
-    return someViewController
+    return postGroupViewController
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
@@ -1,24 +1,47 @@
 //
 //  PostGroupSceneBuilder.swift
-//  
+//
 //
 //  Created by SONG on 7/8/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit.UIButton
 
 import PostGroupSceneAPI
 import PostGroupSceneEntity
+import ToDoGardenUIAPI
 
 public struct PostGroupSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
-    let someWorker: PostGroupWorkable
-    let nextSceneBuilder: NextSceneBuildable
+    let postGroupWorker: PostGroupWorkable
+    let nextSceneBuilder: NextSceneBuildable?
     
-    public init(someWorker: PostGroupWorkable, nextSceneBuilder: NextSceneBuildable) {
-      self.someWorker = someWorker
+    let textInputView: TextInputViewAPI
+    let colorRow: PostGroupColorPickerRowAPI
+    let colorPickerList: ColorPickerListAPI
+    let colorPickButton: UIButton
+    let bottomButton: UIButton
+    let modalBottomButton: UIButton
+    
+    public init(
+      postGroupWorker: PostGroupWorkable,
+      nextSceneBuilder: NextSceneBuildable?,
+      textInputView: TextInputViewAPI,
+      colorRow: PostGroupColorPickerRowAPI,
+      colorPickerList: ColorPickerListAPI,
+      colorPickButton: UIButton,
+      bottomButton: UIButton,
+      modalBottomButton: UIButton
+    ) {
+      self.postGroupWorker = postGroupWorker
       self.nextSceneBuilder = nextSceneBuilder
+      self.textInputView = textInputView
+      self.colorRow = colorRow
+      self.colorPickerList = colorPickerList
+      self.colorPickButton = colorPickButton
+      self.bottomButton = bottomButton
+      self.modalBottomButton = modalBottomButton
     }
   }
   

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
@@ -95,7 +95,8 @@ extension PostGroupSceneBuilder {
   /// - Parameters:
   ///   - viewController: 런타임 의존성을 설정할 ViewController 객체입니다.
   ///   - payload: 런타임에 전달할 의존성입니다.
-  private func setPayload(for viewController: PostGroupViewController, with payload: PostGroupScenePayloadable) {
-    // viewController.router?.dataStore?.name = payload.name
+  private func setPayload(for viewController: PostGroupViewController, with payload: PostGroupScenePayloadable?) {
+    // viewController.setPayload(name: payload?.grouName, color: payload?.color)
+    // TODO: PostGroupScenePayloadable 수정후 주석해제 예정
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
@@ -78,9 +78,9 @@ extension PostGroupSceneBuilder {
   /// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
   private func configureVIPCycle(for viewController: PostGroupViewController) -> PostGroupViewController {
-    let interactor = PostGroupInteractor(someWorker: self.dependency.someWorker)
+    let interactor = PostGroupInteractor(someWorker: self.dependency.postGroupWorker)
     let presenter = PostGroupPresenter()
-    let router = PostGroupRouter(nextSceneBuilder: self.dependency.nextSceneBuilder)
+    let router = PostGroupRouter(nextSceneBuilder: nil)
     viewController.interactor = interactor
     viewController.router = router
     interactor.presenter = presenter

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneConstants.swift
@@ -8,6 +8,24 @@
 import Foundation
 
 enum Constant {
+  enum TextInputView {
+    static let margin: CGFloat = 30.0
+  }
+  
+  enum ColorPickerRow {
+    static let topMargin: CGFloat = 45.0
+    static let leadingMargin: CGFloat = 15.0
+    static let trailingMargin: CGFloat = -30.0
+  }
+  
+  enum ColorPickButton {
+    static let length: CGFloat = 24.0
+  }
+  
+  enum BottomButton {
+    static let bottomMargin: CGFloat = -50.0
+  }
+  
   enum BottomSheet {
     static let multiplier: CGFloat = 0.41
   }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneConstants.swift
@@ -13,7 +13,8 @@ enum Constant {
   }
   
   enum ColorPickerRow {
-    static let topMargin: CGFloat = 45.0
+    static let topMargin: CGFloat = 20.0
+    static let height: CGFloat = 40.0
     static let leadingMargin: CGFloat = 15.0
     static let trailingMargin: CGFloat = -30.0
   }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -60,7 +60,31 @@ class PostGroupViewController: UIViewController, PostGroupViewControllable {
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    self.doSomething()
+    // TODO: NavigationBar setup
+    self.setupTextInputView()
+  }
+  
+  private func setupTextInputView() {
+    self.textInputView.delegate = self
+    self.textInputView.translatesAutoresizingMaskIntoConstraints = false
+    self.view.addSubview(self.textInputView)
+    
+    NSLayoutConstraint.activate(
+      [
+        self.textInputView.topAnchor.constraint(
+          equalTo: self.view.safeAreaLayoutGuide.topAnchor,
+          constant: Constant.TextInputView.margin
+        ),
+        self.textInputView.leadingAnchor.constraint(
+          equalTo: self.view.leadingAnchor,
+          constant: Constant.TextInputView.margin
+        ),
+        self.textInputView.trailingAnchor.constraint(
+          equalTo: self.view.trailingAnchor,
+          constant: -Constant.TextInputView.margin
+        )
+      ]
+    )
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -24,7 +24,7 @@ class PostGroupViewController: UIViewController, PostGroupViewControllable {
   
   private let textInputView: TextInputViewAPI
   private let postGroupColorPickerRow: PostGroupColorPickerRowAPI
-  private let bottomSheet: PostGroupBottomSheet
+  private let postGroupBottomSheet: PostGroupBottomSheet
   private let colorPickButton: UIButton
   private let doneBottomButton: UIButton
   
@@ -40,7 +40,7 @@ class PostGroupViewController: UIViewController, PostGroupViewControllable {
   ) {
     self.textInputView = textInputView
     self.postGroupColorPickerRow = postGroupColorPickerRow
-    self.bottomSheet = PostGroupBottomSheet(
+    self.postGroupBottomSheet = PostGroupBottomSheet(
       colorPickerList: colorPickerList,
       bottomButton: modalBottomButton
     )
@@ -48,7 +48,7 @@ class PostGroupViewController: UIViewController, PostGroupViewControllable {
     self.doneBottomButton = bottomButton
     super.init(nibName: nil, bundle: nil)
     self.view.backgroundColor = UIColor.white
-    self.bottomSheet.delegate = self
+    self.postGroupBottomSheet.delegate = self
   }
   
   @available(*, unavailable)
@@ -127,8 +127,8 @@ class PostGroupViewController: UIViewController, PostGroupViewControllable {
     )
     
     self.colorPickButton.addAction( UIAction { _ in
-      self.bottomSheet.setupCurrentColor(color: self.postGroupColorPickerRow.getColor())
-      self.present(self.bottomSheet, animated: true)
+      self.postGroupBottomSheet.setupCurrentColor(color: self.postGroupColorPickerRow.getColor())
+      self.present(self.postGroupBottomSheet, animated: true)
     }, for: UIControl.Event.touchUpInside)
   }
   

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -63,6 +63,7 @@ class PostGroupViewController: UIViewController, PostGroupViewControllable {
     // TODO: NavigationBar setup
     self.setupTextInputView()
     self.setupPostGroupColorPickerRow()
+    self.setupColorPickButton()
   }
   
   private func setupTextInputView() {
@@ -109,6 +110,25 @@ class PostGroupViewController: UIViewController, PostGroupViewControllable {
         )
       ]
     )
+  }
+  
+  private func setupColorPickButton() {
+    self.colorPickButton.translatesAutoresizingMaskIntoConstraints = false
+    self.view.addSubview(self.colorPickButton)
+    
+    NSLayoutConstraint.activate(
+      [
+        self.colorPickButton.centerYAnchor.constraint(equalTo: self.postGroupColorPickerRow.centerYAnchor),
+        self.colorPickButton.centerXAnchor.constraint(equalTo: self.postGroupColorPickerRow.trailingAnchor),
+        self.colorPickButton.widthAnchor.constraint(equalToConstant: Constant.ColorPickButton.length),
+        self.colorPickButton.heightAnchor.constraint(equalToConstant: Constant.ColorPickButton.length)
+      ]
+    )
+    
+    self.colorPickButton.addAction( UIAction { _ in
+      self.bottomSheet.setupCurrentColor(color: self.postGroupColorPickerRow.getColor())
+      self.present(self.bottomSheet, animated: true)
+    }, for: UIControl.Event.touchUpInside)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import PostGroupSceneAPI
 import PostGroupSceneEntity
 import ToDoGardenUIAPI
+import ToDoGardenUIResource
 
 protocol PostGroupDisplayLogic: AnyObject {
   func displaySomething(viewModel: PostGroup.Something.ViewModel)

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -1,6 +1,6 @@
 //
 //  PostGroupViewController.swift
-//  
+//
 //
 //  Created by SONG on 7/8/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
@@ -9,6 +9,7 @@ import UIKit
 
 import PostGroupSceneAPI
 import PostGroupSceneEntity
+import ToDoGardenUIAPI
 
 protocol PostGroupDisplayLogic: AnyObject {
   func displaySomething(viewModel: PostGroup.Something.ViewModel)
@@ -21,10 +22,33 @@ class PostGroupViewController: UIViewController, PostGroupViewControllable {
   var interactor: PostGroupBusinessLogic?
   var router: (PostGroupRoutingLogic & PostGroupDataPassing)?
   
+  private let textInputView: TextInputViewAPI
+  private let postGroupColorPickerRow: PostGroupColorPickerRowAPI
+  private let bottomSheet: PostGroupBottomSheet
+  private let colorPickButton: UIButton
+  private let doneBottomButton: UIButton
+  
   // MARK: - Object lifecycle
   
-  init() {
+  init(
+    textInputView: TextInputViewAPI,
+    postGroupColorPickerRow: PostGroupColorPickerRowAPI,
+    colorPickerList: ColorPickerListAPI,
+    colorPickButton: UIButton,
+    bottomButton: UIButton,
+    modalBottomButton: UIButton
+  ) {
+    self.textInputView = textInputView
+    self.postGroupColorPickerRow = postGroupColorPickerRow
+    self.bottomSheet = PostGroupBottomSheet(
+      colorPickerList: colorPickerList,
+      bottomButton: modalBottomButton
+    )
+    self.colorPickButton = colorPickButton
+    self.doneBottomButton = bottomButton
     super.init(nibName: nil, bundle: nil)
+    self.view.backgroundColor = UIColor.white
+    self.bottomSheet.delegate = self
   }
   
   @available(*, unavailable)

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -166,12 +166,8 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
     guard let currentColor = self.postGroupColorPickerRow.getColor() else {
       return true
     }
-    
-    if currentColor == UIColor.toDoGardenGrassNone {
-      return true
-    } else {
-      return false
-    }
+
+    return currentColor == UIColor.toDoGardenGrassNone
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -62,6 +62,7 @@ class PostGroupViewController: UIViewController, PostGroupViewControllable {
     super.viewDidLoad()
     // TODO: NavigationBar setup
     self.setupTextInputView()
+    self.setupPostGroupColorPickerRow()
   }
   
   private func setupTextInputView() {
@@ -82,6 +83,29 @@ class PostGroupViewController: UIViewController, PostGroupViewControllable {
         self.textInputView.trailingAnchor.constraint(
           equalTo: self.view.trailingAnchor,
           constant: -Constant.TextInputView.margin
+        )
+      ]
+    )
+  }
+  
+  private func setupPostGroupColorPickerRow() {
+    self.view.addSubview(self.postGroupColorPickerRow)
+    
+    self.postGroupColorPickerRow.translatesAutoresizingMaskIntoConstraints = false
+    
+    NSLayoutConstraint.activate(
+      [
+        self.postGroupColorPickerRow.topAnchor.constraint(
+          equalTo: self.textInputView.bottomAnchor,
+          constant: Constant.ColorPickerRow.topMargin
+        ),
+        self.postGroupColorPickerRow.leadingAnchor.constraint(
+          equalTo: self.view.leadingAnchor,
+          constant: Constant.ColorPickerRow.leadingMargin
+        ),
+        self.postGroupColorPickerRow.trailingAnchor.constraint(
+          equalTo: self.view.trailingAnchor,
+          constant: Constant.ColorPickerRow.trailingMargin
         )
       ]
     )

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -210,10 +210,8 @@ extension PostGroupViewController: PostGroupBottomSheetDelegate {
 // @available(iOS 17.0, *)
 // #Preview {
 //  let textInputView = TextInputView(model: .groupName)
-//  
 //  let colorPickerRow = PostGroupColorPickerRow()
 //  let subject =  CurrentValueSubject<Int?, Never>(nil)
-//  
 //  let colorPickerList = ColorPickerList(colors: [
 //    .toDoGardenBlack,
 //    .toDoGardenBlue,
@@ -228,12 +226,9 @@ extension PostGroupViewController: PostGroupBottomSheetDelegate {
 //    .toDoGardenOlive,
 //    .toDoGardenPink
 //  ], itemsPerRow: 6, selected: subject)
-//  
 //  let colorPickButton = UIButton()
 //  colorPickButton.setImage(UIImage.forwardButtonImage, for: .normal)
-//  
-//  
-//  
+//
 //  let vc = PostGroupViewController(
 //    textInputView: textInputView,
 //    postGroupColorPickerRow: colorPickerRow,

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -201,3 +201,48 @@ extension PostGroupViewController: PostGroupBottomSheetDelegate {
   func dismissedBottomSheet(color: UIColor) {
   }
 }
+
+// MARK: Preview : PostGroupScene의 Package.swift에 있는 주석처리를 해제해주세요.
+//
+// import Combine
+// import ToDoGardenUIComponent
+// #if DEBUG
+// @available(iOS 17.0, *)
+// #Preview {
+//  let textInputView = TextInputView(model: .groupName)
+//  
+//  let colorPickerRow = PostGroupColorPickerRow()
+//  let subject =  CurrentValueSubject<Int?, Never>(nil)
+//  
+//  let colorPickerList = ColorPickerList(colors: [
+//    .toDoGardenBlack,
+//    .toDoGardenBlue,
+//    .toDoGardenBrown,
+//    .toDoGardenEditButtonBlue,
+//    .toDoGardenEditButtonRed,
+//    .toDoGardenEditButtonYellow,
+//    .toDoGardenGrassHigh,
+//    .toDoGardenGrassLow,
+//    .toDoGardenGrassMiddle,
+//    .toDoGardenGray2,
+//    .toDoGardenOlive,
+//    .toDoGardenPink
+//  ], itemsPerRow: 6, selected: subject)
+//  
+//  let colorPickButton = UIButton()
+//  colorPickButton.setImage(UIImage.forwardButtonImage, for: .normal)
+//  
+//  
+//  
+//  let vc = PostGroupViewController(
+//    textInputView: textInputView,
+//    postGroupColorPickerRow: colorPickerRow,
+//    colorPickerList: colorPickerList,
+//    colorPickButton: colorPickButton,
+//    bottomButton: ToDoGardenBoxButton(title: "확인", buttonType: .primaryRoundRectButton),
+//    modalBottomButton: ToDoGardenBoxButton(title: "확인", buttonType: .primaryRoundRectButton)
+//  )
+//  
+//  return vc
+// }
+// #endif

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -64,6 +64,7 @@ class PostGroupViewController: UIViewController, PostGroupViewControllable {
     self.setupTextInputView()
     self.setupPostGroupColorPickerRow()
     self.setupColorPickButton()
+    self.setupBottomButton()
   }
   
   private func setupTextInputView() {
@@ -129,6 +130,47 @@ class PostGroupViewController: UIViewController, PostGroupViewControllable {
       self.bottomSheet.setupCurrentColor(color: self.postGroupColorPickerRow.getColor())
       self.present(self.bottomSheet, animated: true)
     }, for: UIControl.Event.touchUpInside)
+  }
+  
+  private func setupBottomButton() {
+    self.doneBottomButton.translatesAutoresizingMaskIntoConstraints = false
+    self.view.addSubview(self.doneBottomButton)
+    
+    self.doneBottomButton.isEnabled = self.isButtonEnabled()
+    
+    NSLayoutConstraint.activate(
+      [
+        self.doneBottomButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+        self.doneBottomButton.bottomAnchor.constraint(
+          equalTo: self.view.safeAreaLayoutGuide.bottomAnchor,
+          constant: Constant.BottomButton.bottomMargin
+        )
+      ]
+    )
+  }
+  
+  private func isButtonEnabled() -> Bool {
+    return !(self.isTextFieldEmpty()) && !(self.isColorEmpty())
+  }
+  
+  private func isTextFieldEmpty() -> Bool {
+    guard let currentText = self.textInputView.getEditingText() else {
+      return true
+    }
+    
+    return currentText.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).isEmpty
+  }
+  
+  private func isColorEmpty() -> Bool {
+    guard let currentColor = self.postGroupColorPickerRow.getColor() else {
+      return true
+    }
+    
+    if currentColor == UIColor.toDoGardenGrassNone {
+      return true
+    } else {
+      return false
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -190,3 +190,14 @@ extension PostGroupViewController {
     self.interactor?.doSomething(request: request)
   }
 }
+
+extension PostGroupViewController: TextInputViewDelegate {
+  func textInputViewDidEndEditing(isEmpty: Bool) {
+    self.doneBottomButton.isEnabled = self.isButtonEnabled()
+  }
+}
+
+extension PostGroupViewController: PostGroupBottomSheetDelegate {
+  func dismissedBottomSheet(color: UIColor) {
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -102,6 +102,9 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
           equalTo: self.textInputView.bottomAnchor,
           constant: Constant.ColorPickerRow.topMargin
         ),
+        self.postGroupColorPickerRow.heightAnchor.constraint(
+          equalToConstant: Constant.ColorPickerRow.height
+        ),
         self.postGroupColorPickerRow.leadingAnchor.constraint(
           equalTo: self.view.leadingAnchor,
           constant: Constant.ColorPickerRow.leadingMargin

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -16,7 +16,7 @@ protocol PostGroupDisplayLogic: AnyObject {
   func displaySomething(viewModel: PostGroup.Something.ViewModel)
 }
 
-class PostGroupViewController: UIViewController, PostGroupViewControllable {
+final class PostGroupViewController: UIViewController, PostGroupViewControllable {
   
   // MARK: - VIP Properties
   

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -65,7 +65,7 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
     self.setupTextInputView()
     self.setupPostGroupColorPickerRow()
     self.setupColorPickButton()
-    self.setupBottomButton()
+    self.setupDoneBottomButton()
   }
   
   private func setupTextInputView() {
@@ -133,11 +133,11 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
     }, for: UIControl.Event.touchUpInside)
   }
   
-  private func setupBottomButton() {
+  private func setupDoneBottomButton() {
     self.doneBottomButton.translatesAutoresizingMaskIntoConstraints = false
     self.view.addSubview(self.doneBottomButton)
     
-    self.doneBottomButton.isEnabled = self.isButtonEnabled()
+    self.doneBottomButton.isEnabled = self.isDoneBottomButtonEnabled()
     
     NSLayoutConstraint.activate(
       [
@@ -150,7 +150,7 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
     )
   }
   
-  private func isButtonEnabled() -> Bool {
+  private func isDoneBottomButtonEnabled() -> Bool {
     return !(self.isTextFieldEmpty()) && !(self.isColorEmpty())
   }
   
@@ -194,7 +194,7 @@ extension PostGroupViewController {
 
 extension PostGroupViewController: TextInputViewDelegate {
   func textInputViewDidEndEditing(isEmpty: Bool) {
-    self.doneBottomButton.isEnabled = self.isButtonEnabled()
+    self.doneBottomButton.isEnabled = self.isDoneBottomButtonEnabled()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneBuildable.swift
@@ -16,5 +16,5 @@ public protocol PostGroupSceneBuildable {
   ///  VIP Cycle, 런타임 파라미터가 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 파라미터입니다.
   /// - Returns: 런타임 파라미터, VIP Cycle이 설정된 ViewController가 반환되도록 구현합니다.
-  func build(with payload: PostGroupScenePayloadable) -> PostGroupViewControllable
+  func build(with payload: PostGroupScenePayloadable?) -> PostGroupViewControllable
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/PostGroupColorPickerRowAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/PostGroupColorPickerRowAPI.swift
@@ -7,7 +7,7 @@
 
 import UIKit.UIColor
 
-public protocol PostGroupColorPickerRowAPI {
+public protocol PostGroupColorPickerRowAPI: UIView {
   func getColor() -> UIColor?
   func updateColor(with color: UIColor)
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #370

## 🎉 변경 사항
- PostGroupScene(1): 의존성 주입 및 뷰 배치
  ->  페이로드를 제외하고, 파라미터로 전달받은 뷰객체들을 배치하였습니다. 
  
## 📌 PR Point
<img width="202" alt="스크린샷 2024-07-23 오후 4 46 53" src="https://github.com/user-attachments/assets/b27e4db6-99ee-4afe-88f7-8ef518bff46c">
<img width="198" alt="스크린샷 2024-07-23 오후 4 47 22" src="https://github.com/user-attachments/assets/e3ccde47-8279-43b9-b330-addd3ce3d88c">

- `>` 버튼을 터치하면, 색상을 선택할 수 있는 모달이 올라옵니다. 
   -> 다만, 인터랙터 미구현으로 인해 `완료`를 눌러도 적용되지 않습니다. 
   
- `TextInputView`와 `컬러선택` 이 둘 다 동시에 비어있지 않은 경우에만 `doneBottomButton`이 활성화 됩니다. 
   - `TextInputView`는 "" 이외에도 " ", "        " 와 같은 공백만 포함된 문자열에 대해서도 비어있다고 판단합니다. 
   - 즉, 지금 상태로는 `doneBottomButton`을 enable로 만들 수 없습니다. 
   
- 인터랙터 / 프레젠터 /  UseCase / Router 의 구현은 포함되어있지 않습니다. 다음 PR에서 확인하실 수 있을 듯 합니다.
- `TextInputView`를 터치했을 때 시뮬레이터 / 프리뷰 상에서 키보드가 안뜨는 이슈가 있습니다. 
- NavigationBar는 ManageGroupScene과 연결될 때 추가될 예정입니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?