### PR TITLE
EditToDoInteractor VIP 로직 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -88,27 +88,20 @@ extension EditToDoInteractor: EditToDoBusinessLogic {
   
   /// 서버에 투두의 삭제를 요청하는 메서드입니다.
   func deleteToDo(request: EditToDo.DeleteToDo.Request) {
-    let result = self.toDoWorker.deleteToDo(id: self.toDoId)
-    let response = EditToDo.DeleteToDo.Response(deleteResult: result)
+    let deleteResult: Result<Void, Error>
+    do {
+      try self.toDoWorker.deleteToDo(id: self.toDoId)
+      deleteResult = Result.success(())
+    } catch let error {
+      deleteResult = Result.failure(error)
+    }
+
+    let response = EditToDo.DeleteToDo.Response(deleteResult: deleteResult)
     self.presenter?.presentDeleteResult(response: response)
   }
 
   /// 서버에 투두의 수정을 요청하는 메서드입니다.
   func editToDo(request: EditToDo.CompleteEditToDo.Request) {
-    guard var editedToDo = self.toDo
-    else {
-      let response = EditToDo.CompleteEditToDo.Response(editResult: .success(false))
-      self.presenter?.presentEditResult(response: response)
-      return
-    }
-
-    editedToDo.name = request.toDoName
-    let group = request.displayedGroup
-    editedToDo.groupData = EditToDo.Group(id: group.id, name: group.name, color: group.color)
-    
-    let result = self.toDoWorker.editToDo(editedToDo)
-    let response = EditToDo.CompleteEditToDo.Response(editResult: result)
-    self.presenter?.presentEditResult(response: response)
   }
 
   /// EditToDoViewController 컴파일 에러 방지 코드입니다.

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -17,6 +17,7 @@ protocol EditToDoDataStore {
 protocol EditToDoBusinessLogic {
   func fetchToDo(request: EditToDo.FetchToDo.Request)
   func deleteToDo(request: EditToDo.DeleteToDo.Request)
+  func editToDo(request: EditToDo.CompleteEditToDo.Request)
   func doSomething(request: EditToDo.Something.Request)
 }
 
@@ -68,6 +69,24 @@ extension EditToDoInteractor: EditToDoBusinessLogic {
     let result = self.toDoWorker.deleteToDo(id: self.toDoId)
     let response = EditToDo.DeleteToDo.Response(deleteResult: result)
     self.presenter?.presentDeleteResult(response: response)
+  }
+
+  /// 서버에 투두의 수정을 요청하는 메서드입니다.
+  func editToDo(request: EditToDo.CompleteEditToDo.Request) {
+    guard var editedToDo = self.toDo
+    else {
+      let response = EditToDo.CompleteEditToDo.Response(editResult: .success(false))
+      self.presenter?.presentEditResult(response: response)
+      return
+    }
+
+    editedToDo.name = request.toDoName
+    let group = request.displayedGroup
+    editedToDo.groupData = EditToDo.Group(id: group.id, name: group.name, color: group.color)
+    
+    let result = self.toDoWorker.editToDo(editedToDo)
+    let response = EditToDo.CompleteEditToDo.Response(editResult: result)
+    self.presenter?.presentEditResult(response: response)
   }
 
   /// EditToDoViewController 컴파일 에러 방지 코드입니다.

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -16,6 +16,7 @@ protocol EditToDoDataStore {
 
 protocol EditToDoBusinessLogic {
   func fetchToDo(request: EditToDo.FetchToDo.Request)
+  func deleteToDo(request: EditToDo.DeleteToDo.Request)
   func doSomething(request: EditToDo.Something.Request)
 }
 
@@ -43,6 +44,7 @@ final class EditToDoInteractor: EditToDoDataStore {
 // MARK: - Request to worker
 
 extension EditToDoInteractor: EditToDoBusinessLogic {
+  /// 서버로부터 수정할 투두의 정보를 받아오는 메서드입니다.
   func fetchToDo(request: EditToDo.FetchToDo.Request) {
     guard let toDoData = try? self.toDoWorker.fetchToDo(id: self.toDoId),
       let groupList = try? self.groupWorker.fetchGroupList()
@@ -61,6 +63,13 @@ extension EditToDoInteractor: EditToDoBusinessLogic {
     self.presenter?.presentFetchedToDo(response: response)
   }
   
+  /// 서버에 투두의 삭제를 요청하는 메서드입니다.
+  func deleteToDo(request: EditToDo.DeleteToDo.Request) {
+    let result = self.toDoWorker.deleteToDo(id: self.toDoId)
+    let response = EditToDo.DeleteToDo.Response(deleteResult: result)
+    self.presenter?.presentDeleteResult(response: response)
+  }
+
   /// EditToDoViewController 컴파일 에러 방지 코드입니다.
   func doSomething(request: EditToDo.Something.Request) {}
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -102,6 +102,17 @@ extension EditToDoInteractor: EditToDoBusinessLogic {
 
   /// 서버에 투두의 수정을 요청하는 메서드입니다.
   func editToDo(request: EditToDo.CompleteEditToDo.Request) {
+    let editResult: Result<Void, Error>
+    do {
+      let editedToDo = try self.makeToDoForEdit(with: request)
+      try self.toDoWorker.editToDo(editedToDo)
+      editResult = Result.success(())
+    } catch let error {
+      editResult = Result.failure(error)
+    }
+
+    let response = EditToDo.CompleteEditToDo.Response(editResult: editResult)
+    self.presenter?.presentEditResult(response: response)
   }
 
   /// EditToDoViewController 컴파일 에러 방지 코드입니다.
@@ -124,5 +135,29 @@ extension EditToDoInteractor {
     self.toDo?.repetition.isRepeatEveryday = isRepeatEveryday
     let state: EditToDo.EditToDoRepetitionViewState = isRepeatEveryday ? .repeatEveryday : .repeatInRange
     return state
+  }
+
+  private func makeToDoForEdit(
+    with request: EditToDo.CompleteEditToDo.Request
+  ) throws -> EditToDo.ToDo {
+    guard var editedToDo = self.toDo
+    else { throw EditToDoInteractorError.toDoDataNotExisted }
+
+    editedToDo.name = request.toDoName
+    editedToDo.groupData = EditToDo.Group(
+      id: request.displayedGroup.id,
+      name: request.displayedGroup.name,
+      color: request.displayedGroup.color
+    )
+
+    return editedToDo
+  }
+}
+
+// MARK: Private Functions
+
+extension EditToDoInteractor {
+  enum EditToDoInteractorError: Error {
+    case toDoDataNotExisted
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -15,6 +15,7 @@ protocol EditToDoDataStore {
 }
 
 protocol EditToDoBusinessLogic {
+  func changeReptition(request: EditToDo.ChangeRepetition.Request)
   func fetchToDo(request: EditToDo.FetchToDo.Request)
   func deleteToDo(request: EditToDo.DeleteToDo.Request)
   func editToDo(request: EditToDo.CompleteEditToDo.Request)
@@ -45,6 +46,16 @@ final class EditToDoInteractor: EditToDoDataStore {
 // MARK: - Request to worker
 
 extension EditToDoInteractor: EditToDoBusinessLogic {
+  /// 사용자가 투두 반복 설정 뷰를 선택했을 때 호출하는 메서드입니다.
+  /// ex) 사용자가 화면에서 (오늘만 or 다른날도 or 매일) 할래요 뷰를 눌렀음
+  func changeReptition(request: EditToDo.ChangeRepetition.Request) {
+    let isOnlyToday = request.isOnlyToday
+    let isEveryday = request.isEveryday
+    let repetitionViewState = self.makeRepetitionViewState(isOnlyToday: isOnlyToday, isEveryday: isEveryday)
+    let response = EditToDo.ChangeRepetition.Response(editToDoRepetitionViewState: repetitionViewState)
+    self.presenter?.presentChangedRepetition(response: response)
+  }
+
   /// 서버로부터 수정할 투두의 정보를 받아오는 메서드입니다.
   func fetchToDo(request: EditToDo.FetchToDo.Request) {
     guard let toDoData = try? self.toDoWorker.fetchToDo(id: self.toDoId),

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -69,20 +69,27 @@ extension EditToDoInteractor: EditToDoBusinessLogic {
 
   /// 서버로부터 수정할 투두의 정보를 받아오는 메서드입니다.
   func fetchToDo(request: EditToDo.FetchToDo.Request) {
-    guard let toDoData = try? self.toDoWorker.fetchToDo(id: self.toDoId),
-      let groupList = try? self.groupWorker.fetchGroupList()
-    else { return }
+    let fetchResult: Result<EditToDo.FetchToDo.Response.FetchedToDo, Error>
+    do {
+      let toDo = try self.toDoWorker.fetchToDo(id: self.toDoId)
+      let group = try self.groupWorker.fetchGroupList()
+      let repetitionViewState = self.makeRepetitionViewState(
+        isOnlyToday: toDo.repetition.isOnlyToday,
+        isEveryday: toDo.repetition.isRepeatEveryday
+      )
 
-    self.toDo = toDoData
-    
-    let isOnlyToday = toDoData.repetition.isOnlyToday
-    let isEveryday = toDoData.repetition.isRepeatEveryday
-    let repetitionViewState = self.makeRepetitionViewState(isOnlyToday: isOnlyToday, isEveryday: isEveryday)
-    let response = EditToDo.FetchToDo.Response(
-      toDo: toDoData,
-      groupList: groupList,
-      repetitionViewState: repetitionViewState
-    )
+      let fetchedToDo = EditToDo.FetchToDo.Response.FetchedToDo(
+        toDo: toDo,
+        groupList: group,
+        repetitionViewState: repetitionViewState
+      )
+
+      fetchResult = Result.success(fetchedToDo)
+    } catch let error {
+      fetchResult = Result.failure(error)
+    }
+
+    let response = EditToDo.FetchToDo.Response(fetchResult: fetchResult)
     self.presenter?.presentFetchedToDo(response: response)
   }
   

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -19,6 +19,7 @@ protocol EditToDoBusinessLogic {
 }
 
 final class EditToDoInteractor: EditToDoDataStore {
+  private var toDo: EditToDo.ToDo?
   var toDoId: Int?
 
   // MARK: VIP Objects
@@ -41,10 +42,25 @@ final class EditToDoInteractor: EditToDoDataStore {
 // MARK: - Request to worker
 
 extension EditToDoInteractor: EditToDoBusinessLogic {
-  func doSomething(request: EditToDo.Something.Request) {
-    self.someWorker.doSomeWork()
+  func doSomething(request: EditToDo.Something.Request) {}
+}
 
-    let response = EditToDo.Something.Response()
-    self.presenter?.presentSomething(response: response)
+// MARK: Private Functions
+
+extension EditToDoInteractor {
+  private func makeRepetitionViewState(
+    isOnlyToday: Bool,
+    isEveryday: Bool?
+  ) -> EditToDo.EditToDoRepetitionViewState {
+    self.toDo?.repetition.isOnlyToday = isOnlyToday
+    guard isOnlyToday == false
+    else { return EditToDo.EditToDoRepetitionViewState.repeatOnlyToday }
+
+    let isRepeatEveryday = isEveryday ?? (self.toDo?.repetition.isRepeatEveryday ?? true)
+    self.toDo?.repetition.isRepeatEveryday = isRepeatEveryday
+    guard isRepeatEveryday == false
+    else { return EditToDo.EditToDoRepetitionViewState.repeatEveryday }
+
+    return EditToDo.EditToDoRepetitionViewState.repeatInRange
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -16,6 +16,7 @@ protocol EditToDoDataStore {
 
 protocol EditToDoBusinessLogic {
   func changeReptition(request: EditToDo.ChangeRepetition.Request)
+  func changeAlarmActivation(request: EditToDo.ChangeAlarmActivation.Request)
   func fetchToDo(request: EditToDo.FetchToDo.Request)
   func deleteToDo(request: EditToDo.DeleteToDo.Request)
   func editToDo(request: EditToDo.CompleteEditToDo.Request)
@@ -46,6 +47,16 @@ final class EditToDoInteractor: EditToDoDataStore {
 // MARK: - Request to worker
 
 extension EditToDoInteractor: EditToDoBusinessLogic {
+  /// 사용자가 투두 알림 스위치를 통해 활성화 여부를 변경했을 때 호출되는 메서드입니다.
+  func changeAlarmActivation(request: EditToDo.ChangeAlarmActivation.Request) {
+    guard let isAlarmOn = self.toDo?.alarm.isAlarmOn
+    else { return }
+
+    self.toDo?.alarm.isAlarmOn = !isAlarmOn
+    let response = EditToDo.ChangeAlarmActivation.Response(isAlarmOn: !isAlarmOn)
+    self.presenter?.presentAlarmActivation(response: response)
+  }
+  
   /// 사용자가 투두 반복 설정 뷰를 선택했을 때 호출하는 메서드입니다.
   /// ex) 사용자가 화면에서 (오늘만 or 다른날도 or 매일) 할래요 뷰를 눌렀음
   func changeReptition(request: EditToDo.ChangeRepetition.Request) {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -123,14 +123,13 @@ extension EditToDoInteractor {
     isEveryday: Bool?
   ) -> EditToDo.EditToDoRepetitionViewState {
     self.toDo?.repetition.isOnlyToday = isOnlyToday
-    guard isOnlyToday == false
-    else { return EditToDo.EditToDoRepetitionViewState.repeatOnlyToday }
+    if isOnlyToday {
+      return EditToDo.EditToDoRepetitionViewState.repeatOnlyToday
+    }
 
     let isRepeatEveryday = isEveryday ?? (self.toDo?.repetition.isRepeatEveryday ?? true)
     self.toDo?.repetition.isRepeatEveryday = isRepeatEveryday
-    guard isRepeatEveryday == false
-    else { return EditToDo.EditToDoRepetitionViewState.repeatEveryday }
-
-    return EditToDo.EditToDoRepetitionViewState.repeatInRange
+    let state: EditToDo.EditToDoRepetitionViewState = isRepeatEveryday ? .repeatEveryday : .repeatInRange
+    return state
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -15,6 +15,7 @@ protocol EditToDoDataStore {
 }
 
 protocol EditToDoBusinessLogic {
+  func fetchToDo(request: EditToDo.FetchToDo.Request)
   func doSomething(request: EditToDo.Something.Request)
 }
 
@@ -42,6 +43,25 @@ final class EditToDoInteractor: EditToDoDataStore {
 // MARK: - Request to worker
 
 extension EditToDoInteractor: EditToDoBusinessLogic {
+  func fetchToDo(request: EditToDo.FetchToDo.Request) {
+    guard let toDoData = try? self.toDoWorker.fetchToDo(id: self.toDoId),
+      let groupList = try? self.groupWorker.fetchGroupList()
+    else { return }
+
+    self.toDo = toDoData
+    
+    let isOnlyToday = toDoData.repetition.isOnlyToday
+    let isEveryday = toDoData.repetition.isRepeatEveryday
+    let repetitionViewState = self.makeRepetitionViewState(isOnlyToday: isOnlyToday, isEveryday: isEveryday)
+    let response = EditToDo.FetchToDo.Response(
+      toDo: toDoData,
+      groupList: groupList,
+      repetitionViewState: repetitionViewState
+    )
+    self.presenter?.presentFetchedToDo(response: response)
+  }
+  
+  /// EditToDoViewController 컴파일 에러 방지 코드입니다.
   func doSomething(request: EditToDo.Something.Request) {}
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -11,15 +11,15 @@ import EditToDoSceneAPI
 import EditToDoSceneEntity
 
 protocol EditToDoDataStore {
-  // var name: String { get set }
+  var toDoId: Int? { get set }
 }
 
 protocol EditToDoBusinessLogic {
   func doSomething(request: EditToDo.Something.Request)
 }
 
-class EditToDoInteractor: EditToDoDataStore {
-  // var name: String = ""
+final class EditToDoInteractor: EditToDoDataStore {
+  var toDoId: Int?
 
   // MARK: VIP Objects
   var presenter: EditToDoPresentationLogic?

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
@@ -10,6 +10,7 @@ import Foundation
 import EditToDoSceneEntity
 
 protocol EditToDoPresentationLogic {
+  func presentFetchedToDo(response: EditToDo.FetchToDo.Response)
   func presentSomething(response: EditToDo.Something.Response)
 }
 
@@ -20,6 +21,8 @@ class EditToDoPresenter {
 // MARK: - Request to ViewController
 
 extension EditToDoPresenter: EditToDoPresentationLogic {
+  func presentFetchedToDo(response: EditToDo.FetchToDo.Response) {}
+  
   func presentSomething(response: EditToDo.Something.Response) {
     let viewModel = EditToDo.Something.ViewModel()
     self.viewController?.displaySomething(viewModel: viewModel)

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
@@ -12,6 +12,7 @@ import EditToDoSceneEntity
 protocol EditToDoPresentationLogic {
   func presentFetchedToDo(response: EditToDo.FetchToDo.Response)
   func presentDeleteResult(response: EditToDo.DeleteToDo.Response)
+  func presentEditResult(response: EditToDo.CompleteEditToDo.Response)
   func presentSomething(response: EditToDo.Something.Response)
 }
 
@@ -24,6 +25,7 @@ class EditToDoPresenter {
 extension EditToDoPresenter: EditToDoPresentationLogic {
   func presentFetchedToDo(response: EditToDo.FetchToDo.Response) {}
   func presentDeleteResult(response: EditToDo.DeleteToDo.Response) {}
+  func presentEditResult(response: EditToDo.CompleteEditToDo.Response) {}
 
   func presentSomething(response: EditToDo.Something.Response) {
     let viewModel = EditToDo.Something.ViewModel()

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
@@ -10,6 +10,7 @@ import Foundation
 import EditToDoSceneEntity
 
 protocol EditToDoPresentationLogic {
+  func presentAlarmActivation(response: EditToDo.ChangeAlarmActivation.Response)
   func presentChangedRepetition(response: EditToDo.ChangeRepetition.Response)
   func presentFetchedToDo(response: EditToDo.FetchToDo.Response)
   func presentDeleteResult(response: EditToDo.DeleteToDo.Response)
@@ -24,6 +25,7 @@ class EditToDoPresenter {
 // MARK: - Request to ViewController
 
 extension EditToDoPresenter: EditToDoPresentationLogic {
+  func presentAlarmActivation(response: EditToDo.ChangeAlarmActivation.Response) {}
   func presentChangedRepetition(response: EditToDo.ChangeRepetition.Response) {}
   func presentFetchedToDo(response: EditToDo.FetchToDo.Response) {}
   func presentDeleteResult(response: EditToDo.DeleteToDo.Response) {}

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
@@ -11,6 +11,7 @@ import EditToDoSceneEntity
 
 protocol EditToDoPresentationLogic {
   func presentFetchedToDo(response: EditToDo.FetchToDo.Response)
+  func presentDeleteResult(response: EditToDo.DeleteToDo.Response)
   func presentSomething(response: EditToDo.Something.Response)
 }
 
@@ -22,7 +23,8 @@ class EditToDoPresenter {
 
 extension EditToDoPresenter: EditToDoPresentationLogic {
   func presentFetchedToDo(response: EditToDo.FetchToDo.Response) {}
-  
+  func presentDeleteResult(response: EditToDo.DeleteToDo.Response) {}
+
   func presentSomething(response: EditToDo.Something.Response) {
     let viewModel = EditToDo.Something.ViewModel()
     self.viewController?.displaySomething(viewModel: viewModel)

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
@@ -10,6 +10,7 @@ import Foundation
 import EditToDoSceneEntity
 
 protocol EditToDoPresentationLogic {
+  func presentChangedRepetition(response: EditToDo.ChangeRepetition.Response)
   func presentFetchedToDo(response: EditToDo.FetchToDo.Response)
   func presentDeleteResult(response: EditToDo.DeleteToDo.Response)
   func presentEditResult(response: EditToDo.CompleteEditToDo.Response)
@@ -23,6 +24,7 @@ class EditToDoPresenter {
 // MARK: - Request to ViewController
 
 extension EditToDoPresenter: EditToDoPresentationLogic {
+  func presentChangedRepetition(response: EditToDo.ChangeRepetition.Response) {}
   func presentFetchedToDo(response: EditToDo.FetchToDo.Response) {}
   func presentDeleteResult(response: EditToDo.DeleteToDo.Response) {}
   func presentEditResult(response: EditToDo.CompleteEditToDo.Response) {}

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoRouter.swift
@@ -14,7 +14,7 @@ protocol EditToDoRoutingLogic {
 }
 
 protocol EditToDoDataPassing {
-  var dataStore: EditToDoDataStore? { get }
+  var dataStore: EditToDoDataStore? { get set }
 }
 
 class EditToDoRouter: EditToDoDataPassing {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneBuilder.swift
@@ -76,6 +76,6 @@ extension EditToDoSceneBuilder {
   ///   - viewController: 런타임 의존성을 설정할 ViewController 객체입니다.
   ///   - payload: 런타임에 전달할 의존성입니다.
   private func setPayload(for viewController: EditToDoViewController, with payload: EditToDoScenePayloadable) {
-    // viewController.router?.dataStore?.name = payload.name
+    viewController.router?.dataStore?.toDoId = payload.toDoId
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/MockToDoWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/MockToDoWorker.swift
@@ -13,16 +13,16 @@ import EditToDoSceneEntity
 public final class MockToDoWorker {
   public init() {}
 
-  func fetchToDo(id: Int?) throws -> EditToDo.ToDo {
+  func fetchToDo(id: Int?) throws(MockToDoWorkerError) -> EditToDo.ToDo {
     return MockData.FetchToDo.firstData
   }
 
-  func deleteToDo(id: Int?) -> Result<Bool, Error> {
-    return Result.success(true)
+  func deleteToDo(id: Int?) throws(MockToDoWorkerError) {
+
   }
 
-  func editToDo(_ toDo: EditToDo.ToDo?) -> Result<Bool, Error> {
-    return Result.success(true)
+  func editToDo(_ toDo: EditToDo.ToDo) throws(MockToDoWorkerError) {
+    throw MockToDoWorkerError.unknownError
   }
 }
 
@@ -88,5 +88,13 @@ extension MockToDoWorker {
 
       static let defaultCalendar = Calendar(identifier: Calendar.Identifier.gregorian)
     }
+  }
+}
+
+// MARK: Error
+
+extension MockToDoWorker {
+  enum MockToDoWorkerError: Error {
+    case unknownError
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneAPI/EditToDoSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneAPI/EditToDoSceneBuildable.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
 public protocol EditToDoScenePayloadable {
-  // var name: String { get }
+  var toDoId: Int { get }
 }
 
 public protocol EditToDoSceneBuildable {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
@@ -17,10 +17,16 @@ public enum EditToDo {
     public struct Response {
       public let toDo: ToDo
       public let groupList: [Group]
+      public let repetitionViewState: EditToDoRepetitionViewState
 
-      public init(toDo: ToDo, groupList: [Group]) {
+      public init(
+        toDo: ToDo,
+        groupList: [Group],
+        repetitionViewState: EditToDoRepetitionViewState
+      ) {
         self.toDo = toDo
         self.groupList = groupList
+        self.repetitionViewState = repetitionViewState
       }
     }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
@@ -63,38 +63,34 @@ public enum EditToDo {
   }
   
   public enum CompleteEditToDo {
-    public struct ToDoEditData {
-      public let name: String
-      public let groupId: Int
-
-      public init(name: String, groupId: Int) {
-        self.name = name
-        self.groupId = groupId
-      }
-    }
-
-    public struct ToDoScheduleData {
-      public let isAlarmOn: Bool
-      public let isRepeatOnlyToday: Bool
-
-      public init(isAlarmOn: Bool, isRepeatOnlyToday: Bool) {
-        self.isAlarmOn = isAlarmOn
-        self.isRepeatOnlyToday = isRepeatOnlyToday
-      }
-    }
-
     public struct Request {
-      public let toDoEditData: ToDoEditData
-      public let toDoScheduleData: ToDoScheduleData
+      public struct DisplayedGroup {
+        public let id: Int
+        public let name: String
+        public let color: UIColor
 
-      public init(toDoEditData: ToDoEditData, toDoScheduleData: ToDoScheduleData) {
-        self.toDoEditData = toDoEditData
-        self.toDoScheduleData = toDoScheduleData
+        public init(id: Int, name: String, color: UIColor) {
+          self.id = id
+          self.name = name
+          self.color = color
+        }
+      }
+
+      public let toDoName: String
+      public let displayedGroup: DisplayedGroup
+
+      init(toDoName: String, displayedGroup: DisplayedGroup) {
+        self.toDoName = toDoName
+        self.displayedGroup = displayedGroup
       }
     }
 
     public struct Response {
       public let editResult: Result<Bool, Error>
+
+      public init(editResult: Result<Bool, Error>) {
+        self.editResult = editResult
+      }
     }
 
     public struct ViewModel {
@@ -183,8 +179,8 @@ public enum EditToDo {
 
 extension EditToDo {
   public struct ToDo {
-    public let name: String
-    public let groupData: Group
+    public var name: String
+    public var groupData: Group
     public var alarm: ToDoAlarm
     public var repetition: ToDoRepetition
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
@@ -150,7 +150,7 @@ public enum EditToDo {
     }
   }
 
-  // 사용자가 투두를 오늘만 또는 다른날에도 반복하도록 설정하는 유스케이스입니다.
+  /// 사용자가 투두를 오늘만 또는 다른날에도 반복하도록 설정하는 유스케이스입니다.
   public enum ChangeRepetition {
     public struct Request {
       public let isOnlyToday: Bool
@@ -201,6 +201,29 @@ public enum EditToDo {
       public init(startDay: String, endDay: String) {
         self.startDay = startDay
         self.endDay = endDay
+      }
+    }
+  }
+
+  /// 사용자가 투두 알림 여부를 스위치로 활성화 및 비활성화 시키는 유스케이스입니다.
+  public enum ChangeAlarmActivation {
+    public struct Request {
+      public init() {}
+    }
+
+    public struct Response {
+      public let isAlarmOn: Bool
+
+      public init(isAlarmOn: Bool) {
+        self.isAlarmOn = isAlarmOn
+      }
+    }
+
+    public struct ViewModel {
+      public let isAlarmOn: Bool
+
+      public init(isAlarmOn: Bool) {
+        self.isAlarmOn = isAlarmOn
       }
     }
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
@@ -262,7 +262,7 @@ extension EditToDo {
   }
 
   public struct ToDoAlarm {
-    public let isAlarmOn: Bool
+    public var isAlarmOn: Bool
     public var alarmTime: Int?
 
     public init(isAlarmOn: Bool, alarmTime: Int?) {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
@@ -235,6 +235,13 @@ extension EditToDo {
       self.endDate = endDate
     }
   }
+
+  /// 투두 반복 설정 뷰의 상태를 나타내는 데이터입니다.
+  public enum EditToDoRepetitionViewState {
+    case repeatOnlyToday
+    case repeatEveryday
+    case repeatInRange
+  }
 }
 
 extension EditToDo {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
@@ -15,53 +15,69 @@ public enum EditToDo {
     }
 
     public struct Response {
-      public let toDo: ToDo
-      public let groupList: [Group]
-      public let repetitionViewState: EditToDoRepetitionViewState
+      public struct FetchedToDo {
+        public let toDo: ToDo
+        public let groupList: [Group]
+        public let repetitionViewState: EditToDoRepetitionViewState
 
-      public init(
-        toDo: ToDo,
-        groupList: [Group],
-        repetitionViewState: EditToDoRepetitionViewState
-      ) {
-        self.toDo = toDo
-        self.groupList = groupList
-        self.repetitionViewState = repetitionViewState
+        public init(
+          toDo: ToDo,
+          groupList: [Group],
+          repetitionViewState: EditToDoRepetitionViewState
+        ) {
+          self.toDo = toDo
+          self.groupList = groupList
+          self.repetitionViewState = repetitionViewState
+        }
+      }
+
+      public let fetchResult: Result<FetchedToDo, Error>
+
+      public init(fetchResult: Result<FetchedToDo, Error>) {
+        self.fetchResult = fetchResult
       }
     }
 
     public struct ViewModel {
-      public let toDoName: String
-      public let group: Group
-      public let groupList: [Group]
-      public let isAlarmOn: Bool
-      public let alarmTime: String?
-      public let isRepeatOnlyToday: Bool
-      public let startDay: String?
-      public let endDay: String?
+      public struct DisplayedToDo {
+        public let toDoName: String
+        public let group: Group
+        public let groupList: [Group]
+        public let isAlarmOn: Bool
+        public let alarmTime: String?
+        public let repetitionViewState: EditToDoRepetitionViewState
+        public let startDay: String?
+        public let endDay: String?
 
-      public init(
-        toDoName: String,
-        group: Group,
-        groupList: [Group],
-        isAlarmOn: Bool,
-        alarmTime: String?,
-        isRepeatOnlyToday: Bool,
-        startDay: String?,
-        endDay: String?
-      ) {
-        self.toDoName = toDoName
-        self.group = group
-        self.groupList = groupList
-        self.isAlarmOn = isAlarmOn
-        self.alarmTime = alarmTime
-        self.isRepeatOnlyToday = isRepeatOnlyToday
-        self.startDay = startDay
-        self.endDay = endDay
+        public init(
+          toDoName: String,
+          group: Group,
+          groupList: [Group],
+          isAlarmOn: Bool,
+          alarmTime: String?,
+          repetitionViewState: EditToDoRepetitionViewState,
+          startDay: String?,
+          endDay: String?
+        ) {
+          self.toDoName = toDoName
+          self.group = group
+          self.groupList = groupList
+          self.isAlarmOn = isAlarmOn
+          self.alarmTime = alarmTime
+          self.repetitionViewState = repetitionViewState
+          self.startDay = startDay
+          self.endDay = endDay
+        }
+      }
+
+      public let fetchedToDoResult: Result<DisplayedToDo, Error>
+
+      public init(fetchedToDoResult: Result<DisplayedToDo, Error>) {
+        self.fetchedToDoResult = fetchedToDoResult
       }
     }
   }
-  
+
   public enum CompleteEditToDo {
     public struct Request {
       public struct DisplayedGroup {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
@@ -86,17 +86,17 @@ public enum EditToDo {
     }
 
     public struct Response {
-      public let editResult: Result<Bool, Error>
+      public let editResult: Result<Void, Error>
 
-      public init(editResult: Result<Bool, Error>) {
+      public init(editResult: Result<Void, Error>) {
         self.editResult = editResult
       }
     }
 
     public struct ViewModel {
-      public let editResult: Result<Bool, Error>
+      public let editResult: Result<Void, Error>
 
-      public init(editResult: Result<Bool, Error>) {
+      public init(editResult: Result<Void, Error>) {
         self.editResult = editResult
       }
     }
@@ -108,17 +108,17 @@ public enum EditToDo {
     }
 
     public struct Response {
-      public let deleteResult: Result<Bool, Error>
+      public let deleteResult: Result<Void, Error>
 
-      public init(deleteResult: Result<Bool, Error>) {
+      public init(deleteResult: Result<Void, Error>) {
         self.deleteResult = deleteResult
       }
     }
 
     public struct ViewModel {
-      public let deleteResult: Result<Bool, Error>
+      public let deleteResult: Result<Void, Error>
 
-      public init(deleteResult: Result<Bool, Error>) {
+      public init(deleteResult: Result<Void, Error>) {
         self.deleteResult = deleteResult
       }
     }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
@@ -150,6 +150,35 @@ public enum EditToDo {
     }
   }
 
+  // 사용자가 투두를 오늘만 또는 다른날에도 반복하도록 설정하는 유스케이스입니다.
+  public enum ChangeRepetition {
+    public struct Request {
+      public let isOnlyToday: Bool
+      public let isEveryday: Bool?
+
+      public init(isOnlyToday: Bool, isEveryday: Bool?) {
+        self.isOnlyToday = isOnlyToday
+        self.isEveryday = isEveryday
+      }
+    }
+
+    public struct Response {
+      public let editToDoRepetitionViewState: EditToDoRepetitionViewState
+
+      public init(editToDoRepetitionViewState: EditToDoRepetitionViewState) {
+        self.editToDoRepetitionViewState = editToDoRepetitionViewState
+      }
+    }
+
+    public struct ViewModel {
+      public let editToDoRepetitionViewState: EditToDoRepetitionViewState
+
+      public init(editToDoRepetitionViewState: EditToDoRepetitionViewState) {
+        self.editToDoRepetitionViewState = editToDoRepetitionViewState
+      }
+    }
+  }
+
   public enum ChangeRepetitionRange {
     public struct Request {
       public init() {}


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #383

## 🎉 변경 사항
- EditToDoInteractor에 사용되는 VIP 사이클 로직을 추가하였습니다.
- EditToDoPresentationLogic 프로토콜에 VIP 로직 스켈레톤 코드들을 추가하였습니다.
- EditToDoModels에 VIP 사이클에 필요한 데이터들을 추가하였습니다.

## 📌 PR Point
- 구현한 VIP 사이클은 총 5개로, 각각 다음과 같은 유스케이스들을 가집니다.

![image](https://github.com/user-attachments/assets/76c7ae71-c34d-4938-9db5-c3959047fbbb)

### 1. ToDo 정보 받아오기
이전 화면에서 런타임으로 전달받은 수정할 `투두의 ID`를 기반으로 데이터를 받아옵니다. 
- 이 때, 투두의 그룹을 변경할 수 있도록 GroupWorker로부터 `사용자의 전체 그룹 목록`을 받아옵니다.

### 2. ToDo 삭제 / 수정 요청
ToDoWorker로 부터 결과값인 `Result<Bool, Error>` 타입을 받습니다.
- `실패시 Error 타입별로 다른 알럿`을 보여주기 위해 Result 타입을 사용하였습니다.

### 3. 반복 설정
사용자가 반복 설정 뷰를 탭했을 때, UI의 상태를 결정합니다.

ex) 다른날도 할래요 뷰를 눌렀을 때 
-> 기존에 매일 반복하도록 설정했었다면, `매일 버튼 활성화`
-> 기존에 일정 범위만큼만 반복하도록 설정했었다면, `시간지정 버튼 활성화`

|오늘만 반복|매일 반복|일정 범위 반복|
|--|--|--|
|<img width="150" src="https://github.com/user-attachments/assets/9e8f6d7a-8cd2-49c8-b84d-a8c1640a0d48">|<img width="150" src="https://github.com/user-attachments/assets/ec898c92-ac5c-43a4-ae34-1d2f006b7d62">|<img width="150" src="https://github.com/user-attachments/assets/fbb393ed-bf58-423c-ad6b-c308ae3f936b">|

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?