### PR TITLE
EditToDoScene UI 업데이트 VIP 사이클 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -16,7 +16,7 @@ protocol EditToDoDataStore {
 
 protocol EditToDoBusinessLogic {
   func changeReptition(request: EditToDo.ChangeRepetition.Request)
-  func changeAlarmActivation(request: EditToDo.ChangeAlarmActivation.Request)
+  func changeAlarmActivation()
   func fetchToDo()
   func deleteToDo()
   func editToDo(request: EditToDo.CompleteEditToDo.Request)
@@ -47,7 +47,7 @@ final class EditToDoInteractor: EditToDoDataStore {
 
 extension EditToDoInteractor: EditToDoBusinessLogic {
   /// 사용자가 투두 알림 스위치를 통해 활성화 여부를 변경했을 때 호출되는 메서드입니다.
-  func changeAlarmActivation(request: EditToDo.ChangeAlarmActivation.Request) {
+  func changeAlarmActivation() {
     guard let isAlarmOn = self.toDo?.alarm.isAlarmOn
     else { return }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -18,6 +18,7 @@ protocol EditToDoBusinessLogic {
   func changeReptition(request: EditToDo.ChangeRepetition.Request)
   func changeAlarmActivation()
   func fetchAlarmTime()
+  func changeAlarmTime(request: EditToDo.ChangeAlarmTime.Request)
   func fetchToDo()
   func deleteToDo()
   func editToDo(request: EditToDo.CompleteEditToDo.Request)
@@ -62,6 +63,13 @@ extension EditToDoInteractor: EditToDoBusinessLogic {
     let alarmTime = self.toDo?.alarm.alarmTime
     let response = EditToDo.FetchAlarmTime.Response(alarmTime: alarmTime)
     self.presenter?.presentFetchedAlarmTime(response: response)
+  }
+
+  func changeAlarmTime(request: EditToDo.ChangeAlarmTime.Request) {
+    let alarmTime = request.alarmTime
+    self.toDo?.alarm.alarmTime = alarmTime
+    let response = EditToDo.ChangeAlarmTime.Response(alarmTime: alarmTime)
+    self.presenter?.presentChangedAlarmTime(response: response)
   }
 
   /// 사용자가 투두 반복 설정 뷰를 선택했을 때 호출하는 메서드입니다.

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -17,6 +17,7 @@ protocol EditToDoDataStore {
 protocol EditToDoBusinessLogic {
   func changeReptition(request: EditToDo.ChangeRepetition.Request)
   func changeAlarmActivation()
+  func fetchAlarmTime()
   func fetchToDo()
   func deleteToDo()
   func editToDo(request: EditToDo.CompleteEditToDo.Request)
@@ -55,7 +56,14 @@ extension EditToDoInteractor: EditToDoBusinessLogic {
     let response = EditToDo.ChangeAlarmActivation.Response(isAlarmOn: !isAlarmOn)
     self.presenter?.presentAlarmActivation(response: response)
   }
-  
+
+  /// 사용자가 투두 알림 시간 설정 버튼을 눌렀을 때, 기존에 설정했던 시간을 보여주기 위해 호출되는 메서드입니다.
+  func fetchAlarmTime() {
+    let alarmTime = self.toDo?.alarm.alarmTime
+    let response = EditToDo.FetchAlarmTime.Response(alarmTime: alarmTime)
+    self.presenter?.presentFetchedAlarmTime(response: response)
+  }
+
   /// 사용자가 투두 반복 설정 뷰를 선택했을 때 호출하는 메서드입니다.
   /// ex) 사용자가 화면에서 (오늘만 or 다른날도 or 매일) 할래요 뷰를 눌렀음
   func changeReptition(request: EditToDo.ChangeRepetition.Request) {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -30,16 +30,13 @@ final class EditToDoInteractor: EditToDoDataStore {
 
   // MARK: VIP Objects
   var presenter: EditToDoPresentationLogic?
-  private let someWorker: EditToDoWorkable
   private let toDoWorker: ToDoWorkLogic
   private let groupWorker: GroupWorkLogic
 
   public init(
-    someWorker: EditToDoWorkable = EditToDoWorker(),
     toDoWorker: ToDoWorkLogic,
     groupWorker: GroupWorkLogic
   ) {
-    self.someWorker = someWorker
     self.toDoWorker = toDoWorker
     self.groupWorker = groupWorker
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
@@ -14,6 +14,7 @@ protocol EditToDoPresentationLogic {
   func presentDeleteResult(response: EditToDo.DeleteToDo.Response)
   func presentEditResult(response: EditToDo.CompleteEditToDo.Response)
   func presentAlarmActivation(response: EditToDo.ChangeAlarmActivation.Response)
+  func presentFetchedAlarmTime(response: EditToDo.FetchAlarmTime.Response)
   func presentChangedRepetition(response: EditToDo.ChangeRepetition.Response)
 }
 
@@ -69,6 +70,12 @@ extension EditToDoPresenter: EditToDoPresentationLogic {
     self.viewController?.displayChangedAlarm(viewModel: viewModel)
   }
 
+  func presentFetchedAlarmTime(response: EditToDo.FetchAlarmTime.Response) {
+    let alarmTime = self.makeAlarmTime(of: response.alarmTime)
+    let viewModel = EditToDo.FetchAlarmTime.ViewModel(hour: alarmTime.hour, minute: alarmTime.minute)
+    self.viewController?.displayFetchedAlarmTime(viewModel: viewModel)
+  }
+
   func presentChangedRepetition(response: EditToDo.ChangeRepetition.Response) {
     let viewState = response.editToDoRepetitionViewState
     let viewModel = EditToDo.ChangeRepetition.ViewModel(editToDoRepetitionViewState: viewState)
@@ -79,10 +86,16 @@ extension EditToDoPresenter: EditToDoPresentationLogic {
 // MARK: Private Functions
 
 extension EditToDoPresenter {
+  struct AlarmTime {
+    let hour: Int
+    let minute: Int
+  }
+
   private func makeDisplayedToDo(
     from fetchedToDo: EditToDo.FetchToDo.Response.FetchedToDo
   ) -> EditToDo.FetchToDo.ViewModel.DisplayedToDo {
-    let alarmTime = self.makeAlarmTimeString(from: fetchedToDo.toDo.alarm.alarmTime)
+    let alarmTime = self.makeAlarmTime(of: fetchedToDo.toDo.alarm.alarmTime)
+    let alarmTimeString = String(format: "%02d:%02d", alarmTime.hour, alarmTime.minute)
     let startDay = self.makeDayString(from: fetchedToDo.toDo.repetition.startDate)
     let endDay = self.makeDayString(from: fetchedToDo.toDo.repetition.endDate)
 
@@ -91,23 +104,23 @@ extension EditToDoPresenter {
       group: fetchedToDo.toDo.groupData,
       groupList: fetchedToDo.groupList,
       isAlarmOn: fetchedToDo.toDo.alarm.isAlarmOn,
-      alarmTime: alarmTime,
+      alarmTime: alarmTimeString,
       repetitionViewState: fetchedToDo.repetitionViewState,
       startDay: startDay,
       endDay: endDay
     )
   }
 
-  private func makeAlarmTimeString(from time: Double?) -> String? {
+  private func makeAlarmTime(of time: Double?) -> AlarmTime {
     if let time {
       let timeIntValue = Int(time)
       let secondsPerHour = 3600
       let secondsPerMinute = 60
       let hour = timeIntValue / secondsPerHour
-      let minute = (timeIntValue - (hour * secondsPerHour)) % secondsPerMinute
-      return String(format: "%02d:%02d", hour, minute)
+      let minute = (timeIntValue - (hour * secondsPerHour)) / secondsPerMinute
+      return AlarmTime(hour: hour, minute: minute)
     } else {
-      return nil
+      return AlarmTime(hour: 0, minute: 0)
     }
   }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
@@ -15,6 +15,7 @@ protocol EditToDoPresentationLogic {
   func presentEditResult(response: EditToDo.CompleteEditToDo.Response)
   func presentAlarmActivation(response: EditToDo.ChangeAlarmActivation.Response)
   func presentFetchedAlarmTime(response: EditToDo.FetchAlarmTime.Response)
+  func presentChangedAlarmTime(response: EditToDo.ChangeAlarmTime.Response)
   func presentChangedRepetition(response: EditToDo.ChangeRepetition.Response)
 }
 
@@ -74,6 +75,13 @@ extension EditToDoPresenter: EditToDoPresentationLogic {
     let alarmTime = self.makeAlarmTime(of: response.alarmTime)
     let viewModel = EditToDo.FetchAlarmTime.ViewModel(hour: alarmTime.hour, minute: alarmTime.minute)
     self.viewController?.displayFetchedAlarmTime(viewModel: viewModel)
+  }
+
+  func presentChangedAlarmTime(response: EditToDo.ChangeAlarmTime.Response) {
+    let alarmTime = self.makeAlarmTime(of: response.alarmTime)
+    let alarmTimeString = String(format: "%02d:%02d", alarmTime.hour, alarmTime.minute)
+    let viewModel = EditToDo.ChangeAlarmTime.ViewModel(alarmTimeString: alarmTimeString)
+    self.viewController?.displayChangedAlarmTime(viewModel: viewModel)
   }
 
   func presentChangedRepetition(response: EditToDo.ChangeRepetition.Response) {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
@@ -64,7 +64,10 @@ extension EditToDoPresenter: EditToDoPresentationLogic {
     }
   }
 
-  func presentAlarmActivation(response: EditToDo.ChangeAlarmActivation.Response) {}
+  func presentAlarmActivation(response: EditToDo.ChangeAlarmActivation.Response) {
+    let viewModel = EditToDo.ChangeAlarmActivation.ViewModel(isAlarmOn: response.isAlarmOn)
+    self.viewController?.displayChangedAlarm(viewModel: viewModel)
+  }
 
   func presentChangedRepetition(response: EditToDo.ChangeRepetition.Response) {
     let viewState = response.editToDoRepetitionViewState

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
@@ -65,7 +65,12 @@ extension EditToDoPresenter: EditToDoPresentationLogic {
   }
 
   func presentAlarmActivation(response: EditToDo.ChangeAlarmActivation.Response) {}
-  func presentChangedRepetition(response: EditToDo.ChangeRepetition.Response) {}
+
+  func presentChangedRepetition(response: EditToDo.ChangeRepetition.Response) {
+    let viewState = response.editToDoRepetitionViewState
+    let viewModel = EditToDo.ChangeRepetition.ViewModel(editToDoRepetitionViewState: viewState)
+    self.viewController?.displayChangedRepetition(viewModel: viewModel)
+  }
 }
 
 // MARK: Private Functions

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
@@ -19,7 +19,7 @@ protocol EditToDoPresentationLogic {
   func presentChangedRepetition(response: EditToDo.ChangeRepetition.Response)
 }
 
-class EditToDoPresenter {
+final class EditToDoPresenter {
   private let dateFormatter: DateFormatter
 
   weak var viewController: EditToDoDisplayLogic?
@@ -94,7 +94,7 @@ extension EditToDoPresenter: EditToDoPresentationLogic {
 // MARK: Private Functions
 
 extension EditToDoPresenter {
-  struct AlarmTime {
+  private struct AlarmTime {
     let hour: Int
     let minute: Int
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneBuilder.swift
@@ -12,16 +12,13 @@ import EditToDoSceneAPI
 public struct EditToDoSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
-    let someWorker: EditToDoWorkable
     let toDoWorker: ToDoWorkLogic
     let groupWorker: GroupWorkLogic
 
     public init(
-      someWorker: EditToDoWorkable,
       toDoWorker: ToDoWorkLogic,
       groupWorker: GroupWorkLogic
     ) {
-      self.someWorker = someWorker
       self.toDoWorker = toDoWorker
       self.groupWorker = groupWorker
     }
@@ -52,7 +49,6 @@ extension EditToDoSceneBuilder {
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
   private func configureVIPCycle(for viewController: EditToDoViewController) -> EditToDoViewController {
     let interactor = EditToDoInteractor(
-      someWorker: self.dependency.someWorker,
       toDoWorker: self.dependency.toDoWorker,
       groupWorker: self.dependency.groupWorker
     )

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneTheme.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneTheme.swift
@@ -38,4 +38,8 @@ extension EditToDoSceneTheme.StringLiteral {
       static let text = "반복"
     }
   }
+
+  enum ToDoAlarmTimeSettingModal {
+    static let buttonTitle = "완료"
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import EditToDoSceneEntity
+import ToDoGardenUIAPI
 import ToDoGardenUIComponent
 
 final class EditToDoView: UIView {
@@ -68,12 +69,18 @@ extension EditToDoView {
   /// EditToDoView의 Subview들에서 발생한 이벤트들을 전달하는 역할을 합니다.
   protocol EditToDoViewDelegate: AnyObject {
     func didSelectDeleteToDoButton()
+    func didEditToDoName(_ name: String?)
   }
 }
 
 // MARK: GroupSelectionView Delegate Functions
 
-extension EditToDoView: GroupSelectionViewDelegate {
+extension EditToDoView: GroupSelectionViewDelegate, TextInputViewDelegate {
+  func textInputViewDidChange() {
+    let editedName = self.toDoNameInputView.getEditingText()
+    self.delegate?.didEditToDoName(editedName)
+  }
+
   func didSelectGroup(color: UIColor) {
     self.toDoNameInputView.changeBottomLine(color: color)
   }
@@ -116,9 +123,14 @@ extension EditToDoView: UIGestureRecognizerDelegate {
 extension EditToDoView {
   private func setup() {
     self.setupDeleteToDoButton()
+    self.setupToDoNameInputViewDelegate()
     self.setupGroupSelectionViewDelegate()
     self.setupTapGestureDelegate()
     self.setupSubviewsLayout()
+  }
+
+  private func setupToDoNameInputViewDelegate() {
+    self.toDoNameInputView.delegate = self
   }
 
   private func makeGroupLabel() -> UILabel {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -77,13 +77,29 @@ final class EditToDoViewController: UIViewController, EditToDoViewControllable {
 
 // MARK: - Request to interactor
 
-extension EditToDoViewController {
+extension EditToDoViewController: EditToDoScheduleViewDelegate {
   func editToDo() {
     if let toDoNameForEdit = self.editToDoView.getEditingText(),
       let groupForEdit = self.editToDoView.getCurrentGroup() {
       let request = EditToDo.CompleteEditToDo.Request(toDoName: toDoNameForEdit, displayedGroup: groupForEdit)
       self.interactor?.editToDo(request: request)
     }
+  }
+
+  func didSelectOnlyTodayView(isOnlyToday: Bool) {
+
+  }
+
+  func didSelectEverydayButton(isSelected: Bool) {
+
+  }
+
+  func didToggleSwitch() {
+
+  }
+
+  func didSelectAlarmSettingButton() {
+
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -98,7 +98,7 @@ extension EditToDoViewController: EditToDoScheduleViewDelegate {
   }
 
   func didToggleSwitch() {
-
+    self.interactor?.changeAlarmActivation()
   }
 
   func didSelectAlarmSettingButton() {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -183,11 +183,11 @@ extension EditToDoViewController: ToDoGardenAlertControllerDelegate {
   ) {
     self.closeAlert()
     switch buttonType {
-    case .retry:
+    case ToDoGardenUIConstant.Constant.ToDoGardenAlertView.Content.ButtonActionType.retry:
       self.interactor?.fetchToDo()
-    case .goHome:
+    case ToDoGardenUIConstant.Constant.ToDoGardenAlertView.Content.ButtonActionType.goHome:
       self.router?.routeToToDoListScene()
-    case .delete:
+    case ToDoGardenUIConstant.Constant.ToDoGardenAlertView.Content.ButtonActionType.delete:
       self.interactor?.deleteToDo()
     default:
       break
@@ -249,11 +249,11 @@ extension EditToDoViewController {
 
   private func updateRepetitionViewState(_ state: EditToDo.EditToDoRepetitionViewState) {
     switch state {
-    case .repeatOnlyToday:
+    case EditToDo.EditToDoRepetitionViewState.repeatOnlyToday:
       self.editToDoScheduleView.updateToRepeatOnlyToday()
-    case .repeatEveryday:
+    case EditToDo.EditToDoRepetitionViewState.repeatEveryday:
       self.editToDoScheduleView.updateToRepeatEveryday()
-    case .repeatInRange:
+    case EditToDo.EditToDoRepetitionViewState.repeatInRange:
       self.editToDoScheduleView.updateToRepeatInRange()
     }
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -145,7 +145,7 @@ extension EditToDoViewController: EditToDoDisplayLogic {
   }
 
   func displayChangedRepetition(viewModel: EditToDo.ChangeRepetition.ViewModel) {
-    
+    self.updateRepetitionViewState(viewModel.editToDoRepetitionViewState)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -18,6 +18,7 @@ protocol EditToDoDisplayLogic: AnyObject {
   func displayFetchedToDo(viewModel: EditToDo.FetchToDo.ViewModel)
   func displayDeleteToDoResult(viewModel: EditToDo.DeleteToDo.ViewModel)
   func displayEditToDoResult(viewModel: EditToDo.CompleteEditToDo.ViewModel)
+  func displayChangedRepetition(viewModel: EditToDo.ChangeRepetition.ViewModel)
 }
 
 final class EditToDoViewController: UIViewController, EditToDoViewControllable {
@@ -141,6 +142,10 @@ extension EditToDoViewController: EditToDoDisplayLogic {
     case Result.failure(let error):
       self.showErrorAlert(error)
     }
+  }
+
+  func displayChangedRepetition(viewModel: EditToDo.ChangeRepetition.ViewModel) {
+    
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -21,6 +21,7 @@ protocol EditToDoDisplayLogic: AnyObject {
   func displayChangedRepetition(viewModel: EditToDo.ChangeRepetition.ViewModel)
   func displayChangedAlarm(viewModel: EditToDo.ChangeAlarmActivation.ViewModel)
   func displayFetchedAlarmTime(viewModel: EditToDo.FetchAlarmTime.ViewModel)
+  func displayChangedAlarmTime(viewModel: EditToDo.ChangeAlarmTime.ViewModel)
 }
 
 final class EditToDoViewController: UIViewController, EditToDoViewControllable {
@@ -80,7 +81,7 @@ final class EditToDoViewController: UIViewController, EditToDoViewControllable {
 
 // MARK: - Request to interactor
 
-extension EditToDoViewController: EditToDoScheduleViewDelegate {
+extension EditToDoViewController: EditToDoScheduleViewDelegate, ToDoAlarmTimeSettingModalDelegate {
   func editToDo() {
     if let toDoNameForEdit = self.editToDoView.getEditingText(),
       let groupForEdit = self.editToDoView.getCurrentGroup() {
@@ -105,6 +106,11 @@ extension EditToDoViewController: EditToDoScheduleViewDelegate {
 
   func didSelectAlarmSettingButton() {
     self.interactor?.fetchAlarmTime()
+  }
+
+  func didSelectAlarmTime(_ alarmTime: Double) {
+    let request = EditToDo.ChangeAlarmTime.Request(alarmTime: alarmTime)
+    self.interactor?.changeAlarmTime(request: request)
   }
 }
 
@@ -156,10 +162,16 @@ extension EditToDoViewController: EditToDoDisplayLogic {
 
   func displayFetchedAlarmTime(viewModel: EditToDo.FetchAlarmTime.ViewModel) {
     let alarmTimeSettingModal = ToDoAlarmTimeSettingModal()
+    alarmTimeSettingModal.delegate = self
     let hour = viewModel.hour
     let minute = viewModel.minute
     alarmTimeSettingModal.updateInitialAlarmTime(hour: hour, minute: minute)
     self.present(alarmTimeSettingModal, animated: true)
+  }
+
+  func displayChangedAlarmTime(viewModel: EditToDo.ChangeAlarmTime.ViewModel) {
+    let alarmTimeString = viewModel.alarmTimeString
+    self.editToDoScheduleView.updateAlarmTime(alarmTime: alarmTimeString)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -87,11 +87,13 @@ extension EditToDoViewController: EditToDoScheduleViewDelegate {
   }
 
   func didSelectOnlyTodayView(isOnlyToday: Bool) {
-
+    let request = EditToDo.ChangeRepetition.Request(isOnlyToday: isOnlyToday, isEveryday: nil)
+    self.interactor?.changeReptition(request: request)
   }
 
   func didSelectEverydayButton(isSelected: Bool) {
-
+    let request = EditToDo.ChangeRepetition.Request(isOnlyToday: false, isEveryday: isSelected)
+    self.interactor?.changeReptition(request: request)
   }
 
   func didToggleSwitch() {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -20,6 +20,7 @@ protocol EditToDoDisplayLogic: AnyObject {
   func displayEditToDoResult(viewModel: EditToDo.CompleteEditToDo.ViewModel)
   func displayChangedRepetition(viewModel: EditToDo.ChangeRepetition.ViewModel)
   func displayChangedAlarm(viewModel: EditToDo.ChangeAlarmActivation.ViewModel)
+  func displayFetchedAlarmTime(viewModel: EditToDo.FetchAlarmTime.ViewModel)
 }
 
 final class EditToDoViewController: UIViewController, EditToDoViewControllable {
@@ -103,7 +104,7 @@ extension EditToDoViewController: EditToDoScheduleViewDelegate {
   }
 
   func didSelectAlarmSettingButton() {
-
+    self.interactor?.fetchAlarmTime()
   }
 }
 
@@ -151,6 +152,14 @@ extension EditToDoViewController: EditToDoDisplayLogic {
 
   func displayChangedAlarm(viewModel: EditToDo.ChangeAlarmActivation.ViewModel) {
     self.updateAlarmState(isAlarmOn: viewModel.isAlarmOn)
+  }
+
+  func displayFetchedAlarmTime(viewModel: EditToDo.FetchAlarmTime.ViewModel) {
+    let alarmTimeSettingModal = ToDoAlarmTimeSettingModal()
+    let hour = viewModel.hour
+    let minute = viewModel.minute
+    alarmTimeSettingModal.updateInitialAlarmTime(hour: hour, minute: minute)
+    self.present(alarmTimeSettingModal, animated: true)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -269,7 +269,6 @@ extension EditToDoViewController {
       super.viewDidAppear(animated)
       let editToDoViewController = EditToDoSceneBuilder(
         dependency: EditToDoSceneBuilder.Dependency(
-          someWorker: EditToDoWorker(),
           toDoWorker: ToDoWorker(),
           groupWorker: GroupWorker()
         )

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -19,6 +19,7 @@ protocol EditToDoDisplayLogic: AnyObject {
   func displayDeleteToDoResult(viewModel: EditToDo.DeleteToDo.ViewModel)
   func displayEditToDoResult(viewModel: EditToDo.CompleteEditToDo.ViewModel)
   func displayChangedRepetition(viewModel: EditToDo.ChangeRepetition.ViewModel)
+  func displayChangedAlarm(viewModel: EditToDo.ChangeAlarmActivation.ViewModel)
 }
 
 final class EditToDoViewController: UIViewController, EditToDoViewControllable {
@@ -146,6 +147,10 @@ extension EditToDoViewController: EditToDoDisplayLogic {
 
   func displayChangedRepetition(viewModel: EditToDo.ChangeRepetition.ViewModel) {
     self.updateRepetitionViewState(viewModel.editToDoRepetitionViewState)
+  }
+
+  func displayChangedAlarm(viewModel: EditToDo.ChangeAlarmActivation.ViewModel) {
+    self.updateAlarmState(isAlarmOn: viewModel.isAlarmOn)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -29,7 +29,7 @@ final class EditToDoViewController: UIViewController, EditToDoViewControllable {
   private(set) var editModeScrollView: UIScrollView
   private(set) var editToDoView: EditToDoView
   private(set) var editToDoScheduleView: EditToDoScheduleView
-  private(set) var completeEditButton: UIButton
+  private(set) var completeEditButton: ToDoGardenBoxButton
 
   @ExecuteOnce private var scrollToEditToDoMode: (() -> Void)?
 
@@ -207,6 +207,15 @@ extension EditToDoViewController: ToDoGardenAlertControllerDelegate {
 // MARK: Subviews Delegate Functions
 
 extension EditToDoViewController: EditToDoView.EditToDoViewDelegate {
+  func didEditToDoName(_ name: String?) {
+    let isEditedNameEmpty = name?.isEmpty ?? true
+    if isEditedNameEmpty {
+      self.completeEditButton.disable()
+    } else {
+      self.completeEditButton.enable()
+    }
+  }
+
   func didSelectDeleteToDoButton() {
     let deleteToDoAlert = ToDoGardenAlertController(for: ToDoGardenAlertView.Configuration.askToDeleteToDo)
     deleteToDoAlert.delegate = self

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/ToDoAlarmSettingModal.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/ToDoAlarmSettingModal.swift
@@ -1,0 +1,92 @@
+//
+//  ToDoAlarmTimeSettingModal.swift
+//
+//
+//  Created by Wood on 8/23/24.
+//
+
+import UIKit
+
+import ToDoGardenUIComponent
+
+extension EditToDoViewController {
+  final class ToDoAlarmTimeSettingModal: UIViewController {
+    private let completeButton: ToDoGardenBoxButton
+    private let settingTimeView: SettingTimeView
+
+    weak var delegate: ToDoAlarmTimeSettingModalDelegate?
+
+    init() {
+      self.completeButton = ToDoGardenBoxButton(
+        title: EditToDoSceneTheme.StringLiteral.ToDoAlarmTimeSettingModal.buttonTitle,
+        buttonType: ToDoGardenBoxButton.Configuration.primaryRoundRectButton
+      )
+      self.settingTimeView = SettingTimeView(
+        with: self.completeButton,
+        for: SettingTimeView.Configuration.alarmTimeSetting
+      )
+      super.init(nibName: nil, bundle: nil)
+      self.setupPresentationStyle()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      self.setup()
+    }
+
+    func updateInitialAlarmTime(hour: Int, minute: Int) {
+      self.settingTimeView.updateSelectedTime(hour: hour, minute: minute)
+    }
+  }
+}
+
+protocol ToDoAlarmTimeSettingModalDelegate: AnyObject {
+  func didSelectAlarmTime(_ alarmTime: Double)
+}
+
+extension EditToDoViewController.ToDoAlarmTimeSettingModal {
+  private func setupPresentationStyle() {
+    self.sheetPresentationController?.detents = [
+      UISheetPresentationController.Detent.medium()
+    ]
+    self.sheetPresentationController?.prefersGrabberVisible = true
+  }
+
+  private func setup() {
+    self.setupBackgroundColor()
+    self.setupCompleteButtonAction()
+    self.setupSettingTimeViewLayout()
+  }
+
+  private func setupBackgroundColor() {
+    self.view.backgroundColor = UIColor.toDoGardenWhite
+  }
+
+  private func setupCompleteButtonAction() {
+    let buttonAction = UIAction { _ in
+      self.settingTimeView.transformSeconds { (alarmTime: Double) in
+        self.delegate?.didSelectAlarmTime(alarmTime)
+        self.dismiss(animated: true)
+      }
+    }
+
+    self.completeButton.addAction(buttonAction, for: UIControl.Event.touchUpInside)
+  }
+
+  private func setupSettingTimeViewLayout() {
+    self.view.addSubview(self.settingTimeView)
+    self.settingTimeView.usingAutolayout()
+
+    NSLayoutConstraint.activate(
+      [
+        self.settingTimeView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+        self.settingTimeView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
+      ]
+    )
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/ToDoWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/ToDoWorker.swift
@@ -20,7 +20,7 @@ public final class ToDoWorker: ToDoWorkLogic {
   public init() {}
 
   public func fetchToDo(id: Int?) throws -> EditToDo.ToDo {
-    throw MockToDoWorkerError.networkConnectionRequired
+    return MockData.FetchToDo.firstData
   }
 
   public func deleteToDo(id: Int?) throws {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoScheduleView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoScheduleView.swift
@@ -13,6 +13,8 @@ final class EditToDoScheduleView: UIView {
   private let editToDoAlarmView: EditToDoAlarmView
   private let editToDoRepetitionView: EditToDoRepetitionView
 
+  weak var delegate: EditToDoScheduleViewDelegate?
+
   init() {
     self.editToDoAlarmView = EditToDoAlarmView()
     self.editToDoRepetitionView = EditToDoRepetitionView()
@@ -52,13 +54,30 @@ final class EditToDoScheduleView: UIView {
 
 // MARK: Delegate Functions
 
+protocol EditToDoScheduleViewDelegate: AnyObject {
+  func didSelectOnlyTodayView(isOnlyToday: Bool)
+  func didSelectEverydayButton(isSelected: Bool)
+  func didToggleSwitch()
+  func didSelectAlarmSettingButton()
+}
+
 /// 하위 뷰들에서 이벤트를 입력받았을 때 Delegate로 전달받아 호출되는 메서드들입니다.
 extension EditToDoScheduleView: EditToDoRepetitionViewDelegate, EditToDoAlarmViewDelegate {
-  func didSelectOnlyTodayView(isOnlyToday: Bool) {}
-  func didSelectEverydayButton(isSelected: Bool) {}
+  func didSelectOnlyTodayView(isOnlyToday: Bool) {
+    self.delegate?.didSelectOnlyTodayView(isOnlyToday: isOnlyToday)
+  }
+  
+  func didSelectEverydayButton(isSelected: Bool) {
+    self.delegate?.didSelectEverydayButton(isSelected: isSelected)
+  }
 
-  func didToggleSwitch() {}
-  func didSelectAlarmSettingButton() {}
+  func didToggleSwitch() {
+    self.delegate?.didToggleSwitch()
+  }
+  
+  func didSelectAlarmSettingButton() {
+    self.delegate?.didSelectAlarmSettingButton()
+  }
 }
 
 // MARK: Private Functions

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoViewController+setup.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoViewController+setup.swift
@@ -59,6 +59,7 @@ extension EditToDoViewController {
 
   private func setupSubviewsDelegate() {
     self.editToDoView.delegate = self
+    self.editToDoScheduleView.delegate = self
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
@@ -140,6 +140,26 @@ public enum EditToDo {
     }
   }
 
+  public enum FetchAlarmTime {
+    public struct Response {
+      public let alarmTime: Double?
+
+      public init(alarmTime: Double?) {
+        self.alarmTime = alarmTime
+      }
+    }
+
+    public struct ViewModel {
+      public let hour: Int
+      public let minute: Int
+
+      public init(hour: Int, minute: Int) {
+        self.hour = hour
+        self.minute = minute
+      }
+    }
+  }
+
   public enum ChangeAlarmTime {
     public struct Request {
       public let alarmTime: Double

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
@@ -140,6 +140,7 @@ public enum EditToDo {
     }
   }
 
+  /// 사용자가 투두 알림 시간을 변경할 때, 기존에 선택했던 투두 알림 시간을 보여주는 유스케이스입니다.
   public enum FetchAlarmTime {
     public struct Response {
       public let alarmTime: Double?
@@ -160,6 +161,7 @@ public enum EditToDo {
     }
   }
 
+  /// 사용자가 투두 알림 시간을 변경하는 유스케이스입니다.
   public enum ChangeAlarmTime {
     public struct Request {
       public let alarmTime: Double
@@ -170,9 +172,9 @@ public enum EditToDo {
     }
 
     public struct Response {
-      public let alarmTime: Date?
+      public let alarmTime: Double
 
-      public init(alarmTime: Date?) {
+      public init(alarmTime: Double) {
         self.alarmTime = alarmTime
       }
     }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Tests/EditToDoSceneTests/EditToDoInteractorTests.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Tests/EditToDoSceneTests/EditToDoInteractorTests.swift
@@ -26,9 +26,8 @@ class EditToDoInteractorTests: XCTestCase {
     )
     interactor.presenter = mockPresenter
     interactor.toDoId = EditToDoSceneTestData.Interactor.toDoId
-    let request = EditToDo.FetchToDo.Request()
 
-    interactor.fetchToDo(request: request)
+    interactor.fetchToDo()
 
     let fetchedToDo = try XCTUnwrap(interactor.toDo)
     XCTAssertEqual(fetchedToDo, EditToDoSceneTestData.Interactor.toDo)
@@ -48,9 +47,7 @@ class EditToDoInteractorTests: XCTestCase {
       }
     )
     interactor.presenter = mockPresenter
-    let request = EditToDo.FetchToDo.Request()
-
-    interactor.fetchToDo(request: request)
+    interactor.fetchToDo()
 
     XCTAssertNil(interactor.toDo)
   }
@@ -119,9 +116,8 @@ class EditToDoInteractorTests: XCTestCase {
     )
     interactor.presenter = mockPresenter
     interactor.toDoId = EditToDoSceneTestData.Interactor.toDoId
-    let request = EditToDo.DeleteToDo.Request()
 
-    interactor.deleteToDo(request: request)
+    interactor.deleteToDo()
   }
 
   func test_투두_아이디가_존재하지_않으면_투두_삭제를_실패하는가() throws {
@@ -137,9 +133,8 @@ class EditToDoInteractorTests: XCTestCase {
       }
     )
     interactor.presenter = mockPresenter
-    let request = EditToDo.DeleteToDo.Request()
 
-    interactor.deleteToDo(request: request)
+    interactor.deleteToDo()
   }
 
   func test_투두_알림을_활성화하면_정상적으로_변경되는가() throws {
@@ -158,9 +153,8 @@ class EditToDoInteractorTests: XCTestCase {
     toDo.alarm.isAlarmOn = false
     interactor.toDo = EditToDoSceneTestData.Interactor.toDo
     interactor.presenter = mockPresenter
-    let request = EditToDo.ChangeAlarmActivation.Request()
 
-    interactor.changeAlarmActivation(request: request)
+    interactor.changeAlarmActivation()
 
     let toDoOfInteractor = try XCTUnwrap(interactor.toDo)
     XCTAssert(toDoOfInteractor.alarm.isAlarmOn == true)
@@ -299,6 +293,9 @@ class MockToDoPresenter: EditToDoPresentationLogic {
   func presentChangedRepetition(response: EditToDoSceneEntity.EditToDo.ChangeRepetition.Response) {
     self.presentRepetitionValidationClosure?(response.editToDoRepetitionViewState)
   }
+
+  func presentFetchedAlarmTime(response: EditToDoSceneEntity.EditToDo.FetchAlarmTime.Response) {}
+  func presentChangedAlarmTime(response: EditToDoSceneEntity.EditToDo.ChangeAlarmTime.Response) {}
 }
 
 struct MockToDoWorker: ToDoWorkLogic {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Tests/EditToDoSceneTests/EditToDoSceneBuilderTests.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Tests/EditToDoSceneTests/EditToDoSceneBuilderTests.swift
@@ -13,7 +13,6 @@ import XCTest
 class EditToDoSceneBuilderTests: XCTestCase {
   func test_EditToDoSceneBuilder가_투두_아이디를_Interactor에_성공적으로_전달하는가() throws {
     let dependency = EditToDoSceneBuilder.Dependency(
-      someWorker: EditToDoWorker(),
       toDoWorker: MockToDoWorker(),
       groupWorker: MockGroupWorker()
     )


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #433 

## 🎉 변경 사항
- EditToDoScene에 UI 업데이트와 관련된 VIP 사이클들을 추가하였습니다.
  - 서버로의 요청과 관련없는 VIP 사이클들만 추가하였습니다.

## 📌 PR Point
추가한 VIP 사이클들은 다음과 같습니다.

- 반복 범위를 설정하는 유스케이스는 DateRangePIcker가 완성되면 새로운 PR에서 작업하도록 하겠습니다 :)

### 1. 알림 활성화 변경
알림 스위치를 누르면, 투두의 알림 상태를 변경합니다.
- On일 경우 시간 설정 뷰가 Enable, Off일 경우 시간 설정 뷰가 Disable 됩니다.
<img width="250" src="https://github.com/user-attachments/assets/d6b6ca55-702f-4965-bec0-00148cf3548f">

## 2. 알림시간 조회 & 변경
알림 스위치가 켜져있을 때, 시간설정 버튼을 누르면 다음과 같이 동작합니다.
1. 버튼을 누르면 기존에 선택한 알림시간 가져옴 
2. PrickerView가 기존에 선택했던 알림시간에 위치함.
3. 사용자가 새로운 시간을 선택하고 완료버튼을 누르면 변경함.
<img width="1051" alt="스크린샷 2024-08-28 19 30 19" src="https://github.com/user-attachments/assets/22e2af11-5a1b-45c2-bb3c-b6cafbb0b215">

- Preview 동작
<img width="250" src="https://github.com/user-attachments/assets/0a330555-71b8-4792-8f35-0fea0e00a91e">

## 3. 반복 설정 변경
반복 설정 뷰를 누르면, Interactor가 뷰의 상태값을 결정하여 VIP 사이클로 전달합니다.
<img width="250" src="https://github.com/user-attachments/assets/9caf1c02-38a8-4d7d-8bec-9f5850e03e6a">

## 📝 셀프체크리스트
- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?