### PR TITLE
ToDoGardenAlertView 알럿 케이스 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -288,4 +288,8 @@ extension ToDoGardenAlertView.Configuration {
   public static let failToFetchToDo: Self = ToDoGardenAlertView.Configuration.init(
     contents: Constant.ToDoGardenAlertView.Content.failToFetchToDo.viewState
   )
+
+  public static let temporaryErrorOccured: Self = ToDoGardenAlertView.Configuration.init(
+    contents: Constant.ToDoGardenAlertView.Content.temporaryErrorOccured.viewState
+  )
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -289,11 +289,9 @@ extension ToDoGardenAlertView.Configuration {
     contents: Constant.ToDoGardenAlertView.Content.failToFetchToDo.viewState
   )
 
-  public static let temporaryErrorOccurred: Self = ToDoGardenAlertView.Configuration.init(
-    contents: Constant.ToDoGardenAlertView.Content.temporaryErrorOccurred.viewState
-  )
-
-  public static let networkErrorOccurred: Self = ToDoGardenAlertView.Configuration.init(
-    contents: Constant.ToDoGardenAlertView.Content.networkErrorOccurred.viewState
-  )
+  public static let errorOccurred: (String) -> Self = { (errorDescription: String) in
+    return ToDoGardenAlertView.Configuration.init(
+      contents: Constant.ToDoGardenAlertView.Content.errorOccurred(errorDescription).viewState
+    )
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -289,7 +289,11 @@ extension ToDoGardenAlertView.Configuration {
     contents: Constant.ToDoGardenAlertView.Content.failToFetchToDo.viewState
   )
 
-  public static let temporaryErrorOccured: Self = ToDoGardenAlertView.Configuration.init(
-    contents: Constant.ToDoGardenAlertView.Content.temporaryErrorOccured.viewState
+  public static let temporaryErrorOccurred: Self = ToDoGardenAlertView.Configuration.init(
+    contents: Constant.ToDoGardenAlertView.Content.temporaryErrorOccurred.viewState
+  )
+
+  public static let networkErrorOccurred: Self = ToDoGardenAlertView.Configuration.init(
+    contents: Constant.ToDoGardenAlertView.Content.networkErrorOccurred.viewState
   )
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -284,4 +284,8 @@ extension ToDoGardenAlertView.Configuration {
   public static let askToStopResting: Self = ToDoGardenAlertView.Configuration.init(
     contents: Constant.ToDoGardenAlertView.Content.askToStopResting.viewState
   )
+
+  public static let failToFetchToDo: Self = ToDoGardenAlertView.Configuration.init(
+    contents: Constant.ToDoGardenAlertView.Content.failToFetchToDo.viewState
+  )
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
@@ -20,8 +20,7 @@ extension Constant.ToDoGardenAlertView {
     case askToLogout
     case askToStopResting
     case failToFetchToDo
-    case temporaryErrorOccurred
-    case networkErrorOccurred
+    case errorOccurred(String)
   }
 }
 
@@ -281,7 +280,7 @@ extension Constant.ToDoGardenAlertView.Content {
         stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)
       )
 
-    case .temporaryErrorOccurred:
+    case .errorOccurred(let errorDescription):
       return ViewState(
         backPlane: BackPlaneState(
           width: layoutConstant.commonWidth,
@@ -290,26 +289,7 @@ extension Constant.ToDoGardenAlertView.Content {
         ),
         title: TitleViewState(text: "오류 발생", topMargin: layoutConstant.titleTopMarginForHorizontal),
         description: DescriptionViewState(
-          text: "잠시 후\n다시 시도해주세요!",
-          topMargin: layoutConstant.descriptionTopMarginForHorizontal
-        ),
-        buttons: [
-          ButtonLabelState(text: "확인했어요", isRed: false, buttonActionType: ButtonActionType.cancel),
-          ButtonLabelState(text: "홈으로", isRed: true, buttonActionType: ButtonActionType.goHome)
-        ],
-        stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)
-      )
-
-    case .networkErrorOccurred:
-      return ViewState(
-        backPlane: BackPlaneState(
-          width: layoutConstant.commonWidth,
-          height: layoutConstant.heightForHorizontal,
-          cornerRadius: layoutConstant.cornerRadius
-        ),
-        title: TitleViewState(text: "오류 발생", topMargin: layoutConstant.titleTopMarginForHorizontal),
-        description: DescriptionViewState(
-          text: "네트워크 연결이\n불안정합니다.",
+          text: errorDescription,
           topMargin: layoutConstant.descriptionTopMarginForHorizontal
         ),
         buttons: [

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
@@ -20,7 +20,8 @@ extension Constant.ToDoGardenAlertView {
     case askToLogout
     case askToStopResting
     case failToFetchToDo
-    case temporaryErrorOccured
+    case temporaryErrorOccurred
+    case networkErrorOccurred
   }
 }
 
@@ -280,7 +281,7 @@ extension Constant.ToDoGardenAlertView.Content {
         stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)
       )
 
-    case .temporaryErrorOccured:
+    case .temporaryErrorOccurred:
       return ViewState(
         backPlane: BackPlaneState(
           width: layoutConstant.commonWidth,
@@ -290,6 +291,25 @@ extension Constant.ToDoGardenAlertView.Content {
         title: TitleViewState(text: "오류 발생", topMargin: layoutConstant.titleTopMarginForHorizontal),
         description: DescriptionViewState(
           text: "잠시 후\n다시 시도해주세요!",
+          topMargin: layoutConstant.descriptionTopMarginForHorizontal
+        ),
+        buttons: [
+          ButtonLabelState(text: "확인했어요", isRed: false, buttonActionType: ButtonActionType.cancel),
+          ButtonLabelState(text: "홈으로", isRed: true, buttonActionType: ButtonActionType.goHome)
+        ],
+        stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)
+      )
+
+    case .networkErrorOccurred:
+      return ViewState(
+        backPlane: BackPlaneState(
+          width: layoutConstant.commonWidth,
+          height: layoutConstant.heightForHorizontal,
+          cornerRadius: layoutConstant.cornerRadius
+        ),
+        title: TitleViewState(text: "오류 발생", topMargin: layoutConstant.titleTopMarginForHorizontal),
+        description: DescriptionViewState(
+          text: "네트워크 연결이\n불안정합니다.",
           topMargin: layoutConstant.descriptionTopMarginForHorizontal
         ),
         buttons: [

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
@@ -19,6 +19,7 @@ extension Constant.ToDoGardenAlertView {
     case askToUnsubscribe
     case askToLogout
     case askToStopResting
+    case failToFetchToDo
   }
 }
 
@@ -85,6 +86,7 @@ extension Constant.ToDoGardenAlertView.Content {
     case unsubscribe
     case logout
     case stopConcentration
+    case retry
   }
   
   private struct Layout {
@@ -254,6 +256,25 @@ extension Constant.ToDoGardenAlertView.Content {
         buttons: [
           ButtonLabelState(text: "홈으로", isRed: true, buttonActionType: ButtonActionType.goHome),
           ButtonLabelState(text: "집중하기", isRed: false, buttonActionType: ButtonActionType.keepConcentration)
+        ],
+        stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)
+      )
+    
+    case .failToFetchToDo:
+      return ViewState(
+        backPlane: BackPlaneState(
+          width: layoutConstant.commonWidth,
+          height: layoutConstant.heightForHorizontal,
+          cornerRadius: layoutConstant.cornerRadius
+        ),
+        title: TitleViewState(text: "투두 조회 실패", topMargin: layoutConstant.titleTopMarginForHorizontal),
+        description: DescriptionViewState(
+          text: "투두 정보를\n받아오지 못 했어요.",
+          topMargin: layoutConstant.descriptionTopMarginForHorizontal
+        ),
+        buttons: [
+          ButtonLabelState(text: "재시도", isRed: false, buttonActionType: ButtonActionType.retry),
+          ButtonLabelState(text: "홈으로", isRed: true, buttonActionType: ButtonActionType.goHome)
         ],
         stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)
       )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGardenAlertView.swift
@@ -20,6 +20,7 @@ extension Constant.ToDoGardenAlertView {
     case askToLogout
     case askToStopResting
     case failToFetchToDo
+    case temporaryErrorOccured
   }
 }
 
@@ -274,6 +275,25 @@ extension Constant.ToDoGardenAlertView.Content {
         ),
         buttons: [
           ButtonLabelState(text: "재시도", isRed: false, buttonActionType: ButtonActionType.retry),
+          ButtonLabelState(text: "홈으로", isRed: true, buttonActionType: ButtonActionType.goHome)
+        ],
+        stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)
+      )
+
+    case .temporaryErrorOccured:
+      return ViewState(
+        backPlane: BackPlaneState(
+          width: layoutConstant.commonWidth,
+          height: layoutConstant.heightForHorizontal,
+          cornerRadius: layoutConstant.cornerRadius
+        ),
+        title: TitleViewState(text: "오류 발생", topMargin: layoutConstant.titleTopMarginForHorizontal),
+        description: DescriptionViewState(
+          text: "잠시 후\n다시 시도해주세요!",
+          topMargin: layoutConstant.descriptionTopMarginForHorizontal
+        ),
+        buttons: [
+          ButtonLabelState(text: "확인했어요", isRed: false, buttonActionType: ButtonActionType.cancel),
           ButtonLabelState(text: "홈으로", isRed: true, buttonActionType: ButtonActionType.goHome)
         ],
         stackView: StackViewState(isHorizontal: true, height: layoutConstant.stackviewHeightForHorizontal)


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #420

## 🎉 변경 사항
- 투두가든 알럿 뷰에 새로운 케이스들을 추가하였습니다.

## 📌 PR Point
### 투두 조회 실패 알럿
투두 수정화면에서 투두 정보를 불러오는데 실패했을 때 알럿입니다.
- 실패시 좌측 버튼을 눌러 재시도 요청을 할 수 있도록 `ButtonActionType에 retry를 추가`하였습니다.

<img width="250" alt="스크린샷 2024-08-13 17 27 57" src="https://github.com/user-attachments/assets/1d09aa8c-f725-4be2-b077-8abd6fd37bce">

### 오류 발생 알럿
오류 발생시 필요한 알럿입니다.
- 네트워크 에러, 일시적인 에러 총 2개의 케이스를 생성하였습니다.

|네트워크 에러|일시적 에러|
|--|--|
|<img width="250" alt="스크린샷 2024-08-13 17 27 49" src="https://github.com/user-attachments/assets/f8a344f5-972f-4e32-8936-3b09221ee967">|<img width="250" alt="스크린샷 2024-08-13 17 27 40" src="https://github.com/user-attachments/assets/d35b1b0e-bfa3-46a6-866b-2e8bdfb75214">|


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?