### PR TITLE
MockToDoWorker Typed Throw 코드 삭제

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/MockToDoWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/MockToDoWorker.swift
@@ -13,15 +13,15 @@ import EditToDoSceneEntity
 public final class MockToDoWorker {
   public init() {}
 
-  func fetchToDo(id: Int?) throws(MockToDoWorkerError) -> EditToDo.ToDo {
+  func fetchToDo(id: Int?) throws -> EditToDo.ToDo {
     return MockData.FetchToDo.firstData
   }
 
-  func deleteToDo(id: Int?) throws(MockToDoWorkerError) {
+  func deleteToDo(id: Int?) throws {
 
   }
 
-  func editToDo(_ toDo: EditToDo.ToDo) throws(MockToDoWorkerError) {
+  func editToDo(_ toDo: EditToDo.ToDo) throws {
     throw MockToDoWorkerError.unknownError
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #397

## 🎉 변경 사항
- MockToDoWorker에 사용된 Typed throw 코드를 삭제하였습니다.

## 📌 PR Point
- Typed throw는 Swift 6.0부터 지원하기에 컴파일 에러를 발생시켜 삭제하였습니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?