### PR TITLE
AlarmTimeView API 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/AlarmTimeViewAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/AlarmTimeViewAPI.swift
@@ -8,5 +8,7 @@
 import UIKit.UIView
 
 public protocol AlarmTimeViewAPI: UIView {
-  
+  func enable()
+  func disable()
+  func updateAlarmTime(with text: String)
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/AlarmTimeViewAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/AlarmTimeViewAPI.swift
@@ -1,0 +1,12 @@
+//
+//  AlarmTimeViewAPI.swift
+//
+//
+//  Created by Wood on 7/31/24.
+//
+
+import UIKit.UIView
+
+public protocol AlarmTimeViewAPI: UIView {
+  
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/AlarmTimeViewAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/AlarmTimeViewAPI.swift
@@ -8,7 +8,13 @@
 import UIKit.UIView
 
 public protocol AlarmTimeViewAPI: UIView {
+  var delegate: AlarmTimeViewDelegate? { get set }
+
   func enable()
   func disable()
   func updateAlarmTime(with text: String)
+}
+
+public protocol AlarmTimeViewDelegate: AnyObject {
+  func didSelectAlarmTimeSettingButton()
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
@@ -7,10 +7,11 @@
 
 import UIKit
 
+import ToDoGardenUIAPI
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
-public final class AlarmTimeView: UIView {
+public final class AlarmTimeView: UIView, AlarmTimeViewAPI {
   private var model: AlarmTimeView.Model
   private var timeLabel: UILabel
   private var alarmSettingButton: UIButton

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AlarmTimeView.swift
@@ -16,6 +16,8 @@ public final class AlarmTimeView: UIView, AlarmTimeViewAPI {
   private var timeLabel: UILabel
   private var alarmSettingButton: UIButton
 
+  public weak var delegate: AlarmTimeViewDelegate?
+
   public init(model: AlarmTimeView.Model) {
     self.model = model
     self.timeLabel = UILabel()
@@ -46,14 +48,6 @@ public final class AlarmTimeView: UIView, AlarmTimeViewAPI {
   public func updateAlarmTime(with text: String) {
     self.setupAlarmSettingButtonTitle(with: text)
   }
-
-  public func addAlarmSettingAction(_ closure: @escaping () -> Void) {
-    let buttonAction = UIAction { _ in
-      closure()
-    }
-
-    self.alarmSettingButton.addAction(buttonAction, for: UIControl.Event.touchUpInside)
-  }
 }
 
 // MARK: Private Functions
@@ -83,6 +77,7 @@ extension AlarmTimeView {
     self.setupAlarmSettingButtonConfiguration()
     self.setupAlarmSettingButtonUpdateHandler()
     self.setupAlarmSettingButtonTitle(with: self.model.alarmTime)
+    self.setupAlarmSettingButtonAction()
   }
 
   private func setupAlarmSettingButtonConfiguration() {
@@ -115,6 +110,14 @@ extension AlarmTimeView {
     )
     let attributedTitle = AttributedString(text, attributes: attributes)
     self.alarmSettingButton.configuration?.attributedTitle = attributedTitle
+  }
+
+  private func setupAlarmSettingButtonAction() {
+    let buttonAction = UIAction { _ in
+      self.delegate?.didSelectAlarmTimeSettingButton()
+    }
+
+    self.alarmSettingButton.addAction(buttonAction, for: UIControl.Event.touchUpInside)
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #393 

## 🎉 변경 사항
- AlarmTimeView의 인터페이스 역할인 프로토콜을 추가하였습니다.
- 버튼의 터치여부를 전달하는 Delegate 프로토콜을 추가하였습니다.

## 📌 PR Point 
- Scene에서 AlarmTimeView 구체타입 대신 인터페이스를 사용하기 위해 구현하였습니다.
- Delegate는 채택한 상위 뷰에 알림 설정 버튼이 터치되었음을 전달합니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?