### PR TITLE
SettingViewController UI 하위 뷰 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/SettingScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Package.swift
@@ -35,7 +35,10 @@ let package = Package(
       name: "SettingScene",
       dependencies: [
         "SettingSceneAPI",
-        "SettingSceneEntity"
+        "SettingSceneEntity",
+        .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI"),
+        .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
+        .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI")
       ]
     ),
     .testTarget(

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingSceneTheme.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingSceneTheme.swift
@@ -1,0 +1,33 @@
+//
+//  SettingSceneTheme.swift
+//
+//
+//  Created by Wood on 8/8/24.
+//
+
+import UIKit.UIColor
+
+import TDUtility
+
+enum SettingSceneTheme {
+  @DynamicUIProperty static var mainColor = UIColor.toDoGardenGreenDark
+}
+
+extension SettingSceneTheme {
+  enum StringLiteral {}
+}
+
+extension SettingSceneTheme.StringLiteral {
+  enum UserGuideButton {}
+  enum UserSettingView {}
+}
+
+extension SettingSceneTheme.StringLiteral.UserGuideButton {
+  static let title = "이용 가이드"
+}
+
+extension SettingSceneTheme.StringLiteral.UserSettingView {
+  static let userSettingLabelText = "사용자 설정"
+  static let alarmSettingButtonTitle = "알림 설정"
+  static let remindSettingButtonTitle = "리마인드 설정"
+}

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingSceneTheme.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingSceneTheme.swift
@@ -18,8 +18,17 @@ extension SettingSceneTheme {
 }
 
 extension SettingSceneTheme.StringLiteral {
+  enum AppSupportView {}
   enum UserGuideButton {}
   enum UserSettingView {}
+}
+
+extension SettingSceneTheme.StringLiteral.AppSupportView {
+  static let appSupportLabelText = "앱 정보 및 지원"
+  static let announcementButtonTitle = "공지사항"
+  static let privacyPolicyButtonTitle = "개인정보 처리 방침"
+  static let termsOfUseButtonTitle = "서비스 이용 약관"
+  static let sendFeedbackButtonTitle = "피드백 보내기"
 }
 
 extension SettingSceneTheme.StringLiteral.UserGuideButton {

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingSceneTheme.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingSceneTheme.swift
@@ -21,6 +21,7 @@ extension SettingSceneTheme.StringLiteral {
   enum AppSupportView {}
   enum UserGuideButton {}
   enum UserSettingView {}
+  enum VersionInfoView {}
 }
 
 extension SettingSceneTheme.StringLiteral.AppSupportView {
@@ -39,4 +40,11 @@ extension SettingSceneTheme.StringLiteral.UserSettingView {
   static let userSettingLabelText = "사용자 설정"
   static let alarmSettingButtonTitle = "알림 설정"
   static let remindSettingButtonTitle = "리마인드 설정"
+}
+
+extension SettingSceneTheme.StringLiteral.VersionInfoView {
+  static let versionInfoLabelText = "버전정보"
+  static let updateButtonTitle = "최신버전으로 업데이트"
+  static let latestVersionText = "최신 버전"
+  static let priorVersionText = "업데이트 필요"
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController+Constant.swift
@@ -1,0 +1,26 @@
+//
+//  SettingViewController+Constant.swift
+//
+//
+//  Created by Wood on 8/8/24.
+//
+
+import UIKit
+
+extension SettingViewController {
+  enum Constant {}
+}
+
+extension SettingViewController.Constant {
+  enum UserGuideButton {}
+}
+
+extension SettingViewController.Constant.UserGuideButton {
+  enum Layer {
+    static let cornerRadius: CGFloat = 10
+    static let borderWidth: CGFloat = 1.0
+  }
+
+  static let spacing: CGFloat = 3
+  static let layoutMargins = UIEdgeInsets(top: 7, left: 11, bottom: 7, right: 8)
+}

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController+Constant.swift
@@ -13,6 +13,7 @@ extension SettingViewController {
 
 extension SettingViewController.Constant {
   enum UserGuideButton {}
+  enum SettingButtonStackView {}
 }
 
 extension SettingViewController.Constant.UserGuideButton {
@@ -23,4 +24,22 @@ extension SettingViewController.Constant.UserGuideButton {
 
   static let spacing: CGFloat = 3
   static let layoutMargins = UIEdgeInsets(top: 7, left: 11, bottom: 7, right: 8)
+}
+
+extension SettingViewController.Constant.SettingButtonStackView {
+  enum Layer {
+    static let cornerRadius: CGFloat = 10
+    static let borderWidth: CGFloat = 1.0
+  }
+
+  enum ImageView {
+    static let trailingMargin: CGFloat = 8
+  }
+
+  enum TitleLabel {
+    static let leadingMargin: CGFloat = 12
+  }
+
+  static let spacing: CGFloat = 1.0
+  static let buttonHeight: CGFloat = 40
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/AppSupportView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/AppSupportView.swift
@@ -1,0 +1,19 @@
+//
+//  AppSupportView.swift
+//
+//
+//  Created by Wood on 8/8/24.
+//
+
+import UIKit
+
+final class AppSupportView: UIView {
+  init() {
+    super.init(frame: CGRect.zero)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/AppSupportView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/AppSupportView.swift
@@ -8,12 +8,142 @@
 import UIKit
 
 final class AppSupportView: UIView {
+  private let settingButtonStackView: SettingButtonStackView
+
   init() {
+    self.settingButtonStackView = SettingButtonStackView()
     super.init(frame: CGRect.zero)
+    self.setup()
   }
 
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+extension AppSupportView {
+  private func setup() {
+    self.setupAnnouncementButton()
+    self.setupPrivacyPolicyButton()
+    self.setupTermsOfUseButton()
+    self.setupSendFeedbackButton()
+    self.setupLeftImageView()
+  }
+
+  private func setupAnnouncementButton() {
+    let action = UIAction { _ in
+      self.delegate?.didSelectAnnouncementButton()
+    }
+    let announcementButton = UIButton(primaryAction: action)
+
+    self.settingButtonStackView.addSettingButton(
+      announcementButton,
+      title: SettingSceneTheme.StringLiteral.AppSupportView.announcementButtonTitle,
+      isForwardImageNeeded: true
+    )
+  }
+
+  private func setupPrivacyPolicyButton() {
+    let action = UIAction { _ in
+      self.delegate?.didSelectPrivacyPolicyButton()
+    }
+
+    let privacyPolicyButton = UIButton(primaryAction: action)
+    self.settingButtonStackView.addSettingButton(
+      privacyPolicyButton,
+      title: SettingSceneTheme.StringLiteral.AppSupportView.privacyPolicyButtonTitle,
+      isForwardImageNeeded: false
+    )
+  }
+
+  private func setupTermsOfUseButton() {
+    let action = UIAction { _ in
+      self.delegate?.didSelectTemrsOfUseButton()
+    }
+
+    let termsOfUseButton = UIButton(primaryAction: action)
+    self.settingButtonStackView.addSettingButton(
+      termsOfUseButton,
+      title: SettingSceneTheme.StringLiteral.AppSupportView.termsOfUseButtonTitle,
+      isForwardImageNeeded: false
+    )
+  }
+
+  private func setupSendFeedbackButton() {
+    let action = UIAction { _ in
+      self.delegate?.didSelectTemrsOfUseButton()
+    }
+
+    let sendFeedBackButton = UIButton(primaryAction: action)
+    self.settingButtonStackView.addSettingButton(
+      sendFeedBackButton,
+      title: SettingSceneTheme.StringLiteral.AppSupportView.sendFeedbackButtonTitle,
+      isForwardImageNeeded: false
+    )
+  }
+
+  private func setupLeftImageView() {
+    let leftImageView = UIImageView()
+    leftImageView.image = UIImage.leafImage
+    leftImageView.translatesAutoresizingMaskIntoConstraints = false
+    self.setupLeftImageViewLayout(leftImageView)
+    self.setupUserSettingLabel(with: leftImageView)
+    self.setupSettingButtonStackViewLayout(leftImageView)
+  }
+
+  private func setupUserSettingLabel(with leftImageView: UIImageView) {
+    let userSettingLabel = UILabel()
+    userSettingLabel.font = UIFont.pretendardBodySemiBold15
+    userSettingLabel.text = SettingSceneTheme.StringLiteral.AppSupportView.appSupportLabelText
+    userSettingLabel.textColor = SettingSceneTheme.mainColor
+    self.setupUserSettingLabelLayout(userSettingLabel, leftImageView)
+  }
+}
+
+extension AppSupportView {
+  private func setupLeftImageViewLayout(_ imageView: UIImageView) {
+    self.addSubview(imageView)
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+
+    let layout = SettingViewController.Constant.AppSupportView.LeftImageView.self
+    NSLayoutConstraint.activate(
+      [
+        imageView.topAnchor.constraint(equalTo: self.topAnchor),
+        imageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        imageView.widthAnchor.constraint(equalToConstant: layout.width),
+        imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: layout.heightMultiplier)
+      ]
+    )
+  }
+
+  private func setupUserSettingLabelLayout(_ label: UILabel, _ leftImageView: UIImageView) {
+    self.addSubview(label)
+    label.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate(
+      [
+        label.leadingAnchor.constraint(equalTo: leftImageView.trailingAnchor),
+        label.centerYAnchor.constraint(equalTo: leftImageView.centerYAnchor)
+      ]
+    )
+  }
+
+  private func setupSettingButtonStackViewLayout(_ leftImageView: UIImageView) {
+    self.addSubview(self.settingButtonStackView)
+    self.settingButtonStackView.translatesAutoresizingMaskIntoConstraints = false
+
+    let layout = SettingViewController.Constant.AppSupportView.SettingButtonStackView.self
+    NSLayoutConstraint.activate(
+      [
+        self.settingButtonStackView.topAnchor.constraint(
+          equalTo: leftImageView.bottomAnchor,
+          constant: layout.topMargin
+        ),
+        self.settingButtonStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.settingButtonStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        self.settingButtonStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+      ]
+    )
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/AppSupportView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/AppSupportView.swift
@@ -162,3 +162,12 @@ extension AppSupportView {
     )
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let view = AppSupportView()
+  view.widthAnchor.constraint(equalToConstant: 300).isActive = true
+  return view
+}
+#endif

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/AppSupportView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/AppSupportView.swift
@@ -10,6 +10,8 @@ import UIKit
 final class AppSupportView: UIView {
   private let settingButtonStackView: SettingButtonStackView
 
+  weak var delegate: AppSupportViewDelegate?
+
   init() {
     self.settingButtonStackView = SettingButtonStackView()
     super.init(frame: CGRect.zero)
@@ -21,6 +23,17 @@ final class AppSupportView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
 }
+
+// MARK: Private Functions
+
+protocol AppSupportViewDelegate: AnyObject {
+  func didSelectAnnouncementButton()
+  func didSelectPrivacyPolicyButton()
+  func didSelectTemrsOfUseButton()
+  func didSelectSendFeedBackButton()
+}
+
+// MARK: Private Functions
 
 extension AppSupportView {
   private func setup() {
@@ -100,6 +113,8 @@ extension AppSupportView {
     self.setupUserSettingLabelLayout(userSettingLabel, leftImageView)
   }
 }
+
+// MARK: Auto Layout
 
 extension AppSupportView {
   private func setupLeftImageViewLayout(_ imageView: UIImageView) {

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/SettingButtonStackView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/SettingButtonStackView.swift
@@ -7,13 +7,79 @@
 
 import UIKit
 
-public final class SettingButtonStackView: UIStackView {
-  public init() {
+final class SettingButtonStackView: UIStackView {
+  init() {
     super.init(frame: CGRect.zero)
   }
 
   @available(*, unavailable)
   required init(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+
+  func addSettingButton(_ button: UIButton, title: String, isForwardImageNeeded: Bool) {
+    if isForwardImageNeeded {
+      self.setupButtonImage(button)
+    }
+
+    self.setupButtonTitle(button, title: title)
+    button.backgroundColor = UIColor.toDoGardenWhite
+    button.heightAnchor.constraint(
+      equalToConstant: SettingViewController.Constant.SettingButtonStackView.buttonHeight
+    ).isActive = true
+    self.addArrangedSubview(button)
+  }
+}
+
+extension SettingButtonStackView {
+  private func setup() {
+    self.setupStackView()
+    self.setupLayerUI()
+  }
+
+  private func setupStackView() {
+    self.backgroundColor = UIColor.toDoGardenGreenBackground
+    self.axis = NSLayoutConstraint.Axis.vertical
+    self.distribution = UIStackView.Distribution.equalSpacing
+    let layout = SettingViewController.Constant.SettingButtonStackView.self
+    self.spacing = layout.spacing
+  }
+
+  private func setupLayerUI() {
+    let layout = SettingViewController.Constant.SettingButtonStackView.self
+    self.layer.cornerRadius = layout.Layer.cornerRadius
+    self.layer.borderWidth = layout.Layer.borderWidth
+    self.layer.borderColor = UIColor.toDoGardenGreenBackground.cgColor
+  }
+
+  private func setupButtonImage(_ button: UIButton) {
+    button.setImage(UIImage.forwardButtonImage, for: UIControl.State.normal)
+    button.imageView?.contentMode = .right
+    button.imageView?.translatesAutoresizingMaskIntoConstraints = false
+    button.imageView?.centerYAnchor.constraint(equalTo: button.centerYAnchor).isActive = true
+    button.imageView?.trailingAnchor.constraint(
+      equalTo: button.trailingAnchor,
+      constant: -SettingViewController.Constant.SettingButtonStackView.ImageView.trailingMargin
+    ).isActive = true
+  }
+
+  private func setupButtonTitle(_ button: UIButton, title: String) {
+    button.setAttributedTitle(
+      NSAttributedString(
+        string: title,
+        attributes: [
+          NSAttributedString.Key.font: UIFont.pretendardBodyRegular,
+          NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+        ]
+      ),
+      for: UIControl.State.normal
+    )
+
+    button.titleLabel?.translatesAutoresizingMaskIntoConstraints = false
+    button.titleLabel?.leadingAnchor.constraint(
+      equalTo: button.leadingAnchor,
+      constant: SettingViewController.Constant.SettingButtonStackView.TitleLabel.leadingMargin
+    ).isActive = true
+    button.titleLabel?.centerYAnchor.constraint(equalTo: button.centerYAnchor).isActive = true
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/SettingButtonStackView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/SettingButtonStackView.swift
@@ -7,9 +7,12 @@
 
 import UIKit
 
+/// 설정 화면에서 필요한 여러개의 버튼들을 담는 StackView 입니다. 
+/// UserSettingView, AppSupportView에서 사용됩니다.
 final class SettingButtonStackView: UIStackView {
   init() {
     super.init(frame: CGRect.zero)
+    self.setup()
   }
 
   @available(*, unavailable)

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/SettingButtonStackView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/SettingButtonStackView.swift
@@ -1,0 +1,19 @@
+//
+//  SettingButtonStackView.swift
+//
+//
+//  Created by Wood on 8/8/24.
+//
+
+import UIKit
+
+public final class SettingButtonStackView: UIStackView {
+  public init() {
+    super.init(frame: CGRect.zero)
+  }
+
+  @available(*, unavailable)
+  required init(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/SettingButtonStackView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/SettingButtonStackView.swift
@@ -27,6 +27,7 @@ final class SettingButtonStackView: UIStackView {
 
     self.setupButtonTitle(button, title: title)
     button.backgroundColor = UIColor.toDoGardenWhite
+    button.tintColor = UIColor.toDoGardenGreenDark
     button.heightAnchor.constraint(
       equalToConstant: SettingViewController.Constant.SettingButtonStackView.buttonHeight
     ).isActive = true

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/SettingViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/SettingViewController+Constant.swift
@@ -13,6 +13,7 @@ extension SettingViewController {
 
 extension SettingViewController.Constant {
   enum UserGuideButton {}
+  enum UserSettingView {}
   enum SettingButtonStackView {}
 }
 
@@ -24,6 +25,17 @@ extension SettingViewController.Constant.UserGuideButton {
 
   static let spacing: CGFloat = 3
   static let layoutMargins = UIEdgeInsets(top: 7, left: 11, bottom: 7, right: 8)
+}
+
+extension SettingViewController.Constant.UserSettingView {
+  enum LeftImageView {
+    static let width: CGFloat = 18
+    static let heightMultiplier: CGFloat = 1.0
+  }
+  
+  enum SettingButtonStackView {
+    static let topMargin: CGFloat = 4
+  }
 }
 
 extension SettingViewController.Constant.SettingButtonStackView {

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/SettingViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/SettingViewController+Constant.swift
@@ -12,9 +12,21 @@ extension SettingViewController {
 }
 
 extension SettingViewController.Constant {
+  enum AppSupportView {}
   enum UserGuideButton {}
   enum UserSettingView {}
   enum SettingButtonStackView {}
+}
+
+extension SettingViewController.Constant.AppSupportView {
+  enum LeftImageView {
+    static let width: CGFloat = 18
+    static let heightMultiplier: CGFloat = 1.0
+  }
+
+  enum SettingButtonStackView {
+    static let topMargin: CGFloat = 4
+  }
 }
 
 extension SettingViewController.Constant.UserGuideButton {
@@ -32,7 +44,7 @@ extension SettingViewController.Constant.UserSettingView {
     static let width: CGFloat = 18
     static let heightMultiplier: CGFloat = 1.0
   }
-  
+
   enum SettingButtonStackView {
     static let topMargin: CGFloat = 4
   }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/SettingViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/SettingViewController+Constant.swift
@@ -16,6 +16,7 @@ extension SettingViewController.Constant {
   enum UserGuideButton {}
   enum UserSettingView {}
   enum SettingButtonStackView {}
+  enum VersionInfoView {}
 }
 
 extension SettingViewController.Constant.AppSupportView {
@@ -66,4 +67,18 @@ extension SettingViewController.Constant.SettingButtonStackView {
 
   static let spacing: CGFloat = 1.0
   static let buttonHeight: CGFloat = 40
+}
+
+extension SettingViewController.Constant.VersionInfoView {
+  enum VersionInfoLabel {
+    static let topMargin: CGFloat = 7
+    static let leadingMargin: CGFloat = 4
+  }
+
+  enum UpdateButton {
+    static let cornerRadius: CGFloat = 10
+    static let topMargin: CGFloat = 7
+    static let leadingMargin: CGFloat = 21
+    static let height: CGFloat = 40
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserGuideButton.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserGuideButton.swift
@@ -12,10 +12,75 @@ import ToDoGardenUIResource
 final class UserGuideButton: UIStackView {
   init() {
     super.init(frame: CGRect.zero)
+    self.setupUI()
   }
 
   @available(*, unavailable)
   required init(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: Private Functions
+extension UserGuideButton {
+  private func setupUI() {
+    self.setupStackViewUI()
+    self.setupEditIconImageView()
+    self.setupToDoGardenLogoImageView()
+    self.setupUserGuideLabel()
+    self.setupRightForwardImage()
+  }
+
+  private func setupStackViewUI() {
+    self.isLayoutMarginsRelativeArrangement = true
+    self.layoutMargins = UIEdgeInsets(top: 7, left: 15, bottom: 7, right: 8)
+    self.spacing = 5
+    self.backgroundColor = UIColor.toDoGardenGreenBackground
+    self.layer.cornerRadius = 10
+    self.layer.borderWidth = 1.0
+    self.layer.borderColor = UIColor.toDoGardenGreenGray.cgColor
+  }
+
+  private func setupEditIconImageView() {
+    let editIconImageView = UIImageView()
+    editIconImageView.image = UIImage.editIconImage.withTintColor(UIColor.toDoGardenGreenDark)
+    editIconImageView.setContentHuggingPriority(
+      UILayoutPriority.defaultHigh,
+      for: NSLayoutConstraint.Axis.horizontal
+    )
+    self.addArrangedSubview(editIconImageView)
+  }
+
+  private func setupToDoGardenLogoImageView() {
+    let userGuideImageView = UIImageView()
+    userGuideImageView.image = UIImage.toDoGardenLogoImage
+    userGuideImageView.setContentHuggingPriority(
+      UILayoutPriority.defaultHigh,
+      for: NSLayoutConstraint.Axis.horizontal
+    )
+    self.addArrangedSubview(userGuideImageView)
+  }
+
+  private func setupUserGuideLabel() {
+    let userGuideLabel = UILabel()
+    userGuideLabel.font = UIFont.pretendardDetailLight
+    userGuideLabel.textColor = UIColor.toDoGardenGreenDark
+    userGuideLabel.text = "이용 가이드"
+    userGuideLabel.textAlignment = NSTextAlignment.left
+    userGuideLabel.setContentHuggingPriority(
+      UILayoutPriority.defaultLow,
+      for: NSLayoutConstraint.Axis.horizontal
+    )
+    self.addArrangedSubview(userGuideLabel)
+  }
+
+  private func setupRightForwardImage() {
+    let rightForwardImageView = UIImageView()
+    rightForwardImageView.image = UIImage.forwardButtonImage
+    rightForwardImageView.setContentHuggingPriority(
+      UILayoutPriority.defaultHigh,
+      for: NSLayoutConstraint.Axis.horizontal
+    )
+    self.addArrangedSubview(rightForwardImageView)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserGuideButton.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserGuideButton.swift
@@ -66,7 +66,7 @@ extension UserGuideButton {
     let userGuideLabel = UILabel()
     userGuideLabel.font = UIFont.pretendardDetailLight
     userGuideLabel.textColor = UIColor.toDoGardenGreenDark
-    userGuideLabel.text = "이용 가이드"
+    userGuideLabel.text = SettingSceneTheme.StringLiteral.UserGuideButton.title
     userGuideLabel.textAlignment = NSTextAlignment.left
     userGuideLabel.setContentHuggingPriority(
       UILayoutPriority.defaultLow,

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserGuideButton.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserGuideButton.swift
@@ -1,0 +1,21 @@
+//
+//  UserGuideButton.swift
+//
+//
+//  Created by Wood on 8/8/24.
+//
+
+import UIKit
+
+import ToDoGardenUIResource
+
+final class UserGuideButton: UIStackView {
+  init() {
+    super.init(frame: CGRect.zero)
+  }
+
+  @available(*, unavailable)
+  required init(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserGuideButton.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserGuideButton.swift
@@ -33,11 +33,12 @@ extension UserGuideButton {
 
   private func setupStackViewUI() {
     self.isLayoutMarginsRelativeArrangement = true
-    self.layoutMargins = UIEdgeInsets(top: 7, left: 15, bottom: 7, right: 8)
-    self.spacing = 5
+    let constant = SettingViewController.Constant.UserGuideButton.self
+    self.layoutMargins = constant.layoutMargins
+    self.spacing = constant.spacing
     self.backgroundColor = UIColor.toDoGardenGreenBackground
-    self.layer.cornerRadius = 10
-    self.layer.borderWidth = 1.0
+    self.layer.cornerRadius = constant.Layer.cornerRadius
+    self.layer.borderWidth = constant.Layer.borderWidth
     self.layer.borderColor = UIColor.toDoGardenGreenGray.cgColor
   }
 
@@ -84,3 +85,10 @@ extension UserGuideButton {
     self.addArrangedSubview(rightForwardImageView)
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  return UserGuideButton()
+}
+#endif

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserSettingView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserSettingView.swift
@@ -1,0 +1,129 @@
+//
+//  UserSettingView.swift
+//
+//
+//  Created by Wood on 8/8/24.
+//
+
+import UIKit
+
+final class UserSettingView: UIView {
+  private let alarmSettingButton: UIButton
+  private let remindSettingButton: UIButton
+  private let settingButtonStackView: SettingButtonStackView
+
+  init() {
+    self.alarmSettingButton = UIButton()
+    self.remindSettingButton = UIButton()
+    self.settingButtonStackView = SettingButtonStackView()
+    super.init(frame: CGRect.zero)
+    self.setup()
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: Private Functions
+
+extension UserSettingView {
+  private func setup() {
+    self.setupAlarmSettingButtonAction()
+    self.setupRemindSettingButtonAction()
+    self.setupLeftImageView()
+  }
+
+  private func setupAlarmSettingButtonAction() {
+    let action = UIAction { _ in
+
+    }
+
+    self.alarmSettingButton.addAction(action, for: UIControl.Event.touchUpInside)
+    self.settingButtonStackView.addSettingButton(
+      self.alarmSettingButton,
+      title: SettingSceneTheme.StringLiteral.UserSettingView.alarmSettingButtonTitle,
+      isForwardImageNeeded: true
+    )
+  }
+
+  private func setupRemindSettingButtonAction() {
+    let action = UIAction { _ in
+
+    }
+
+    self.remindSettingButton.addAction(action, for: UIControl.Event.touchUpInside)
+    self.settingButtonStackView.addSettingButton(
+      self.remindSettingButton,
+      title: SettingSceneTheme.StringLiteral.UserSettingView.remindSettingButtonTitle,
+      isForwardImageNeeded: true
+    )
+  }
+
+  private func setupLeftImageView() {
+    let leftImageView = UIImageView()
+    leftImageView.image = UIImage.bellIconImage
+    leftImageView.translatesAutoresizingMaskIntoConstraints = false
+    self.setupLeftImageViewLayout(leftImageView)
+    self.setupUserSettingLabel(with: leftImageView)
+    self.setupSettingButtonStackViewLayout(leftImageView)
+  }
+
+  private func setupUserSettingLabel(with leftImageView: UIImageView) {
+    let userSettingLabel = UILabel()
+    userSettingLabel.font = UIFont.pretendardBodySemiBold15
+    userSettingLabel.text = SettingSceneTheme.StringLiteral.UserSettingView.userSettingLabelText
+    userSettingLabel.textColor = SettingSceneTheme.mainColor
+    self.setupUserSettingLabelLayout(userSettingLabel, leftImageView)
+  }
+}
+
+// MARK: Auto Layout
+
+extension UserSettingView {
+  private func setupLeftImageViewLayout(_ imageView: UIImageView) {
+    self.addSubview(imageView)
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+
+    let layout = SettingViewController.Constant.UserSettingView.LeftImageView.self
+    NSLayoutConstraint.activate(
+      [
+        imageView.topAnchor.constraint(equalTo: self.topAnchor),
+        imageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        imageView.widthAnchor.constraint(equalToConstant: layout.width),
+        imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: layout.heightMultiplier)
+      ]
+    )
+  }
+
+  private func setupUserSettingLabelLayout(_ label: UILabel, _ leftImageView: UIImageView) {
+    self.addSubview(label)
+    label.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate(
+      [
+        label.leadingAnchor.constraint(equalTo: leftImageView.trailingAnchor),
+        label.centerYAnchor.constraint(equalTo: leftImageView.centerYAnchor)
+      ]
+    )
+  }
+
+  private func setupSettingButtonStackViewLayout(_ leftImageView: UIImageView) {
+    self.addSubview(self.settingButtonStackView)
+    self.settingButtonStackView.translatesAutoresizingMaskIntoConstraints = false
+
+    let layout = SettingViewController.Constant.UserSettingView.SettingButtonStackView.self
+    NSLayoutConstraint.activate(
+      [
+        self.settingButtonStackView.topAnchor.constraint(
+          equalTo: leftImageView.bottomAnchor,
+          constant: layout.topMargin
+        ),
+        self.settingButtonStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.settingButtonStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        self.settingButtonStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+      ]
+    )
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserSettingView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserSettingView.swift
@@ -136,3 +136,12 @@ extension UserSettingView {
     )
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let view = UserSettingView()
+  view.widthAnchor.constraint(equalToConstant: 300).isActive = true
+  return view
+}
+#endif

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserSettingView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserSettingView.swift
@@ -8,15 +8,11 @@
 import UIKit
 
 final class UserSettingView: UIView {
-  private let alarmSettingButton: UIButton
-  private let remindSettingButton: UIButton
   private let settingButtonStackView: SettingButtonStackView
 
   weak var delegate: UserSettingViewDelegate?
 
   init() {
-    self.alarmSettingButton = UIButton()
-    self.remindSettingButton = UIButton()
     self.settingButtonStackView = SettingButtonStackView()
     super.init(frame: CGRect.zero)
     self.setup()
@@ -49,9 +45,9 @@ extension UserSettingView {
       self.delegate?.didSelectSettingAlarmButton()
     }
 
-    self.alarmSettingButton.addAction(action, for: UIControl.Event.touchUpInside)
+    let alarmSettingButton = UIButton(primaryAction: action)
     self.settingButtonStackView.addSettingButton(
-      self.alarmSettingButton,
+      alarmSettingButton,
       title: SettingSceneTheme.StringLiteral.UserSettingView.alarmSettingButtonTitle,
       isForwardImageNeeded: true
     )
@@ -62,9 +58,9 @@ extension UserSettingView {
       self.delegate?.didSelectSettingRemindButton()
     }
 
-    self.remindSettingButton.addAction(action, for: UIControl.Event.touchUpInside)
+    let remindSettingButton = UIButton(primaryAction: action)
     self.settingButtonStackView.addSettingButton(
-      self.remindSettingButton,
+      remindSettingButton,
       title: SettingSceneTheme.StringLiteral.UserSettingView.remindSettingButtonTitle,
       isForwardImageNeeded: true
     )

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserSettingView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserSettingView.swift
@@ -12,6 +12,8 @@ final class UserSettingView: UIView {
   private let remindSettingButton: UIButton
   private let settingButtonStackView: SettingButtonStackView
 
+  weak var delegate: UserSettingViewDelegate?
+
   init() {
     self.alarmSettingButton = UIButton()
     self.remindSettingButton = UIButton()
@@ -26,6 +28,13 @@ final class UserSettingView: UIView {
   }
 }
 
+// MARK: Delegate Functions
+
+protocol UserSettingViewDelegate: AnyObject {
+  func didSelectSettingAlarmButton()
+  func didSelectSettingRemindButton()
+}
+
 // MARK: Private Functions
 
 extension UserSettingView {
@@ -37,7 +46,7 @@ extension UserSettingView {
 
   private func setupAlarmSettingButtonAction() {
     let action = UIAction { _ in
-
+      self.delegate?.didSelectSettingAlarmButton()
     }
 
     self.alarmSettingButton.addAction(action, for: UIControl.Event.touchUpInside)
@@ -50,7 +59,7 @@ extension UserSettingView {
 
   private func setupRemindSettingButtonAction() {
     let action = UIAction { _ in
-
+      self.delegate?.didSelectSettingRemindButton()
     }
 
     self.remindSettingButton.addAction(action, for: UIControl.Event.touchUpInside)

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/VersionInfoView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/VersionInfoView.swift
@@ -186,3 +186,19 @@ extension VersionInfoView {
     )
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let stackView = UIStackView()
+  stackView.axis = .vertical
+  stackView.widthAnchor.constraint(equalToConstant: 300).isActive = true
+  let emptyView = UIView()
+  emptyView.heightAnchor.constraint(equalToConstant: 100).isActive = true
+  stackView.addArrangedSubview(emptyView)
+  let view = VersionInfoView()
+  view.updateToPriorVersion("v.0.1.2")
+  stackView.addArrangedSubview(view)
+  return stackView
+}
+#endif

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/VersionInfoView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/VersionInfoView.swift
@@ -12,6 +12,8 @@ final class VersionInfoView: UIView {
   private let currentVersionLabel: UILabel
   private let updateButton: UIButton
 
+  weak var delegate: VersionInfoViewDelegate?
+
   init() {
     self.upToDateVersionLabel = UILabel()
     self.currentVersionLabel = UILabel()
@@ -36,6 +38,10 @@ final class VersionInfoView: UIView {
     self.currentVersionLabel.text = version
     self.updateButton.isHidden = false
   }
+}
+
+protocol VersionInfoViewDelegate: AnyObject {
+  func didSelectUpdateButton()
 }
 
 // MARK: Private Functions
@@ -83,6 +89,7 @@ extension VersionInfoView {
     let layout = SettingViewController.Constant.VersionInfoView.UpdateButton.self
     self.updateButton.layer.cornerRadius = layout.cornerRadius
     self.setupUpdateButtonTitle()
+    self.setupUpdateButtonAction()
   }
 
   private func setupUpdateButtonTitle() {
@@ -102,6 +109,14 @@ extension VersionInfoView {
       equalTo: self.updateButton.leadingAnchor,
       constant: SettingViewController.Constant.VersionInfoView.UpdateButton.leadingMargin
     ).isActive = true
+  }
+
+  private func setupUpdateButtonAction() {
+    let action = UIAction { _ in
+      self.delegate?.didSelectUpdateButton()
+    }
+
+    self.updateButton.addAction(action, for: UIControl.Event.touchUpInside)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/VersionInfoView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/VersionInfoView.swift
@@ -93,22 +93,14 @@ extension VersionInfoView {
   }
 
   private func setupUpdateButtonTitle() {
-    let title = NSAttributedString(
-      string: SettingSceneTheme.StringLiteral.VersionInfoView.updateButtonTitle,
-      attributes: [
-        NSAttributedString.Key.font: UIFont.pretendardBodyMedium,
-        NSAttributedString.Key.foregroundColor: SettingSceneTheme.mainColor
-      ]
-    )
-    self.updateButton.setAttributedTitle(title, for: UIControl.State.normal)
-    self.updateButton.titleLabel?.translatesAutoresizingMaskIntoConstraints = false
-    self.updateButton.titleLabel?.centerYAnchor.constraint(
-      equalTo: self.updateButton.centerYAnchor
-    ).isActive = true
-    self.updateButton.titleLabel?.leadingAnchor.constraint(
-      equalTo: self.updateButton.leadingAnchor,
-      constant: SettingViewController.Constant.VersionInfoView.UpdateButton.leadingMargin
-    ).isActive = true
+    var configuration = UIButton.Configuration.plain()
+    var title = AttributedString(SettingSceneTheme.StringLiteral.VersionInfoView.updateButtonTitle)
+    title.font = UIFont.pretendardBodySemiBold
+    title.foregroundColor = SettingSceneTheme.mainColor
+    configuration.attributedTitle = title
+    configuration.cornerStyle = UIButton.Configuration.CornerStyle.large
+    self.updateButton.configuration = configuration
+    self.updateButton.contentHorizontalAlignment = UIControl.ContentHorizontalAlignment.leading
   }
 
   private func setupUpdateButtonAction() {

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/VersionInfoView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/VersionInfoView.swift
@@ -1,0 +1,19 @@
+//
+//  VersionInfoView.swift
+//  
+//
+//  Created by Wood on 8/8/24.
+//
+
+import UIKit
+
+final class VersionInfoView: UIView {
+  init() {
+    super.init(frame: CGRect.zero)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/VersionInfoView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/VersionInfoView.swift
@@ -1,6 +1,6 @@
 //
 //  VersionInfoView.swift
-//  
+//
 //
 //  Created by Wood on 8/8/24.
 //
@@ -8,12 +8,154 @@
 import UIKit
 
 final class VersionInfoView: UIView {
+  private let upToDateVersionLabel: UILabel
+  private let currentVersionLabel: UILabel
+  private let updateButton: UIButton
+
   init() {
+    self.upToDateVersionLabel = UILabel()
+    self.currentVersionLabel = UILabel()
+    self.updateButton = UIButton()
     super.init(frame: CGRect.zero)
+    self.setup()
   }
 
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: Private Functions
+
+extension VersionInfoView {
+  private func setup() {
+    self.setupVersionInfoLabel()
+    self.setupUpToDateLabel()
+    self.setupCurrentVersionLabel()
+    self.setupUpdateButton()
+    self.setupUpToDateVersionLabelLayout()
+    self.setupCurrentVersionLabelLayout()
+    self.setupUpdateButtonLayout()
+  }
+
+  private func setupVersionInfoLabel() {
+    let label = UILabel()
+    let text = NSMutableAttributedString(string: "")
+    let attachment = NSTextAttachment(image: UIImage.leafImage)
+    text.append(NSAttributedString(attachment: attachment))
+    let title = NSAttributedString(
+      string: SettingSceneTheme.StringLiteral.VersionInfoView.latestVersionText,
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardBodySemiBold15,
+        NSAttributedString.Key.foregroundColor: SettingSceneTheme.mainColor
+      ]
+    )
+    text.append(title)
+    label.attributedText = text
+    self.setupVersionInfoLabelLayout(label)
+  }
+
+  private func setupUpToDateLabel() {
+    self.upToDateVersionLabel.font = UIFont.pretendardBodySemiBold15
+    self.upToDateVersionLabel.textColor = SettingSceneTheme.mainColor
+  }
+
+  private func setupCurrentVersionLabel() {
+    self.currentVersionLabel.font = UIFont.pretendardBodySemiBold15
+    self.currentVersionLabel.textColor = UIColor.toDoGardenGreenGray
+  }
+
+  private func setupUpdateButton() {
+    self.updateButton.backgroundColor = UIColor.toDoGardenGreenBackground
+    let layout = SettingViewController.Constant.VersionInfoView.UpdateButton.self
+    self.updateButton.layer.cornerRadius = layout.cornerRadius
+    self.setupUpdateButtonTitle()
+  }
+
+  private func setupUpdateButtonTitle() {
+    let title = NSAttributedString(
+      string: SettingSceneTheme.StringLiteral.VersionInfoView.updateButtonTitle,
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardBodyMedium,
+        NSAttributedString.Key.foregroundColor: SettingSceneTheme.mainColor
+      ]
+    )
+    self.updateButton.setAttributedTitle(title, for: UIControl.State.normal)
+    self.updateButton.titleLabel?.translatesAutoresizingMaskIntoConstraints = false
+    self.updateButton.titleLabel?.centerYAnchor.constraint(
+      equalTo: self.updateButton.centerYAnchor
+    ).isActive = true
+    self.updateButton.titleLabel?.leadingAnchor.constraint(
+      equalTo: self.updateButton.leadingAnchor,
+      constant: SettingViewController.Constant.VersionInfoView.UpdateButton.leadingMargin
+    ).isActive = true
+  }
+}
+
+// MARK: Auto Layout
+
+extension VersionInfoView {
+  private func setupVersionInfoLabelLayout(_ label: UILabel) {
+    self.addSubview(label)
+    label.translatesAutoresizingMaskIntoConstraints = false
+
+    let layout = SettingViewController.Constant.VersionInfoView.VersionInfoLabel.self
+    NSLayoutConstraint.activate(
+      [
+        label.topAnchor.constraint(
+          equalTo: self.topAnchor,
+          constant: layout.topMargin
+        ),
+        label.leadingAnchor.constraint(
+          equalTo: self.leadingAnchor,
+          constant: layout.leadingMargin
+        )
+      ]
+    )
+  }
+
+  private func setupUpToDateVersionLabelLayout() {
+    self.addSubview(self.upToDateVersionLabel)
+    self.upToDateVersionLabel.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate(
+      [
+        self.upToDateVersionLabel.topAnchor.constraint(equalTo: self.topAnchor),
+        self.upToDateVersionLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+      ]
+    )
+  }
+
+  private func setupCurrentVersionLabelLayout() {
+    self.addSubview(self.currentVersionLabel)
+    self.currentVersionLabel.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate(
+      [
+        self.currentVersionLabel.topAnchor.constraint(equalTo: self.upToDateVersionLabel.bottomAnchor),
+        self.currentVersionLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+      ]
+    )
+  }
+
+  private func setupUpdateButtonLayout() {
+    self.addSubview(self.updateButton)
+    self.updateButton.translatesAutoresizingMaskIntoConstraints = false
+
+    let layout = SettingViewController.Constant.VersionInfoView.UpdateButton.self
+    NSLayoutConstraint.activate(
+      [
+        self.updateButton.topAnchor.constraint(
+          equalTo: self.currentVersionLabel.bottomAnchor,
+          constant: layout.topMargin
+        ),
+        self.updateButton.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.updateButton.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        self.updateButton.heightAnchor.constraint(
+          equalToConstant: layout.height
+        )
+      ]
+    )
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/VersionInfoView.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/VersionInfoView.swift
@@ -24,6 +24,18 @@ final class VersionInfoView: UIView {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+
+  func updateToLatestVersion(_ version: String) {
+    self.upToDateVersionLabel.text = SettingSceneTheme.StringLiteral.VersionInfoView.latestVersionText
+    self.currentVersionLabel.text = version
+    self.updateButton.isHidden = true
+  }
+
+  func updateToPriorVersion(_ version: String) {
+    self.upToDateVersionLabel.text = SettingSceneTheme.StringLiteral.VersionInfoView.priorVersionText
+    self.currentVersionLabel.text = version
+    self.updateButton.isHidden = false
+  }
 }
 
 // MARK: Private Functions
@@ -45,7 +57,7 @@ extension VersionInfoView {
     let attachment = NSTextAttachment(image: UIImage.leafImage)
     text.append(NSAttributedString(attachment: attachment))
     let title = NSAttributedString(
-      string: SettingSceneTheme.StringLiteral.VersionInfoView.latestVersionText,
+      string: SettingSceneTheme.StringLiteral.VersionInfoView.versionInfoLabelText,
       attributes: [
         NSAttributedString.Key.font: UIFont.pretendardBodySemiBold15,
         NSAttributedString.Key.foregroundColor: SettingSceneTheme.mainColor


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #405 

## 🎉 변경 사항
- SettingViewController UI 구현에 필요한 하위 뷰들을 추가하였습니다.
- 레이아웃 관련 상수를 담는 Constant를 추가하였습니다.
- StringLiteral, mainColor를 담는 Theme 레이어를 추가하였습니다.

## 📌 PR Point
- 총 4개의 서브뷰와 관련 Constant, Theme를 함께 추가하느라 File Changed수가 많습니다.
- 각각의 서브뷰 구현 파일에 Preview를 추가하였습니다.
- 구현한 하위 뷰들은 다음과 같습니다.

|서브뷰 이름|이미지|설명|
|---|---|---|
|UserGuideButton|<img width="404" alt="스크린샷 2024-08-06 23 04 29" src="https://github.com/user-attachments/assets/55787027-e5af-4820-af9b-778f54b89d40">|이용가이드 Scene으로 이동|
|UserSettingView|<img width="400" alt="스크린샷 2024-08-06 23 04 33" src="https://github.com/user-attachments/assets/e83d3a46-96d8-4da7-9723-93b0295ccd6e">|각 버튼에 맞는 새로운 Scene으로 이동|
|AppSupportView|<img width="300" alt="스크린샷 2024-08-06 23 04 38" src="https://github.com/user-attachments/assets/e754214e-d5d3-4570-ba34-5ccae72c0d58">|각 버튼에 맞는 새로운 Scene으로 이동|
|VersionInfoView|<img width="405" alt="스크린샷 2024-08-06 23 04 46" src="https://github.com/user-attachments/assets/ca958fd9-aa98-4799-bcbe-5fd2279f0087">|현재 버전 정보 표시 & 이전 버전일 경우 업데이트 버튼이 보여짐|

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?