### PR TITLE
친구의 가든 뷰 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Package.swift
@@ -27,7 +27,13 @@ let package = Package(
   ],
   targets: [
     .target(
-      name: "ShareGardenSceneEntity"
+      name: "ShareGardenSceneEntity",
+      dependencies: [
+        Target.Dependency.product(
+          name: "ToDoGardenUIComponent",
+          package: "ToDoGardenUI"
+        )
+      ]
     ),
     .target(
       name: "ShareGardenSceneAPI",

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -49,4 +49,13 @@ extension ShareGardenSceneViewController.Constant.Layout {
     static let estimatedItemHeight: CGFloat = 48.0
     static let gradientLayerHeight: CGFloat = 25.0
   }
+  
+  enum FriendsGardenView {
+    static let editButtonWidth: CGFloat = 35.0
+    static let editButtonHeight: CGFloat = 35.0
+    static let stackViewSpacing = 15.0
+    static let sectionHeaderViewLeftInsetRatio: CGFloat = 28.0 / 375.0
+    static let sectionHeaderViewRightInsetRatio: CGFloat = 22.0 / 375.0
+    static let searchGardenButtonHorizontalInsetRatio: CGFloat = 19.0 / 375.0
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -38,4 +38,9 @@ extension ShareGardenSceneViewController.Constant.Layout {
   enum SectionHeaderView {
     static let spacingRatio: CGFloat = 100 / 323
   }
+  
+  enum FriendsGardenListViewCell {
+    static let contentViewBottomInsetWhenSelected: CGFloat = 15
+    static let gardenViewTopInsetWhenSelected: CGFloat = 9
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -43,4 +43,10 @@ extension ShareGardenSceneViewController.Constant.Layout {
     static let contentViewBottomInsetWhenSelected: CGFloat = 15
     static let gardenViewTopInsetWhenSelected: CGFloat = 9
   }
+  
+  enum FriendsGardenListView {
+    static let fullWidthRatio: CGFloat = 1.0
+    static let estimatedItemHeight: CGFloat = 48.0
+    static let gradientLayerHeight: CGFloat = 25.0
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -36,6 +36,6 @@ extension ShareGardenSceneViewController.Constant.StringLiteral {
 
 extension ShareGardenSceneViewController.Constant.Layout {
   enum SectionHeaderView {
-    static let spacingRatio: CGFloat = 194 / 323
+    static let spacingRatio: CGFloat = 100 / 323
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -27,6 +27,29 @@ extension ShareGardenSceneViewController.FriendsGardenView {
       return friendListView
     }()
     
+    private let gradientLayer: CAGradientLayer = {
+      let gradientLayer = CAGradientLayer()
+      gradientLayer.colors = [
+        UIColor.white.withAlphaComponent(1.0).cgColor,
+        UIColor.white.withAlphaComponent(0.8).cgColor,
+        UIColor.white.withAlphaComponent(0.3).cgColor,
+        UIColor.white.withAlphaComponent(0.0).cgColor
+      ]
+      gradientLayer.locations = [0.0, 0.4, 0.8, 1.0]
+      gradientLayer.startPoint = CGPoint(x: 0.5, y: 0.0)
+      gradientLayer.endPoint = CGPoint(x: 0.5, y: 1.0)
+      gradientLayer.isHidden = true
+      
+      return gradientLayer
+    }()
+    
+    override var bounds: CGRect {
+      didSet {
+        self.addGradientLayerIfNeeded()
+      }
+    }
+    
+    private var isGradientLayerAdded: Bool = false
     private let friendsGardenStore: FriendsGardenStore
     
     init(friendsGardenStore: FriendsGardenStore) {
@@ -142,5 +165,23 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
     }
     
     return false
+  }
+
+// MARK: - Gradient layer
+
+extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView {
+  
+  private func addGradientLayerIfNeeded() {
+    guard self.bounds.width != CGFloat.zero,
+      self.isGradientLayerAdded == false
+    else { return }
+    
+    self.gradientLayer.frame = CGRect(
+      x: CGFloat.zero,
+      y: CGFloat.zero,
+      width: self.bounds.width,
+      height: 25
+    )
+    self.layer.addSublayer(self.gradientLayer)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -45,7 +45,9 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     
     override var bounds: CGRect {
       didSet {
-        self.addGradientLayerIfNeeded()
+        if self.bounds.width != CGFloat.zero && self.isGradientLayerAdded == false {
+          self.addGradientLayer()
+        }
       }
     }
     
@@ -177,11 +179,7 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
 // MARK: - Gradient layer
 
 extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView {
-  private func addGradientLayerIfNeeded() {
-    guard self.bounds.width != CGFloat.zero,
-      self.isGradientLayerAdded == false
-    else { return }
-    
+  private func addGradientLayer() {
     self.gradientLayer.frame = CGRect(
       x: CGFloat.zero,
       y: CGFloat.zero,

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -16,6 +16,7 @@ protocol FriendsGardenStore {
 extension ShareGardenSceneViewController.FriendsGardenView {
   final class FriendsGardenListView: UICollectionView {
     private let friendsGardenStore: FriendsGardenStore
+    private lazy var friendsGardenListDataSource: DataSource = self.setupDataSource()
     
     init(friendsGardenStore: FriendsGardenStore) {
       self.friendsGardenStore = friendsGardenStore
@@ -29,6 +30,22 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     required init?(coder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
     }
+
+// MARK: - Type info
+
+extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView {
+  private enum Section {
+    case main
+  }
+  
+  private typealias DataSource = UICollectionViewDiffableDataSource<Section, ShareGardenScene.FriendsGarden.ID>
+  private typealias FriendsGardenListViewCell =
+  ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListViewCell
+  private typealias Snapshot =
+  NSDiffableDataSourceSnapshot<
+    ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView.Section,
+    ShareGardenScene.FriendsGarden.ID
+  >
 }
 
 // MARK: - layout
@@ -49,3 +66,24 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
     return UICollectionViewCompositionalLayout(section: section)
   }
 }
+
+// MARK: - Data Source
+
+extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView {
+  private func setupDataSource() -> DataSource {
+    let cellRegistration = UICollectionView.CellRegistration<
+      FriendsGardenListViewCell,
+      ShareGardenScene.FriendsGarden.ID
+    > { [weak self] cell, _, identifier in
+      guard let friendsGarden = self?.friendsGardenStore.fetchBy(identifier)
+      else { return }
+      
+      cell.configure(with: friendsGarden)
+    }
+    
+    return DataSource(collectionView: self) { collectionView, indexPath, identifier in
+      collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: identifier)
+    }
+  }
+}
+

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -14,17 +14,25 @@ protocol FriendsGardenStore {
 }
 
 extension ShareGardenSceneViewController.FriendsGardenView {
-  final class FriendsGardenListView: UICollectionView {
-    private let friendsGardenStore: FriendsGardenStore
+  final class FriendsGardenListView: UIView {
     private lazy var friendsGardenListDataSource: DataSource = self.setupDataSource()
-    
-    init(friendsGardenStore: FriendsGardenStore) {
-      self.friendsGardenStore = friendsGardenStore
-      super.init(
+    private lazy var friendListView: UICollectionView = {
+      let friendListView = UICollectionView(
         frame: CGRect.zero,
         collectionViewLayout: Self.makeFreindsGardenListViewLayout()
       )
-      self.delegate = self
+      friendListView.delegate = self
+      friendListView.backgroundColor = UIColor.white
+      
+      return friendListView
+    }()
+    
+    private let friendsGardenStore: FriendsGardenStore
+    
+    init(friendsGardenStore: FriendsGardenStore) {
+      self.friendsGardenStore = friendsGardenStore
+      super.init(frame: CGRect.zero)
+      self.setup()
     }
     
     @available(*, unavailable)
@@ -41,11 +49,16 @@ extension ShareGardenSceneViewController.FriendsGardenView {
   }
 }
 
+// MARK: - Setup
+
 extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView {
-  private func appendMainSectionIfNeeded(_ snapshot: inout Snapshot) {
-    if snapshot.sectionIdentifiers.contains(Section.main) == false {
-      snapshot.appendSections([Section.main])
-    }
+  private func setup () {
+    self.addSubviews()
+    self.setupLayoutCosntraints()
+  }
+  
+  private func addSubviews() {
+    self.addSubview(self.friendListView)
   }
 }
 
@@ -83,6 +96,15 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
     
     return UICollectionViewCompositionalLayout(section: section)
   }
+  
+  private func setupLayoutCosntraints() {
+    self.setupFriendListViewLayoutConstraints()
+  }
+  
+  private func setupFriendListViewLayoutConstraints() {
+    self.friendListView.usingAutolayout()
+    self.friendListView.equalToParent()
+  }
 }
 
 // MARK: - Data Source
@@ -99,8 +121,14 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
       cell.configure(with: friendsGarden)
     }
     
-    return DataSource(collectionView: self) { collectionView, indexPath, identifier in
+    return DataSource(collectionView: self.friendListView) { collectionView, indexPath, identifier in
       collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: identifier)
+    }
+  }
+  
+  private func appendMainSectionIfNeeded(_ snapshot: inout Snapshot) {
+    if snapshot.sectionIdentifiers.contains(Section.main) == false {
+      snapshot.appendSections([Section.main])
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -30,6 +30,23 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     required init?(coder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
     }
+    
+    func append(_ identifiers: [ShareGardenScene.FriendsGarden.ID]) {
+      var snapshot = self.friendsGardenListDataSource.snapshot()
+      self.appendMainSectionIfNeeded(&snapshot)
+      snapshot.appendItems(identifiers, toSection: Section.main)
+      self.friendsGardenListDataSource.apply(snapshot)
+    }
+  }
+}
+
+extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView {
+  private func appendMainSectionIfNeeded(_ snapshot: inout Snapshot) {
+    if snapshot.sectionIdentifiers.contains(Section.main) == false {
+      snapshot.appendSections([Section.main])
+    }
+  }
+}
 
 // MARK: - Type info
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -131,7 +131,6 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
   }
   
   private func setupFriendListViewLayoutConstraints() {
-    self.friendListView.usingAutolayout()
     self.friendListView.equalToParent()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -49,6 +49,8 @@ extension ShareGardenSceneViewController.FriendsGardenView {
       }
     }
     
+    private static let layoutConstant = ShareGardenSceneViewController.Constant.Layout.FriendsGardenListView.self
+    
     private var isGradientLayerAdded: Bool = false
     private let friendsGardenStore: FriendsGardenStore
     
@@ -107,8 +109,12 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
 extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView {
   private static func makeFreindsGardenListViewLayout() -> UICollectionViewCompositionalLayout {
     let itemSize = NSCollectionLayoutSize(
-      widthDimension: NSCollectionLayoutDimension.fractionalWidth(1.0),
-      heightDimension: NSCollectionLayoutDimension.estimated(48)
+      widthDimension: NSCollectionLayoutDimension.fractionalWidth(
+        Self.layoutConstant.fullWidthRatio
+      ),
+      heightDimension: NSCollectionLayoutDimension.estimated(
+        Self.layoutConstant.estimatedItemHeight
+      )
     )
     let item = NSCollectionLayoutItem(layoutSize: itemSize)
     let group = NSCollectionLayoutGroup.vertical(
@@ -202,7 +208,7 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
       x: CGFloat.zero,
       y: CGFloat.zero,
       width: self.bounds.width,
-      height: 25
+      height: Self.layoutConstant.gradientLayerHeight
     )
     self.layer.addSublayer(self.gradientLayer)
   }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -166,10 +166,32 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
     
     return false
   }
+  
+  func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    if scrollView.contentOffset.y <= 0 {
+      self.hideGradientLayerIfNeeded()
+    } else {
+      self.showGradientLayerOnTopIfNeeded()
+    }
+  }
+}
 
 // MARK: - Gradient layer
 
 extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView {
+  private func showGradientLayerOnTopIfNeeded() {
+    guard self.gradientLayer.isHidden
+    else { return }
+    
+    self.gradientLayer.isHidden = false
+  }
+  
+  private func hideGradientLayerIfNeeded() {
+    guard self.gradientLayer.isHidden == false
+    else { return }
+    
+    self.gradientLayer.isHidden = true
+  }
   
   private func addGradientLayerIfNeeded() {
     guard self.bounds.width != CGFloat.zero,

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -24,6 +24,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
         frame: CGRect.zero,
         collectionViewLayout: Self.makeFreindsGardenListViewLayout()
       )
+      self.delegate = self
     }
     
     @available(*, unavailable)
@@ -104,3 +105,14 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
   }
 }
 
+extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView: UICollectionViewDelegate {
+  func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+    if collectionView.indexPathsForSelectedItems?.contains(indexPath) ?? false {
+      collectionView.deselectItem(at: indexPath, animated: true)
+    } else {
+      collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
+    }
+    
+    return false
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -1,0 +1,51 @@
+//
+//  FriendsGardenListView.swift
+//  ShareGardenScene
+//
+//  Created by Noah on 8/23/24.
+//
+
+import UIKit
+
+import ShareGardenSceneEntity
+
+protocol FriendsGardenStore {
+  func fetchBy(_ id: ShareGardenScene.FriendsGarden.ID) -> ShareGardenScene.FriendsGarden?
+}
+
+extension ShareGardenSceneViewController.FriendsGardenView {
+  final class FriendsGardenListView: UICollectionView {
+    private let friendsGardenStore: FriendsGardenStore
+    
+    init(friendsGardenStore: FriendsGardenStore) {
+      self.friendsGardenStore = friendsGardenStore
+      super.init(
+        frame: CGRect.zero,
+        collectionViewLayout: Self.makeFreindsGardenListViewLayout()
+      )
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - layout
+
+extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView {
+  private static func makeFreindsGardenListViewLayout() -> UICollectionViewCompositionalLayout {
+    let itemSize = NSCollectionLayoutSize(
+      widthDimension: NSCollectionLayoutDimension.fractionalWidth(1.0),
+      heightDimension: NSCollectionLayoutDimension.estimated(48)
+    )
+    let item = NSCollectionLayoutItem(layoutSize: itemSize)
+    let group = NSCollectionLayoutGroup.vertical(
+      layoutSize: itemSize,
+      subitems: [item]
+    )
+    let section = NSCollectionLayoutSection(group: group)
+    
+    return UICollectionViewCompositionalLayout(section: section)
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -67,7 +67,9 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     
     func append(_ identifiers: [ShareGardenScene.FriendsGarden.ID]) {
       var snapshot = self.friendsGardenListDataSource.snapshot()
-      self.appendMainSectionIfNeeded(&snapshot)
+      if snapshot.sectionIdentifiers.contains(Section.main) == false {
+        snapshot.appendSections([Section.main])
+      }
       snapshot.appendItems(identifiers, toSection: Section.main)
       self.friendsGardenListDataSource.apply(snapshot)
     }
@@ -151,12 +153,6 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
     
     return DataSource(collectionView: self.friendListView) { collectionView, indexPath, identifier in
       collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: identifier)
-    }
-  }
-  
-  private func appendMainSectionIfNeeded(_ snapshot: inout Snapshot) {
-    if snapshot.sectionIdentifiers.contains(Section.main) == false {
-      snapshot.appendSections([Section.main])
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -168,7 +168,7 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
   }
   
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    if scrollView.contentOffset.y <= 0 {
+    if scrollView.contentOffset.y <= CGFloat.zero {
       self.hideGradientLayerIfNeeded()
     } else {
       self.showGradientLayerOnTopIfNeeded()

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -169,31 +169,14 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
   }
   
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    if scrollView.contentOffset.y <= CGFloat.zero {
-      self.hideGradientLayerIfNeeded()
-    } else {
-      self.showGradientLayerOnTopIfNeeded()
-    }
+    let isStartPointReached = scrollView.contentOffset.y <= CGFloat.zero
+    self.gradientLayer.isHidden = isStartPointReached
   }
 }
 
 // MARK: - Gradient layer
 
 extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView {
-  private func showGradientLayerOnTopIfNeeded() {
-    guard self.gradientLayer.isHidden
-    else { return }
-    
-    self.gradientLayer.isHidden = false
-  }
-  
-  private func hideGradientLayerIfNeeded() {
-    guard self.gradientLayer.isHidden == false
-    else { return }
-    
-    self.gradientLayer.isHidden = true
-  }
-  
   private func addGradientLayerIfNeeded() {
     guard self.bounds.width != CGFloat.zero,
       self.isGradientLayerAdded == false

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewCell.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewCell.swift
@@ -37,6 +37,18 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     
     private let gardenView: GardenView = GardenView()
     
+    // MARK: - Constraints
+    
+    private var selectedConstriaints: [NSLayoutConstraint] = []
+    private var deSelectedConstraints: [NSLayoutConstraint] = []
+    
+    override var isSelected: Bool {
+      didSet {
+        self.toggleConstraintsForSelectionState()
+        self.invalidateIntrinsicContentSize()
+      }
+    }
+    
     override init(frame: CGRect) {
       super.init(frame: frame)
       self.setup()
@@ -56,6 +68,8 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
     self.setupAppearance()
     self.addSubviews()
     self.setupLayoutConstraints()
+    self.setupConstraintsForSelectionState()
+    self.toggleConstraintsForSelectionState()
   }
   
   private func setupAppearance() {
@@ -66,6 +80,48 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
   private func addSubviews() {
     self.contentView.addSubview(self.gardenView)
     self.contentView.addSubview(self.profileInfoView)
+  }
+}
+
+// MARK: - Setup layout for selection state
+
+extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListViewCell {
+  private func setupConstraintsForSelectionState() {
+    let contentViewBottomSelected = self.contentView.bottomAnchor.constraint(
+      equalTo: self.gardenView.bottomAnchor,
+      constant: 15
+    )
+    contentViewBottomSelected.priority = UILayoutPriority.defaultLow
+    self.selectedConstriaints.append(contentViewBottomSelected)
+    
+    let contentViewBottomDeselected = self.contentView.bottomAnchor.constraint(
+      equalTo: self.profileInfoView.bottomAnchor
+    )
+    contentViewBottomDeselected.priority = UILayoutPriority.defaultLow
+    self.deSelectedConstraints.append(contentViewBottomDeselected)
+    
+    let gardenViewTopSelected = self.gardenView.topAnchor.constraint(
+      equalTo: self.profileInfoView.bottomAnchor,
+      constant: 9
+    )
+    gardenViewTopSelected.priority = UILayoutPriority.defaultLow
+    self.selectedConstriaints.append(gardenViewTopSelected)
+    
+    let gardenViewTopDeselected = self.gardenView.topAnchor.constraint(
+      equalTo: self.profileInfoView.topAnchor
+    )
+    gardenViewTopDeselected.priority = UILayoutPriority.defaultLow
+    self.deSelectedConstraints.append(gardenViewTopDeselected)
+  }
+  
+  private func toggleConstraintsForSelectionState() {
+    self.selectedConstriaints.forEach {
+      $0.isActive = self.isSelected
+    }
+    
+    self.deSelectedConstraints.forEach {
+      $0.isActive = !self.isSelected
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewCell.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewCell.swift
@@ -1,0 +1,109 @@
+//
+//  FriendsGardenListViewCell.swift
+//  ShareGardenScene
+//
+//  Created by Noah on 8/24/24.
+//
+
+import UIKit
+
+import ToDoGardenUIComponent
+import ToDoGardenUIResource
+
+import ShareGardenSceneEntity
+
+extension ShareGardenSceneViewController.FriendsGardenView {
+  final class FriendsGardenListViewCell: UICollectionViewCell {
+    
+    // MARK: - UI Properties
+    
+    /// 링크의 issue가 close되면, 구현이 바뀌게 될 예정입니다.
+    ///
+    /// [이슈 링크](https://github.com/ToDo-Garden/ToDo-Garden/issues/439)
+    private let profileInfoView: Styled.Row = {
+      let profileInfoView = Styled.Row(
+        configuration: Styled.Row.Configuration.profile(
+          Styled.Row.Configuration.ProfileModel.gardenInfo(
+            image: UIImage.defaultFriendProfileImage,
+            title: "이인우",
+            description: "연속 19일 집중!"
+          )
+        )
+      )
+      profileInfoView.backgroundColor = UIColor.white
+      
+      return profileInfoView
+    }()
+    
+    private let gardenView: GardenView = GardenView()
+    
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+      self.setup()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+  }
+}
+
+// MARK: - Setup
+
+extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListViewCell {
+  private func setup() {
+    self.setupAppearance()
+    self.addSubviews()
+    self.setupLayoutConstraints()
+  }
+  
+  private func setupAppearance() {
+    self.contentView.backgroundColor = UIColor.white
+    self.contentView.clipsToBounds = true
+  }
+  
+  private func addSubviews() {
+    self.contentView.addSubview(self.gardenView)
+    self.contentView.addSubview(self.profileInfoView)
+  }
+}
+
+// MARK: - Setup default layout constraints
+
+extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListViewCell {
+  private func setupLayoutConstraints() {
+    self.setupContentViewLayoutConstraints()
+    self.setupContentsContainerLayoutConstraints()
+    self.setupGardenViewLayoutConstraints()
+  }
+  
+  private func setupContentViewLayoutConstraints() {
+    self.contentView.usingAutolayout()
+    
+    NSLayoutConstraint.activate([
+      self.contentView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.contentView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.contentView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.contentView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+    ])
+  }
+  
+  private func setupContentsContainerLayoutConstraints() {
+    self.profileInfoView.usingAutolayout()
+    
+    NSLayoutConstraint.activate([
+      self.profileInfoView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
+      self.profileInfoView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
+      self.profileInfoView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor)
+    ])
+  }
+  
+  private func setupGardenViewLayoutConstraints() {
+    self.gardenView.usingAutolayout()
+    
+    self.gardenView.centerXAnchor.constraint(
+      equalTo: self.contentView.centerXAnchor
+    ).isActive = true
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewCell.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewCell.swift
@@ -94,9 +94,11 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
 
 extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListViewCell {
   private func setupConstraintsForSelectionState() {
+    let layoutConstant = ShareGardenSceneViewController.Constant.Layout.FriendsGardenListViewCell.self
+    
     let contentViewBottomSelected = self.contentView.bottomAnchor.constraint(
       equalTo: self.gardenView.bottomAnchor,
-      constant: 15
+      constant: layoutConstant.contentViewBottomInsetWhenSelected
     )
     contentViewBottomSelected.priority = UILayoutPriority.defaultLow
     self.selectedConstriaints.append(contentViewBottomSelected)
@@ -109,7 +111,7 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
     
     let gardenViewTopSelected = self.gardenView.topAnchor.constraint(
       equalTo: self.profileInfoView.bottomAnchor,
-      constant: 9
+      constant: layoutConstant.gardenViewTopInsetWhenSelected
     )
     gardenViewTopSelected.priority = UILayoutPriority.defaultLow
     self.selectedConstriaints.append(gardenViewTopSelected)

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewCell.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewCell.swift
@@ -100,7 +100,6 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
       equalTo: self.gardenView.bottomAnchor,
       constant: layoutConstant.contentViewBottomInsetWhenSelected
     )
-    contentViewBottomSelected.priority = UILayoutPriority.defaultLow
     self.selectedConstriaints.append(contentViewBottomSelected)
     
     let contentViewBottomDeselected = self.contentView.bottomAnchor.constraint(
@@ -119,7 +118,6 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
     let gardenViewTopDeselected = self.gardenView.topAnchor.constraint(
       equalTo: self.profileInfoView.topAnchor
     )
-    gardenViewTopDeselected.priority = UILayoutPriority.defaultLow
     self.deSelectedConstraints.append(gardenViewTopDeselected)
   }
   

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewCell.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewCell.swift
@@ -58,6 +58,13 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     required init?(coder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
     }
+    
+    /// [이슈](https://github.com/ToDo-Garden/ToDo-Garden/issues/439) 가 해결되면,
+    /// `profileInfoView`를 설정할 예정입니다.
+    func configure(with friendsGarden: ShareGardenScene.FriendsGarden) {
+      // TODO: - profileInfoView 설정 예정
+      self.gardenView.configure(with: friendsGarden.pomodoroRecords)
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -8,8 +8,11 @@
 import UIKit
 
 import TDUtility
+
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
+
+import ShareGardenSceneEntity
 
 extension ShareGardenSceneViewController {
   final class FriendsGardenView: UIStackView {
@@ -41,11 +44,14 @@ extension ShareGardenSceneViewController {
       return searchGardenButton
     }()
     
+    private let friendsGardenListView: FriendsGardenListView
+    
     // MARK: - Properties
     
     @ExecuteOnce private var setupLayoutIfNeeded: (() -> Void)?
     
-    init() {
+    init(friendsGardenStore: FriendsGardenStore) {
+      self.friendsGardenListView = FriendsGardenListView(friendsGardenStore: friendsGardenStore)
       super.init(frame: CGRect.zero)
       self.setup()
     }
@@ -82,6 +88,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
   private func addSubviews() {
     self.addArrangedSubview(self.sectionHeaderView)
     self.addArrangedSubview(self.searchGardenButton)
+    self.addArrangedSubview(self.friendsGardenListView)
   }
 }
 
@@ -91,6 +98,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
   private func setupLayoutConstraints() {
     self.setupSectionHeaderViewLayoutConstraints()
     self.setupSearchGardenButtonLayoutConstraints()
+    self.setupFriendsGadenListViewLayoutConstraints()
   }
   
   private func setupSectionHeaderViewLayoutConstraints() {
@@ -121,6 +129,15 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     NSLayoutConstraint.activate([
       self.searchGardenButton.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: horizontalInset),
       self.searchGardenButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -horizontalInset)
+    ])
+  }
+  
+  private func setupFriendsGadenListViewLayoutConstraints() {
+    self.friendsGardenListView.usingAutolayout()
+    
+    NSLayoutConstraint.activate([
+      self.friendsGardenListView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.friendsGardenListView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
     ])
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -34,6 +34,13 @@ extension ShareGardenSceneViewController {
       return SectionHeaderView(sectionTitle: title, rightActionButton: editButton)
     }()
     
+    private let searchGardenButton: UIButton = {
+      let searchGardenButton = UIButton()
+      searchGardenButton.searchGardenButtonStyle()
+      
+      return searchGardenButton
+    }()
+    
     // MARK: - Properties
     
     @ExecuteOnce private var setupLayoutIfNeeded: (() -> Void)?
@@ -74,6 +81,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
   
   private func addSubviews() {
     self.addArrangedSubview(self.sectionHeaderView)
+    self.addArrangedSubview(self.searchGardenButton)
   }
 }
 
@@ -102,6 +110,17 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     NSLayoutConstraint.activate([
       self.sectionHeaderView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
       self.sectionHeaderView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+    ])
+  }
+  
+  private func setupSearchGardenButtonLayoutConstraints() {
+    let horizontalInset: CGFloat = self.bounds.width * (19 / 375)
+    
+    self.searchGardenButton.usingAutolayout()
+    
+    NSLayoutConstraint.activate([
+      self.searchGardenButton.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: horizontalInset),
+      self.searchGardenButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -horizontalInset)
     ])
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -1,0 +1,42 @@
+//
+//  FriendsGardenView.swift
+//  ShareGardenScene
+//
+//  Created by Noah on 8/20/24.
+//
+
+import UIKit
+
+import TDUtility
+import ToDoGardenUIConstant
+import ToDoGardenUIResource
+
+extension ShareGardenSceneViewController {
+  final class FriendsGardenView: UIStackView {
+    
+    init() {
+      super.init(frame: CGRect.zero)
+      self.setup()
+    }
+    
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+  }
+}
+
+// MARK: - Setup view appearance
+
+extension ShareGardenSceneViewController.FriendsGardenView {
+  private func setup() {
+    self.setupStackView()
+  }
+  
+  private func setupStackView() {
+    self.spacing = 15
+    self.distribution = UIStackView.Distribution.fill
+    self.axis = NSLayoutConstraint.Axis.vertical
+    self.alignment = UIStackView.Alignment.center
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -14,6 +14,30 @@ import ToDoGardenUIResource
 extension ShareGardenSceneViewController {
   final class FriendsGardenView: UIStackView {
     
+    // MARK: - UI Properties
+    
+    private let sectionHeaderView: SectionHeaderView = {
+      let editButton = UIButton()
+      let editButtonTitle = ShareGardenSceneViewController.Constant
+        .StringLiteral.FriendsGardenSectionHeaderView.rightActionButtonTitle
+      editButton.setTitle(editButtonTitle, for: UIControl.State.normal)
+      editButton.setTitleColor(UIColor.toDoGardenEditButtonOrange, for: UIControl.State.normal)
+      editButton.setTitleColor(UIColor.toDoGardenGray, for: UIControl.State.highlighted)
+      editButton.titleLabel?.font = UIFont.pretendardDetailRegular12
+      editButton.usingAutolayout()
+      editButton.widthAnchor.constraint(equalToConstant: 35).isActive = true
+      editButton.heightAnchor.constraint(equalToConstant: 35).isActive = true
+      
+      let title = ShareGardenSceneViewController.Constant
+        .StringLiteral.FriendsGardenSectionHeaderView.title
+      
+      return SectionHeaderView(sectionTitle: title, rightActionButton: editButton)
+    }()
+    
+    // MARK: - Properties
+    
+    @ExecuteOnce private var setupLayoutIfNeeded: (() -> Void)?
+    
     init() {
       super.init(frame: CGRect.zero)
       self.setup()
@@ -23,6 +47,13 @@ extension ShareGardenSceneViewController {
     required init(coder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
     }
+    
+    override func layoutSubviews() {
+      super.layoutSubviews()
+      self.setupLayoutIfNeeded = {
+        self.setupLayoutConstraints()
+      }
+    }
   }
 }
 
@@ -31,6 +62,7 @@ extension ShareGardenSceneViewController {
 extension ShareGardenSceneViewController.FriendsGardenView {
   private func setup() {
     self.setupStackView()
+    self.addSubviews()
   }
   
   private func setupStackView() {
@@ -38,5 +70,38 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     self.distribution = UIStackView.Distribution.fill
     self.axis = NSLayoutConstraint.Axis.vertical
     self.alignment = UIStackView.Alignment.center
+  }
+  
+  private func addSubviews() {
+    self.addArrangedSubview(self.sectionHeaderView)
+  }
+}
+
+// MARK: - Setup layout constraints
+
+extension ShareGardenSceneViewController.FriendsGardenView {
+  private func setupLayoutConstraints() {
+    self.setupSectionHeaderViewLayoutConstraints()
+    self.setupSearchGardenButtonLayoutConstraints()
+  }
+  
+  private func setupSectionHeaderViewLayoutConstraints() {
+    let leftInset: CGFloat = self.bounds.width * (28 / 375)
+    let rightInset: CGFloat = self.bounds.width * (22 / 375)
+    
+    self.sectionHeaderView.layoutMargins = UIEdgeInsets(
+      top: CGFloat.zero,
+      left: leftInset,
+      bottom: CGFloat.zero,
+      right: rightInset
+    )
+    self.sectionHeaderView.isLayoutMarginsRelativeArrangement = true
+    
+    self.sectionHeaderView.usingAutolayout()
+    
+    NSLayoutConstraint.activate([
+      self.sectionHeaderView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.sectionHeaderView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+    ])
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -28,8 +28,10 @@ extension ShareGardenSceneViewController {
       editButton.setTitleColor(UIColor.toDoGardenGray, for: UIControl.State.highlighted)
       editButton.titleLabel?.font = UIFont.pretendardDetailRegular12
       editButton.usingAutolayout()
-      editButton.widthAnchor.constraint(equalToConstant: 35).isActive = true
-      editButton.heightAnchor.constraint(equalToConstant: 35).isActive = true
+      let editButtonWidth = FriendsGardenView.layoutConstant.editButtonWidth
+      let editButtonHeight = FriendsGardenView.layoutConstant.editButtonHeight
+      editButton.widthAnchor.constraint(equalToConstant: editButtonWidth).isActive = true
+      editButton.heightAnchor.constraint(equalToConstant: editButtonHeight).isActive = true
       
       let title = ShareGardenSceneViewController.Constant
         .StringLiteral.FriendsGardenSectionHeaderView.title
@@ -47,7 +49,7 @@ extension ShareGardenSceneViewController {
     private let friendsGardenListView: FriendsGardenListView
     
     // MARK: - Properties
-    
+    private static let layoutConstant = ShareGardenSceneViewController.Constant.Layout.FriendsGardenView.self
     @ExecuteOnce private var setupLayoutIfNeeded: (() -> Void)?
     
     init(friendsGardenStore: FriendsGardenStore) {
@@ -79,7 +81,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
   }
   
   private func setupStackView() {
-    self.spacing = 15
+    self.spacing = Self.layoutConstant.stackViewSpacing
     self.distribution = UIStackView.Distribution.fill
     self.axis = NSLayoutConstraint.Axis.vertical
     self.alignment = UIStackView.Alignment.center
@@ -102,8 +104,8 @@ extension ShareGardenSceneViewController.FriendsGardenView {
   }
   
   private func setupSectionHeaderViewLayoutConstraints() {
-    let leftInset: CGFloat = self.bounds.width * (28 / 375)
-    let rightInset: CGFloat = self.bounds.width * (22 / 375)
+    let leftInset: CGFloat = self.bounds.width * Self.layoutConstant.sectionHeaderViewLeftInsetRatio
+    let rightInset: CGFloat = self.bounds.width * Self.layoutConstant.sectionHeaderViewRightInsetRatio
     
     self.sectionHeaderView.layoutMargins = UIEdgeInsets(
       top: CGFloat.zero,
@@ -122,7 +124,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
   }
   
   private func setupSearchGardenButtonLayoutConstraints() {
-    let horizontalInset: CGFloat = self.bounds.width * (19 / 375)
+    let horizontalInset: CGFloat = self.bounds.width * Self.layoutConstant.searchGardenButtonHorizontalInsetRatio
     
     self.searchGardenButton.usingAutolayout()
     

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneEntity/ShareGardenSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneEntity/ShareGardenSceneModels.swift
@@ -6,7 +6,28 @@
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
 import Foundation
+// TODO: - PomodoroRecordCollection 이관 예정
+import ToDoGardenUIComponent
 
 public enum ShareGardenScene {
   // MARK: Use cases
+  
+  public struct FriendsGarden: Identifiable, Sendable {
+    public let id: UUID
+    public let nickname: String
+    public let focusStreakDays: Int
+    public let pomodoroRecords: PomodoroRecordCollection
+    
+    public init(
+      id: UUID = UUID(),
+      nickname: String,
+      focusStreakDays: Int,
+      pomodoroRecords: PomodoroRecordCollection
+    ) {
+      self.id = id
+      self.nickname = nickname
+      self.focusStreakDays = focusStreakDays
+      self.pomodoroRecords = pomodoroRecords
+    }
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecord.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecord.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct PomodoroRecord {
+public struct PomodoroRecord: Sendable {
   let date: Date
   let pomodoroCount: Int
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecordCollection.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/Model/PomodoroRecordCollection.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// PomodoroRecord 객체를 저장하는 first class collection입니다.
-public struct PomodoroRecordCollection {
+public struct PomodoroRecordCollection: Sendable {
   private var pomodoroRecords: [PomodoroRecord]
   private var maxPomodoroCount: Int?
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/Assets.xcassets/ToDoGardenEditButtonOrange.colorset/Contents.json
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/Assets.xcassets/ToDoGardenEditButtonOrange.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x0A",
+          "green" : "0xAC",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIColor+ToDoGarden.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIColor+ToDoGarden.swift
@@ -50,6 +50,8 @@ extension UIColor {
   
   public static let toDoGardenEditButtonYellow = UIColor(resource: .toDoGardenEditButtonYellow)
   
+  public static let toDoGardenEditButtonOrange = UIColor(resource: .toDoGardenEditButtonOrange)
+  
   public static let toDoGardenLightRed = UIColor(resource: .toDoGardenLightRed)
   
   public static let toDoGardenWhite = UIColor(resource: .toDoGardenWhite)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIFont+ToDoGarden.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIFont+ToDoGarden.swift
@@ -65,6 +65,11 @@ extension UIFont {
 		size: 15
 	) ?? UIFont.systemFont(ofSize: 15, weight: .regular)
 	
+  public static let pretendardDetailRegular12: UIFont = UIFont(
+    name: PretendardFont.regular.name,
+    size: 12
+  ) ?? UIFont.systemFont(ofSize: 12, weight: .regular)
+  
 	public static let pretendardDetailLight: UIFont = UIFont(
 		name: PretendardFont.light.name,
 		size: 12


### PR DESCRIPTION
## 💡 관련 이슈
- related: #298 
- related: #439 

## 🎉 변경 사항

친구의 가든 뷰 UI를 구현하였습니다.

| 친구의 가든 |
| --- |
|<img src="https://github.com/user-attachments/assets/8e68bb6a-7ebe-46fd-9a01-f7dfccd39b5f" width="500"/>|

## 📌 PR Point

### 📏 Expanding 효과 구현

친구의 가든을 리스트로 확인할 수 있는 뷰를 구현하였습니다.
|Expanding 효과 |
|---|
|<img src="https://github.com/user-attachments/assets/4383641d-1ec5-4813-8753-2b6e5bff22e5" width="200" />|

셀이 선택되었을 때와, 셀이 선택되지 않았을 때의 레이아웃을 달리하여 Expanding 효과를 구현하였습니다.

### 📜 자연스러운 스크롤 경험을 위한 CAGradientLayer 추가

| 적용 전 |
|---|
|<img width="400" alt="Screenshot 2024-09-02 at 12 36 42 AM" src="https://github.com/user-attachments/assets/adf4e05b-bfff-454b-9865-fb357a32ade7">|

기존 구현 방식의 경우 리스트를 스크롤 시 리스트의 요소가 상단부에 가려질 경우 마치 요소가 잘리는 듯한 느낌이 있었습니다.

자연스러운 스크롤 경험을 제공하기 위해 리스트 상단에 CAGradientLayer를 추가하여 자연스럽게 요소가 스크롤링 되어 사라지는 듯한 느낌이 들도록 하였습니다.

| 적용 후 |
|---|
|<img width="400" alt="Screenshot 2024-09-02 at 12 37 22 AM" src="https://github.com/user-attachments/assets/ba295e62-791b-4599-ad91-cb75ea0b2d70">|

또한 스크롤이 최상단에 있을 경우 CAGradientLayer가 노출이 되지 않도록 하여 최초의 요소가 가려지지 않도록 하였습니다.

```swift
  func scrollViewDidScroll(_ scrollView: UIScrollView) {
    if scrollView.contentOffset.y <= CGFloat.zero {
      self.hideGradientLayerIfNeeded()
    } else {
      self.showGradientLayerOnTopIfNeeded()
    }
  }

```

### 📦 PomodoroRecord Collection 이관 예정

현재 GardenView를 화면에 그리기 위해선 `PomodoroRecord`라는 모델이 필요합니다.
(PomodoroRecord Collection은 PomodoroRecord 자료구조를 관리하는 일급 컬렉션입니다.)
현재 투두가든의 구조는 데이터 모델은 ~SceneEntity라는 모듈에서 관리하고 있습니다.
따라서 PomodoroRecord를 사용하기 위해선 `ToDoGardenUIComponent`를 import 해야합니다.

모델을 관리하는 모듈에서 UI와 관련된 모듈을 import하는 것이 어색하다고 생각되어 PomodoroRecord 모델을 `ToDoGardenUIComponent`가 아닌 곳으로 이관하려 합니다.

해당 모델을 어느 모듈에 두어야할지 결정한 후에 별도의 이슈를 작성해 진행하도록 하겠습니다 🫡

### 📝 Styled.Row 컴포넌트 이슈 관련 주석 추가
현재 Styled.Row 컴포넌트에서 식별된 문제는 아래의 이슈에 작성되어 있으며 해당 이슈와 관련된 구현 내용은 별도의 주석으로 코드에 추가해두었습니다. 
해당 이슈가 close되면, 변경사항을 적용할 예정입니다 :)
- #439 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?