### PR TITLE
GroupSelectionView 수정

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
@@ -48,16 +48,6 @@ extension EditableGroupTableViewDelegate: UITableViewDelegate {
     return self.cellHeight
   }
 
-  func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-    let headerView = UIView()
-    headerView.backgroundColor = UIColor.toDoGardenGreenGray
-    return headerView
-  }
-
-  func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-    return Constant.GroupSelectionView.Layout.EditableGroupTableViewDelegate.headerViewHeight
-  }
-
   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     guard let newItem = self.tableViewDataSource.itemIdentifier(for: indexPath)
     else { return }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
@@ -108,6 +108,7 @@ extension EditableGroupTableViewDelegate {
   private func setupTableView(_ tableView: UITableView) {
     tableView.delegate = self
     self.tableViewDataSource = self.makeDiffableDataSource(tableView: tableView)
+    self.tableViewDataSource.defaultRowAnimation = UITableView.RowAnimation.right
     tableView.dataSource = self.tableViewDataSource
   }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupTableViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupTableViewCell.swift
@@ -87,8 +87,9 @@ extension EditableGroupTableViewCell {
     let layout = Constant.GroupSelectionView.Layout.EditableGroupTableViewCell.SeparatorView.self
     NSLayoutConstraint.activate(
       [
-        separatorView.topAnchor.constraint(equalTo: self.bottomAnchor),
-        separatorView.widthAnchor.constraint(equalTo: self.widthAnchor),
+        separatorView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor),
+        separatorView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
+        separatorView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor),
         separatorView.heightAnchor.constraint(equalToConstant: layout.width)
       ]
     )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -93,31 +93,21 @@ extension GroupSelectionView {
 
   private func setupShowGroupMenuButton() {
     self.showGroupListButton.setImage(UIImage.forwardButtonImage, for: UIControl.State.normal)
-    self.showGroupListButton.changesSelectionAsPrimaryAction = true
-    self.showGroupListButton.addAction(self.makeShowEditableGroupButtonAction(), for: UIControl.Event.touchUpInside)
-  }
 
-  private func makeShowEditableGroupButtonAction() -> UIAction {
-    return UIAction { [weak self] _ in
+    let buttonAction = UIAction { [weak self] _ in
       guard let self else { return }
 
       let isSelected = self.showGroupListButton.isSelected
-      self.animateRotatingButton(isSelected: isSelected)
+      self.showGroupListButton.animateRotating(with: Constant.GroupSelectionView.Animation.duration)
       self.animateShowingEditableGroupMenu(isSelected: isSelected)
     }
-  }
-
-  private func animateRotatingButton(isSelected: Bool) {
-    let transform = isSelected ? CGAffineTransform(rotationAngle: CGFloat.pi / 2) : CGAffineTransform.identity
-    UIView.animate(withDuration: Constant.GroupSelectionView.Animation.duration) {
-      self.showGroupListButton.transform = transform
-    }
+    self.showGroupListButton.addAction(buttonAction, for: UIControl.Event.touchUpInside)
   }
 
   private func animateShowingEditableGroupMenu(isSelected: Bool) {
     let height = self.model.cellHeight * CGFloat(self.model.visibleCellCount)
-    let heightConstant: CGFloat = isSelected ? height : 0
-    let isSeparatorLineHidden = !isSelected
+    let heightConstant: CGFloat = isSelected ? 0 : height
+    let isSeparatorLineHidden = isSelected
     UIView.animate(withDuration: Constant.GroupSelectionView.Animation.duration) {
       self.heightConstraint.constant = heightConstant + self.model.cellHeight
       self.tableViewHeightConstraint.constant = heightConstant

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -14,6 +14,7 @@ public final class GroupSelectionView: UIView, GroupSelectionViewAPI {
   private let model: GroupSelectionView.Model
   private let showGroupListButton: UIButton
   private let currentGroupRow: Styled.Row
+  private let groupListSeparatorLineView: UIView
   private let editableGroupListTableView: UITableView
   private let editableGroupListTableViewDelegate: EditableGroupTableViewDelegate
   private var tableViewHeightConstraint: NSLayoutConstraint
@@ -31,6 +32,7 @@ public final class GroupSelectionView: UIView, GroupSelectionViewAPI {
       ),
       with: [self.showGroupListButton]
     )
+    self.groupListSeparatorLineView = UIView()
     self.editableGroupListTableView = UITableView()
     self.editableGroupListTableViewDelegate = EditableGroupTableViewDelegate(
       tableView: self.editableGroupListTableView,
@@ -115,9 +117,11 @@ extension GroupSelectionView {
   private func animateShowingEditableGroupMenu(isSelected: Bool) {
     let height = self.model.cellHeight * CGFloat(self.model.visibleCellCount)
     let heightConstant: CGFloat = isSelected ? height : 0
+    let isSeparatorLineHidden = !isSelected
     UIView.animate(withDuration: Constant.GroupSelectionView.Animation.duration) {
       self.heightConstraint.constant = heightConstant + self.model.cellHeight
       self.tableViewHeightConstraint.constant = heightConstant
+      self.groupListSeparatorLineView.isHidden = isSeparatorLineHidden
       self.superview?.layoutIfNeeded()
     }
   }
@@ -157,6 +161,7 @@ extension GroupSelectionView {
     self.setupCurrentGroupRowLayout()
     let containerView = self.makeGroupListContainerView()
     self.setupContainerViewLayout(containerView: containerView)
+    self.setupGroupListSeparatorLineViewLayout(with: containerView)
     self.setupGroupListTableViewLayout(with: containerView)
     self.setupHeightLayout()
   }
@@ -219,13 +224,30 @@ extension GroupSelectionView {
     )
   }
 
+  private func setupGroupListSeparatorLineViewLayout(with containerView: UIView) {
+    self.groupListSeparatorLineView.isHidden = true
+    self.groupListSeparatorLineView.backgroundColor = UIColor.toDoGardenGreenGray
+    containerView.addSubview(self.groupListSeparatorLineView)
+    self.groupListSeparatorLineView.usingAutolayout()
+
+    let height = Constant.GroupSelectionView.Layout.EditableGroupTableViewDelegate.headerViewHeight
+    NSLayoutConstraint.activate(
+      [
+        self.groupListSeparatorLineView.topAnchor.constraint(equalTo: containerView.topAnchor),
+        self.groupListSeparatorLineView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+        self.groupListSeparatorLineView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+        self.groupListSeparatorLineView.heightAnchor.constraint(equalToConstant: height)
+      ]
+    )
+  }
+
   private func setupGroupListTableViewLayout(with containerView: UIView) {
     containerView.addSubview(self.editableGroupListTableView)
     self.editableGroupListTableView.usingAutolayout()
 
     NSLayoutConstraint.activate(
       [
-        self.editableGroupListTableView.topAnchor.constraint(equalTo: containerView.topAnchor),
+        self.editableGroupListTableView.topAnchor.constraint(equalTo: self.groupListSeparatorLineView.bottomAnchor),
         self.editableGroupListTableView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
         self.editableGroupListTableView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
         self.editableGroupListTableView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GroupSelectionView.swift
@@ -28,7 +28,7 @@ extension Constant.GroupSelectionView.Layout {
 extension Constant.GroupSelectionView.Layout.TableViewContainer {
   public enum Layer {}
 
-  public static let topMargin: CGFloat = 6
+  public static let topMargin: CGFloat = 14
   public static let leadingMargin: CGFloat = 10
   public static let trailingMargin: CGFloat = 5
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #377 

## 🎉 변경 사항
- [리뷰](https://github.com/ToDo-Garden/ToDo-Garden/pull/374#pullrequestreview-2198333395)를 반영하여 GroupSelectionView에서 발생하던 UI 버그들을 해결하였습니다.

## 📌 PR Point
1. Cell들 사이 Separator가 보이지 않던 버그를 해결하였습니다.
SeparatorView의 레이아웃을 정확하게 잡아주었습니다.

2. 그룹 목록의 HeaderView가 스크롤해도 최상단에 위치가 고정되도록 수정하였습니다.

3. 그룹 변경시 Cell들의 삽입/삭제 애니메이션을 하나로 통일하였습니다.
삽입: 우 > 좌 | 삭제: 좌 > 우 로 이동방향을 통일시켰습니다.

### Preview
<img width="250" src="https://github.com/user-attachments/assets/169a9008-8cbc-4d92-89bc-313e50d38482">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?