### PR TITLE
EditToDoSceneBuilder Domain Context Worker 의존성 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         "EditToDoSceneAPI",
         "EditToDoSceneEntity",
         .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI"),
-        // .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
+        .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
         .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI")
       ]
     )

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -1,6 +1,6 @@
 //
 //  EditToDoInteractor.swift
-//  
+//
 //
 //  Created by Wood on 6/29/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
@@ -20,11 +20,21 @@ protocol EditToDoBusinessLogic {
 
 class EditToDoInteractor: EditToDoDataStore {
   // var name: String = ""
+
+  // MARK: VIP Objects
   var presenter: EditToDoPresentationLogic?
   private let someWorker: EditToDoWorkable
-  
-  init(someWorker: EditToDoWorkable) {
+  private let toDoWorker: MockToDoWorker
+  private let groupWorker: MockGroupWorker
+
+  public init(
+    someWorker: EditToDoWorkable,
+    toDoWorker: MockToDoWorker,
+    groupWorker: MockGroupWorker
+  ) {
     self.someWorker = someWorker
+    self.toDoWorker = toDoWorker
+    self.groupWorker = groupWorker
   }
 }
 
@@ -33,7 +43,7 @@ class EditToDoInteractor: EditToDoDataStore {
 extension EditToDoInteractor: EditToDoBusinessLogic {
   func doSomething(request: EditToDo.Something.Request) {
     self.someWorker.doSomeWork()
-    
+
     let response = EditToDo.Something.Response()
     self.presenter?.presentSomething(response: response)
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneBuilder.swift
@@ -1,6 +1,6 @@
 //
 //  EditToDoSceneBuilder.swift
-//  
+//
 //
 //  Created by Wood on 6/29/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
@@ -13,16 +13,25 @@ public struct EditToDoSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
     let someWorker: EditToDoWorkable
+    let toDoWorker: MockToDoWorker
+    let groupWorker: MockGroupWorker
     let nextSceneBuilder: NextSceneBuildable
-    
-    public init(someWorker: EditToDoWorkable, nextSceneBuilder: NextSceneBuildable) {
+
+    public init(
+      someWorker: EditToDoWorkable,
+      toDoWorker: MockToDoWorker,
+      groupWorker: MockGroupWorker,
+      nextSceneBuilder: NextSceneBuildable
+    ) {
       self.someWorker = someWorker
+      self.toDoWorker = toDoWorker
+      self.groupWorker = groupWorker
       self.nextSceneBuilder = nextSceneBuilder
     }
   }
-  
+
   private let dependency: Dependency
-  
+
   public init(dependency: Dependency) {
     self.dependency = dependency
   }
@@ -35,7 +44,7 @@ extension EditToDoSceneBuilder: EditToDoSceneBuildable {
   public func build(with payload: EditToDoScenePayloadable) -> EditToDoViewControllable {
     let someViewController = self.configureVIPCycle(for: EditToDoViewController())
     self.setPayload(for: someViewController, with: payload)
-    
+
     return someViewController
   }
 }
@@ -45,7 +54,11 @@ extension EditToDoSceneBuilder {
   /// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
   private func configureVIPCycle(for viewController: EditToDoViewController) -> EditToDoViewController {
-    let interactor = EditToDoInteractor(someWorker: self.dependency.someWorker)
+    let interactor = EditToDoInteractor(
+      someWorker: self.dependency.someWorker,
+      toDoWorker: self.dependency.toDoWorker,
+      groupWorker: self.dependency.groupWorker
+    )
     let presenter = EditToDoPresenter()
     let router = EditToDoRouter(nextSceneBuilder: self.dependency.nextSceneBuilder)
     viewController.interactor = interactor
@@ -54,10 +67,10 @@ extension EditToDoSceneBuilder {
     presenter.viewController = viewController
     router.viewController = viewController
     router.dataStore = interactor
-    
+
     return viewController
   }
-  
+
   /// ViewController에 런타임 파라미터 `payload`를 설정합니다.
   /// - Parameters:
   ///   - viewController: 런타임 의존성을 설정할 ViewController 객체입니다.

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/MockGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/MockGroupWorker.swift
@@ -10,7 +10,9 @@ import UIKit.UIColor
 import EditToDoSceneEntity
 
 /// Group Context를 가정한 Mock Worker 입니다.
-final class MockGroupWorker {
+public final class MockGroupWorker {
+  public init() {}
+
   func fetchGroupList() throws -> [EditToDo.Group] {
     return MockData.groupList
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/MockToDoWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/MockToDoWorker.swift
@@ -10,7 +10,9 @@ import UIKit.UIColor
 import EditToDoSceneEntity
 
 /// ToDo Context를 가정한 Mock Worker 입니다.
-final class MockToDoWorker {
+public final class MockToDoWorker {
+  public init() {}
+
   func fetchToDo(id: Int?) throws -> EditToDo.ToDo {
     return MockData.FetchToDo.firstData
   }


### PR DESCRIPTION
## 💡 관련 이슈
- related: #382
- closed: #384 

## 🎉 변경 사항
- Domain Context의 Mock Worker들을 Builder에서 주입받을 수 있도록 수정하였습니다.

## 📌 PR Point
- Builder에서 의존성을 주입받을 수 있게 하기 위해 File Changed 수가 많습니다
- Interactor를 테스트 가능하게 하고자, Worker들을 주입받을 수 있게 변경하였습니다.
- Mock Worker들의 접근제어자를 public으로 변경하였습니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?