### PR TITLE
EditToDoViewController UI 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneTheme.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneTheme.swift
@@ -12,11 +12,11 @@ extension EditToDoSceneTheme {
 
 extension EditToDoSceneTheme.StringLiteral {
   enum CompleteEditingButton {
-    static let title = "ToDo 편집"
+    static let title = "완료"
   }
 
   enum EditToDoViewController {
-    static let title = "완료"
+    static let title = "ToDo 편집"
   }
 
   enum EditToDoView {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -201,11 +201,12 @@ extension EditToDoView {
     self.addSubview(self.groupSelectionView)
     self.groupSelectionView.translatesAutoresizingMaskIntoConstraints = false
 
+    let layout = EditToDoViewController.Constant.Layout.EditToDoView.GroupSelectionView.self
     NSLayoutConstraint.activate(
       [
         self.groupSelectionView.topAnchor.constraint(
           equalTo: label.bottomAnchor,
-          constant: 10
+          constant: layout.topMargin
         ),
         self.groupSelectionView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
         self.groupSelectionView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
@@ -224,7 +225,7 @@ extension EditToDoView {
       [
         self.deleteToDoButton.topAnchor.constraint(
           equalTo: self.groupSelectionView.topAnchor,
-          constant: 59
+          constant: layout.topMargin
         ),
         self.deleteToDoButton.leadingAnchor.constraint(
           equalTo: self.leadingAnchor,

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController+Constant.swift
@@ -44,14 +44,14 @@ extension EditToDoViewController.Constant.Layout.EditToDoView {
     static let leadingMargin: CGFloat = 19
   }
 
-  enum EditGroupRow {
-    static let bottomMargin: CGFloat = 18
+  enum GroupSelectionView {
+    static let topMargin: CGFloat = 18
   }
 
   enum DeleteToDoButton {
     static let titleLeadingMargin: CGFloat = 14
     static let cornerRadius: CGFloat = 10
-    static let topMargin: CGFloat = 28
+    static let topMargin: CGFloat = 59
     static let leadingMargin: CGFloat = 13
     static let trailingMargin: CGFloat = 6
     static let height: CGFloat = 44
@@ -59,13 +59,11 @@ extension EditToDoViewController.Constant.Layout.EditToDoView {
 }
 
 extension EditToDoViewController.Constant.Layout.EditToDoScheduleView {
+  enum EditToDoAlarmView {}
   enum EditToDoRepetitionView {}
+}
 
-  enum AlarmSwitch {
-    static let topMargin: CGFloat = 10
-    static let trailingMargin: CGFloat = 20
-  }
-
+extension EditToDoViewController.Constant.Layout.EditToDoScheduleView.EditToDoAlarmView {
   enum AlarmLabel {
     static let leadingMargin: CGFloat = 4
   }
@@ -76,6 +74,9 @@ extension EditToDoViewController.Constant.Layout.EditToDoScheduleView {
     static let trailingMargin: CGFloat = 11
     static let height: CGFloat = 53
   }
+
+  static let topMargin: CGFloat = 10
+  static let height: CGFloat = 92
 }
 
 extension EditToDoViewController.Constant.Layout.EditToDoScheduleView.EditToDoRepetitionView {
@@ -83,8 +84,10 @@ extension EditToDoViewController.Constant.Layout.EditToDoScheduleView.EditToDoRe
     static let leadingMargin: CGFloat = 3
   }
 
-  enum RepeatOnlyTodayButton {
+  enum RepeatOnlyTodayView {
     static let topMargin: CGFloat = 11
+    static let leadingMargin: CGFloat = 18
+    static let trailingMargin: CGFloat = 11
   }
 
   enum RepeatOtherDaysView {
@@ -92,4 +95,5 @@ extension EditToDoViewController.Constant.Layout.EditToDoScheduleView.EditToDoRe
   }
 
   static let topMargin: CGFloat = 49
+  static let height: CGFloat = 231
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -97,6 +97,7 @@ extension EditToDoViewController {
   private func setup() {
     self.setupUI()
     self.setupEditModeScrollView()
+    self.setupEditModeSegmentedControlAction()
     self.setupSubviewsLayout()
   }
 
@@ -111,6 +112,23 @@ extension EditToDoViewController {
     self.editModeScrollView.isPagingEnabled = true
     self.editModeScrollView.delegate = self
     self.editModeScrollView.bounces = false
+  }
+
+  private func setupEditModeSegmentedControlAction() {
+    let segmentedControlAction = UIAction { _ in
+      if let editMode = self.editToDoSegmentedControl.editMode {
+        self.changeEditMode(by: editMode)
+      }
+    }
+
+    self.editToDoSegmentedControl.addAction(segmentedControlAction, for: UIControl.Event.valueChanged)
+  }
+
+  private func changeEditMode(by editMode: EditToDoSegmentedControl.EditMode) {
+    let editModeType = EditToDoSegmentedControl.EditMode.self
+    let pointX = editMode == editModeType.notification ? 0 : self.editModeScrollView.frame.width
+    let contentOffset = CGPoint(x: pointX, y: 0)
+    self.editModeScrollView.setContentOffset(contentOffset, animated: true)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -19,6 +19,7 @@ protocol EditToDoDisplayLogic: AnyObject {
 final class EditToDoViewController: UIViewController, EditToDoViewControllable {
   private(set) var editToDoSegmentedControl: EditToDoSegmentedControl
   private(set) var editModeScrollView: UIScrollView
+  private(set) var editToDoView: EditToDoView
   private(set) var completeEditButton: UIButton
 
   @ExecuteOnce private var scrollToEditToDoMode: (() -> Void)?
@@ -33,6 +34,10 @@ final class EditToDoViewController: UIViewController, EditToDoViewControllable {
   init() {
     self.editToDoSegmentedControl = EditToDoSegmentedControl()
     self.editModeScrollView = UIScrollView()
+    self.editToDoView = EditToDoView(
+      toDoNameInputView: TextInputView(model: TextInputView.Model.toDoName),
+      groupSelectionView: GroupSelectionView(model: GroupSelectionView.Model.primary)
+    )
     self.completeEditButton = ToDoGardenBoxButton(
       title: EditToDoSceneTheme.StringLiteral.CompleteEditingButton.title,
       buttonType: ToDoGardenBoxButton.Configuration.primaryRoundRectButton

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -20,6 +20,7 @@ final class EditToDoViewController: UIViewController, EditToDoViewControllable {
   private(set) var editToDoSegmentedControl: EditToDoSegmentedControl
   private(set) var editModeScrollView: UIScrollView
   private(set) var editToDoView: EditToDoView
+  private(set) var editToDoScheduleView: EditToDoScheduleView
   private(set) var completeEditButton: UIButton
 
   @ExecuteOnce private var scrollToEditToDoMode: (() -> Void)?
@@ -38,6 +39,7 @@ final class EditToDoViewController: UIViewController, EditToDoViewControllable {
       toDoNameInputView: TextInputView(model: TextInputView.Model.toDoName),
       groupSelectionView: GroupSelectionView(model: GroupSelectionView.Model.primary)
     )
+    self.editToDoScheduleView = EditToDoScheduleView()
     self.completeEditButton = ToDoGardenBoxButton(
       title: EditToDoSceneTheme.StringLiteral.CompleteEditingButton.title,
       buttonType: ToDoGardenBoxButton.Configuration.primaryRoundRectButton

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -19,6 +19,7 @@ protocol EditToDoDisplayLogic: AnyObject {
 final class EditToDoViewController: UIViewController, EditToDoViewControllable {
   private(set) var editToDoSegmentedControl: EditToDoSegmentedControl
   private(set) var editModeScrollView: UIScrollView
+  private(set) var completeEditButton: UIButton
 
   @ExecuteOnce private var scrollToEditToDoMode: (() -> Void)?
 
@@ -32,6 +33,10 @@ final class EditToDoViewController: UIViewController, EditToDoViewControllable {
   init() {
     self.editToDoSegmentedControl = EditToDoSegmentedControl()
     self.editModeScrollView = UIScrollView()
+    self.completeEditButton = ToDoGardenBoxButton(
+      title: EditToDoSceneTheme.StringLiteral.CompleteEditingButton.title,
+      buttonType: ToDoGardenBoxButton.Configuration.primaryRoundRectButton
+    )
     super.init(nibName: nil, bundle: nil)
   }
   

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -36,7 +36,20 @@ class EditToDoViewController: UIViewController, EditToDoViewControllable {
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    self.doSomething()
+    self.setup()
+  }
+}
+
+// MARK: Private Functions
+
+extension EditToDoViewController {
+  private func setup() {
+    self.setupUI()
+  }
+
+  private func setupUI() {
+    self.title = EditToDoSceneTheme.StringLiteral.EditToDoViewController.title
+    self.view.backgroundColor = UIColor.toDoGardenWhite
   }
 }
 
@@ -50,12 +63,7 @@ extension EditToDoViewController: EditToDoDisplayLogic {
 
 // MARK: - Request to interactor
 
-extension EditToDoViewController {
-  func doSomething() {
-    let request = EditToDo.Something.Request()
-    self.interactor?.doSomething(request: request)
-  }
-}
+extension EditToDoViewController {}
 
 #if DEBUG
 @available(iOS 17.0, *)

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -18,6 +18,7 @@ protocol EditToDoDisplayLogic: AnyObject {
 
 final class EditToDoViewController: UIViewController, EditToDoViewControllable {
   private(set) var editToDoSegmentedControl: EditToDoSegmentedControl
+  private(set) var editModeScrollView: UIScrollView
 
   @ExecuteOnce private var scrollToEditToDoMode: (() -> Void)?
 
@@ -30,6 +31,7 @@ final class EditToDoViewController: UIViewController, EditToDoViewControllable {
   
   init() {
     self.editToDoSegmentedControl = EditToDoSegmentedControl()
+    self.editModeScrollView = UIScrollView()
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -47,6 +49,7 @@ final class EditToDoViewController: UIViewController, EditToDoViewControllable {
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
+    // MARK: 투두 수정화면 진입시 투두 수정 모드로 변경합니다.
     self.scrollToEditToDoMode = {
       self.editToDoSegmentedControl.editMode = EditToDoSegmentedControl.EditMode.todo
       self.editToDoSegmentedControl.sendActions(for: UIControl.Event.valueChanged)
@@ -59,12 +62,20 @@ final class EditToDoViewController: UIViewController, EditToDoViewControllable {
 extension EditToDoViewController {
   private func setup() {
     self.setupUI()
+    self.setupEditModeScrollView()
     self.setupSubviewsLayout()
   }
 
   private func setupUI() {
     self.title = EditToDoSceneTheme.StringLiteral.EditToDoViewController.title
     self.view.backgroundColor = UIColor.toDoGardenWhite
+  }
+
+  private func setupEditModeScrollView() {
+    self.editModeScrollView.showsVerticalScrollIndicator = false
+    self.editModeScrollView.showsHorizontalScrollIndicator = false
+    self.editModeScrollView.isPagingEnabled = true
+    self.editModeScrollView.bounces = false
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -69,6 +69,28 @@ final class EditToDoViewController: UIViewController, EditToDoViewControllable {
   }
 }
 
+// MARK: ScrollView Delegate Functions
+
+extension EditToDoViewController: UIScrollViewDelegate {
+  func scrollViewWillEndDragging(
+    _ scrollView: UIScrollView,
+    withVelocity velocity: CGPoint,
+    targetContentOffset: UnsafeMutablePointer<CGPoint>
+  ) {
+    let targetOffset = targetContentOffset.pointee.x
+    self.changeSegmentedControlEditMode(by: targetOffset)
+  }
+
+  /// 화면을 스크롤 했을 때, 수정모드에 맞게 SegmentedControl의 Index를 변경하는 메서드입니다.
+  private func changeSegmentedControlEditMode(by targetOffset: CGFloat) {
+    let scrollViewWidth = self.editModeScrollView.frame.width
+    let targetOffset = targetOffset
+    let editModeType = EditToDoSegmentedControl.EditMode.self
+    let editMode = targetOffset == scrollViewWidth ? editModeType.todo : editModeType.notification
+    self.editToDoSegmentedControl.selectedSegmentIndex = editMode.rawValue
+  }
+}
+
 // MARK: Private Functions
 
 extension EditToDoViewController {
@@ -87,6 +109,7 @@ extension EditToDoViewController {
     self.editModeScrollView.showsVerticalScrollIndicator = false
     self.editModeScrollView.showsHorizontalScrollIndicator = false
     self.editModeScrollView.isPagingEnabled = true
+    self.editModeScrollView.delegate = self
     self.editModeScrollView.bounces = false
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -9,13 +9,18 @@ import UIKit
 
 import EditToDoSceneAPI
 import EditToDoSceneEntity
+import TDUtility
+import ToDoGardenUIComponent
 
 protocol EditToDoDisplayLogic: AnyObject {
   func displaySomething(viewModel: EditToDo.Something.ViewModel)
 }
 
-class EditToDoViewController: UIViewController, EditToDoViewControllable {
-  
+final class EditToDoViewController: UIViewController, EditToDoViewControllable {
+  private(set) var editToDoSegmentedControl: EditToDoSegmentedControl
+
+  @ExecuteOnce private var scrollToEditToDoMode: (() -> Void)?
+
   // MARK: - VIP Properties
   
   var interactor: EditToDoBusinessLogic?
@@ -24,6 +29,7 @@ class EditToDoViewController: UIViewController, EditToDoViewControllable {
   // MARK: - Object lifecycle
   
   init() {
+    self.editToDoSegmentedControl = EditToDoSegmentedControl()
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -38,6 +44,14 @@ class EditToDoViewController: UIViewController, EditToDoViewControllable {
     super.viewDidLoad()
     self.setup()
   }
+
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    self.scrollToEditToDoMode = {
+      self.editToDoSegmentedControl.editMode = EditToDoSegmentedControl.EditMode.todo
+      self.editToDoSegmentedControl.sendActions(for: UIControl.Event.valueChanged)
+    }
+  }
 }
 
 // MARK: Private Functions
@@ -45,6 +59,7 @@ class EditToDoViewController: UIViewController, EditToDoViewControllable {
 extension EditToDoViewController {
   private func setup() {
     self.setupUI()
+    self.setupSubviewsLayout()
   }
 
   private func setupUI() {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -56,3 +56,10 @@ extension EditToDoViewController {
     self.interactor?.doSomething(request: request)
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  return UINavigationController(rootViewController: EditToDoViewController())
+}
+#endif

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
@@ -132,12 +132,12 @@ extension EditToDoAlarmView {
   private func setupAlarmLabelConstraints() {
     self.alarmLabel.usingAutolayout()
 
-    let layout = EditToDoViewController.Constant.Layout.EditToDoScheduleView.AlarmLabel.self
+    let layout = EditToDoViewController.Constant.Layout.EditToDoScheduleView.EditToDoAlarmView.self
     NSLayoutConstraint.activate(
       [
         self.alarmLabel.leadingAnchor.constraint(
           equalTo: self.alarmTimeSettingView.leadingAnchor,
-          constant: layout.leadingMargin
+          constant: layout.AlarmLabel.leadingMargin
         ),
         self.alarmLabel.centerYAnchor.constraint(equalTo: self.alarmSwitch.centerYAnchor)
       ]
@@ -147,23 +147,23 @@ extension EditToDoAlarmView {
   private func setupAlarmTimeSettingViewConstraints() {
     self.alarmTimeSettingView.usingAutolayout()
 
-    let layout = EditToDoViewController.Constant.Layout.EditToDoScheduleView.AlarmTimeSettingView.self
+    let layout = EditToDoViewController.Constant.Layout.EditToDoScheduleView.EditToDoAlarmView.self
     NSLayoutConstraint.activate(
       [
         self.alarmTimeSettingView.topAnchor.constraint(
           equalTo: self.alarmSwitch.bottomAnchor,
-          constant: layout.topMargin
+          constant: layout.AlarmTimeSettingView.topMargin
         ),
         self.alarmTimeSettingView.leadingAnchor.constraint(
           equalTo: self.leadingAnchor,
-          constant: layout.leadingMargin
+          constant: layout.AlarmTimeSettingView.leadingMargin
         ),
         self.alarmTimeSettingView.trailingAnchor.constraint(
           equalTo: self.trailingAnchor,
-          constant: -layout.trailingMargin
+          constant: -layout.AlarmTimeSettingView.trailingMargin
         ),
         self.alarmTimeSettingView.heightAnchor.constraint(
-          equalToConstant: layout.height
+          equalToConstant: layout.AlarmTimeSettingView.height
         )
       ]
     )

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
@@ -87,6 +87,7 @@ extension EditToDoAlarmView {
     self.alarmLabel.font = UIFont.pretendardHeadSemiBold
     let text = EditToDoSceneTheme.StringLiteral.ToDoScheduleView.AlarmLabel.text
     self.alarmLabel.text = text
+    self.alarmLabel.textColor = EditToDoSceneTheme.mainColor
   }
 
   private func setupAlarmSwitchAction() {
@@ -123,10 +124,7 @@ extension EditToDoAlarmView {
     NSLayoutConstraint.activate(
       [
         self.alarmSwitch.topAnchor.constraint(equalTo: self.topAnchor),
-        self.alarmSwitch.trailingAnchor.constraint(
-          equalTo: self.trailingAnchor,
-          constant: -2
-        )
+        self.alarmSwitch.trailingAnchor.constraint(equalTo: self.alarmTimeSettingView.trailingAnchor)
       ]
     )
   }
@@ -138,7 +136,7 @@ extension EditToDoAlarmView {
     NSLayoutConstraint.activate(
       [
         self.alarmLabel.leadingAnchor.constraint(
-          equalTo: self.leadingAnchor,
+          equalTo: self.alarmTimeSettingView.leadingAnchor,
           constant: layout.leadingMargin
         ),
         self.alarmLabel.centerYAnchor.constraint(equalTo: self.alarmSwitch.centerYAnchor)
@@ -156,9 +154,17 @@ extension EditToDoAlarmView {
           equalTo: self.alarmSwitch.bottomAnchor,
           constant: layout.topMargin
         ),
-        self.alarmTimeSettingView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-        self.alarmTimeSettingView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-        self.alarmTimeSettingView.heightAnchor.constraint(equalToConstant: layout.height)
+        self.alarmTimeSettingView.leadingAnchor.constraint(
+          equalTo: self.leadingAnchor,
+          constant: layout.leadingMargin
+        ),
+        self.alarmTimeSettingView.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: -layout.trailingMargin
+        ),
+        self.alarmTimeSettingView.heightAnchor.constraint(
+          equalToConstant: layout.height
+        )
       ]
     )
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoRepetitionView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoRepetitionView.swift
@@ -141,15 +141,15 @@ extension EditToDoRepetitionView {
       [
         self.repeatOnlyTodayView.topAnchor.constraint(
           equalTo: self.repetitionLabel.bottomAnchor,
-          constant: layout.RepeatOnlyTodayButton.topMargin
+          constant: layout.RepeatOnlyTodayView.topMargin
         ),
         self.repeatOnlyTodayView.leadingAnchor.constraint(
           equalTo: self.leadingAnchor,
-          constant: 18
+          constant: layout.RepeatOnlyTodayView.leadingMargin
         ),
         self.repeatOnlyTodayView.trailingAnchor.constraint(
           equalTo: self.trailingAnchor,
-          constant: -11
+          constant: -layout.RepeatOnlyTodayView.trailingMargin
         )
       ]
     )

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoRepetitionView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoRepetitionView.swift
@@ -126,7 +126,7 @@ extension EditToDoRepetitionView {
       [
         self.repetitionLabel.topAnchor.constraint(equalTo: self.topAnchor),
         self.repetitionLabel.leadingAnchor.constraint(
-          equalTo: self.leadingAnchor,
+          equalTo: self.repeatOnlyTodayView.leadingAnchor,
           constant: layout.RepetitionLabel.leadingMargin
         )
       ]
@@ -143,8 +143,14 @@ extension EditToDoRepetitionView {
           equalTo: self.repetitionLabel.bottomAnchor,
           constant: layout.RepeatOnlyTodayButton.topMargin
         ),
-        self.repeatOnlyTodayView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-        self.repeatOnlyTodayView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+        self.repeatOnlyTodayView.leadingAnchor.constraint(
+          equalTo: self.leadingAnchor,
+          constant: 18
+        ),
+        self.repeatOnlyTodayView.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: -11
+        )
       ]
     )
   }
@@ -159,8 +165,8 @@ extension EditToDoRepetitionView {
           equalTo: self.repeatOnlyTodayView.bottomAnchor,
           constant: layout.RepeatOtherDaysView.topMargin
         ),
-        self.repeatOtherDaysView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-        self.repeatOtherDaysView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+        self.repeatOtherDaysView.leadingAnchor.constraint(equalTo: self.repeatOnlyTodayView.leadingAnchor),
+        self.repeatOtherDaysView.trailingAnchor.constraint(equalTo: self.repeatOnlyTodayView.trailingAnchor)
       ]
     )
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoScheduleView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoScheduleView.swift
@@ -94,7 +94,10 @@ extension EditToDoScheduleView {
 
     NSLayoutConstraint.activate(
       [
-        self.editToDoAlarmView.topAnchor.constraint(equalTo: self.topAnchor),
+        self.editToDoAlarmView.topAnchor.constraint(
+          equalTo: self.topAnchor,
+          constant: 10
+        ),
         self.editToDoAlarmView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
         self.editToDoAlarmView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
         self.editToDoAlarmView.heightAnchor.constraint(equalToConstant: 92)

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoScheduleView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoScheduleView.swift
@@ -92,15 +92,16 @@ extension EditToDoScheduleView {
   private func setupEditToDoAlarmViewLayout() {
     self.editToDoAlarmView.usingAutolayout()
 
+    let layout = EditToDoViewController.Constant.Layout.EditToDoScheduleView.EditToDoAlarmView.self
     NSLayoutConstraint.activate(
       [
         self.editToDoAlarmView.topAnchor.constraint(
           equalTo: self.topAnchor,
-          constant: 10
+          constant: layout.topMargin
         ),
         self.editToDoAlarmView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
         self.editToDoAlarmView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-        self.editToDoAlarmView.heightAnchor.constraint(equalToConstant: 92)
+        self.editToDoAlarmView.heightAnchor.constraint(equalToConstant: layout.height)
       ]
     )
   }
@@ -117,7 +118,7 @@ extension EditToDoScheduleView {
         ),
         self.editToDoRepetitionView.leadingAnchor.constraint(equalTo: self.editToDoAlarmView.leadingAnchor),
         self.editToDoRepetitionView.trailingAnchor.constraint(equalTo: self.editToDoAlarmView.trailingAnchor),
-        self.editToDoRepetitionView.heightAnchor.constraint(equalToConstant: 231)
+        self.editToDoRepetitionView.heightAnchor.constraint(equalToConstant: layout.height)
       ]
     )
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoViewController+setupSubviewsLayout.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoViewController+setupSubviewsLayout.swift
@@ -10,6 +10,7 @@ import UIKit
 extension EditToDoViewController {
   func setupSubviewsLayout() {
     self.setupEditToDoSegmentedControlLayout()
+    self.setupCompleteEditButtonLayout()
     self.setupEditModeScrollViewLayout()
   }
 
@@ -35,6 +36,21 @@ extension EditToDoViewController {
         self.editToDoSegmentedControl.heightAnchor.constraint(
           equalToConstant: constant.height
         )
+      ]
+    )
+  }
+
+  private func setupCompleteEditButtonLayout() {
+    self.view.addSubview(self.completeEditButton)
+    self.completeEditButton.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate(
+      [
+        self.completeEditButton.bottomAnchor.constraint(
+          equalTo: self.view.safeAreaLayoutGuide.bottomAnchor,
+          constant: -EditToDoViewController.Constant.Layout.CompleteEditingButton.bottomMargin
+        ),
+        self.completeEditButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
       ]
     )
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoViewController+setupSubviewsLayout.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoViewController+setupSubviewsLayout.swift
@@ -1,0 +1,40 @@
+//
+//  EditToDoViewController+setupSubviewsLayout.swift
+//
+//
+//  Created by Wood on 8/5/24.
+//
+
+import UIKit
+
+extension EditToDoViewController {
+  func setupSubviewsLayout() {
+    self.setupEditToDoSegmentedControlLayout()
+  }
+
+  private func setupEditToDoSegmentedControlLayout() {
+    self.view.addSubview(self.editToDoSegmentedControl)
+    self.editToDoSegmentedControl.translatesAutoresizingMaskIntoConstraints = false
+
+    let constant = EditToDoViewController.Constant.Layout.EditModeSegmentedControl.self
+    NSLayoutConstraint.activate(
+      [
+        self.editToDoSegmentedControl.topAnchor.constraint(
+          equalTo: self.view.safeAreaLayoutGuide.topAnchor,
+          constant: constant.topMargin
+        ),
+        self.editToDoSegmentedControl.leadingAnchor.constraint(
+          equalTo: self.view.safeAreaLayoutGuide.leadingAnchor,
+          constant: constant.leadingMargin
+        ),
+        self.editToDoSegmentedControl.trailingAnchor.constraint(
+          equalTo: self.view.safeAreaLayoutGuide.trailingAnchor,
+          constant: -constant.trailingMargin
+        ),
+        self.editToDoSegmentedControl.heightAnchor.constraint(
+          equalToConstant: constant.height
+        )
+      ]
+    )
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoViewController+setupSubviewsLayout.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoViewController+setupSubviewsLayout.swift
@@ -10,6 +10,7 @@ import UIKit
 extension EditToDoViewController {
   func setupSubviewsLayout() {
     self.setupEditToDoSegmentedControlLayout()
+    self.setupEditModeScrollViewLayout()
   }
 
   private func setupEditToDoSegmentedControlLayout() {
@@ -33,6 +34,32 @@ extension EditToDoViewController {
         ),
         self.editToDoSegmentedControl.heightAnchor.constraint(
           equalToConstant: constant.height
+        )
+      ]
+    )
+  }
+
+  private func setupEditModeScrollViewLayout() {
+    self.view.addSubview(self.editModeScrollView)
+    self.editModeScrollView.translatesAutoresizingMaskIntoConstraints = false
+
+    let constant = EditToDoViewController.Constant.Layout.EditModeScrollView.self
+    NSLayoutConstraint.activate(
+      [
+        self.editModeScrollView.topAnchor.constraint(
+          equalTo: self.editToDoSegmentedControl.bottomAnchor,
+          constant: constant.topMargin
+        ),
+        self.editModeScrollView.leadingAnchor.constraint(
+          equalTo: self.view.safeAreaLayoutGuide.leadingAnchor,
+          constant: constant.leadingMargin
+        ),
+        self.editModeScrollView.trailingAnchor.constraint(
+          equalTo: self.view.safeAreaLayoutGuide.trailingAnchor,
+          constant: -constant.trailingMargin
+        ),
+        self.editModeScrollView.bottomAnchor.constraint(
+          equalTo: self.completeEditButton.topAnchor
         )
       ]
     )

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoViewController+setupSubviewsLayout.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoViewController+setupSubviewsLayout.swift
@@ -14,6 +14,7 @@ extension EditToDoViewController {
     self.setupEditModeScrollViewLayout()
     let contentView = self.buildEditModeScrollContentView()
     self.setupEditToDoViewLayout(with: contentView)
+    self.setupEditToDoScheduleViewLayout(with: contentView)
   }
 
   private func setupEditToDoSegmentedControlLayout() {
@@ -120,6 +121,19 @@ extension EditToDoViewController {
         self.editToDoView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
         self.editToDoView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
         self.editToDoView.widthAnchor.constraint(equalTo: self.editModeScrollView.frameLayoutGuide.widthAnchor)
+      ]
+    )
+  }
+
+  private func setupEditToDoScheduleViewLayout(with contentView: UIView) {
+    self.editToDoScheduleView.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate(
+      [
+        self.editToDoScheduleView.topAnchor.constraint(equalTo: contentView.topAnchor),
+        self.editToDoScheduleView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+        self.editToDoScheduleView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+        self.editToDoScheduleView.widthAnchor.constraint(equalTo: self.editModeScrollView.frameLayoutGuide.widthAnchor)
       ]
     )
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoViewController+setupSubviewsLayout.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoViewController+setupSubviewsLayout.swift
@@ -12,6 +12,8 @@ extension EditToDoViewController {
     self.setupEditToDoSegmentedControlLayout()
     self.setupCompleteEditButtonLayout()
     self.setupEditModeScrollViewLayout()
+    let contentView = self.buildEditModeScrollContentView()
+    self.setupEditToDoViewLayout(with: contentView)
   }
 
   private func setupEditToDoSegmentedControlLayout() {
@@ -77,6 +79,47 @@ extension EditToDoViewController {
         self.editModeScrollView.bottomAnchor.constraint(
           equalTo: self.completeEditButton.topAnchor
         )
+      ]
+    )
+  }
+
+  private func buildEditModeScrollContentView() -> UIView {
+    let contentView = UIView()
+    contentView.addSubview(self.editToDoView)
+    contentView.addSubview(self.editToDoScheduleView)
+    self.setupContentViewLayout(contentView: contentView)
+    return contentView
+  }
+
+  private func setupContentViewLayout(contentView: UIView) {
+    self.editModeScrollView.addSubview(contentView)
+    contentView.translatesAutoresizingMaskIntoConstraints = false
+
+    let widthConstraint = self.editModeScrollView.widthAnchor.constraint(greaterThanOrEqualTo: self.view.widthAnchor)
+    widthConstraint.priority = UILayoutPriority.defaultLow
+    widthConstraint.isActive = true
+
+    NSLayoutConstraint.activate(
+      [
+        contentView.topAnchor.constraint(equalTo: self.editModeScrollView.contentLayoutGuide.topAnchor),
+        contentView.leadingAnchor.constraint(equalTo: self.editModeScrollView.contentLayoutGuide.leadingAnchor),
+        contentView.trailingAnchor.constraint(equalTo: self.editModeScrollView.contentLayoutGuide.trailingAnchor),
+        contentView.bottomAnchor.constraint(equalTo: self.editModeScrollView.contentLayoutGuide.bottomAnchor),
+        contentView.heightAnchor.constraint(equalTo: self.editModeScrollView.heightAnchor)
+      ]
+    )
+  }
+
+  private func setupEditToDoViewLayout(with contentView: UIView) {
+    self.editToDoView.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate(
+      [
+        self.editToDoView.topAnchor.constraint(equalTo: contentView.topAnchor),
+        self.editToDoView.leadingAnchor.constraint(equalTo: self.editToDoScheduleView.trailingAnchor),
+        self.editToDoView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+        self.editToDoView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+        self.editToDoView.widthAnchor.constraint(equalTo: self.editModeScrollView.frameLayoutGuide.widthAnchor)
       ]
     )
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #403 

## 🎉 변경 사항
- EditToDoViewController에 UI를 추가하였습니다.

## 📌 PR Point
- VIP Cycle과 관련된 로직들은 별도의 PR에서 진행하고자 추가하지 않았습니다.
- 레이아웃과 관련된 매직 넘버들도 별도의 PR에서 Constant에 옮기려고 합니다.

<img width="621" alt="스크린샷 2024-08-08 12 36 46" src="https://github.com/user-attachments/assets/07a3eed4-ae32-4256-9010-09a63fee5613">

### 화면 UI 동작
- `알림 스위치`를 누르면 알림을 활성화 / 비활성화 합니다.
  - 스위치가 On이면, `알림 시간을 선택 뷰도 활성화`됩니다.
  - 활성화 여부는 VIP Cycle을 통해 변경되므로, 동작 확인 불가능

- `그룹 선택 뷰`를 누르면 수정할 그룹의 목록을 보여줍니다.
  - 그룹 목록을 VIP Cycle을 통해 받아오므로, 동작 확인 불가능

- `오늘만/다른날도 할래요 뷰`들을 누르면 선택여부에 따라 활성화됩니다.
  - 눌렀을 때 어떤 뷰를 업데이트할 지 VIP Cycle을 통해 업데이트하므로, 동작 확인 불가능

- `완료 버튼`을 누르면 투두 수정을 요청합니다.
  - 서버에 요청하기 위해 VIP Cycle이 필요

- `삭제 버튼`을 누르면 투두 삭제를 요청합니다.
  - 서버에 요청하기 위해 VIP Cycle이 필요

### 동작 화면 GIF
- 아래는 화면 동작을 GIF로 첨부하였습니다.
<img width="300" src="https://github.com/user-attachments/assets/2cfe5ed5-aed8-4cd4-88a6-26d9b710e375">

### 관련 기술서 및 백로그
- [백로그 링크](https://docs.google.com/spreadsheets/d/17tg1z_x2UiSDCYD5yLnisMQkEVDgYIJNFICO8gTPkK4/edit?gid=917831885#gid=917831885&range=B82)
- [화면 기술서](https://www.notion.so/ToDo-440263b923604e0481d4e23183cc0677?pvs=4)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?