### PR TITLE
그룹관리 VIP 사이클 개선

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -17,25 +17,19 @@ protocol ManageGroupBusinessLogic {
   func fetchGroupList(request: ManageGroup.FetchGroupList.Request) async
   func saveGroupList(request: ManageGroup.SaveGroupList.Request) async
   func deleteGroup(request: ManageGroup.DeleteGroup.Request)
-  func reorderGroup(request: ManageGroup.ReorderGroup.Request)
-  func addReorderedGroups(
-    id: String,
-    sourceIndex: Int,
-    destinationIndex: Int
-  )
   func cancelEditing()
 }
 
 class ManageGroupInteractor: ManageGroupDataStore {
   var presenter: ManageGroupPresentationLogic?
-  //  private var reorderedGroups: [ManageGroup.ReorderedGroup]
   private let manageGroupWorker: ManageGroupWorkable
+  private var currentGroups: [ManageGroup.ToDoGroup]
   
   init(
     worker: ManageGroupWorkable
   ) {
-    //    self.reorderedGroups = []
     self.manageGroupWorker = worker
+    self.currentGroups = []
   }
 }
 
@@ -67,18 +61,12 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
   }
   
   func deleteGroup(request: ManageGroup.DeleteGroup.Request) {
-  }
-  
-  func reorderGroup(request: ManageGroup.ReorderGroup.Request) {
+    self.currentGroups.remove(at: request.index)
+    let response = ManageGroup.DeleteGroup.Response(id: request.id, index: request.index)
+    self.presenter?.presentDeletedGroup(response: response)
   }
   
   func cancelEditing() {
-  }
-  
-  func addReorderedGroups(
-    id: String,
-    sourceIndex: Int,
-    destinationIndex: Int
-  ) {
+    self.presenter?.presentCancelEditingGroup()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -14,7 +14,8 @@ protocol ManageGroupDataStore {
 }
 
 protocol ManageGroupBusinessLogic {
-  func fetchGroupList(request: ManageGroup.FetchGroupList.Request)
+  func fetchGroupList(request: ManageGroup.FetchGroupList.Request) async
+  func saveGroupList(request: ManageGroup.SaveGroupList.Request) async
   func deleteGroup(request: ManageGroup.DeleteGroup.Request)
   func reorderGroup(request: ManageGroup.ReorderGroup.Request)
   func addReorderedGroups(
@@ -41,11 +42,28 @@ class ManageGroupInteractor: ManageGroupDataStore {
 // MARK: - Request to worker
 
 extension ManageGroupInteractor: ManageGroupBusinessLogic {
-  func fetchGroupList(request: ManageGroup.FetchGroupList.Request) {
-    self.manageGroupWorker.fetchGroupList(request: request)
-    
-    let response = ManageGroup.FetchGroupList.Response(with: "SomeResponse")
-    self.presenter?.presentFetchedGroupList(response: response)
+  func fetchGroupList(request: ManageGroup.FetchGroupList.Request) async {
+    let result = await self.manageGroupWorker.fetchGroupList(request: request)
+    switch result {
+    case .success(let groups):
+      self.currentGroups = groups
+      let response = ManageGroup.FetchGroupList.Response(with: groups)
+      self.presenter?.presentFetchedGroupList(response: response)
+    case .failure(let error):
+      print("Error fetching group list: \(error)")
+    }
+  }
+  
+  func saveGroupList(request: ManageGroupSceneEntity.ManageGroup.SaveGroupList.Request) async {
+    let result = await self.manageGroupWorker.saveGroupList(request: request)
+    switch result {
+    case .success(let groups):
+      self.currentGroups = groups
+      let response = ManageGroup.SaveGroupList.Response(with: groups)
+      self.presenter?.presentSaveGroupList(response: response)
+    case .failure(let error):
+      print("Error fetching group list: \(error)")
+    }
   }
   
   func deleteGroup(request: ManageGroup.DeleteGroup.Request) {

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -17,7 +17,6 @@ protocol ManageGroupBusinessLogic {
   func fetchGroupList(request: ManageGroup.FetchGroupList.Request) async
   func saveGroupList(request: ManageGroup.SaveGroupList.Request) async
   func deleteGroup(request: ManageGroup.DeleteGroup.Request)
-  func cancelEditing()
 }
 
 class ManageGroupInteractor: ManageGroupDataStore {
@@ -64,9 +63,5 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
     self.currentGroups.remove(at: request.index)
     let response = ManageGroup.DeleteGroup.Response(id: request.id, index: request.index)
     self.presenter?.presentDeletedGroup(response: response)
-  }
-  
-  func cancelEditing() {
-    self.presenter?.presentCancelEditingGroup()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -53,7 +53,7 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
     case .success(let groups):
       self.currentGroups = groups
       let response = ManageGroup.SaveGroupList.Response(with: groups)
-      self.presenter?.presentSaveGroupList(response: response)
+      self.presenter?.presentSavedGroupList(response: response)
     case .failure(let error):
       print("Error fetching group list: \(error)")
     }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
@@ -13,7 +13,6 @@ protocol ManageGroupPresentationLogic {
   func presentFetchedGroupList(response: ManageGroup.FetchGroupList.Response)
   func presentSaveGroupList(response: ManageGroup.SaveGroupList.Response)
   func presentDeletedGroup(response: ManageGroup.DeleteGroup.Response)
-  func presentCancelEditingGroup()
 }
 
 class ManageGroupPresenter {
@@ -39,9 +38,5 @@ extension ManageGroupPresenter: ManageGroupPresentationLogic {
       index: response.index
     )
     self.viewController?.displayDeletedGroup(viewModel: viewModel)
-  }
-  
-  func presentCancelEditingGroup() {
-    self.viewController?.displayCancelEditingGroup()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
@@ -11,7 +11,7 @@ import ManageGroupSceneEntity
 
 protocol ManageGroupPresentationLogic {
   func presentFetchedGroupList(response: ManageGroup.FetchGroupList.Response)
-  func presentSaveGroupList(response: ManageGroup.SaveGroupList.Response)
+  func presentSavedGroupList(response: ManageGroup.SaveGroupList.Response)
   func presentDeletedGroup(response: ManageGroup.DeleteGroup.Response)
 }
 
@@ -27,7 +27,7 @@ extension ManageGroupPresenter: ManageGroupPresentationLogic {
     self.viewController?.displayFetchedGroupList(viewModel: viewModel)
   }
   
-  func presentSaveGroupList(response: ManageGroup.SaveGroupList.Response) {
+  func presentSavedGroupList(response: ManageGroup.SaveGroupList.Response) {
     let viewModel = ManageGroup.SaveGroupList.ViewModel(with: response.data)
     self.viewController?.displaySavedGroupList(viewModel: viewModel)
   }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
@@ -13,7 +13,7 @@ protocol ManageGroupPresentationLogic {
   func presentFetchedGroupList(response: ManageGroup.FetchGroupList.Response)
   func presentSaveGroupList(response: ManageGroup.SaveGroupList.Response)
   func presentDeletedGroup(response: ManageGroup.DeleteGroup.Response)
-  func presentReorderedGroup(response: ManageGroup.ReorderGroup.Response)
+  func presentCancelEditingGroup()
 }
 
 class ManageGroupPresenter {
@@ -34,8 +34,14 @@ extension ManageGroupPresenter: ManageGroupPresentationLogic {
   }
   
   func presentDeletedGroup(response: ManageGroup.DeleteGroup.Response) {
+    let viewModel = ManageGroup.DeleteGroup.ViewModel(
+      id: response.id,
+      index: response.index
+    )
+    self.viewController?.displayDeletedGroup(viewModel: viewModel)
   }
   
-  func presentReorderedGroup(response: ManageGroup.ReorderGroup.Response) {
+  func presentCancelEditingGroup() {
+    self.viewController?.displayCancelEditingGroup()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
@@ -11,22 +11,26 @@ import ManageGroupSceneEntity
 
 protocol ManageGroupPresentationLogic {
   func presentFetchedGroupList(response: ManageGroup.FetchGroupList.Response)
+  func presentSaveGroupList(response: ManageGroup.SaveGroupList.Response)
   func presentDeletedGroup(response: ManageGroup.DeleteGroup.Response)
   func presentReorderedGroup(response: ManageGroup.ReorderGroup.Response)
 }
 
 class ManageGroupPresenter {
   weak var viewController: ManageGroupDisplayLogic?
-  private let fetchedData: [ManageGroup.ToDoGroup] = ManageGroupMockData.fetchedData
 }
 
 // MARK: - Request to ViewController
 
 extension ManageGroupPresenter: ManageGroupPresentationLogic {
   func presentFetchedGroupList(response: ManageGroup.FetchGroupList.Response) {
-    let todoGroup = self.fetchedData
-    let viewModel = ManageGroup.FetchGroupList.ViewModel(with: todoGroup)
+    let viewModel = ManageGroup.FetchGroupList.ViewModel(with: response.data)
     self.viewController?.displayFetchedGroupList(viewModel: viewModel)
+  }
+  
+  func presentSaveGroupList(response: ManageGroup.SaveGroupList.Response) {
+    let viewModel = ManageGroup.SaveGroupList.ViewModel(with: response.data)
+    self.viewController?.displaySavedGroupList(viewModel: viewModel)
   }
   
   func presentDeletedGroup(response: ManageGroup.DeleteGroup.Response) {

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneConstants.swift
@@ -12,6 +12,7 @@ enum Constant {
     static let navigationbarTitle: String = "그룹관리"
     static let rightBarButtonTitleEdit: String = "편집"
     static let rightBarButtonTitleCancel: String = "취소"
+    static let leftBarButtonTitleSave: String = "저장"
     static let addGroupFooterButtonTitle: String = "그룹 추가하기"
   }
   
@@ -19,6 +20,7 @@ enum Constant {
     
     enum Cell {
       static let height: CGFloat = 45.0
+      static let cornerRadius: CGFloat = 15.0
     }
     enum FooterView {
       static let height: CGFloat = 50.0

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupTableViewDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupTableViewDelegate.swift
@@ -19,6 +19,13 @@ final class ManageGroupTableViewDelegate: NSObject {
   
   private var onPostGroup: ((String, UIColor) -> Void)?
   private var onDeleteGroup: ((String, Int) -> Void)?
+  private var onReorderingStateChange: ((Bool) -> Void)?
+  
+  private var isReordering: Bool = false {
+    didSet {
+      self.onReorderingStateChange?(isReordering)
+    }
+  }
   
   init(
     displayedGroups: [ManageGroup.ToDoGroup],
@@ -35,6 +42,10 @@ final class ManageGroupTableViewDelegate: NSObject {
   
   func setOnDeleteGroup(_ handler: @escaping (String, Int) -> Void) {
     self.onDeleteGroup = handler
+  }
+  
+  func setOnReorderingStateChange(_ handler: @escaping (Bool) -> Void) {
+    self.onReorderingStateChange = handler
   }
   
   func saveDisplayGroupsBeforeEditing() {
@@ -93,6 +104,8 @@ extension ManageGroupTableViewDelegate: UITableViewDelegate {
     commit editingStyle: UITableViewCell.EditingStyle,
     forRowAt indexPath: IndexPath
   ) {
+    guard !isReordering else { return }
+    
     let index = indexPath.row
     let id = self.displayedGroups[index].id
     
@@ -112,6 +125,14 @@ extension ManageGroupTableViewDelegate: UITableViewDelegate {
 
 // MARK: - UITableViewDragDelegate
 extension ManageGroupTableViewDelegate: UITableViewDragDelegate {
+  func tableView(_ tableView: UITableView, dragSessionWillBegin session: UIDragSession) {
+    self.isReordering = true
+  }
+  
+  func tableView(_ tableView: UITableView, dragSessionDidEnd session: UIDragSession) {
+    self.isReordering = false
+  }
+  
   func tableView(_ tableView: UITableView, dragSessionAllowsMoveOperation session: UIDragSession) -> Bool {
     return tableView.isEditing
   }
@@ -168,9 +189,6 @@ extension ManageGroupTableViewDelegate: UITableViewDropDelegate {
         tableView.moveRow(at: sourceIndexPath, to: destinationIndexPath)
       }, completion: nil)
       coordinator.drop(item.dragItem, toRowAt: destinationIndexPath)
-      
-      let id = self.displayedGroups[sourceIndexPath.row].id
-      self.onReorderGroups?(id, sourceIndexPath.row, destinationIndexPath.row)
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupTableViewDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupTableViewDelegate.swift
@@ -14,10 +14,10 @@ final class ManageGroupTableViewDelegate: NSObject {
   
   // MARK: - Properties
   var displayedGroups: [ManageGroup.ToDoGroup]
+  var displayedGroupsBeforeEditing: [ManageGroup.ToDoGroup]
   private let footerView: UIView
   
   private var onPostGroup: ((String, UIColor) -> Void)?
-  private var onReorderGroups: ((String, Int, Int) -> Void)?
   private var onDeleteGroup: ((String, Int) -> Void)?
   
   init(
@@ -25,6 +25,7 @@ final class ManageGroupTableViewDelegate: NSObject {
     footerView: UIView
   ) {
     self.displayedGroups = displayedGroups
+    self.displayedGroupsBeforeEditing = displayedGroups
     self.footerView = footerView
   }
   
@@ -32,12 +33,12 @@ final class ManageGroupTableViewDelegate: NSObject {
     self.onPostGroup = handler
   }
   
-  func setOnReorderGroups(_ handler: @escaping (String, Int, Int) -> Void) {
-    self.onReorderGroups = handler
-  }
-  
   func setOnDeleteGroup(_ handler: @escaping (String, Int) -> Void) {
     self.onDeleteGroup = handler
+  }
+  
+  func saveDisplayGroupsBeforeEditing() {
+    self.displayedGroupsBeforeEditing = self.displayedGroups
   }
 }
 
@@ -63,7 +64,7 @@ extension ManageGroupTableViewDelegate: UITableViewDataSource {
       return UITableViewCell()
     }
     
-    let singleGroup = displayedGroups[indexPath.row]
+    let singleGroup = self.displayedGroups[indexPath.row]
     
     cell.applyModelPrimary(
       id: singleGroup.id,

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -276,7 +276,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
       )
     }
   }
-
+  
   private func updateTableViewWithAnimation(
     oldGroups: [ManageGroup.ToDoGroup],
     newGroups: [ManageGroup.ToDoGroup]
@@ -314,7 +314,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     let oldIDs = oldGroups.map { $0.id }
     let newIDs = newGroups.map { $0.id }
     
-    let insertions = calculateInsertions(newIDs: newIDs, oldIDs: oldIDs)
+    let insertions = calculateInsertions(newIDs: newIDs, oldIDs: Set(oldIDs))
     let oldIndexMap = createOldIndexMap(oldGroups: oldGroups)
     let (moves, updates) = calculateMovesAndUpdates(
       newGroups: newGroups,
@@ -325,7 +325,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
   }
   // swiftlint:enable large_tuple
   
-  private func calculateInsertions(newIDs: [String], oldIDs: [String]) -> [IndexPath] {
+  private func calculateInsertions(newIDs: [String], oldIDs: Set<String>) -> [IndexPath] {
     var insertions: [IndexPath] = []
     for (newIndex, newID) in newIDs.enumerated() where !oldIDs.contains(newID) {
       insertions.append(IndexPath(row: newIndex, section: 0))
@@ -356,7 +356,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
         if oldIndex != newIndex {
           moves.append(
             (from: IndexPath(row: oldIndex, section: 0),
-              to: IndexPath(row: newIndex, section: 0))
+             to: IndexPath(row: newIndex, section: 0))
           )
         } else if oldGroups[oldIndex] != newGroup {
           updates.append(IndexPath(row: newIndex, section: 0))

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -33,7 +33,7 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
   let groupListTableView: ManageGroupTableView
   
   private let groupListTableViewCell: ManageGroupTableViewCell
-  
+  private var editModeLeftBarButton: UIBarButtonItem
   // MARK: - Object lifecycle
   
   init() {
@@ -43,6 +43,7 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
       reuseIdentifier: ManageGroupTableViewCell.identifier
     )
     self.rightBarButton = UIBarButtonItem()
+    self.editModeLeftBarButton = UIBarButtonItem()
     self.manageGroupTableViewDelegate = nil
     self.footerView = UIView()
     super.init(nibName: nil, bundle: nil)
@@ -101,26 +102,44 @@ extension ManageGroupViewController {
     )
     self.rightBarButton.tintColor = UIColor.toDoGardenOrange
     self.navigationItem.setRightBarButton(self.rightBarButton, animated: true)
+    self.editModeLeftBarButton = UIBarButtonItem(
+      title: Constant.StringLiteral.leftBarButtonTitleSave,
+      style: UIBarButtonItem.Style.plain,
+      target: self,
+      action: #selector(self.saveAndOutEditingMode)
+    )
+    self.editModeLeftBarButton.tintColor = UIColor.toDoGardenGreenDark
+    self.navigationItem.setLeftBarButton(nil, animated: true)
   }
   
   @objc private func setEditingMode() {
-    self.rightBarButton.isEnabled = false
     let isEditingMode = self.groupListTableView.isEditing
+    self.updateBarButtonItems(isEditingMode: isEditingMode)
+    if isEditingMode {
+      self.cancelEditing()
+    }
+    self.rightBarButton.isEnabled = true
+  }
+  
+  @objc private func saveAndOutEditingMode() {
+    let isEditingMode = self.groupListTableView.isEditing
+    self.updateBarButtonItems(isEditingMode: isEditingMode)
+    if isEditingMode {
+      self.saveGroupList()
+    }
+    self.rightBarButton.isEnabled = true
+  }
+  
+  private func updateBarButtonItems(isEditingMode: Bool) {
     self.groupListTableView.setEditingMode(!isEditingMode, animated: true)
-    
     if isEditingMode {
       self.rightBarButton.title = Constant.StringLiteral.rightBarButtonTitleEdit
+      self.navigationItem.setLeftBarButton(nil, animated: true)
     } else {
+      self.navigationItem.setLeftBarButton(self.editModeLeftBarButton, animated: true)
       self.rightBarButton.title = Constant.StringLiteral.rightBarButtonTitleCancel
-    }
-    
-    UIView.animate(withDuration: Constant.Animation.duration) { [weak self] in
-      self?.view.layoutIfNeeded()
-    } completion: { _ in
-      if isEditingMode {
-        self.interactor?.cancelEditing()
-      }
-      self.rightBarButton.isEnabled = true
+      self.manageGroupTableViewDelegate?.displayedGroupsBeforeEditing =
+      self.manageGroupTableViewDelegate?.displayedGroups ?? []
     }
   }
   
@@ -137,6 +156,9 @@ extension ManageGroupViewController {
     self.setupTouchActions()
     self.setupTableViewNoBounce()
     self.setupTableViewLayout()
+    self.manageGroupTableViewDelegate?.setOnReorderingStateChange { [weak self] isReordering in
+      self?.rightBarButton.isEnabled = !isReordering
+    }
   }
   
   private func setupTouchActions() {

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -356,7 +356,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
         if oldIndex != newIndex {
           moves.append(
             (from: IndexPath(row: oldIndex, section: 0),
-             to: IndexPath(row: newIndex, section: 0))
+            to: IndexPath(row: newIndex, section: 0))
           )
         } else if oldGroups[oldIndex] != newGroup {
           updates.append(IndexPath(row: newIndex, section: 0))

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -15,6 +15,7 @@ import ToDoGardenUIResource
 
 protocol ManageGroupDisplayLogic: AnyObject {
   func displayFetchedGroupList(viewModel: ManageGroup.FetchGroupList.ViewModel)
+  func displaySavedGroupList(viewModel: ManageGroup.SaveGroupList.ViewModel)
   func displayDeletedGroup(viewModel: ManageGroup.DeleteGroup.ViewModel)
   func displayReorderedGroup(viewModel: ManageGroup.ReorderGroup.ViewModel)
 }
@@ -25,7 +26,7 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
   
   var interactor: ManageGroupBusinessLogic?
   var router: (ManageGroupRoutingLogic & ManageGroupDataPassing)?
-
+  
   public var rightBarButton: UIBarButtonItem
   public var footerView: UIView
   
@@ -38,7 +39,6 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
   // MARK: - Object lifecycle
   
   init() {
-    self.displayedGroups = ManageGroup.FetchGroupList.ViewModel(with: []).list
     self.groupListTableView = ManageGroupTableView()
     self.groupListTableViewCell = ManageGroupTableViewCell(
       style: UITableViewCell.CellStyle.default,
@@ -69,7 +69,17 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
   
   func fetchGroupList() {
     let request = ManageGroup.FetchGroupList.Request()
-    self.interactor?.fetchGroupList(request: request)
+    Task {
+      await interactor?.fetchGroupList(request: request)
+    }
+  }
+  
+  func saveGroupList() {
+    let groupList = self.manageGroupTableViewDelegate?.displayedGroups
+    let request = ManageGroup.SaveGroupList.Request(with: groupList ?? [] )
+    Task {
+      await interactor?.saveGroupList(request: request)
+    }
   }
   
   func deleteGroup(id: String, index: Int) {

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -17,11 +17,10 @@ protocol ManageGroupDisplayLogic: AnyObject {
   func displayFetchedGroupList(viewModel: ManageGroup.FetchGroupList.ViewModel)
   func displaySavedGroupList(viewModel: ManageGroup.SaveGroupList.ViewModel)
   func displayDeletedGroup(viewModel: ManageGroup.DeleteGroup.ViewModel)
-  func displayReorderedGroup(viewModel: ManageGroup.ReorderGroup.ViewModel)
+  func displayCancelEditingGroup()
 }
 
 public class ManageGroupViewController: UIViewController, ManageGroupViewControllable {
-  
   // MARK: - VIP Properties
   
   var interactor: ManageGroupBusinessLogic?
@@ -30,7 +29,6 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
   public var rightBarButton: UIBarButtonItem
   public var footerView: UIView
   
-  var displayedGroups: [ManageGroup.ToDoGroup]
   var manageGroupTableViewDelegate: ManageGroupTableViewDelegate?
   let groupListTableView: ManageGroupTableView
   
@@ -66,7 +64,6 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
   }
   
   // MARK: - Request to interactor
-  
   func fetchGroupList() {
     let request = ManageGroup.FetchGroupList.Request()
     Task {
@@ -83,26 +80,16 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
   }
   
   func deleteGroup(id: String, index: Int) {
-    // TODO: 이후 PR에 포함될 예정
-    print("deleteGroup, groupID: \(id), groupIndex: \(index)")
+    let request = ManageGroup.DeleteGroup.Request(id: id, index: index)
+    self.interactor?.deleteGroup(request: request)
   }
   
-  func reorderGroup() {
-    // TODO: 이후 PR에 포함될 예정
-  }
-  
-  func addReorderedGroups(
-    id: String,
-    sourceIndex: Int,
-    destinationIndex: Int
-  ) {
-    // TODO: 이후 PR에 포함될 예정
-    print("add to ReorderedGroups, groupID: \(id), sourceIndex: \(sourceIndex), destinationIndex: \(destinationIndex)")
+  func cancelEditing() {
+    self.interactor?.cancelEditing()
   }
 }
 
 // MARK: - Setup
-
 extension ManageGroupViewController {
   func setupNavigationBar() {
     self.navigationItem.title = Constant.StringLiteral.navigationbarTitle
@@ -140,15 +127,13 @@ extension ManageGroupViewController {
   func setupTableView() {
     self.footerView = self.buildAddGroupFooterButton()
     self.manageGroupTableViewDelegate = ManageGroupTableViewDelegate(
-      displayedGroups: self.displayedGroups,
+      displayedGroups: [],
       footerView: self.footerView
     )
-    
     self.groupListTableView.delegate = self.manageGroupTableViewDelegate
     self.groupListTableView.dataSource = self.manageGroupTableViewDelegate
     self.groupListTableView.dragDelegate = self.manageGroupTableViewDelegate
     self.groupListTableView.dropDelegate = self.manageGroupTableViewDelegate
-    
     self.setupTouchActions()
     self.setupTableViewNoBounce()
     self.setupTableViewLayout()
@@ -157,10 +142,6 @@ extension ManageGroupViewController {
   private func setupTouchActions() {
     self.manageGroupTableViewDelegate?.setOnPostGroup { [weak self] groupName, color in
       self?.routeToPostGroupScene(groupName: groupName, color: color)
-    }
-    
-    self.manageGroupTableViewDelegate?.setOnReorderGroups { [weak self] id, sourceIndex, destinationIndex in
-      self?.addReorderedGroups(id: id, sourceIndex: sourceIndex, destinationIndex: destinationIndex)
     }
     
     self.manageGroupTableViewDelegate?.setOnDeleteGroup { [weak self] id, index in
@@ -175,7 +156,6 @@ extension ManageGroupViewController {
   private func setupTableViewLayout() {
     self.view.addSubview(self.groupListTableView)
     self.groupListTableView.usingAutolayout()
-    
     NSLayoutConstraint.activate(
       [
         self.groupListTableView.leadingAnchor.constraint(
@@ -222,7 +202,6 @@ extension ManageGroupViewController {
   }
   
   private func setupFooterButtonConstraints(_ button: UIButton, on footerView: UIView) {
-    
     NSLayoutConstraint.activate([
       button.centerYAnchor.constraint(equalTo: footerView.centerYAnchor),
       button.leadingAnchor.constraint(

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -17,7 +17,6 @@ protocol ManageGroupDisplayLogic: AnyObject {
   func displayFetchedGroupList(viewModel: ManageGroup.FetchGroupList.ViewModel)
   func displaySavedGroupList(viewModel: ManageGroup.SaveGroupList.ViewModel)
   func displayDeletedGroup(viewModel: ManageGroup.DeleteGroup.ViewModel)
-  func displayCancelEditingGroup()
 }
 
 public class ManageGroupViewController: UIViewController, ManageGroupViewControllable {
@@ -86,7 +85,12 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
   }
   
   func cancelEditing() {
-    self.interactor?.cancelEditing()
+    let oldGroups = self.manageGroupTableViewDelegate?.displayedGroups
+    let newGroups = self.manageGroupTableViewDelegate?.displayedGroupsBeforeEditing
+    self.manageGroupTableViewDelegate?.displayedGroups =
+    self.manageGroupTableViewDelegate?.displayedGroupsBeforeEditing ?? []
+    self.updateTableViewWithAnimation(oldGroups: oldGroups ?? [], newGroups: newGroups ?? [])
+    self.manageGroupTableViewDelegate?.saveDisplayGroupsBeforeEditing()
   }
 }
 
@@ -361,15 +365,6 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     }
     moves.sort { $0.from.row > $1.from.row }
     return (moves, updates)
-  }
-  
-  func displayCancelEditingGroup() {
-    let oldGroups = self.manageGroupTableViewDelegate?.displayedGroups
-    let newGroups = self.manageGroupTableViewDelegate?.displayedGroupsBeforeEditing
-    self.manageGroupTableViewDelegate?.displayedGroups =
-    self.manageGroupTableViewDelegate?.displayedGroupsBeforeEditing ?? []
-    self.updateTableViewWithAnimation(oldGroups: oldGroups ?? [], newGroups: newGroups ?? [])
-    self.manageGroupTableViewDelegate?.saveDisplayGroupsBeforeEditing()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -225,22 +225,131 @@ extension ManageGroupViewController {
 // MARK: - Confirm display logic protocol
 
 extension ManageGroupViewController: ManageGroupDisplayLogic {
+  
   func displayFetchedGroupList(viewModel: ManageGroup.FetchGroupList.ViewModel) {
-    self.displayedGroups = viewModel.list
-    self.manageGroupTableViewDelegate?.displayedGroups = viewModel.list
-    self.groupListTableView.reloadData()
+    let oldGroups = self.manageGroupTableViewDelegate?.displayedGroups
+    let newGroups = viewModel.list
+    self.manageGroupTableViewDelegate?.displayedGroups = newGroups
+    self.updateTableViewWithAnimation(oldGroups: oldGroups ?? [], newGroups: newGroups)
+  }
+  
+  func displaySavedGroupList(viewModel: ManageGroup.SaveGroupList.ViewModel) {
+    let oldGroups = self.manageGroupTableViewDelegate?.displayedGroups
+    let newGroups = viewModel.list
+    self.manageGroupTableViewDelegate?.displayedGroups = newGroups
+    self.updateTableViewWithAnimation(oldGroups: oldGroups ?? [], newGroups: newGroups)
   }
   
   func displayDeletedGroup(viewModel: ManageGroup.DeleteGroup.ViewModel) {
-    // TODO: 이후 PR에 포함될 예정
+    let index = viewModel.index
+    Task { @MainActor in
+      self.manageGroupTableViewDelegate?.displayedGroups.remove(at: index)
+      self.groupListTableView.deleteRows(
+        at: [IndexPath(row: index, section: 0)],
+        with: UITableView.RowAnimation.fade
+      )
+    }
+  }
+
+  private func updateTableViewWithAnimation(
+    oldGroups: [ManageGroup.ToDoGroup],
+    newGroups: [ManageGroup.ToDoGroup]
+  ) {
+    let changes = calculateTableViewChanges(oldGroups: oldGroups, newGroups: newGroups)
+    self.rightBarButton.isEnabled = false
+    Task { @MainActor in
+      self.groupListTableView.performBatchUpdates({
+        self.groupListTableView.insertRows(
+          at: changes.insertions,
+          with: UITableView.RowAnimation.fade
+        )
+        changes.moves.forEach { move in
+          self.groupListTableView.moveRow(at: move.from, to: move.to)
+        }
+      }, completion: { _ in
+        self.groupListTableView.reloadRows(
+          at: changes.updates,
+          with: UITableView.RowAnimation.none
+        )
+        self.rightBarButton.isEnabled = true
+      })
+    }
   }
   
-  func displayReorderedGroup(viewModel: ManageGroup.ReorderGroup.ViewModel) {
-    // TODO: 이후 PR에 포함될 예정
+  // swiftlint:disable large_tuple
+  private func calculateTableViewChanges(
+    oldGroups: [ManageGroup.ToDoGroup],
+    newGroups: [ManageGroup.ToDoGroup]
+  ) -> (
+    insertions: [IndexPath],
+    moves: [(from: IndexPath, to: IndexPath)],
+    updates: [IndexPath]
+  ) {
+    let oldIDs = oldGroups.map { $0.id }
+    let newIDs = newGroups.map { $0.id }
+    
+    let insertions = calculateInsertions(newIDs: newIDs, oldIDs: oldIDs)
+    let oldIndexMap = createOldIndexMap(oldGroups: oldGroups)
+    let (moves, updates) = calculateMovesAndUpdates(
+      newGroups: newGroups,
+      oldGroups: oldGroups,
+      oldIndexMap: oldIndexMap
+    )
+    return (insertions, moves, updates)
+  }
+  // swiftlint:enable large_tuple
+  
+  private func calculateInsertions(newIDs: [String], oldIDs: [String]) -> [IndexPath] {
+    var insertions: [IndexPath] = []
+    for (newIndex, newID) in newIDs.enumerated() where !oldIDs.contains(newID) {
+      insertions.append(IndexPath(row: newIndex, section: 0))
+    }
+    return insertions
+  }
+  
+  private func createOldIndexMap(oldGroups: [ManageGroup.ToDoGroup]) -> [String: Int] {
+    var oldIndexMap = [String: Int]()
+    for (index, group) in oldGroups.enumerated() {
+      oldIndexMap[group.id] = index
+    }
+    return oldIndexMap
+  }
+  
+  private func calculateMovesAndUpdates(
+    newGroups: [ManageGroup.ToDoGroup],
+    oldGroups: [ManageGroup.ToDoGroup],
+    oldIndexMap: [String: Int]
+  ) -> (
+    moves: [(from: IndexPath, to: IndexPath)],
+    updates: [IndexPath]
+  ) {
+    var moves: [(from: IndexPath, to: IndexPath)] = []
+    var updates: [IndexPath] = []
+    for (newIndex, newGroup) in newGroups.enumerated() {
+      if let oldIndex = oldIndexMap[newGroup.id] {
+        if oldIndex != newIndex {
+          moves.append(
+            (from: IndexPath(row: oldIndex, section: 0),
+              to: IndexPath(row: newIndex, section: 0))
+          )
+        } else if oldGroups[oldIndex] != newGroup {
+          updates.append(IndexPath(row: newIndex, section: 0))
+        }
+      }
+    }
+    moves.sort { $0.from.row > $1.from.row }
+    return (moves, updates)
+  }
+  
+  func displayCancelEditingGroup() {
+    let oldGroups = self.manageGroupTableViewDelegate?.displayedGroups
+    let newGroups = self.manageGroupTableViewDelegate?.displayedGroupsBeforeEditing
+    self.manageGroupTableViewDelegate?.displayedGroups =
+    self.manageGroupTableViewDelegate?.displayedGroupsBeforeEditing ?? []
+    self.updateTableViewWithAnimation(oldGroups: oldGroups ?? [], newGroups: newGroups ?? [])
+    self.manageGroupTableViewDelegate?.saveDisplayGroupsBeforeEditing()
   }
 }
-
-// MARK: - Request to interactor
 
 extension ManageGroupViewController {
   func routeToPostGroupScene(groupName: String?, color: UIColor?) {

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -391,8 +391,7 @@ extension ManageGroupViewController {
   let sceneBuilder = ManageGroupSceneBuilder(
     dependency: .init(manageGroupWorker: worker, nextSceneBuilder: nil)
   )
-  
-  let vcPreview = sceneBuilder.build(with: nil)
-  return vcPreview
+  let naviController = UINavigationController(rootViewController: sceneBuilder.build(with: nil))
+  return naviController
 }
 #endif

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
@@ -38,13 +38,14 @@ public final class ManageGroupViewControllerForGuide: ManageGroupViewController 
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-  
   let viewController = ManageGroupViewControllerForGuide()
   viewController.loadViewIfNeeded()
   viewController.footerView.backgroundColor = .red
   viewController.groupCells.forEach { cell in
     cell.backgroundColor = .green
   }
-  return viewController
+  
+  let naviController = UINavigationController(rootViewController: viewController)
+  return naviController
 }
 #endif

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
@@ -30,7 +30,6 @@ public final class ManageGroupViewControllerForGuide: ManageGroupViewController 
   
   override func fetchGroupList() {
     let fetchedData = ManageGroupMockData.guideSceneData
-    self.displayedGroups = fetchedData
     self.manageGroupTableViewDelegate?.displayedGroups = fetchedData
     self.groupListTableView.reloadData()
   }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
@@ -13,8 +13,9 @@ import ManageGroupSceneEntity
 public class ManageGroupWorker: ManageGroupWorkable {
   public init() {}
   
-  public func fetchGroupList(request: ManageGroupSceneEntity.ManageGroup.FetchGroupList.Request) async -> Result<[ManageGroup.ToDoGroup], Error> {
-    
+  public func fetchGroupList(
+    request: ManageGroupSceneEntity.ManageGroup.FetchGroupList.Request
+  ) async -> Result<[ManageGroup.ToDoGroup], Error> {
     do {
       let groups = try await fetchGroupsFromDatabase()
       return .success(groups)
@@ -23,7 +24,9 @@ public class ManageGroupWorker: ManageGroupWorkable {
     }
   }
   
-  public func saveGroupList(request: ManageGroupSceneEntity.ManageGroup.SaveGroupList.Request) async -> Result<[ManageGroupSceneEntity.ManageGroup.ToDoGroup], any Error> {
+  public func saveGroupList(
+    request: ManageGroupSceneEntity.ManageGroup.SaveGroupList.Request
+  ) async -> Result<[ManageGroupSceneEntity.ManageGroup.ToDoGroup], any Error> {
     do {
       let groups = try await saveGroupsInDatabase(groupList: request.list)
       return .success(groups)

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
@@ -13,15 +13,31 @@ import ManageGroupSceneEntity
 public class ManageGroupWorker: ManageGroupWorkable {
   public init() {}
   
-  public func fetchGroupList(request: ManageGroupSceneEntity.ManageGroup.FetchGroupList.Request) {
+  public func fetchGroupList(request: ManageGroupSceneEntity.ManageGroup.FetchGroupList.Request) async -> Result<[ManageGroup.ToDoGroup], Error> {
     
+    do {
+      let groups = try await fetchGroupsFromDatabase()
+      return .success(groups)
+    } catch {
+      return .failure(error)
+    }
   }
   
-  public func deleteGroup(request: ManageGroupSceneEntity.ManageGroup.DeleteGroup.Request) {
-    
+  public func saveGroupList(request: ManageGroupSceneEntity.ManageGroup.SaveGroupList.Request) async -> Result<[ManageGroupSceneEntity.ManageGroup.ToDoGroup], any Error> {
+    do {
+      let groups = try await saveGroupsInDatabase(groupList: request.list)
+      return .success(groups)
+    } catch {
+      return .failure(error)
+    }
+  }
+
+  private func fetchGroupsFromDatabase() async throws -> [ManageGroup.ToDoGroup] {
+    let fetchedData: [ManageGroup.ToDoGroup] = ManageGroupMockData.fetchedData
+    return fetchedData
   }
   
-  public func reorderGroup(request: ManageGroup.ReorderGroup.Request) {
-    
+  private func saveGroupsInDatabase(groupList: [ManageGroup.ToDoGroup]) async throws -> [ManageGroup.ToDoGroup] {
+    return groupList
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneAPI/ManageGroupWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneAPI/ManageGroupWorkable.swift
@@ -10,7 +10,6 @@ import Foundation
 import ManageGroupSceneEntity
 
 public protocol ManageGroupWorkable {
-  func fetchGroupList(request: ManageGroup.FetchGroupList.Request)
-  func reorderGroup(request: ManageGroup.ReorderGroup.Request)
-  func deleteGroup(request: ManageGroup.DeleteGroup.Request)
+  func fetchGroupList(request: ManageGroupSceneEntity.ManageGroup.FetchGroupList.Request) async -> Result<[ManageGroup.ToDoGroup], Error>
+  func saveGroupList(request: ManageGroupSceneEntity.ManageGroup.SaveGroupList.Request) async -> Result<[ManageGroup.ToDoGroup], Error>
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneAPI/ManageGroupWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneAPI/ManageGroupWorkable.swift
@@ -10,6 +10,10 @@ import Foundation
 import ManageGroupSceneEntity
 
 public protocol ManageGroupWorkable {
-  func fetchGroupList(request: ManageGroupSceneEntity.ManageGroup.FetchGroupList.Request) async -> Result<[ManageGroup.ToDoGroup], Error>
-  func saveGroupList(request: ManageGroupSceneEntity.ManageGroup.SaveGroupList.Request) async -> Result<[ManageGroup.ToDoGroup], Error>
+  func fetchGroupList(
+    request: ManageGroupSceneEntity.ManageGroup.FetchGroupList.Request
+  ) async -> Result<[ManageGroup.ToDoGroup], Error>
+  func saveGroupList(
+    request: ManageGroupSceneEntity.ManageGroup.SaveGroupList.Request
+  ) async -> Result<[ManageGroup.ToDoGroup], Error>
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneEntity/ManageGroupModels.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneEntity/ManageGroupModels.swift
@@ -108,17 +108,3 @@ public enum ManageGroup {
     }
   }
 }
-
-extension ManageGroup {
-  public struct ReorderedGroup {
-    let id: String
-    let sourceIndex: Int
-    let destinationIndex: Int
-    
-    public init(id: String, sourceIndex: Int, destinationIndex: Int) {
-      self.id = id
-      self.sourceIndex = sourceIndex
-      self.destinationIndex = destinationIndex
-    }
-  }
-}

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneEntity/ManageGroupModels.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneEntity/ManageGroupModels.swift
@@ -8,7 +8,7 @@
 import UIKit.UIColor
 
 public enum ManageGroup {
-  public struct ToDoGroup {
+  public struct ToDoGroup: Equatable {
     public let id: String
     public let groupName: String
     public let progressColor: UIColor
@@ -20,6 +20,13 @@ public enum ManageGroup {
       self.progressColor = progressColor
       self.progressRate = progressRate
     }
+    
+    public static func == (lhs: ToDoGroup, rhs: ToDoGroup) -> Bool {
+      return lhs.id == rhs.id &&
+      lhs.groupName == rhs.groupName &&
+      lhs.progressColor == rhs.progressColor &&
+      lhs.progressRate == rhs.progressRate
+    }
   }
   // MARK: Use cases
   
@@ -29,8 +36,31 @@ public enum ManageGroup {
     }
     
     public struct Response {
-      let data: String
-      public init(with data: String) {
+      public let data: [ToDoGroup]
+      public init(with data: [ToDoGroup]) {
+        self.data = data
+      }
+    }
+    
+    public struct ViewModel {
+      public let list: [ToDoGroup]
+      public init(with list: [ToDoGroup]) {
+        self.list = list
+      }
+    }
+  }
+  
+  public enum SaveGroupList {
+    public struct Request {
+      public let list: [ToDoGroup]
+      public init(with list: [ToDoGroup]) {
+        self.list = list
+      }
+    }
+    
+    public struct Response {
+      public let data: [ToDoGroup]
+      public init(with data: [ToDoGroup]) {
         self.data = data
       }
     }
@@ -74,30 +104,6 @@ public enum ManageGroup {
       ) {
         self.id = id
         self.index = index
-      }
-    }
-  }
-  
-  public enum ReorderGroup {
-    public struct Request {
-      public var reorderedGroups: [ReorderedGroup]
-      
-      public init() {
-        self.reorderedGroups = []
-      }
-    }
-    
-    public struct Response {
-      public let data: Bool
-      public init(with data: Bool) {
-        self.data = data
-      }
-    }
-    
-    public struct ViewModel {
-      public var data: Bool
-      public init(with data: Bool) {
-        self.data = data
       }
     }
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #444
## 🎉 변경 사항
- "저장"기능 추가 
- 편집으로 인한 변경사항들을 UI업데이트 하는 로직 개선

## 📌 PR Point
<img width="527" alt="스크린샷 2024-09-03 오후 5 32 49" src="https://github.com/user-attachments/assets/860adba7-0f2c-4410-8942-2d44a8fafaaf">
_____________________

<img width="875" alt="스크린샷 2024-09-03 오후 5 33 18" src="https://github.com/user-attachments/assets/de440074-8acb-415f-8a3c-0196c6feb4e3">

↑ 비동기 처리가 되어야 하는 흐름에 async/await를 걸어 주었습니다. 
↑ "저장" 기능이 생겼습니다. 행해진 모든 변경사항은 "저장"을 누르지 않으면 결과적으로 반영되지 않습니다. 
_____________________

<img width="846" alt="스크린샷 2024-09-03 오후 5 35 56" src="https://github.com/user-attachments/assets/10e9999e-1297-4d39-b96b-be31943d54fd">

↑ "저장" 또는 "취소" 시 UI업데이트가 요구됩니다. 해당 테이블뷰에 대한 모든 UI업데이트(편집내용 저장 or 원상복구)는 <oldGroups>과 <newGroups>의 비교를 통해 , 일괄적으로 `performBatchUpdates{}` 안에서 일어납니다. 
↑ 네트워크에 연결되어 있지 않아도 "취소" 작업이 가능해졌습니다.
↑ 순서 변경시, 그룹 하나하나 어디서 어디로 이동했는지 정보를 기억하지 않고, "취소" 또는 "저장" 시 최후의 결과만 기억합니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?