### PR TITLE
Styled Row 추가 구현

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 extension Styled.Row {
@@ -50,7 +51,8 @@ extension Styled.Row.Configuration {
         titleFont: UIFont.pretendardHeadBold,
         description: description,
         descriptionFont: UIFont.pretendardDetailLight,
-        axis: NSLayoutConstraint.Axis.vertical
+        axis: NSLayoutConstraint.Axis.vertical,
+        profileSize: Constant.Styled.Row.Profile.shareProfileSize
       )
     }
     
@@ -65,7 +67,8 @@ extension Styled.Row.Configuration {
         titleFont: UIFont.pretendardBodySemiBold,
         description: description,
         descriptionFont: UIFont.pretendardBodyMedium,
-        axis: NSLayoutConstraint.Axis.horizontal
+        axis: NSLayoutConstraint.Axis.horizontal,
+        profileSize: Constant.Styled.Row.Profile.friendListProfileSize
       )
     }
     var image: UIImage = UIImage.defaultFriendProfileImage
@@ -74,6 +77,7 @@ extension Styled.Row.Configuration {
     var description: String
     var descriptionFont: UIFont
     var axis: NSLayoutConstraint.Axis
+    var profileSize: CGSize
   }
   
   public struct ListPrimaryModel: Equatable {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
@@ -57,7 +57,7 @@ extension Styled.Row.Configuration {
     }
     
     public static func gardenInfo(
-      image: UIImage = UIImage.defaultProfileImage,
+      image: UIImage = UIImage.defaultFriendProfileImage,
       title: String,
       description: String
     ) -> Self {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
@@ -10,7 +10,7 @@ extension Styled.Row {
     let imageView = self.buildImageView(
       stack: stack,
       image: model.image,
-      size: Constant.Styled.Row.Profile.profileSize
+      size: model.profileSize
     )
     self.buildInnerStack(stack: stack, model: model)
     if model.axis == NSLayoutConstraint.Axis.vertical {
@@ -25,7 +25,6 @@ extension Styled.Row {
   }
   
   private func buildProfileStyleStack(stack: UIStackView) {
-    stack.isLayoutMarginsRelativeArrangement = true
     stack.spacing = Constant.Styled.Row.Profile.stackSpacing
     self.buildStack(
       stack: stack,

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+Styled+Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+Styled+Row.swift
@@ -24,7 +24,8 @@ public extension Constant.Styled.Row.ToDoList {
 }
 
 public extension Constant.Styled.Row.Profile {
-  static let profileSize = CGSize(width: 55, height: 55)
+  static let shareProfileSize = CGSize(width: 55, height: 55)
+  static let friendListProfileSize = CGSize(width: 36, height: 36)
   static let accessorySize = CGSize(width: 24, height: 24)
   static let stackSpacing = CGFloat(15)
   static let stackEdgeInsets = NSDirectionalEdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 36)


### PR DESCRIPTION
## 💡 관련 이슈
#439 

## 🎉 변경 사항
- 이미지 크기 다르게 적용하기
- 기본 이미지 적용(친구 리스트)
<img width="369" alt="image" src="https://github.com/user-attachments/assets/b00cdf69-8ae1-47b7-9001-08d472be3121">

#439 이슈에서 1번의 경우 기존 Styled Row의 기존 구현 방식의 틀을 변경하는 방법이 더 좋겠다는 판단을 했습니다.
변경하고자 하는 방식은 enum을 추가해서 공유에서 사용하는 뷰인지 친구리스트에서 사용하는 뷰인지 판단할 수 있도록 구현할 예정입니다.
그렇게 되면서 기존 구현 방식도 변경이 필요하게됩니다. 해당 작업은 개인 작업을 마무리한 후 진행하도록 하겠습니다.

## 📝 셀프체크리스트
- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?