### PR TITLE
textInputView delegate 메서드 수정

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/TextInputViewAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/TextInputViewAPI.swift
@@ -15,5 +15,5 @@ public protocol TextInputViewAPI: UIView {
 }
 
 public protocol TextInputViewDelegate: AnyObject {
-  func textInputViewDidEndEditing(isEmpty: Bool)
+  func textInputViewDidChange()
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -131,13 +131,15 @@ extension TextInputView: UITextFieldDelegate {
 
     self.updatePlaceholderLabelText(isEditing: false)
     self.updatePlaceholderLabelPosition(isEditing: false)
-    self.delegate?.textInputViewDidEndEditing(isEmpty: textField.text?.isEmpty ?? true)
   }
 
   public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
     textField.resignFirstResponder()
-    self.delegate?.textInputViewDidEndEditing(isEmpty: textField.text?.isEmpty ?? true)
     return true
+  }
+  
+  public func textFieldDidChangeSelection(_ textField: UITextField) {
+    self.delegate?.textInputViewDidChange()
   }
 
   private func updatePlaceholderLabelText(isEditing: Bool) {


### PR DESCRIPTION

## 💡 관련 이슈
- closed: #380 
## 🎉 변경 사항
- textInputViewDidChange() 로 변경
## 📌 PR Point
- 기존의 텍스트필드 편집이 End되어야만 delegate 메서드를 호출했었습니다. 
- End가 아닌, 텍스트필드의 내용이 바뀔 때마다 delegate 메서드를 호출합니다.
## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?