### PR TITLE
DateRangePickerCalendar 반복일 전달 함수 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateRangePicker/DateRangePickerCalendar.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateRangePicker/DateRangePickerCalendar.swift
@@ -44,6 +44,9 @@ public final class DateRangePickerCalendar: CalendarView {
 #Preview {
   let calendarView = DateRangePickerCalendar(model: CalendarView.Model.primary)
   calendarView.widthAnchor.constraint(equalToConstant: 323).isActive = true
+  calendarView.getDateRange { startDate, endDate in
+    print(startDate, endDate)
+  }
   return calendarView
 }
 #endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateRangePicker/DateRangePickerCalendar.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateRangePicker/DateRangePickerCalendar.swift
@@ -30,6 +30,13 @@ public final class DateRangePickerCalendar: CalendarView {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+
+  func getDateRange(_ closure: @escaping (Date?, Date?) -> Void) {
+    guard let dateRangePickerDelegate = self.calendarViewDelegate
+    as? DateRangeSelectionDelegate else { return }
+
+    dateRangePickerDelegate.registerSelectedRangeSendingClosure(closure)
+  }
 }
 
 #if DEBUG

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateRangePicker/DateRangeSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateRangePicker/DateRangeSelectionDelegate.swift
@@ -13,7 +13,8 @@ final class DateRangeSelectionDelegate: CalendarViewSingleSelectionDelegate {
   var endDate: CalendarItem?
   
   private var lastScrollTime: TimeInterval = 0
-  
+  private var selectedRangeSendingClosure: ((Date?, Date?) -> Void)?
+
   override init(
     collectionView: UICollectionView,
     collectionViewLayoutModel: CalendarView.Model.CollectionViewLayout,
@@ -93,5 +94,14 @@ final class DateRangeSelectionDelegate: CalendarViewSingleSelectionDelegate {
       self.updateVisibleSelection()
       self.lastScrollTime = currentTime
     }
+  }
+}
+
+// MARK: Selected Range Sending Closure
+
+extension DateRangeSelectionDelegate {
+  /// 선택된 범위의 시작일과 종료일을 DateRangePickerCalendar에 전달하는 클로저를 등록하는 함수입니다.
+  func registerSelectedRangeSendingClosure(_ closure: @escaping (Date?, Date?) -> Void) {
+    self.selectedRangeSendingClosure = closure
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateRangePicker/DateRangeSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateRangePicker/DateRangeSelectionDelegate.swift
@@ -9,9 +9,17 @@ import UIKit
 
 final class DateRangeSelectionDelegate: CalendarViewSingleSelectionDelegate {
   var currentSelectionState: RangeSelectionState
-  var startDate: CalendarItem?
-  var endDate: CalendarItem?
-  
+  var startDate: CalendarItem? {
+    willSet {
+      self.selectedRangeSendingClosure?(newValue?.date, self.endDate?.date)
+    }
+  }
+  var endDate: CalendarItem? {
+    willSet {
+      self.selectedRangeSendingClosure?(self.startDate?.date, newValue?.date)
+    }
+  }
+
   private var lastScrollTime: TimeInterval = 0
   private var selectedRangeSendingClosure: ((Date?, Date?) -> Void)?
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #435 

## 🎉 변경 사항
- DateRangePickerCalendar에 선택한 투두 반복범위를 전달받는 클로저를 추가하였습니다.

## 📌 PR Point
- 투두 수정화면에서 선택한 반복 날짜 데이터를 전달받기 위해 구현하였습니다.
- 선택된 반복 날짜들을 아래 사진과 같이 Label의 Text로 업데이트하는데 필요합니다.
<img width="200" alt="스크린샷 2024-06-11 13 06 09" src="https://github.com/user-attachments/assets/6e9469d1-c9cb-44f0-b32f-d95c851bdd37">


- 다음과 같이 사용하며, 아래 코드는 Preview에도 구현되어있어 동작을 확인하실 수 있습니다.

``` Swift
let calendarView = DateRangePickerCalendar(model: CalendarView.Model.primary)
calendarView.getDateRange { startDate, endDate in
    print(startDate, endDate)
}
```

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?