### PR TITLE
나의 가든 뷰 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -21,6 +21,11 @@ extension ShareGardenSceneViewController.Constant.StringLiteral {
     static let title = "나의 가든"
   }
   
+  enum ProfileInfoView {
+    static let nicknamePlaceholder = "                      "
+    static let descriptionPlaceholder = " "
+  }
+  
   enum FriendsGardenSectionHeaderView {
     static let title = "친구의 가든"
     static let rightActionButtonTitle = "편집"

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -7,12 +7,40 @@
 
 import UIKit
 
+import TDUtility
+import ToDoGardenUIResource
+
 extension ShareGardenSceneViewController {
   final class MyGardenView: UIStackView {
+    
+    // MARK: - UI Properties
+    
+    private let sectionHeaderView: SectionHeaderView = {
+      let shareButton = UIButton()
+      shareButton.setImage(UIImage.shareIconImage, for: UIControl.State.normal)
+      
+      let sectionHeaderView = SectionHeaderView(
+        sectionTitle: "나의 가든",
+        rightActionButton: shareButton
+      )
+      
+      return sectionHeaderView
+    }()
+    
+    // MARK: - Properties
+    
+    @ExecuteOnce private var setupLayoutIfNeeded: (() -> Void)?
     
     init() {
       super.init(frame: CGRect.zero)
       self.setup()
+    }
+    
+    override func layoutSubviews() {
+      super.layoutSubviews()
+      self.setupLayoutIfNeeded = {
+        self.setupLayoutConstraints()
+      }
     }
     
     @available(*, unavailable)
@@ -25,6 +53,7 @@ extension ShareGardenSceneViewController {
 extension ShareGardenSceneViewController.MyGardenView {
   private func setup() {
     self.setupStackView()
+    self.addSubviews()
   }
   
   private func setupStackView() {
@@ -32,5 +61,25 @@ extension ShareGardenSceneViewController.MyGardenView {
     self.distribution = UIStackView.Distribution.fillEqually
     self.axis = NSLayoutConstraint.Axis.vertical
     self.alignment = UIStackView.Alignment.center
+  }
+  
+  private func addSubviews() {
+    self.addArrangedSubview(self.sectionHeaderView)
+  }
+}
+
+extension ShareGardenSceneViewController.MyGardenView {
+  private func setupLayoutConstraints() {
+    self.setupSectionHeaderViewLayoutConstraints()
+  }
+  
+  private func setupSectionHeaderViewLayoutConstraints() {
+    let leadingMargin: CGFloat = self.bounds.width * (28 / 375)
+    let trailingMargin: CGFloat = self.bounds.width * (24 / 375)
+    
+    NSLayoutConstraint.activate([
+      self.sectionHeaderView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: leadingMargin),
+      self.sectionHeaderView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -trailingMargin)
+    ])
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import TDUtility
+import ToDoGardenUIComponent
 import ToDoGardenUIResource
 
 extension ShareGardenSceneViewController {
@@ -25,6 +26,19 @@ extension ShareGardenSceneViewController {
       )
       
       return sectionHeaderView
+    }()
+    
+    private let profileInfoView: Styled.Row = {
+      let profileInfoView = Styled.Row(
+        configuration: Styled.Row.Configuration.profile(
+          Styled.Row.Configuration.ProfileModel.primary(
+            title: "이인우",
+            description: "함께하는 걸 좋아하는 iOS개발자"
+          )
+        )
+      )
+      
+      return profileInfoView
     }()
     
     // MARK: - Properties
@@ -65,6 +79,7 @@ extension ShareGardenSceneViewController.MyGardenView {
   
   private func addSubviews() {
     self.addArrangedSubview(self.sectionHeaderView)
+    self.addArrangedSubview(self.profileInfoView)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -19,9 +19,10 @@ extension ShareGardenSceneViewController {
     private let sectionHeaderView: SectionHeaderView = {
       let shareButton = UIButton()
       shareButton.setImage(UIImage.shareIconImage, for: UIControl.State.normal)
+      let title = ShareGardenSceneViewController.Constant.StringLiteral.MyGardenSectionHeaderView.title
       
       let sectionHeaderView = SectionHeaderView(
-        sectionTitle: "나의 가든",
+        sectionTitle: title,
         rightActionButton: shareButton
       )
       
@@ -29,11 +30,16 @@ extension ShareGardenSceneViewController {
     }()
     
     private let profileInfoView: Styled.Row = {
+      let nicknamePlaceholder = ShareGardenSceneViewController.Constant
+        .StringLiteral.ProfileInfoView.nicknamePlaceholder
+      let descriptionPlaceholder = ShareGardenSceneViewController.Constant
+        .StringLiteral.ProfileInfoView.descriptionPlaceholder
+      
       let profileInfoView = Styled.Row(
         configuration: Styled.Row.Configuration.profile(
           Styled.Row.Configuration.ProfileModel.primary(
-            title: "이인우",
-            description: "함께하는 걸 좋아하는 iOS개발자"
+            title: nicknamePlaceholder,
+            description: descriptionPlaceholder
           )
         )
       )

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -70,7 +70,6 @@ extension ShareGardenSceneViewController {
         self.setupShimmering()
       }
     }
-    
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -77,9 +77,9 @@ extension ShareGardenSceneViewController.MyGardenView {
   
   private func setupStackView() {
     self.spacing = 14
-    self.distribution = UIStackView.Distribution.fillEqually
+    self.distribution = UIStackView.Distribution.fillProportionally
     self.axis = NSLayoutConstraint.Axis.vertical
-    self.alignment = UIStackView.Alignment.fill
+    self.alignment = UIStackView.Alignment.center
   }
   
   private func addSubviews() {
@@ -94,6 +94,7 @@ extension ShareGardenSceneViewController.MyGardenView {
 extension ShareGardenSceneViewController.MyGardenView {
   private func setupLayoutConstraints() {
     self.setupSectionHeaderViewLayoutConstraints()
+    self.setupProfileInfoViewLayoutConstraints()
   }
   
   private func setupSectionHeaderViewLayoutConstraints() {
@@ -107,6 +108,21 @@ extension ShareGardenSceneViewController.MyGardenView {
       right: rightInset
     )
     self.sectionHeaderView.isLayoutMarginsRelativeArrangement = true
+    
+    self.sectionHeaderView.usingAutolayout()
+    NSLayoutConstraint.activate([
+      self.sectionHeaderView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.sectionHeaderView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+    ])
+  }
+  
+  private func setupProfileInfoViewLayoutConstraints() {
+    self.profileInfoView.usingAutolayout()
+    
+    NSLayoutConstraint.activate([
+      self.profileInfoView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.profileInfoView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+    ])
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -41,6 +41,8 @@ extension ShareGardenSceneViewController {
       return profileInfoView
     }()
     
+    private let gardenView: GardenView = GardenView()
+    
     // MARK: - Properties
     
     @ExecuteOnce private var setupLayoutIfNeeded: (() -> Void)?
@@ -83,6 +85,7 @@ extension ShareGardenSceneViewController.MyGardenView {
   private func addSubviews() {
     self.addArrangedSubview(self.sectionHeaderView)
     self.addArrangedSubview(self.profileInfoView)
+    self.addArrangedSubview(self.gardenView)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -12,11 +12,25 @@ extension ShareGardenSceneViewController {
     
     init() {
       super.init(frame: CGRect.zero)
+      self.setup()
     }
     
     @available(*, unavailable)
     required init(coder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
     }
+  }
+}
+
+extension ShareGardenSceneViewController.MyGardenView {
+  private func setup() {
+    self.setupStackView()
+  }
+  
+  private func setupStackView() {
+    self.spacing = 14
+    self.distribution = UIStackView.Distribution.fillEqually
+    self.axis = NSLayoutConstraint.Axis.vertical
+    self.alignment = UIStackView.Alignment.center
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -54,6 +54,7 @@ extension ShareGardenSceneViewController {
       super.layoutSubviews()
       self.setupLayoutIfNeeded = {
         self.setupLayoutConstraints()
+        self.setupShimmering()
       }
     }
     
@@ -99,5 +100,22 @@ extension ShareGardenSceneViewController.MyGardenView {
       right: rightInset
     )
     self.sectionHeaderView.isLayoutMarginsRelativeArrangement = true
+  }
+}
+
+extension ShareGardenSceneViewController.MyGardenView {
+  private func setupShimmering() {
+    self.setupProfileInfoViewShimmering()
+  }
+  
+  private func setupProfileInfoViewShimmering() {
+    var stack = profileInfoView.subviews
+    
+    while stack.isEmpty == false {
+      let currentView = stack.removeLast()
+      currentView.isShimmering = true
+      
+      stack.append(contentsOf: currentView.subviews)
+    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -60,7 +60,7 @@ extension ShareGardenSceneViewController.MyGardenView {
     self.spacing = 14
     self.distribution = UIStackView.Distribution.fillEqually
     self.axis = NSLayoutConstraint.Axis.vertical
-    self.alignment = UIStackView.Alignment.center
+    self.alignment = UIStackView.Alignment.fill
   }
   
   private func addSubviews() {
@@ -74,12 +74,15 @@ extension ShareGardenSceneViewController.MyGardenView {
   }
   
   private func setupSectionHeaderViewLayoutConstraints() {
-    let leadingMargin: CGFloat = self.bounds.width * (28 / 375)
-    let trailingMargin: CGFloat = self.bounds.width * (24 / 375)
+    let leftInset: CGFloat = self.bounds.width * (28 / 375)
+    let rightInset: CGFloat = self.bounds.width * (24 / 375)
     
-    NSLayoutConstraint.activate([
-      self.sectionHeaderView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: leadingMargin),
-      self.sectionHeaderView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -trailingMargin)
-    ])
+    self.sectionHeaderView.layoutMargins = UIEdgeInsets(
+      top: CGFloat.zero,
+      left: leftInset,
+      bottom: CGFloat.zero,
+      right: rightInset
+    )
+    self.sectionHeaderView.isLayoutMarginsRelativeArrangement = true
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -65,6 +65,8 @@ extension ShareGardenSceneViewController {
   }
 }
 
+// MARK: - Setup view appearance
+
 extension ShareGardenSceneViewController.MyGardenView {
   private func setup() {
     self.setupStackView()
@@ -84,6 +86,8 @@ extension ShareGardenSceneViewController.MyGardenView {
   }
 }
 
+// MARK: - Setup layout constraints
+
 extension ShareGardenSceneViewController.MyGardenView {
   private func setupLayoutConstraints() {
     self.setupSectionHeaderViewLayoutConstraints()
@@ -102,6 +106,8 @@ extension ShareGardenSceneViewController.MyGardenView {
     self.sectionHeaderView.isLayoutMarginsRelativeArrangement = true
   }
 }
+
+// MARK: - Setup shimmer
 
 extension ShareGardenSceneViewController.MyGardenView {
   private func setupShimmering() {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -1,0 +1,22 @@
+//
+//  MyGardenView.swift
+//  ShareGardenScene
+//
+//  Created by Noah on 8/13/24.
+//
+
+import UIKit
+
+extension ShareGardenSceneViewController {
+  final class MyGardenView: UIStackView {
+    
+    init() {
+      super.init(frame: CGRect.zero)
+    }
+    
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -58,6 +58,11 @@ extension ShareGardenSceneViewController {
       self.setup()
     }
     
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+    
     override func layoutSubviews() {
       super.layoutSubviews()
       self.setupLayoutIfNeeded = {
@@ -66,10 +71,6 @@ extension ShareGardenSceneViewController {
       }
     }
     
-    @available(*, unavailable)
-    required init(coder: NSCoder) {
-      fatalError("init(coder:) has not been implemented")
-    }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/GardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/GardenView.swift
@@ -16,6 +16,13 @@ public final class GardenView: UIView {
   private let pomodoroRecordCollectionView: PomodoroRecordCollectionView
   @ExecuteOnce private var setupLayoutIfNeeded: (() -> Void)?
   
+  public override var intrinsicContentSize: CGSize {
+    let contentWidth: CGFloat = Constant.GardenView.Layout.contentWidth
+    let contentHeight: CGFloat = Constant.GardenView.Layout.contentHeight
+    
+    return CGSize(width: contentWidth, height: contentHeight)
+  }
+  
   public init() {
     self.pomodoroRecordCollectionView = PomodoroRecordCollectionView()
     super.init(frame: CGRect.zero)
@@ -69,6 +76,8 @@ extension GardenView {
   private func setupLayoutConstraints() {
     self.setupPomodoroRecordsCollectionViewLayoutConstraints()
   }
+  
+  // TODO: - Intrinsic content size를 기준으로 수정
   
   private func setupPomodoroRecordsCollectionViewLayoutConstraints() {
     self.pomodoroRecordCollectionView.usingAutolayout()

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenView.swift
@@ -15,6 +15,8 @@ extension Constant.GardenView.Layout {
   public enum PomodoroRecordCollectionView { }
   public static let cornerRadiusRatio: CGFloat = 13.68 / 332.0
   public static let borderWidth: CGFloat = 1.0
+  public static let contentWidth: CGFloat = 332.0
+  public static let contentHeight: CGFloat = 119.0
 }
 
 extension Constant.GardenView.Layout.PomodoroRecordCollectionView {


### PR DESCRIPTION
## 💡 관련 이슈
- related: #298

## 🎉 변경 사항

|MyGardenView|
|---|
|<img width="500" alt="Screenshot 2024-08-20 at 4 49 20 PM" src="https://github.com/user-attachments/assets/af3cca91-21d2-4325-9efc-d1d524d5ac25">|

ShareGardenSceneViewController의 상단 섹션에 해당하는 MyGardenView를 추가하였습니다.


## 📌 PR Point

- GardenView의 콘텐츠 크기를 디자인 가이드에 맞게 고정해주었습니다
- `profileInfoView`의 title과 description을 런타임에 로드한 정보에 따라 교체할 예정입니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?