### PR TITLE
EditToDoView 수정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -7,18 +7,19 @@
 
 import UIKit
 
-import ToDoGardenUIAPI
+import EditToDoSceneEntity
+import ToDoGardenUIComponent
 
 final class EditToDoView: UIView {
-  private let toDoNameInputView: TextInputViewAPI
-  private let groupSelectionView: GroupSelectionViewAPI
+  private let toDoNameInputView: TextInputView
+  private let groupSelectionView: GroupSelectionView
   private let deleteToDoButton: UIButton
 
   weak var delegate: EditToDoView.EditToDoViewDelegate?
 
-  init(toDoNameInputView: TextInputViewAPI, groupSelectionView: GroupSelectionViewAPI) {
-    self.toDoNameInputView = toDoNameInputView
-    self.groupSelectionView = groupSelectionView
+  init() {
+    self.toDoNameInputView = TextInputView(model: TextInputView.Model.groupName)
+    self.groupSelectionView = GroupSelectionView(model: GroupSelectionView.Model.primary)
     self.deleteToDoButton = UIButton()
     super.init(frame: CGRect.zero)
     self.setup()
@@ -34,11 +35,13 @@ final class EditToDoView: UIView {
   }
 
   func updateGroup(
-    current: EditToDoView.GroupItem,
-    editableGroupList: [EditToDoView.GroupItem]
+    current: EditToDo.Group,
+    editableGroupList: [EditToDo.Group]
   ) {
-    self.toDoNameInputView.changeBottomLine(color: current.groupColor)
-    self.groupSelectionView.updateGroup(current: current, editableList: editableGroupList)
+    self.toDoNameInputView.changeBottomLine(color: current.color)
+    let currentItem = self.makeGroupSelectionViewItem(from: current)
+    let groupSelectionViewItemList = editableGroupList.map { self.makeGroupSelectionViewItem(from: $0) }
+    self.groupSelectionView.updateGroup(current: currentItem, editableList: groupSelectionViewItemList)
   }
 
   func getCurrentGroupId() -> Int? {
@@ -87,7 +90,7 @@ extension EditToDoView: UIGestureRecognizerDelegate {
     else { return false }
 
     if self.toDoNameInputView.isFirstResponder {
-      self.toDoNameInputView.resignFirstResponder()
+      _ = self.toDoNameInputView.resignFirstResponder()
     }
 
     return true
@@ -140,6 +143,14 @@ extension EditToDoView {
     }
 
     self.deleteToDoButton.addAction(deleteToDoAction, for: UIControl.Event.touchUpInside)
+  }
+
+  private func makeGroupSelectionViewItem(from group: EditToDo.Group) -> GroupSelectionViewItem {
+    return GroupSelectionViewItem(
+      groupId: group.id,
+      groupName: group.name,
+      groupColor: group.color
+    )
   }
 }
 
@@ -256,18 +267,6 @@ extension EditToDoView {
         titleLabel.centerYAnchor.constraint(equalTo: self.deleteToDoButton.centerYAnchor)
       ]
     )
-  }
-}
-
-extension EditToDoView {
-  struct GroupItem: GroupSelectionViewItemAPI {
-    let groupId: Int
-    let groupName: String
-    let groupColor: UIColor
-
-    static func < (lhs: EditToDoView.GroupItem, rhs: EditToDoView.GroupItem) -> Bool {
-      lhs.groupId > rhs.groupId
-    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -270,30 +270,22 @@ extension EditToDoView {
   }
 }
 
-// MARK: Preview를 확인하기 위해 Package.swift 파일에서 UIComponent 의존성을 추가해주세요.
-//  import ToDoGardenUIComponent
-//  @available(iOS 17.0, *)
-//  #Preview {
-//    let scheduleView = EditToDoView(
-//      toDoNameInputView: TextInputView(model: TextInputView.Model.toDoName),
-//      groupSelectionView: GroupSelectionView(model: GroupSelectionView.Model.primary)
-//    )
-//    scheduleView.updateGroup(
-//      current: EditToDoView.GroupItem(groupId: 002, groupName: "영어", groupColor: UIColor.toDoGardenRed),
-//      editableGroupList: [
-//        EditToDoView.GroupItem(groupId: 001, groupName: "CS 지식", groupColor: UIColor.toDoGardenBrown),
-//        EditToDoView.GroupItem(groupId: 002, groupName: "영어", groupColor: UIColor.toDoGardenRed),
-//        EditToDoView.GroupItem(groupId: 003, groupName: "국어", groupColor: UIColor.toDoGardenBlue),
-//        EditToDoView.GroupItem(groupId: 004, groupName: "수학", groupColor: UIColor.toDoGardenMint),
-//        EditToDoView.GroupItem(groupId: 005, groupName: "Swift", groupColor: UIColor.toDoGardenYellow),
-//        EditToDoView.GroupItem(groupId: 006, groupName: "런닝", groupColor: UIColor.toDoGardenPurple),
-//        EditToDoView.GroupItem(groupId: 007, groupName: "지구과학", groupColor: UIColor.toDoGardenGreenDark),
-//        EditToDoView.GroupItem(groupId: 008, groupName: "물리", groupColor: UIColor.toDoGardenOrange)
-//      ]
-//    )
-//    scheduleView.translatesAutoresizingMaskIntoConstraints = false
-//    scheduleView.widthAnchor.constraint(equalToConstant: 400).isActive = true
-//    scheduleView.heightAnchor.constraint(equalToConstant: 600).isActive = true
-//
-//    return scheduleView
-//  }
+@available(iOS 17.0, *)
+#Preview {
+  let editToDoView = EditToDoView()
+  editToDoView.updateGroup(
+    current: EditToDo.Group(id: 003, name: "국어", color: UIColor.toDoGardenBlue),
+    editableGroupList: [
+      EditToDo.Group(id: 001, name: "CS 지식", color: UIColor.toDoGardenBrown),
+      EditToDo.Group(id: 002, name: "영어", color: UIColor.toDoGardenRed),
+      EditToDo.Group(id: 003, name: "국어", color: UIColor.toDoGardenBlue),
+      EditToDo.Group(id: 004, name: "수학", color: UIColor.toDoGardenMint),
+      EditToDo.Group(id: 005, name: "Swift", color: UIColor.toDoGardenYellow),
+      EditToDo.Group(id: 006, name: "런닝", color: UIColor.toDoGardenPurple),
+      EditToDo.Group(id: 007, name: "지구과학", color: UIColor.toDoGardenGreenDark),
+      EditToDo.Group(id: 008, name: "물리", color: UIColor.toDoGardenOrange)
+    ]
+  )
+  editToDoView.widthAnchor.constraint(equalToConstant: 400).isActive = true
+  return editToDoView
+}

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -35,10 +35,7 @@ final class EditToDoViewController: UIViewController, EditToDoViewControllable {
   init() {
     self.editToDoSegmentedControl = EditToDoSegmentedControl()
     self.editModeScrollView = UIScrollView()
-    self.editToDoView = EditToDoView(
-      toDoNameInputView: TextInputView(model: TextInputView.Model.toDoName),
-      groupSelectionView: GroupSelectionView(model: GroupSelectionView.Model.primary)
-    )
+    self.editToDoView = EditToDoView()
     self.editToDoScheduleView = EditToDoScheduleView()
     self.completeEditButton = ToDoGardenBoxButton(
       title: EditToDoSceneTheme.StringLiteral.CompleteEditingButton.title,

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/GroupSelectionViewAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/GroupSelectionViewAPI.swift
@@ -14,8 +14,6 @@ public protocol GroupSelectionViewItemAPI: Hashable, Comparable {
 }
 
 public protocol GroupSelectionViewAPI: UIView {
-  var delegate: GroupSelectionViewDelegate? { get set }
-
   func updateGroup(
     current: any GroupSelectionViewItemAPI,
     editableList: [any GroupSelectionViewItemAPI]

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/GroupSelectionViewAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/GroupSelectionViewAPI.swift
@@ -22,7 +22,3 @@ public protocol GroupSelectionViewAPI: UIView {
   )
   func getCurrentGroupId() -> Int?
 }
-
-public protocol GroupSelectionViewDelegate: AnyObject {
-  func didSelectGroup(color: UIColor)
-}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/EditableGroupListTableViewDelegate.swift
@@ -31,13 +31,12 @@ final class EditableGroupTableViewDelegate: NSObject {
   }
 
   func updateGroup(
-    currentItem: any GroupSelectionViewItemAPI,
-    editableItems: [any GroupSelectionViewItemAPI]
+    currentItem: EditableGroupItem,
+    editableItems: [EditableGroupItem]
   ) {
-    self.updateCurrentGroup(item: currentItem)
-    let groupItems = self.makeEditableGroupItems(items: editableItems)
-    self.storeEditableGroupIndex(groupItems: groupItems)
-    self.reloadNewEditableGroups(groupItems: groupItems)
+    self.currentGroupItem = currentItem
+    self.storeEditableGroupIndex(groupItems: editableItems)
+    self.reloadNewEditableGroups(groupItems: editableItems)
   }
 }
 
@@ -84,27 +83,6 @@ extension EditableGroupTableViewDelegate: UITableViewDelegate {
 // MARK: Private Functions
 
 extension EditableGroupTableViewDelegate {
-  private func updateCurrentGroup(item: any GroupSelectionViewItemAPI) {
-    let currentItem = EditableGroupItem(
-      groupId: item.groupId,
-      groupName: item.groupName,
-      groupColor: item.groupColor
-    )
-    self.currentGroupItem = currentItem
-  }
-
-  private func makeEditableGroupItems(
-    items: [any GroupSelectionViewItemAPI]
-  ) -> [EditableGroupItem] {
-    return items.map { (item: any GroupSelectionViewItemAPI) in
-      return EditableGroupItem(
-        groupId: item.groupId,
-        groupName: item.groupName,
-        groupColor: item.groupColor
-      )
-    }
-  }
-
   private func setupTableView(_ tableView: UITableView) {
     tableView.delegate = self
     self.tableViewDataSource = self.makeDiffableDataSource(tableView: tableView)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupListTableViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupListTableViewDelegate.swift
@@ -14,10 +14,10 @@ final class GroupListTableViewDelegate: NSObject {
   private let cellHeight: CGFloat
   private var editableGroupIndexDictionary: [Int: Int]
   private var tableViewDataSource: UITableViewDiffableDataSource<
-    EditableGroupSection,
-    EditableGroupItem
+    GroupSelectionViewSection,
+    GroupSelectionViewItem
   >!
-  private(set) var currentGroupItem: EditableGroupItem? {
+  private(set) var currentGroupItem: GroupSelectionViewItem? {
     willSet { self.groupListSelectionDelegate?.send(groupItem: newValue) }
   }
 
@@ -31,8 +31,8 @@ final class GroupListTableViewDelegate: NSObject {
   }
 
   func updateGroup(
-    currentItem: EditableGroupItem,
-    editableItems: [EditableGroupItem]
+    currentItem: GroupSelectionViewItem,
+    editableItems: [GroupSelectionViewItem]
   ) {
     self.currentGroupItem = currentItem
     self.storeEditableGroupIndex(groupItems: editableItems)
@@ -41,7 +41,7 @@ final class GroupListTableViewDelegate: NSObject {
 }
 
 protocol GroupListSelectionDelegate: AnyObject {
-  func send(groupItem: EditableGroupItem?)
+  func send(groupItem: GroupSelectionViewItem?)
 }
 
 // MARK: TableView Delegate Functions
@@ -63,8 +63,8 @@ extension GroupListTableViewDelegate: UITableViewDelegate {
     self.tableViewDataSource.apply(snapshot, animatingDifferences: true)
   }
 
-  private func insertInCorrectOrder(oldItem: EditableGroupItem?) ->
-  NSDiffableDataSourceSnapshot<EditableGroupSection, EditableGroupItem> {
+  private func insertInCorrectOrder(oldItem: GroupSelectionViewItem?) ->
+  NSDiffableDataSourceSnapshot<GroupSelectionViewSection, GroupSelectionViewItem> {
     var snapshot = self.tableViewDataSource.snapshot()
     guard let oldItem = oldItem
     else { return snapshot }
@@ -95,15 +95,15 @@ extension GroupListTableViewDelegate {
   }
 
   private func makeDiffableDataSource(tableView: UITableView) -> UITableViewDiffableDataSource<
-    EditableGroupSection,
-    EditableGroupItem
+    GroupSelectionViewSection,
+    GroupSelectionViewItem
   > {
     return UITableViewDiffableDataSource<
-      EditableGroupSection,
-      EditableGroupItem
+      GroupSelectionViewSection,
+      GroupSelectionViewItem
     >(tableView: tableView) { (tableView, indexPath, itemIdentifier) in
       guard let cell = tableView.dequeueReusableCell(
-        type: EditableGroupTableViewCell.self,
+        type: GroupSelectionViewCell.self,
         for: indexPath
       ) else { return UITableViewCell() }
 
@@ -112,24 +112,24 @@ extension GroupListTableViewDelegate {
     }
   }
 
-  private func storeEditableGroupIndex(groupItems: [EditableGroupItem]) {
-    groupItems.enumerated().forEach { (index: Int, item: EditableGroupItem) in
+  private func storeEditableGroupIndex(groupItems: [GroupSelectionViewItem]) {
+    groupItems.enumerated().forEach { (index: Int, item: GroupSelectionViewItem) in
       let id = item.groupId
       self.editableGroupIndexDictionary[id] = index
     }
   }
 
-  private func reloadNewEditableGroups(groupItems: [EditableGroupItem]) {
-    var snapshot = NSDiffableDataSourceSnapshot<EditableGroupSection, EditableGroupItem>()
+  private func reloadNewEditableGroups(groupItems: [GroupSelectionViewItem]) {
+    var snapshot = NSDiffableDataSourceSnapshot<GroupSelectionViewSection, GroupSelectionViewItem>()
     snapshot.appendSections([.main])
-    let items = groupItems.filter { (item: EditableGroupItem) in
+    let items = groupItems.filter { (item: GroupSelectionViewItem) in
       if let currentGroupItem = self.currentGroupItem {
         return item != currentGroupItem
       }
 
       return false
     }
-    snapshot.appendItems(items, toSection: EditableGroupSection.main)
+    snapshot.appendItems(items, toSection: GroupSelectionViewSection.main)
     self.tableViewDataSource.apply(snapshot, animatingDifferences: true)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupListTableViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupListTableViewDelegate.swift
@@ -1,5 +1,5 @@
 //
-//  EditableGroupTableViewDelegate.swift
+//  GroupListTableViewDelegate.swift
 //
 //
 //  Created by Wood on 7/9/24.
@@ -10,7 +10,7 @@ import UIKit
 import ToDoGardenUIAPI
 import ToDoGardenUIConstant
 
-final class EditableGroupTableViewDelegate: NSObject {
+final class GroupListTableViewDelegate: NSObject {
   private let cellHeight: CGFloat
   private var editableGroupIndexDictionary: [Int: Int]
   private var tableViewDataSource: UITableViewDiffableDataSource<
@@ -18,10 +18,10 @@ final class EditableGroupTableViewDelegate: NSObject {
     EditableGroupItem
   >!
   private(set) var currentGroupItem: EditableGroupItem? {
-    willSet { self.selectedGroupSender?.send(groupItem: newValue) }
+    willSet { self.groupListSelectionDelegate?.send(groupItem: newValue) }
   }
 
-  weak var selectedGroupSender: GroupDataSendable?
+  weak var groupListSelectionDelegate: GroupListSelectionDelegate?
 
   init(tableView: UITableView, cellHeight: CGFloat) {
     self.cellHeight = cellHeight
@@ -40,9 +40,13 @@ final class EditableGroupTableViewDelegate: NSObject {
   }
 }
 
+protocol GroupListSelectionDelegate: AnyObject {
+  func send(groupItem: EditableGroupItem?)
+}
+
 // MARK: TableView Delegate Functions
 
-extension EditableGroupTableViewDelegate: UITableViewDelegate {
+extension GroupListTableViewDelegate: UITableViewDelegate {
   func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
     return self.cellHeight
   }
@@ -82,7 +86,7 @@ extension EditableGroupTableViewDelegate: UITableViewDelegate {
 
 // MARK: Private Functions
 
-extension EditableGroupTableViewDelegate {
+extension GroupListTableViewDelegate {
   private func setupTableView(_ tableView: UITableView) {
     tableView.delegate = self
     self.tableViewDataSource = self.makeDiffableDataSource(tableView: tableView)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -15,8 +15,8 @@ public final class GroupSelectionView: UIView {
   private let showGroupListButton: UIButton
   private let currentGroupRow: Styled.Row
   private let groupListSeparatorLineView: UIView
-  private let editableGroupListTableView: UITableView
-  private let editableGroupListTableViewDelegate: EditableGroupTableViewDelegate
+  private let groupListTableView: UITableView
+  private let groupListTableViewDelegate: GroupListTableViewDelegate
   private var tableViewHeightConstraint: NSLayoutConstraint
   private var heightConstraint: NSLayoutConstraint
 
@@ -35,9 +35,9 @@ public final class GroupSelectionView: UIView {
       with: [self.showGroupListButton]
     )
     self.groupListSeparatorLineView = UIView()
-    self.editableGroupListTableView = UITableView()
-    self.editableGroupListTableViewDelegate = EditableGroupTableViewDelegate(
-      tableView: self.editableGroupListTableView,
+    self.groupListTableView = UITableView()
+    self.groupListTableViewDelegate = GroupListTableViewDelegate(
+      tableView: self.groupListTableView,
       cellHeight: self.model.cellHeight
     )
     self.tableViewHeightConstraint = NSLayoutConstraint()
@@ -55,14 +55,14 @@ public final class GroupSelectionView: UIView {
     current: EditableGroupItem,
     editableList: [EditableGroupItem]
   ) {
-    self.editableGroupListTableViewDelegate.updateGroup(
+    self.groupListTableViewDelegate.updateGroup(
       currentItem: current,
       editableItems: editableList
     )
   }
 
   public func getCurrentGroupId() -> Int? {
-    return self.editableGroupListTableViewDelegate.currentGroupItem?.groupId
+    return self.groupListTableViewDelegate.currentGroupItem?.groupId
   }
 }
 
@@ -70,11 +70,7 @@ public protocol GroupSelectionViewDelegate: AnyObject {
   func didSelectGroup(color: UIColor)
 }
 
-protocol GroupDataSendable: AnyObject {
-  func send(groupItem: EditableGroupItem?)
-}
-
-extension GroupSelectionView: GroupDataSendable {
+extension GroupSelectionView: GroupListSelectionDelegate {
   func send(groupItem: EditableGroupItem?) {
     guard let groupItem = groupItem
     else { return }
@@ -124,7 +120,7 @@ extension GroupSelectionView {
   }
 
   private func setupEditableGroupListTableView() {
-    self.editableGroupListTableView.register(
+    self.groupListTableView.register(
       EditableGroupTableViewCell.self,
       forCellReuseIdentifier: EditableGroupTableViewCell.identifier
     )
@@ -132,18 +128,18 @@ extension GroupSelectionView {
   }
 
   private func setupEditableGroupListTableViewUI() {
-    self.editableGroupListTableView.sectionHeaderTopPadding = 0
-    self.editableGroupListTableView.separatorStyle = UITableViewCell.SeparatorStyle.none
+    self.groupListTableView.sectionHeaderTopPadding = 0
+    self.groupListTableView.separatorStyle = UITableViewCell.SeparatorStyle.none
     let layout = Constant.GroupSelectionView.Layout.EditableGroupTableView.Layer.self
-    self.editableGroupListTableView.layer.cornerRadius = layout.cornerRadius
-    self.editableGroupListTableView.layer.maskedCorners = [
+    self.groupListTableView.layer.cornerRadius = layout.cornerRadius
+    self.groupListTableView.layer.maskedCorners = [
       CACornerMask.layerMinXMaxYCorner,
       CACornerMask.layerMaxXMaxYCorner
     ]
   }
 
   private func setupSelectedGroupSender() {
-    self.editableGroupListTableViewDelegate.selectedGroupSender = self
+    self.groupListTableViewDelegate.groupListSelectionDelegate = self
   }
 }
 
@@ -239,15 +235,15 @@ extension GroupSelectionView {
   }
 
   private func setupGroupListTableViewLayout(with containerView: UIView) {
-    containerView.addSubview(self.editableGroupListTableView)
-    self.editableGroupListTableView.usingAutolayout()
+    containerView.addSubview(self.groupListTableView)
+    self.groupListTableView.usingAutolayout()
 
     NSLayoutConstraint.activate(
       [
-        self.editableGroupListTableView.topAnchor.constraint(equalTo: self.groupListSeparatorLineView.bottomAnchor),
-        self.editableGroupListTableView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-        self.editableGroupListTableView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-        self.editableGroupListTableView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
+        self.groupListTableView.topAnchor.constraint(equalTo: self.groupListSeparatorLineView.bottomAnchor),
+        self.groupListTableView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+        self.groupListTableView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+        self.groupListTableView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
       ]
     )
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -52,8 +52,8 @@ public final class GroupSelectionView: UIView {
   }
 
   public func updateGroup(
-    current: EditableGroupItem,
-    editableList: [EditableGroupItem]
+    current: GroupSelectionViewItem,
+    editableList: [GroupSelectionViewItem]
   ) {
     self.groupListTableViewDelegate.updateGroup(
       currentItem: current,
@@ -71,7 +71,7 @@ public protocol GroupSelectionViewDelegate: AnyObject {
 }
 
 extension GroupSelectionView: GroupListSelectionDelegate {
-  func send(groupItem: EditableGroupItem?) {
+  func send(groupItem: GroupSelectionViewItem?) {
     guard let groupItem = groupItem
     else { return }
 
@@ -121,8 +121,8 @@ extension GroupSelectionView {
 
   private func setupEditableGroupListTableView() {
     self.groupListTableView.register(
-      EditableGroupTableViewCell.self,
-      forCellReuseIdentifier: EditableGroupTableViewCell.identifier
+      GroupSelectionViewCell.self,
+      forCellReuseIdentifier: GroupSelectionViewCell.identifier
     )
     self.setupEditableGroupListTableViewUI()
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -66,6 +66,10 @@ public final class GroupSelectionView: UIView {
   }
 }
 
+public protocol GroupSelectionViewDelegate: AnyObject {
+  func didSelectGroup(color: UIColor)
+}
+
 protocol GroupDataSendable: AnyObject {
   func send(groupItem: EditableGroupItem?)
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionView.swift
@@ -10,7 +10,7 @@ import UIKit
 import ToDoGardenUIAPI
 import ToDoGardenUIConstant
 
-public final class GroupSelectionView: UIView, GroupSelectionViewAPI {
+public final class GroupSelectionView: UIView {
   private let model: GroupSelectionView.Model
   private let showGroupListButton: UIButton
   private let currentGroupRow: Styled.Row
@@ -52,8 +52,8 @@ public final class GroupSelectionView: UIView, GroupSelectionViewAPI {
   }
 
   public func updateGroup(
-    current: any GroupSelectionViewItemAPI,
-    editableList: [any GroupSelectionViewItemAPI]
+    current: EditableGroupItem,
+    editableList: [EditableGroupItem]
   ) {
     self.editableGroupListTableViewDelegate.updateGroup(
       currentItem: current,

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  EditableGroupTableViewCell.swift
+//  GroupSelectionViewCell.swift
 //
 //
 //  Created by Wood on 7/4/24.
@@ -9,7 +9,7 @@ import UIKit
 
 import ToDoGardenUIConstant
 
-final class EditableGroupTableViewCell: UITableViewCell {
+final class GroupSelectionViewCell: UITableViewCell {
   private let editableGroupRow: Styled.Row
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -30,7 +30,7 @@ final class EditableGroupTableViewCell: UITableViewCell {
     fatalError("init(coder:) has not been implemented")
   }
 
-  func updateUI(groupItem: EditableGroupItem) {
+  func updateUI(groupItem: GroupSelectionViewItem) {
     let groupName = groupItem.groupName
     let groupColor = groupItem.groupColor
     self.editableGroupRow.groupListModel = Styled.Row.Configuration.ListPrimaryModel(
@@ -42,7 +42,7 @@ final class EditableGroupTableViewCell: UITableViewCell {
 
 // MARK: Private Functions
 
-extension EditableGroupTableViewCell {
+extension GroupSelectionViewCell {
   private func setup() {
     let separatorView = self.makeSeperatorView()
     self.addSubviews(with: separatorView)
@@ -58,7 +58,7 @@ extension EditableGroupTableViewCell {
 
 // MARK: About Auto Layout
 
-extension EditableGroupTableViewCell {
+extension GroupSelectionViewCell {
   private func addSubviews(with separtorView: UIView) {
     self.contentView.addSubview(self.editableGroupRow)
     self.contentView.addSubview(separtorView)
@@ -98,7 +98,11 @@ extension EditableGroupTableViewCell {
 
 @available(iOS 17.0, *)
 #Preview {
-  let cell = EditableGroupTableViewCell()
-  cell.updateUI(groupItem: EditableGroupItem(groupId: 0, groupName: "영어독해", groupColor: UIColor.toDoGardenGreenDark))
+  let cell = GroupSelectionViewCell()
+  cell.updateUI(
+    groupItem: GroupSelectionViewItem(
+      groupId: 0, groupName: "영어독해", groupColor: UIColor.toDoGardenGreenDark
+    )
+  )
   return cell
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionViewSection.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionViewSection.swift
@@ -1,5 +1,5 @@
 //
-//  EditableGroupSection+Item.swift
+//  GroupSelectionViewSection+Item.swift
 //
 //
 //  Created by Wood on 7/3/24.
@@ -9,11 +9,11 @@ import UIKit.UIColor
 
 import ToDoGardenUIAPI
 
-enum EditableGroupSection {
+enum GroupSelectionViewSection {
   case main
 }
 
-public struct EditableGroupItem {
+public struct GroupSelectionViewItem {
   public let groupId: Int
   public let groupName: String
   public let groupColor: UIColor
@@ -25,14 +25,14 @@ public struct EditableGroupItem {
   }
 }
 
-extension EditableGroupItem: Hashable {
+extension GroupSelectionViewItem: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(self.groupId)
   }
 }
 
-extension EditableGroupItem: Comparable {
-  public static func < (lhs: EditableGroupItem, rhs: EditableGroupItem) -> Bool {
+extension GroupSelectionViewItem: Comparable {
+  public static func < (lhs: GroupSelectionViewItem, rhs: GroupSelectionViewItem) -> Bool {
     return lhs.groupId > rhs.groupId
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #424

## 🎉 변경 사항
- EditToDoView 초기화시 컴포넌트를 추상화한 API 주입 로직을 삭제하였습니다.
- GroupSelectionView 관련 객체들의 네이밍을 수정하였습니다.

## 📌 PR Point
### 1. Component API 주입 로직 삭제
기존에 Component를 추상화한 API를 의존하여 컴파일 의존성을 끊어내고자 했었지만,
Preview를 이용하면 Component 사용이 필연적이기에 삭제하였습니다.
- https://github.com/ToDo-Garden/ToDo-Garden/pull/399#discussion_r1703971820
(상단 리뷰 comment를 보고 반영하였습니다)

### 2. GroupSelectionView 네이밍 수정
GroupSelectionView와 관련된 객체들의 네이밍들이 통일되지 않아 모호했었기에 통일하였습니다.
- `EditableGroupItem` > `GroupSelectionViewItem`: 그룹 목록에 보여지는 그룹단위 Item입니다.
- `EditableGroupCell` > `GroupSelectionViewCell`: 그룹 목록에 보여지는 Cell입니다.
- `EditableGroupTableViewDelegate` > `GroupListTableViewDelegate`:  그룹 목록을 조작하는 TableView Delegate입니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?