### PR TITLE
Styled Row 추가 구현

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -37,7 +37,8 @@ extension ShareGardenSceneViewController {
       
       let profileInfoView = Styled.Row(
         configuration: Styled.Row.Configuration.profile(
-          Styled.Row.Configuration.ProfileModel.primary(
+          Styled.Row.Configuration.ProfileModel(
+            style: Styled.Row.Configuration.ProfileModel.Style.shareProfile,
             title: nicknamePlaceholder,
             description: descriptionPlaceholder
           )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
@@ -35,7 +35,7 @@ extension Styled {
       }
     }
 
-    @Published var configuration: Configuration
+    @Published public var configuration: Configuration
     var cancellables: Set<AnyCancellable> = []
     
     public init(configuration: Configuration) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
@@ -36,7 +36,7 @@ extension Styled {
     }
 
     @Published public var configuration: Configuration
-    public var isSelected: Bool = false
+    @Published public var isSelected: Bool = false
     var cancellables: Set<AnyCancellable> = []
     
     public init(configuration: Configuration) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
@@ -36,6 +36,7 @@ extension Styled {
     }
 
     @Published public var configuration: Configuration
+    public var isSelected: Bool = false
     var cancellables: Set<AnyCancellable> = []
     
     public init(configuration: Configuration) {
@@ -183,8 +184,8 @@ extension Styled.Row {
     configuration: .profile(
       .init(
         style: .setting,
-        title: "ABCD",
-        description:"ER"
+        title: "Setting",
+        description: "안녕하세요"
       )
     )
   )
@@ -194,8 +195,8 @@ extension Styled.Row {
     configuration: .profile(
       .init(
         style: .shareProfile,
-        title: "ABCD",
-        description:"ER"
+        title: "Share Profile",
+        description: "안녕하세요"
       )
     )
   )
@@ -205,8 +206,8 @@ extension Styled.Row {
     configuration: .profile(
       .init(
         style: .shareRow,
-        title: "ABCD",
-        description:"ERasdfasdfadsfas"
+        title: "Share Row",
+        description: "15일째 연속 집중!"
       )
     )
   )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
@@ -56,10 +56,14 @@ extension Styled {
     }
     
     private func build() {
-      let stack = UIStackView(frame: CGRect.zero)
+      var stack = UIStackView(frame: CGRect.zero)
       switch self.configuration {
       case let Configuration.profile(profileModel):
-        self.buildProfileStyle(stack: stack, model: profileModel)
+        stack = self.buildProfileStyle(model: profileModel)
+        self.layoutContainer(
+          stack,
+          innerPadding: profileModel[style: \.innerPadding]
+        )
       case let Configuration.listPrimary(listPrimaryModel):
         self.buildListPrimaryStyle(stack: stack, model: listPrimaryModel)
       case let Configuration.todoList(todoListModel):
@@ -83,6 +87,44 @@ extension Styled {
 }
 
 // MARK: - Shared View Logic
+// 앞으로의 방향
+extension Styled.Row {
+  func buildImageView(
+    image: UIImage,
+    size: CGSize
+  ) -> UIImageView {
+    let imageView = UIImageView(image: image)
+    imageView.usingAutolayout()
+    NSLayoutConstraint.activate([
+      imageView.widthAnchor.constraint(equalToConstant: size.width),
+      imageView.heightAnchor.constraint(equalToConstant: size.height)
+    ])
+    return imageView
+  }
+  
+  func buildTextLabel(
+    text: String,
+    font: UIFont,
+    textColor: UIColor
+  ) -> UILabel {
+    let label = UILabel()
+    label.text = text
+    label.font = font
+    label.textColor = textColor
+    return label
+  }
+  
+  private func layoutContainer(
+    _ stack: UIStackView,
+    innerPadding: NSDirectionalEdgeInsets
+  ) {
+    stack.isLayoutMarginsRelativeArrangement = true
+    stack.directionalLayoutMargins = innerPadding
+    self.addSubview(stack)
+    stack.equalToParent()
+  }
+}
+
 extension Styled.Row {
   func buildStack(
     stack: UIStackView,
@@ -137,23 +179,53 @@ extension Styled.Row {
 
 @available(iOS 17.0, *)
 #Preview {
-  let stack = UIStackView()
-  stack.axis = .vertical
-  stack.spacing = 20
-
   let row = Styled.Row(
-    configuration: .listPrimary(.init(title: "영어독해", color: .red))
+    configuration: .profile(
+      .init(
+        style: .setting,
+        title: "ABCD",
+        description:"ER"
+      )
+    )
   )
-  stack.addArrangedSubview(row)
-
-  let button = UIButton()
-  button.setImage(UIImage.forwardButtonImage, for: UIControl.State.normal)
-
+  row.backgroundColor = .systemIndigo
+  
   let row2 = Styled.Row(
-    configuration: .listPrimary(.init(title: "영어독해", color: .toDoGardenYellow)),
-    with: [button]
+    configuration: .profile(
+      .init(
+        style: .shareProfile,
+        title: "ABCD",
+        description:"ER"
+      )
+    )
   )
-  stack.addArrangedSubview(row2)
+  row2.backgroundColor = .yellow
+  
+  let row3 = Styled.Row(
+    configuration: .profile(
+      .init(
+        style: .shareRow,
+        title: "ABCD",
+        description:"ERasdfasdfadsfas"
+      )
+    )
+  )
+  row3.backgroundColor = .brown
 
+  let stack = UIVStackView(
+    arrangedSubviews: [
+      row, row2, row3
+    ]
+  )
+  row.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+  row2.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+  row3.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+
+  stack.alignment = .leading
+  stack.backgroundColor = .green
+  
+  stack.translatesAutoresizingMaskIntoConstraints = false
+  stack.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width).isActive = true
+  
   return stack
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
@@ -39,51 +39,33 @@ extension Styled.Row {
 }
 
 extension Styled.Row.Configuration {
-  public struct ProfileModel: Equatable {
-    public static func primary(
-      image: UIImage = UIImage.defaultProfileImage,
+  public struct ProfileModel {
+    public var style: Style
+    public var title: String
+    public var description: String
+    public var image: UIImage
+    
+    public init(
+      style: Style,
       title: String,
-      description: String
-    ) -> Self {
-      return Self(
-        image: image,
-        title: title,
-        titleFont: UIFont.pretendardHeadBold,
-        description: description,
-        descriptionFont: UIFont.pretendardDetailLight,
-        axis: NSLayoutConstraint.Axis.vertical,
-        profileSize: Constant.Styled.Row.Profile.shareProfileSize
-      )
+      description: String,
+      image: UIImage? = nil
+    ) {
+      self.style = style
+      self.title = title
+      self.description = description
+      self.image = image ?? style.defaultImage
     }
     
-    public static func gardenInfo(
-      image: UIImage = UIImage.defaultFriendProfileImage,
-      title: String,
-      description: String
-    ) -> Self {
-      return Self(
-        image: image,
-        title: title,
-        titleFont: UIFont.pretendardBodySemiBold,
-        description: description,
-        descriptionFont: UIFont.pretendardBodyMedium,
-        axis: NSLayoutConstraint.Axis.horizontal,
-        profileSize: Constant.Styled.Row.Profile.friendListProfileSize
-      )
+    subscript<T>(style keypath: KeyPath<Style, T>) -> T {
+      style[keyPath: keypath]
     }
-    var image: UIImage = UIImage.defaultFriendProfileImage
-    var title: String
-    var titleFont: UIFont
-    var description: String
-    var descriptionFont: UIFont
-    var axis: NSLayoutConstraint.Axis
-    var profileSize: CGSize
   }
   
   public struct ListPrimaryModel: Equatable {
     let title: String
     let color: UIColor
-
+    
     public init(title: String, color: UIColor) {
       self.title = title
       self.color = color
@@ -113,5 +95,65 @@ extension Styled.Row.Configuration {
       self.isSelected = isSelected
       self.hasAlert = hasAlert
     }
+  }
+}
+
+extension Styled.Row.Configuration.ProfileModel {
+  public enum Style {
+    var axis: NSLayoutConstraint.Axis {
+      self == .shareRow
+      ? NSLayoutConstraint.Axis.horizontal
+      : NSLayoutConstraint.Axis.vertical
+    }
+    
+    var innerPadding: NSDirectionalEdgeInsets {
+      switch self {
+      case Self.setting:
+        return NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
+      case Self.shareProfile:
+        return NSDirectionalEdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 36)
+      case Self.shareRow:
+        return NSDirectionalEdgeInsets(top: 6, leading: 25, bottom: 6, trailing: 25)
+      }
+    }
+    
+    var defaultImage: UIImage {
+      self == Self.shareRow
+      ? UIImage.defaultProfileImage
+      : UIImage.defaultFriendProfileImage
+    }
+    
+    var imageSize: CGSize {
+      self == Self.shareRow
+      ? CGSize(width: 36, height: 36)
+      : CGSize(width: 56, height: 56)
+    }
+    
+    var profileImageTrailingPadding: CGFloat {
+      switch self {
+      case Self.setting:
+        return 8
+      case Self.shareProfile:
+        return 15
+      case Self.shareRow:
+        return 6
+      }
+    }
+    
+    var titleFont: UIFont {
+      self == Self.shareRow
+      ? UIFont.pretendardBodyBold
+      : UIFont.pretendardHeadBold
+    }
+    
+    var descriptionFont: UIFont {
+      self == Self.shareRow
+      ? UIFont.pretendardBodyMedium
+      : UIFont.pretendardDetailLight
+    }
+    
+    case setting
+    case shareProfile
+    case shareRow
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
@@ -101,7 +101,7 @@ extension Styled.Row.Configuration {
 extension Styled.Row.Configuration.ProfileModel {
   public enum Style {
     var axis: NSLayoutConstraint.Axis {
-      self == .shareRow
+      self == Self.shareRow
       ? NSLayoutConstraint.Axis.horizontal
       : NSLayoutConstraint.Axis.vertical
     }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
@@ -24,15 +24,13 @@ extension Styled.Row {
     let profileImageTrailingPadding = UIView()
     
     let innerStack = self.buildInnerStack(model: model)
-    let forwardImageView = self.buildImageView(
-      image: UIImage.forwardButtonImage,
-      size: Constant.Styled.Row.Profile.accessorySize
-    )
+    let forwordButton = self.buildForwordButton(model: model)
+    
     var subviews = [
       profileImageView,
       profileImageTrailingPadding,
       innerStack,
-      forwardImageView
+      forwordButton
     ]
     if model[style: \.axis] == .vertical {
       subviews.insert(UIView(), at: 3)
@@ -69,6 +67,32 @@ extension Styled.Row {
     }
     
     return stack
+  }
+  
+  private func buildForwordButton(model: Configuration.ProfileModel) -> UIButton {
+    let action = UIAction { action in
+      guard
+        model.style == Configuration.ProfileModel.Style.shareRow,
+        let button = action.sender as? UIButton,
+        let imageView = button.imageView
+      else { return }
+      let angle = imageView.transform == CGAffineTransform.identity
+      ? CGFloat.pi / 2
+      : 0
+      UIView.animate(withDuration: 0.2) {
+        imageView.transform = CGAffineTransform(rotationAngle: angle)
+      }
+    }
+    let button = UIButton(
+      configuration: UIButton.Configuration.plain(),
+      primaryAction: action
+    )
+    button.configuration?.image = UIImage.forwardButtonImage
+    let size = Constant.Styled.Row.Profile.accessorySize
+    button.widthAnchor.constraint(equalToConstant: size.width).isActive = true
+    button.heightAnchor.constraint(equalToConstant: size.height).isActive = true
+    
+    return button
   }
   
   private func bindingProfileImageState(imageView: UIImageView) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
@@ -10,10 +10,10 @@ extension Styled.Row {
     let imageView = self.buildImageView(
       stack: stack,
       image: model.image,
-      size: model.profileSize
+      size: model[style: \.imageSize]
     )
     self.buildInnerStack(stack: stack, model: model)
-    if model.axis == NSLayoutConstraint.Axis.vertical {
+    if model[style: \.axis] == NSLayoutConstraint.Axis.vertical {
       stack.addSpacing()
     }
     self.buildImageView(
@@ -34,18 +34,19 @@ extension Styled.Row {
   
   private func buildInnerStack(stack: UIStackView, model: Configuration.ProfileModel) {
     let innerStack = UIStackView()
-    innerStack.axis = model.axis
+    innerStack.axis = model[style: \.axis]
+    
     let titleLabel = self.buildTextLabel(
       stack: innerStack,
       text: model.title,
-      font: model.titleFont,
+      font: model[style: \.titleFont],
       textColor: .toDoGardenGreenDark
     )
-    addConditionalSpacing(innerStack, axis: model.axis)
+    addConditionalSpacing(innerStack, axis: model[style: \.axis])
     let descriptionLabel = self.buildTextLabel(
       stack: innerStack,
       text: model.description,
-      font: model.descriptionFont,
+      font: model[style: \.descriptionFont],
       textColor: .toDoGardenGreenDark
     )
     stack.addArrangedSubview(innerStack)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
@@ -5,66 +5,70 @@ import ToDoGardenUIConstant
 
 // MARK: - ProfileStyle
 extension Styled.Row {
-  func buildProfileStyle(stack: UIStackView, model: Configuration.ProfileModel) {
-    self.buildProfileStyleStack(stack: stack)
-    let imageView = self.buildImageView(
-      stack: stack,
-      image: model.image,
+  func buildProfileStyle(model: Configuration.ProfileModel) -> UIStackView {
+    let stack = UIHStackView(
+      spacing: 0,
+      arrangedSubviews: self.buildProfileSubviews(model: model)
+    )
+    stack.addInnerPadding(model[style: \.innerPadding])
+    
+    return stack
+  }
+  
+  private func buildProfileSubviews(model: Configuration.ProfileModel) -> [UIView] {
+    let profileImageView = self.buildImageView(
+      image: model[style: \.defaultImage],
       size: model[style: \.imageSize]
     )
-    self.buildInnerStack(stack: stack, model: model)
-    if model[style: \.axis] == NSLayoutConstraint.Axis.vertical {
-      stack.addSpacing()
-    }
-    self.buildImageView(
-      stack: stack,
+    self.bindingProfileImageState(imageView: profileImageView)
+    let profileImageTrailingPadding = UIView()
+    
+    let innerStack = self.buildInnerStack(model: model)
+    let forwardImageView = self.buildImageView(
       image: UIImage.forwardButtonImage,
       size: Constant.Styled.Row.Profile.accessorySize
     )
-    self.bindingProfileImageState(imageView: imageView)
-  }
-  
-  private func buildProfileStyleStack(stack: UIStackView) {
-    stack.spacing = Constant.Styled.Row.Profile.stackSpacing
-    self.buildStack(
-      stack: stack,
-      edgeInsets: Constant.Styled.Row.Profile.stackEdgeInsets
-    )
-  }
-  
-  private func buildInnerStack(stack: UIStackView, model: Configuration.ProfileModel) {
-    let innerStack = UIStackView()
-    innerStack.axis = model[style: \.axis]
+    var subviews = [
+      profileImageView,
+      profileImageTrailingPadding,
+      innerStack,
+      forwardImageView
+    ]
+    if model[style: \.axis] == .vertical {
+      subviews.insert(UIView(), at: 3)
+    }
+    profileImageTrailingPadding.widthAnchor
+      .constraint(equalToConstant: model[style: \.profileImageTrailingPadding]).isActive = true
     
+    return subviews
+  }
+  
+  private func buildInnerStack(model: Configuration.ProfileModel) -> UIStackView {
     let titleLabel = self.buildTextLabel(
-      stack: innerStack,
       text: model.title,
       font: model[style: \.titleFont],
-      textColor: .toDoGardenGreenDark
+      textColor: UIColor.toDoGardenGreenDark
     )
-    addConditionalSpacing(innerStack, axis: model[style: \.axis])
     let descriptionLabel = self.buildTextLabel(
-      stack: innerStack,
       text: model.description,
       font: model[style: \.descriptionFont],
-      textColor: .toDoGardenGreenDark
+      textColor: UIColor.toDoGardenGreenDark
     )
-    stack.addArrangedSubview(innerStack)
-    bindingProfileInnerTitleState(
+    self.bindingProfileInnerTitleState(
       titleLabel: titleLabel,
       descriptionLabel: descriptionLabel
     )
-  }
-  
-  private func addConditionalSpacing(_ stack: UIStackView, axis: NSLayoutConstraint.Axis) {
-    switch axis {
-    case NSLayoutConstraint.Axis.vertical:
-      stack.spacing = Constant.Styled.Row.Profile.conditionSpacing
-    case NSLayoutConstraint.Axis.horizontal:
-      stack.addSpacing()
-    @unknown default:
-      break
+    
+    let spacing = UIView()
+    let subviews: [UIView] = [titleLabel, spacing, descriptionLabel]
+    let stack = UIStackView(arrangedSubviews: subviews)
+    stack.axis = model[style: \.axis]
+    
+    if model[style: \.axis] == NSLayoutConstraint.Axis.vertical {
+      spacing.heightAnchor.constraint(equalToConstant: 3).isActive = true
     }
+    
+    return stack
   }
   
   private func bindingProfileImageState(imageView: UIImageView) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
@@ -11,10 +11,9 @@ extension Styled.Row {
       arrangedSubviews: self.buildProfileSubviews(model: model)
     )
     stack.addInnerPadding(model[style: \.innerPadding])
-    
     return stack
   }
-  
+
   private func buildProfileSubviews(model: Configuration.ProfileModel) -> [UIView] {
     let profileImageView = self.buildImageView(
       image: model[style: \.defaultImage],
@@ -24,13 +23,16 @@ extension Styled.Row {
     let profileImageTrailingPadding = UIView()
     
     let innerStack = self.buildInnerStack(model: model)
-    let forwordButton = self.buildForwordButton(model: model)
+    let forwardImage = UIImageView(image: UIImage.forwardButtonImage)
+    if model.style == Configuration.ProfileModel.Style.shareRow {
+      self.bindingForwardImage(imageView: forwardImage)
+    }
     
     var subviews = [
       profileImageView,
       profileImageTrailingPadding,
       innerStack,
-      forwordButton
+      forwardImage
     ]
     if model[style: \.axis] == .vertical {
       subviews.insert(UIView(), at: 3)
@@ -69,32 +71,6 @@ extension Styled.Row {
     return stack
   }
   
-  private func buildForwordButton(model: Configuration.ProfileModel) -> UIButton {
-    let action = UIAction { action in
-      guard
-        model.style == Configuration.ProfileModel.Style.shareRow,
-        let button = action.sender as? UIButton,
-        let imageView = button.imageView
-      else { return }
-      let angle = imageView.transform == CGAffineTransform.identity
-      ? CGFloat.pi / 2
-      : 0
-      UIView.animate(withDuration: 0.2) {
-        imageView.transform = CGAffineTransform(rotationAngle: angle)
-      }
-    }
-    let button = UIButton(
-      configuration: UIButton.Configuration.plain(),
-      primaryAction: action
-    )
-    button.configuration?.image = UIImage.forwardButtonImage
-    let size = Constant.Styled.Row.Profile.accessorySize
-    button.widthAnchor.constraint(equalToConstant: size.width).isActive = true
-    button.heightAnchor.constraint(equalToConstant: size.height).isActive = true
-    
-    return button
-  }
-  
   private func bindingProfileImageState(imageView: UIImageView) {
     self.$configuration
       .map(\.profileModel?.image)
@@ -121,6 +97,17 @@ extension Styled.Row {
       .removeDuplicates()
       .sink { [weak titleLabel] text in
         titleLabel?.text = text
+      }
+      .store(in: &cancellables)
+  }
+  
+  private func bindingForwardImage(imageView: UIImageView) {
+    self.$isSelected
+      .sink { [weak imageView] isSelected in
+        let angle = isSelected ? CGFloat.pi / 2 : 0
+        UIView.animate(withDuration: 0.2) {
+          imageView?.transform = CGAffineTransform(rotationAngle: angle)
+        }
       }
       .store(in: &cancellables)
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIStackView+Extension.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIStackView+Extension.swift
@@ -1,4 +1,3 @@
-import enum SwiftUICore.Edge
 import UIKit
 
 extension UIStackView {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIStackView+Extension.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIStackView+Extension.swift
@@ -1,3 +1,4 @@
+import enum SwiftUICore.Edge
 import UIKit
 
 extension UIStackView {
@@ -22,8 +23,13 @@ extension UIStackView {
   
   // 스택뷰에 뷰를 추가하고 여백을 추가합니다.
   public func addArrangedSubViewWithSpacing(_ view: UIView, spacing: CGFloat? = nil) {
-    addArrangedSubview(view)
-    addSpacing(spacing)
+    self.addArrangedSubview(view)
+    self.addSpacing(spacing)
+  }
+  
+  public func addInnerPadding(_ value: NSDirectionalEdgeInsets) {
+    self.isLayoutMarginsRelativeArrangement = true
+    self.directionalLayoutMargins = value
   }
 }
 
@@ -41,6 +47,8 @@ open class UIHStackView: UIStackView {
     arrangedSubviews subviews: [UIView]
   ) {
     super.init(frame: CGRect.zero)
+    self.alignment = alignment
+    self.spacing = spacing
     subviews.forEach {
       self.addArrangedSubview($0)
     }
@@ -66,6 +74,9 @@ open class UIVStackView: UIStackView {
     arrangedSubviews subviews: [UIView]
   ) {
     super.init(frame: CGRect.zero)
+    self.alignment = alignment
+    self.spacing = spacing
+    super.axis = .vertical
     subviews.forEach {
       self.addArrangedSubview($0)
     }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+Styled+Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+Styled+Row.swift
@@ -28,7 +28,6 @@ public extension Constant.Styled.Row.Profile {
   static let friendListProfileSize = CGSize(width: 36, height: 36)
   static let accessorySize = CGSize(width: 24, height: 24)
   static let stackSpacing = CGFloat(15)
-  static let stackEdgeInsets = NSDirectionalEdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 36)
   static let conditionSpacing = CGFloat(3)
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
#439 , [Notion](https://www.notion.so/Styled-Row-b33dd35cdde148a48e5a354edcc4e645?pvs=4)

## 🎉 변경 사항
뷰 작성 방식 변경
Stack을 전달하는 형태로 내부에서 서브뷰를 추가하는 방식에서 Stack을 리턴시키고 호출자가 해당 리턴값을 사용하도록 수정.
제가 아닌 사람이 해당 코드를 보게 됐을 경우, 내부에서 Stack을 처리하는게 일반적인 방법은 아니라는 생각이 들어서 조금 더 접근하기 쉽도록 수정했습니다.

Styled Row로 생성할 수 있는 모든 뷰
<img width="446" alt="image" src="https://github.com/user-attachments/assets/e3b85e2e-5c83-4c9e-aea5-ae391ad6d1bc">

Center X가 맞지 않는 문제 수정
![image](https://github.com/user-attachments/assets/9ba894b7-4c60-4a80-b83f-56b5bbf4c5ad)


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?