### PR TITLE
SettingTimeView 시작 시간 업데이트 함수 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/SettingTimeViewAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/SettingTimeViewAPI.swift
@@ -1,0 +1,15 @@
+//
+//  SettingTimeViewAPI.swift
+//
+//
+//  Created by Wood on 7/31/24.
+//
+
+import UIKit.UIView
+
+public protocol SettingTimeViewAPI: UIView {
+  var seconds: Double { get }
+
+  func transformSeconds(completion: @escaping (Double) -> Void)
+  func updateSelectedTime(hour: Int, minute: Int, seconds: Int)
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -11,7 +11,7 @@ import ToDoGardenUIAPI
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
-public class SettingTimeView: UIView, SettingTimeViewAPI {
+public final class SettingTimeView: UIView, SettingTimeViewAPI {
   private var configuration: Configuration
   private let timepicker: ToDoGardenTimePicker
   private let button: UIButton

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -7,10 +7,11 @@
 
 import UIKit
 
+import ToDoGardenUIAPI
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
-public class SettingTimeView: UIView {
+public class SettingTimeView: UIView, SettingTimeViewAPI {
   private var configuration: Configuration
   private let timepicker: ToDoGardenTimePicker
   private let button: UIButton

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -44,6 +44,10 @@ public class SettingTimeView: UIView {
     let calculatedDate = self.timepicker.transformSeconds()
     completion(calculatedDate)
   }
+
+  public func updateSelectedTime(hour: Int, minute: Int, seconds: Int = 0) {
+    self.timepicker.updateSelectedTime(hour: hour, minute: minute, seconds: seconds)
+  }
 }
 
 extension SettingTimeView {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingTimeView.swift
@@ -194,8 +194,9 @@ extension SettingTimeView: UIPickerViewDataSource {
 #Preview {
   let button = ToDoGardenBoxButton(title: "asdasd", buttonType: .primaryRoundRectButton)
   
-  let view = SettingTimeView(with: button, for: .focusTimeSetting)
-  
+  let view = SettingTimeView(with: button, for: .alarmTimeSetting)
+  view.updateSelectedTime(hour: 20, minute: 18)
+
   let action = UIAction { _ in
     view.transformSeconds { time in print(time) }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -83,6 +83,13 @@ final public class ToDoGardenTimePicker: UIPickerView {
       ]
     )
   }
+
+extension ToDoGardenTimePicker {
+  enum TimeComponents: Int {
+    case hour    = 0
+    case minute  = 1
+    case seconds = 2
+  }
 }
 
 final private class HighlightedView: UIView {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -56,6 +56,10 @@ final public class ToDoGardenTimePicker: UIPickerView {
 
     self.updateSelectedComponent(TimeComponents.hour, value: hour)
     self.updateSelectedComponent(TimeComponents.minute, value: minute)
+
+    guard self.configuration != Constant.SettingTimeView.TimePicker.alarmTime
+    else { return }
+
     self.updateSelectedComponent(TimeComponents.seconds, value: seconds)
   }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -84,6 +84,30 @@ final public class ToDoGardenTimePicker: UIPickerView {
     )
   }
 
+  private func verifyTotalComponentValue(hour: Int, minute: Int, seconds: Int) -> Bool {
+    return self.verifyTime(of: TimeComponents.hour, hour) &&
+      self.verifyTime(of: TimeComponents.minute, minute) &&
+      self.verifyTime(of: TimeComponents.seconds, seconds)
+  }
+
+  private func verifyTime(of component: TimeComponents, _ value: Int) -> Bool {
+    let maximumValue: Int
+    let minimumValue: Int
+    switch component {
+    case TimeComponents.hour:
+      minimumValue = 0
+      maximumValue = 23
+      return minimumValue <= value && value <= maximumValue
+    case TimeComponents.minute:
+      minimumValue = 0
+      maximumValue = 60
+      return minimumValue <= value && value <= maximumValue
+    case TimeComponents.seconds:
+      minimumValue = 0
+      maximumValue = 60
+      return minimumValue <= value && value <= maximumValue
+    }
+  }
 extension ToDoGardenTimePicker {
   enum TimeComponents: Int {
     case hour    = 0

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenTimePicker.swift
@@ -49,7 +49,16 @@ final public class ToDoGardenTimePicker: UIPickerView {
     }
     return self.timeBuilder.buildTimeInterval(from: components)
   }
-  
+
+  func updateSelectedTime(hour: Int, minute: Int, seconds: Int = 0) {
+    guard self.verifyTotalComponentValue(hour: hour, minute: minute, seconds: seconds)
+    else { return }
+
+    self.updateSelectedComponent(TimeComponents.hour, value: hour)
+    self.updateSelectedComponent(TimeComponents.minute, value: minute)
+    self.updateSelectedComponent(TimeComponents.seconds, value: seconds)
+  }
+
   func setInitialSelection() {
     self.selectRow(10, inComponent: 1, animated: false)
   }
@@ -108,6 +117,13 @@ final public class ToDoGardenTimePicker: UIPickerView {
       return minimumValue <= value && value <= maximumValue
     }
   }
+
+  private func updateSelectedComponent(_ component: TimeComponents, value: Int) {
+    let componentIndex = component.rawValue
+    self.selectRow(value, inComponent: componentIndex, animated: false)
+  }
+}
+
 extension ToDoGardenTimePicker {
   enum TimeComponents: Int {
     case hour    = 0


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #390 

## 🎉 변경 사항
- SettingTimeView에서 TimePIcker의 시작 시간을 변경하는 함수를 추가하였습니다.

## 📌 PR Point
- 시, 분, 초 단위로 시작시간을 업데이트 할 수 있는 함수입니다.
- 파라미터로 입력된 값이 범위를 벗어나면 UI가 업데이트되지 않도록 구현하였습니다.
  - ex) hour: 30, minute: -1 -> UI 업데이트 X
``` Swift
let view = SettingTimeView(with: button, for: .alarmTimeSetting)
view.updateSelectedTime(hour: 20, minute: 18)
```

- 집중 및 휴식시간 뷰에서 사용하는 경우는 없지만, 설정이 가능하도록 구현하였습니다.
- Preview에서 동작을 확인할 수 있습니다.
<img width="250" alt="스크린샷 2024-07-30 19 01 55" src="https://github.com/user-attachments/assets/573cdd83-fcd7-485d-b327-a1de5920404b">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?