### PR TITLE
PostGroupScene(2) : UseCase에 따른 VIP사이클 구성

### DIFF
--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -1,40 +1,90 @@
 //
 //  PostGroupInteractor.swift
-//  
+//
 //
 //  Created by SONG on 7/8/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit.UIColor
 
 import PostGroupSceneAPI
 import PostGroupSceneEntity
 
 protocol PostGroupDataStore {
-  // var name: String { get set }
+  var payload: PostGroupScenePayloadable? { get set }
 }
 
 protocol PostGroupBusinessLogic {
-  func doSomething(request: PostGroup.Something.Request)
+  func setPayload()
+  func changeColor(request: PostGroup.ChangeColor.Request)
+  func touchDoneButton(request: PostGroup.TouchDoneButton.Request)
 }
 
 class PostGroupInteractor: PostGroupDataStore {
-  // var name: String = ""
   var presenter: PostGroupPresentationLogic?
-  private let someWorker: PostGroupWorkable
+  private let postGroupWorker: PostGroupWorkable
+  var payload: PostGroupScenePayloadable?
   
-  init(someWorker: PostGroupWorkable) {
-    self.someWorker = someWorker
+  init(postGroupWorker: PostGroupWorkable) {
+    self.postGroupWorker = postGroupWorker
   }
 }
 
 // MARK: - Request to worker
 
 extension PostGroupInteractor: PostGroupBusinessLogic {
-  func doSomething(request: PostGroup.Something.Request) {
-    self.someWorker.doSomeWork()
+  func touchDoneButton(request: PostGroupSceneEntity.PostGroup.TouchDoneButton.Request) {
+    guard let groupID = payload?.groupID else { return }
     
-    let response = PostGroup.Something.Response()
-    self.presenter?.presentSomething(response: response)
+    self.postGroupWorker.touchDoneButton(
+      groupID: groupID,
+      groupName: request.groupName,
+      groupColor: request.groupColor
+    )
+    
+    let response = PostGroup.TouchDoneButton.Response(
+      groupID: groupID,
+      groupName: request.groupName,
+      groupColor: request.groupColor
+    )
+    
+    self.presenter?.presentTouchedDoneButton(response: response)
+  }
+  
+  func changeColor(request: PostGroup.ChangeColor.Request) {
+    self.postGroupWorker.changeColor(groupColor: request.groupColor)
+    // 성공했다고 가정
+    let response = PostGroup.ChangeColor.Response(groupID: "ID", groupColor: request.groupColor)
+    self.presenter?.presentChangedColor(response: response)
+  }
+  
+  func setPayload() {
+    let isButtonEnable: Bool = self.isButtonEnable(groupName: payload?.groupName, groupColor: payload?.groupColor)
+    
+    let response = PostGroup.SetPayload.Response(
+      groupName: self.convertGroupName(groupName: payload?.groupName),
+      groupColor: payload?.groupColor,
+      isDoneBottomButtonEnable: isButtonEnable
+    )
+    self.presenter?.presentSetPayload(response: response)
+  }
+}
+
+extension PostGroupInteractor {
+  private func convertGroupName(groupName: String?) -> String {
+    guard let groupName = groupName else {
+      return ""
+    }
+    return groupName
+  }
+  
+  private func isButtonEnable(groupName: String?, groupColor: UIColor?) -> Bool {
+    var isButtonEnable: Bool
+    if (groupName == nil) || (groupColor == nil) {
+      isButtonEnable = false
+    } else {
+      isButtonEnable = true
+    }
+    return isButtonEnable
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -34,7 +34,9 @@ class PostGroupInteractor: PostGroupDataStore {
 
 extension PostGroupInteractor: PostGroupBusinessLogic {
   func touchDoneButton(request: PostGroupSceneEntity.PostGroup.TouchDoneButton.Request) {
-    guard let groupID = payload?.groupID else { return }
+    guard let groupID = payload?.groupID else {
+      return
+    }
     
     self.postGroupWorker.touchDoneButton(
       groupID: groupID,

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -64,7 +64,7 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
     let isButtonEnable: Bool = self.isButtonEnable(groupName: payload?.groupName, groupColor: payload?.groupColor)
     
     let response = PostGroup.SetPayload.Response(
-      groupName: self.convertGroupName(groupName: payload?.groupName),
+      groupName: payload?.groupName ?? "",
       groupColor: payload?.groupColor,
       isDoneBottomButtonEnable: isButtonEnable
     )
@@ -73,12 +73,6 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
 }
 
 extension PostGroupInteractor {
-  private func convertGroupName(groupName: String?) -> String {
-    guard let groupName = groupName else {
-      return ""
-    }
-    return groupName
-  }
   
   private func isButtonEnable(groupName: String?, groupColor: UIColor?) -> Bool {
     var isButtonEnable: Bool

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -15,7 +15,7 @@ protocol PostGroupDataStore {
 }
 
 protocol PostGroupBusinessLogic {
-  func setPayload()
+  func loadGroupData()
   func changeColor(request: PostGroup.ChangeColor.Request)
   func touchDoneButton(request: PostGroup.TouchDoneButton.Request)
 }
@@ -60,15 +60,15 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
     self.presenter?.presentChangedColor(response: response)
   }
   
-  func setPayload() {
+  func loadGroupData() {
     let isButtonEnable: Bool = self.isButtonEnable(groupName: payload?.groupName, groupColor: payload?.groupColor)
     
-    let response = PostGroup.SetPayload.Response(
+    let response = PostGroup.LoadGroupData.Response(
       groupName: payload?.groupName ?? "",
       groupColor: payload?.groupColor,
       isDoneBottomButtonEnable: isButtonEnable
     )
-    self.presenter?.presentSetPayload(response: response)
+    self.presenter?.presentLoadGroupData(response: response)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupPresenter.swift
@@ -11,7 +11,7 @@ import PostGroupSceneEntity
 
 protocol PostGroupPresentationLogic {
   func presentChangedColor(response: PostGroup.ChangeColor.Response)
-  func presentSetPayload(response: PostGroup.SetPayload.Response)
+  func presentLoadGroupData(response: PostGroup.LoadGroupData.Response)
   func presentTouchedDoneButton(response: PostGroup.TouchDoneButton.Response)
 }
 
@@ -27,8 +27,8 @@ extension PostGroupPresenter: PostGroupPresentationLogic {
     self.viewController?.displayChangedColor(viewModel: viewModel)
   }
   
-  func presentSetPayload(response: PostGroup.SetPayload.Response) {
-    let viewModel = PostGroup.SetPayload.ViewModel(
+  func presentLoadGroupData(response: PostGroup.LoadGroupData.Response) {
+    let viewModel = PostGroup.LoadGroupData.ViewModel(
       groupName: response.groupName,
       groupColor: response.groupColor,
       isDoneBottomButtonEnable: response.isDoneBottomButtonEnable

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupPresenter.swift
@@ -1,6 +1,6 @@
 //
 //  PostGroupPresenter.swift
-//  
+//
 //
 //  Created by SONG on 7/8/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
@@ -10,7 +10,9 @@ import Foundation
 import PostGroupSceneEntity
 
 protocol PostGroupPresentationLogic {
-  func presentSomething(response: PostGroup.Something.Response)
+  func presentChangedColor(response: PostGroup.ChangeColor.Response)
+  func presentSetPayload(response: PostGroup.SetPayload.Response)
+  func presentTouchedDoneButton(response: PostGroup.TouchDoneButton.Response)
 }
 
 class PostGroupPresenter {
@@ -20,8 +22,22 @@ class PostGroupPresenter {
 // MARK: - Request to ViewController
 
 extension PostGroupPresenter: PostGroupPresentationLogic {
-  func presentSomething(response: PostGroup.Something.Response) {
-    let viewModel = PostGroup.Something.ViewModel()
-    self.viewController?.displaySomething(viewModel: viewModel)
+  func presentChangedColor(response: PostGroup.ChangeColor.Response) {
+    let viewModel = PostGroup.ChangeColor.ViewModel(groupColor: response.groupColor)
+    self.viewController?.displayChangedColor(viewModel: viewModel)
+  }
+  
+  func presentSetPayload(response: PostGroup.SetPayload.Response) {
+    let viewModel = PostGroup.SetPayload.ViewModel(
+      groupName: response.groupName,
+      groupColor: response.groupColor,
+      isDoneBottomButtonEnable: response.isDoneBottomButtonEnable
+    )
+    self.viewController?.displayPayload(viewModel: viewModel)
+  }
+  
+  func presentTouchedDoneButton(response: PostGroup.TouchDoneButton.Response) {
+    let viewModel = PostGroup.TouchDoneButton.ViewModel()
+    self.viewController?.displayTouchedDondButton(viewModel: viewModel)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupRouter.swift
@@ -14,7 +14,7 @@ protocol PostGroupRoutingLogic {
 }
 
 protocol PostGroupDataPassing {
-  var dataStore: PostGroupDataStore? { get }
+  var dataStore: PostGroupDataStore? { get set }
 }
 
 class PostGroupRouter: PostGroupDataPassing {

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
@@ -78,7 +78,7 @@ extension PostGroupSceneBuilder {
   /// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
   private func configureVIPCycle(for viewController: PostGroupViewController) -> PostGroupViewController {
-    let interactor = PostGroupInteractor(someWorker: self.dependency.postGroupWorker)
+    let interactor = PostGroupInteractor(postGroupWorker: self.dependency.postGroupWorker)
     let presenter = PostGroupPresenter()
     let router = PostGroupRouter(nextSceneBuilder: nil)
     viewController.interactor = interactor
@@ -96,7 +96,6 @@ extension PostGroupSceneBuilder {
   ///   - viewController: 런타임 의존성을 설정할 ViewController 객체입니다.
   ///   - payload: 런타임에 전달할 의존성입니다.
   private func setPayload(for viewController: PostGroupViewController, with payload: PostGroupScenePayloadable?) {
-    // viewController.setPayload(name: payload?.grouName, color: payload?.color)
-    // TODO: PostGroupScenePayloadable 수정후 주석해제 예정
+    viewController.router?.dataStore?.payload = payload
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
@@ -67,7 +67,7 @@ extension PostGroupSceneBuilder: PostGroupSceneBuildable {
         modalBottomButton: self.dependency.modalBottomButton
       )
     )
-    self.setPayload(for: postGroupViewController, with: payload)
+    self.loadGroupData(for: postGroupViewController, with: payload)
     
     return postGroupViewController
   }
@@ -95,7 +95,7 @@ extension PostGroupSceneBuilder {
   /// - Parameters:
   ///   - viewController: 런타임 의존성을 설정할 ViewController 객체입니다.
   ///   - payload: 런타임에 전달할 의존성입니다.
-  private func setPayload(for viewController: PostGroupViewController, with payload: PostGroupScenePayloadable?) {
+  private func loadGroupData(for viewController: PostGroupViewController, with payload: PostGroupScenePayloadable?) {
     viewController.router?.dataStore?.payload = payload
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -70,8 +70,8 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
     self.setupDoneBottomButton()
   }
   
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
     self.setPayload()
   }
   private func setupTextInputView() {

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -13,7 +13,9 @@ import ToDoGardenUIAPI
 import ToDoGardenUIResource
 
 protocol PostGroupDisplayLogic: AnyObject {
-  func displaySomething(viewModel: PostGroup.Something.ViewModel)
+  func displayChangedColor(viewModel: PostGroup.ChangeColor.ViewModel)
+  func displayPayload(viewModel: PostGroup.SetPayload.ViewModel)
+  func displayTouchedDondButton(viewModel: PostGroup.TouchDoneButton.ViewModel)
 }
 
 final class PostGroupViewController: UIViewController, PostGroupViewControllable {
@@ -68,6 +70,10 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
     self.setupDoneBottomButton()
   }
   
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    self.setPayload()
+  }
   private func setupTextInputView() {
     self.textInputView.delegate = self
     self.textInputView.translatesAutoresizingMaskIntoConstraints = false
@@ -93,7 +99,6 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
   
   private func setupPostGroupColorPickerRow() {
     self.view.addSubview(self.postGroupColorPickerRow)
-    
     self.postGroupColorPickerRow.translatesAutoresizingMaskIntoConstraints = false
     
     NSLayoutConstraint.activate(
@@ -151,6 +156,19 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
         )
       ]
     )
+    
+    self.doneBottomButton.addAction(
+      UIAction { [weak self] _ in
+        guard let groupName = self?.textInputView.getEditingText(),
+          let groupColor = self?.postGroupColorPickerRow.getColor() else {
+          return
+        }
+        
+        let request = PostGroup.TouchDoneButton.Request(groupName: groupName, groupColor: groupColor)
+        self?.interactor?.touchDoneButton(request: request)
+      },
+      for: UIControl.Event.touchUpInside
+    )
   }
   
   private func isDoneBottomButtonEnabled() -> Bool {
@@ -169,7 +187,7 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
     guard let currentColor = self.postGroupColorPickerRow.getColor() else {
       return true
     }
-
+    
     return currentColor == UIColor.toDoGardenGrassNone
   }
 }
@@ -177,28 +195,42 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
 // MARK: - Confirm display logic protocol
 
 extension PostGroupViewController: PostGroupDisplayLogic {
-  func displaySomething(viewModel: PostGroup.Something.ViewModel) {
-    // self.nameTextField.text = viewModel.name
+  func displayChangedColor(viewModel: PostGroupSceneEntity.PostGroup.ChangeColor.ViewModel) {
+    self.postGroupColorPickerRow.updateColor(with: viewModel.groupColor)
+    self.doneBottomButton.isEnabled = self.isDoneBottomButtonEnabled()
+    self.textInputView.changeBottomLine(color: viewModel.groupColor)
+  }
+  
+  func displayPayload(viewModel: PostGroupSceneEntity.PostGroup.SetPayload.ViewModel) {
+    self.textInputView.setBeginEditing(with: viewModel.groupName)
+    self.postGroupColorPickerRow.updateColor(with: viewModel.groupColor ?? UIColor.toDoGardenGrassNone)
+    self.doneBottomButton.isEnabled = viewModel.isDoneBottomButtonEnable
+  }
+  
+  func displayTouchedDondButton(viewModel: PostGroup.TouchDoneButton.ViewModel) {
+    print("Route to ManageGroupScene")
   }
 }
 
 // MARK: - Request to interactor
 
 extension PostGroupViewController {
-  func doSomething() {
-    let request = PostGroup.Something.Request()
-    self.interactor?.doSomething(request: request)
+  func setPayload() {
+    self.interactor?.setPayload()
   }
 }
 
 extension PostGroupViewController: TextInputViewDelegate {
-  func textInputViewDidEndEditing(isEmpty: Bool) {
+  
+  func textInputViewDidChange() {
     self.doneBottomButton.isEnabled = self.isDoneBottomButtonEnabled()
   }
 }
 
 extension PostGroupViewController: PostGroupBottomSheetDelegate {
   func dismissedBottomSheet(color: UIColor) {
+    let request = PostGroup.ChangeColor.Request(groupColor: color)
+    self.interactor?.changeColor(request: request)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -14,7 +14,7 @@ import ToDoGardenUIResource
 
 protocol PostGroupDisplayLogic: AnyObject {
   func displayChangedColor(viewModel: PostGroup.ChangeColor.ViewModel)
-  func displayPayload(viewModel: PostGroup.SetPayload.ViewModel)
+  func displayPayload(viewModel: PostGroup.LoadGroupData.ViewModel)
   func displayTouchedDondButton(viewModel: PostGroup.TouchDoneButton.ViewModel)
 }
 
@@ -72,7 +72,7 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
   
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
-    self.setPayload()
+    self.loadGroupData()
   }
   private func setupTextInputView() {
     self.textInputView.delegate = self
@@ -201,7 +201,7 @@ extension PostGroupViewController: PostGroupDisplayLogic {
     self.textInputView.changeBottomLine(color: viewModel.groupColor)
   }
   
-  func displayPayload(viewModel: PostGroupSceneEntity.PostGroup.SetPayload.ViewModel) {
+  func displayPayload(viewModel: PostGroupSceneEntity.PostGroup.LoadGroupData.ViewModel) {
     self.textInputView.setBeginEditing(with: viewModel.groupName)
     self.postGroupColorPickerRow.updateColor(with: viewModel.groupColor ?? UIColor.toDoGardenGrassNone)
     self.doneBottomButton.isEnabled = viewModel.isDoneBottomButtonEnable
@@ -215,8 +215,8 @@ extension PostGroupViewController: PostGroupDisplayLogic {
 // MARK: - Request to interactor
 
 extension PostGroupViewController {
-  func setPayload() {
-    self.interactor?.setPayload()
+  func loadGroupData() {
+    self.interactor?.loadGroupData()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupWorker.swift
@@ -18,20 +18,25 @@ public struct PostGroupWorker: PostGroupWorkable {
   }
   
   public func touchDoneButton(groupID: String, groupName: String, groupColor: UIColor) {
-    // 서버에 그룹 변경을 요청 
+    // 서버에 그룹 변경을 요청
   }
 }
 
 extension PostGroupWorker {
   private func hexStringFromColor(_ color: UIColor) -> String {
+    let multiplier: CGFloat = 255.0
+    let redShift: Int = 16
+    let greenShift: Int = 8
+    
     var red: CGFloat = CGFloat.zero
     var green: CGFloat = CGFloat.zero
     var blue: CGFloat = CGFloat.zero
     var alpha: CGFloat = CGFloat.zero
     
     color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-    
-    let rgb: Int = (Int)(red * 255) << 16 | (Int)(green * 255) << 8 | (Int)(blue * 255) << 0
+    let rgb: Int = (Int(red * multiplier) << redShift) |
+    (Int(green * multiplier) << greenShift) |
+    (Int(blue * multiplier))
     
     return String(format: "#%06x", rgb)
   }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupWorker.swift
@@ -18,7 +18,7 @@ public struct PostGroupWorker: PostGroupWorkable {
   }
   
   public func touchDoneButton(groupID: String, groupName: String, groupColor: UIColor) {
-    
+    // 서버에 그룹 변경을 요청 
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupWorker.swift
@@ -1,15 +1,38 @@
 //
 //  PostGroupWorker.swift
-//  
+//
 //
 //  Created by SONG on 7/8/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit.UIColor
 
 import PostGroupSceneAPI
 
-struct PostGroupWorker: PostGroupWorkable {
-  func doSomeWork() {
+public struct PostGroupWorker: PostGroupWorkable {
+  public init() {}
+  
+  public func changeColor(groupColor: UIColor) {
+    // 서버에 hex를 요청 파이어베이스 명세에 따라 로직 변경 가능성 농후
+    // self.hexStringFromColor(color)
+  }
+  
+  public func touchDoneButton(groupID: String, groupName: String, groupColor: UIColor) {
+    
+  }
+}
+
+extension PostGroupWorker {
+  private func hexStringFromColor(_ color: UIColor) -> String {
+    var red: CGFloat = CGFloat.zero
+    var green: CGFloat = CGFloat.zero
+    var blue: CGFloat = CGFloat.zero
+    var alpha: CGFloat = CGFloat.zero
+    
+    color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+    
+    let rgb: Int = (Int)(red * 255) << 16 | (Int)(green * 255) << 8 | (Int)(blue * 255) << 0
+    
+    return String(format: "#%06x", rgb)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneBuildable.swift
@@ -5,11 +5,13 @@
 //  Created by SONG on 7/8/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit.UIColor
 
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
 public protocol PostGroupScenePayloadable {
-  // var name: String { get }
+  var groupID: String? { get }
+  var groupName: String? { get }
+  var groupColor: UIColor? { get }
 }
 
 public protocol PostGroupSceneBuildable {

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupWorkable.swift
@@ -5,8 +5,13 @@
 //  Created by SONG on 7/8/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit.UIColor
 
 public protocol PostGroupWorkable {
-  func doSomeWork()
+  func changeColor(groupColor: UIColor)
+  func touchDoneButton(
+    groupID: String,
+    groupName: String,
+    groupColor: UIColor
+  )
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneEntity/PostGroupModels.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneEntity/PostGroupModels.swift
@@ -37,7 +37,7 @@ public enum PostGroup {
     }
   }
   
-  public enum SetPayload {
+  public enum LoadGroupData {
     
     public struct Response {
       public let groupName: String

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneEntity/PostGroupModels.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneEntity/PostGroupModels.swift
@@ -5,21 +5,92 @@
 //  Created by SONG on 7/8/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit.UIColor
 
 public enum PostGroup {
   
   // MARK: Use cases
-  
-  public enum Something {
+  public enum ChangeColor {
     public struct Request {
-      public init() { }
+      public let groupColor: UIColor
+      public init(groupColor: UIColor) {
+        self.groupColor = groupColor
+      }
     }
     public struct Response {
-      public init() { }
+      public let groupID: String
+      public let groupColor: UIColor
+      public init(groupID: String, groupColor: UIColor) {
+        self.groupID = groupID
+        self.groupColor = groupColor
+      }
     }
     public struct ViewModel {
-      public init() { }
+      public let groupColor: UIColor
+      public init(groupColor: UIColor) {
+        self.groupColor = groupColor
+      }
+    }
+  }
+  
+  public enum SetPayload {
+    
+    public struct Response {
+      public let groupName: String
+      public let groupColor: UIColor?
+      public let isDoneBottomButtonEnable: Bool
+      public init(
+        groupName: String,
+        groupColor: UIColor?,
+        isDoneBottomButtonEnable: Bool
+      ) {
+        self.groupName = groupName
+        self.groupColor = groupColor
+        self.isDoneBottomButtonEnable = isDoneBottomButtonEnable
+      }
+    }
+    public struct ViewModel {
+      public let groupName: String
+      public let groupColor: UIColor?
+      public let isDoneBottomButtonEnable: Bool
+      public init(
+        groupName: String,
+        groupColor: UIColor?,
+        isDoneBottomButtonEnable: Bool
+      ) {
+        self.groupName = groupName
+        self.groupColor = groupColor
+        self.isDoneBottomButtonEnable = isDoneBottomButtonEnable
+      }
+    }
+  }
+  
+  public enum TouchDoneButton {
+    public struct Request {
+      public let groupName: String
+      public let groupColor: UIColor
+      public init(groupName: String, groupColor: UIColor) {
+        self.groupName = groupName
+        self.groupColor = groupColor
+      }
+    }
+    public struct Response {
+      public let groupID: String
+      public let groupName: String
+      public let groupColor: UIColor
+      public init(
+        groupID: String,
+        groupName: String,
+        groupColor: UIColor
+      ) {
+        self.groupID = groupID
+        self.groupName = groupName
+        self.groupColor = groupColor
+      }
+    }
+    public struct ViewModel {
+      public init() {
+      }
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneEntity/PostGroupModels.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneEntity/PostGroupModels.swift
@@ -13,13 +13,16 @@ public enum PostGroup {
   public enum ChangeColor {
     public struct Request {
       public let groupColor: UIColor
+      
       public init(groupColor: UIColor) {
         self.groupColor = groupColor
       }
     }
+    
     public struct Response {
       public let groupID: String
       public let groupColor: UIColor
+      
       public init(groupID: String, groupColor: UIColor) {
         self.groupID = groupID
         self.groupColor = groupColor
@@ -27,6 +30,7 @@ public enum PostGroup {
     }
     public struct ViewModel {
       public let groupColor: UIColor
+      
       public init(groupColor: UIColor) {
         self.groupColor = groupColor
       }
@@ -39,6 +43,7 @@ public enum PostGroup {
       public let groupName: String
       public let groupColor: UIColor?
       public let isDoneBottomButtonEnable: Bool
+      
       public init(
         groupName: String,
         groupColor: UIColor?,
@@ -49,10 +54,12 @@ public enum PostGroup {
         self.isDoneBottomButtonEnable = isDoneBottomButtonEnable
       }
     }
+    
     public struct ViewModel {
       public let groupName: String
       public let groupColor: UIColor?
       public let isDoneBottomButtonEnable: Bool
+      
       public init(
         groupName: String,
         groupColor: UIColor?,
@@ -69,15 +76,18 @@ public enum PostGroup {
     public struct Request {
       public let groupName: String
       public let groupColor: UIColor
+      
       public init(groupName: String, groupColor: UIColor) {
         self.groupName = groupName
         self.groupColor = groupColor
       }
     }
+    
     public struct Response {
       public let groupID: String
       public let groupName: String
       public let groupColor: UIColor
+      
       public init(
         groupID: String,
         groupName: String,
@@ -88,7 +98,9 @@ public enum PostGroup {
         self.groupColor = groupColor
       }
     }
+    
     public struct ViewModel {
+      
       public init() {
       }
     }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #379 
## 🎉 변경 사항
- UseCase에 따른 VIP사이클에 필요한 파일들을 추가합니다. 
## 📌 PR Point
useCase 1) 페이로드 설정
useCase 2) 컬러 변경 
useCase 2) 완료버튼 터치 

 위 세가지의 useCase를 처리하기 위한 VIP사이클을 실행할 수 있습니다. 
 ++ 각 UseCase에 대한 Worker의 네트워크단 로직은 아직 미구현입니다. 
 ++ 요청실패에 대한 처리는 다음 PR에 있을 예정입니다. 현재코드의 로직은 "요청성공"을 가정하고 있습니다. 
 
동작 요약은 아래와 같습니다. 
 
![스크린샷 2024-07-29 오후 5 13 05](https://github.com/user-attachments/assets/eaa9d79f-9a9a-4f37-9287-daad0ed55610)
![스크린샷 2024-07-29 오후 5 13 19](https://github.com/user-attachments/assets/a751b4c4-5360-4809-bb77-35fc4040bf83)
![스크린샷 2024-07-29 오후 5 13 34](https://github.com/user-attachments/assets/1cfedb1b-70db-42ec-ba20-59097b22eaea)


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?