### PR TITLE
UserInfoSceneViewController UI 하위뷰 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -24,8 +24,7 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   private let editProfileImageButton: UIButton
   private let userInfoCollectionView: UICollectionView
   private var userInfoCollectionViewDataSource: DiffableDataSource?
-  private let logOutButton: UIButton
-  private let withdrawMembershipButton: UIButton
+  private let manageAccountView: ManageAccountView
 
   // MARK: - VIP Properties
   
@@ -41,8 +40,7 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
       frame: CGRect.zero,
       collectionViewLayout: UICollectionViewLayout()
     )
-    self.logOutButton = UIButton()
-    self.withdrawMembershipButton = UIButton()
+    self.manageAccountView = ManageAccountView()
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -110,10 +108,6 @@ extension UserInfoSceneViewController {
     self.setupMainUI()
     self.setupEditProfileImageButton()
     self.setupUserInfoCollectionView()
-    self.setupLogOutButtonTitle()
-    self.setupLogOutButtonAction()
-    self.setupWithdrawMembershipButton()
-    self.setupWithdrawMembershipButtonAction()
     self.loadUserInfoCollectionViewData()
     self.setupSubviewsLayout()
   }
@@ -151,55 +145,6 @@ extension UserInfoSceneViewController {
     self.userInfoCollectionViewDataSource = self.makeDiffableDataSource(with: self.userInfoCollectionView)
     self.userInfoCollectionView.dataSource = self.userInfoCollectionViewDataSource
     self.userInfoCollectionView.collectionViewLayout = self.makeCompositionalLayout()
-  }
-
-  private func setupLogOutButtonTitle() {
-    self.logOutButton.backgroundColor = UIColor.toDoGardenGreenBackground
-    let cornerRadius = Constant.LogOutButton.Layer.cornerRadius
-    self.logOutButton.layer.cornerRadius = cornerRadius
-    self.logOutButton.setTitleColor(UIColor.toDoGardenEditButtonRed, for: UIControl.State.normal)
-    let title = NSAttributedString(
-      string: UserInfoSceneTheme.StringLiteral.LogOutButton.title,
-      attributes: [
-        NSAttributedString.Key.font: UIFont.pretendardBodyMedium,
-        NSAttributedString.Key.strokeColor: UIColor.toDoGardenEditButtonRed
-      ]
-    )
-    self.logOutButton.setAttributedTitle(title, for: UIControl.State.normal)
-  }
-
-  private func setupLogOutButtonAction() {
-    let logOutAction = UIAction { [weak self] _ in
-      guard let self else { return }
-
-      self.showAlertController(for: ToDoGardenAlertView.Configuration.askToLogout)
-    }
-
-    self.logOutButton.addAction(logOutAction, for: UIControl.Event.touchUpInside)
-  }
-
-  private func setupWithdrawMembershipButton() {
-    let buttonTitle = UserInfoSceneTheme.StringLiteral.WithdrawMembershipButton.title
-    let attributedTitle = buttonTitle.applyTextAttributes(
-      attributes: [
-        NSAttributedString.Key.font: UIFont.pretendardBodySemiBold15,
-        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGray2,
-        NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue,
-        NSAttributedString.Key.underlineColor: UIColor.toDoGardenGray2
-      ]
-    )
-
-    self.withdrawMembershipButton.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
-  }
-
-  private func setupWithdrawMembershipButtonAction() {
-    let withdrawMembershipAction = UIAction { [weak self] _ in
-      guard let self else { return }
-
-      self.showAlertController(for: ToDoGardenAlertView.Configuration.askToUnsubscribe)
-    }
-
-    self.withdrawMembershipButton.addAction(withdrawMembershipAction, for: UIControl.Event.touchUpInside)
   }
 
   private func loadUserInfoCollectionViewData() {
@@ -245,8 +190,7 @@ extension UserInfoSceneViewController {
     self.setupProfileImageViewLayout()
     self.setupEditProfileImageButtonLayout()
     self.setupUserInfoCollectionViewLayout()
-    self.setupLogOutButtonLayout()
-    self.setupWithdrawMembershipButtonLayout()
+    self.setupManageAccountViewLayout()
   }
 
   private func setupProfileImageViewLayout() {
@@ -308,51 +252,22 @@ extension UserInfoSceneViewController {
     )
   }
 
-  private func setupLogOutButtonLayout() {
-    self.view.addSubview(self.logOutButton)
-    self.setupLogOutButtonTitleLayout()
-    self.logOutButton.usingAutolayout()
+  private func setupManageAccountViewLayout() {
+    self.view.addSubview(self.manageAccountView)
+    self.manageAccountView.usingAutolayout()
 
     NSLayoutConstraint.activate(
       [
-        self.logOutButton.topAnchor.constraint(
+        self.manageAccountView.topAnchor.constraint(
           equalTo: self.userInfoCollectionView.bottomAnchor,
-          constant: Constant.LogOutButton.topMargin
+          constant: Constant.ManageAccountView.topMargin
         ),
-        self.logOutButton.leadingAnchor.constraint(equalTo: self.userInfoCollectionView.leadingAnchor),
-        self.logOutButton.trailingAnchor.constraint(equalTo: self.userInfoCollectionView.trailingAnchor),
-        self.logOutButton.heightAnchor.constraint(equalToConstant: Constant.LogOutButton.height)
-      ]
-    )
-  }
-
-  private func setupLogOutButtonTitleLayout() {
-    if let titleLabel = self.logOutButton.titleLabel {
-      titleLabel.usingAutolayout()
-
-      NSLayoutConstraint.activate(
-        [
-          titleLabel.leadingAnchor.constraint(
-            equalTo: self.logOutButton.leadingAnchor,
-            constant: Constant.LogOutButton.titleLeadingMargin
-          ),
-          titleLabel.centerYAnchor.constraint(equalTo: self.logOutButton.centerYAnchor)
-        ]
-      )
-    }
-  }
-
-  private func setupWithdrawMembershipButtonLayout() {
-    self.view.addSubview(self.withdrawMembershipButton)
-    self.withdrawMembershipButton.usingAutolayout()
-
-    NSLayoutConstraint.activate(
-      [
-        self.withdrawMembershipButton.topAnchor.constraint(
-          equalTo: self.logOutButton.bottomAnchor,
-          constant: Constant.WithdrawMembershipButton.topMargin
+        self.manageAccountView.leadingAnchor.constraint(
+          equalTo: self.userInfoCollectionView.leadingAnchor
         ),
-        self.withdrawMembershipButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
+        self.manageAccountView.trailingAnchor.constraint(
+          equalTo: self.userInfoCollectionView.trailingAnchor
+        )
       ]
     )
   }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -101,7 +101,11 @@ extension UserInfoSceneViewController: ToDoGardenAlertControllerDelegate {
 
 // MARK: Subviews Delegate Functions
 
-extension UserInfoSceneViewController: ManageAccountViewDelegate {
+extension UserInfoSceneViewController: ManageAccountViewDelegate, ProfileInfoViewDelegate {
+  func didSelectEditProfileButton() {
+    // TODO: 이미지 선택 로직 구현 예정
+  }
+
   func didSelectLogOutButton() {
     self.showAlertController(for: ToDoGardenAlertView.Configuration.askToLogout)
   }
@@ -128,6 +132,7 @@ extension UserInfoSceneViewController {
   }
 
   private func setupSubviewsDelegate() {
+    self.profileInfoView.delegate = self
     self.manageAccountView.delegate = self
   }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -20,8 +20,7 @@ protocol UserInfoSceneDisplayLogic: AnyObject {
 }
 
 final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewControllable {
-  private let profileImageView: ProfileImageView
-  private let editProfileImageButton: UIButton
+  private let profileInfoView: ProfileInfoView
   private let userInfoCollectionView: UICollectionView
   private var userInfoCollectionViewDataSource: DiffableDataSource?
   private let manageAccountView: ManageAccountView
@@ -34,8 +33,7 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   // MARK: - Object lifecycle
   
   init() {
-    self.profileImageView = ProfileImageView(size: Constant.ProfileImageView.size)
-    self.editProfileImageButton = UIButton()
+    self.profileInfoView = ProfileInfoView()
     self.userInfoCollectionView = UICollectionView(
       frame: CGRect.zero,
       collectionViewLayout: UICollectionViewLayout()
@@ -119,7 +117,6 @@ extension UserInfoSceneViewController {
   private func setup() {
     self.setupMainUI()
     self.setupSubviewsDelegate()
-    self.setupEditProfileImageButton()
     self.setupUserInfoCollectionView()
     self.loadUserInfoCollectionViewData()
     self.setupSubviewsLayout()
@@ -132,20 +129,6 @@ extension UserInfoSceneViewController {
 
   private func setupSubviewsDelegate() {
     self.manageAccountView.delegate = self
-  }
-
-  private func setupEditProfileImageButton() {
-    let buttonTitle = UserInfoSceneTheme.StringLiteral.EditProfileImageButton.title
-    let attributedTitle = buttonTitle.applyTextAttributes(
-      attributes: [
-        NSAttributedString.Key.font: UIFont.pretendardBodyMedium,
-        NSAttributedString.Key.foregroundColor: UserInfoSceneTheme.mainColor,
-        NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue,
-        NSAttributedString.Key.underlineColor: UserInfoSceneTheme.mainColor
-      ]
-    )
-
-    self.editProfileImageButton.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
   }
 
   private func setupUserInfoCollectionView() {
@@ -204,41 +187,28 @@ extension UserInfoSceneViewController {
 
 extension UserInfoSceneViewController {
   private func setupSubviewsLayout() {
-    self.setupProfileImageViewLayout()
-    self.setupEditProfileImageButtonLayout()
+    self.setupProfileInfoViewLayout()
     self.setupUserInfoCollectionViewLayout()
     self.setupManageAccountViewLayout()
   }
 
-  private func setupProfileImageViewLayout() {
-    self.view.addSubview(self.profileImageView)
-    self.profileImageView.usingAutolayout()
+  private func setupProfileInfoViewLayout() {
+    self.view.addSubview(self.profileInfoView)
+    self.profileInfoView.usingAutolayout()
 
-    let constant = Constant.ProfileImageView.self
     NSLayoutConstraint.activate(
       [
-        self.profileImageView.topAnchor.constraint(
+        self.profileInfoView.topAnchor.constraint(
           equalTo: self.view.safeAreaLayoutGuide.topAnchor,
-          constant: constant.topMargin
+          constant: Constant.ProfileInfoView.topMargin
         ),
-        self.profileImageView.widthAnchor.constraint(equalToConstant: constant.size.width),
-        self.profileImageView.heightAnchor.constraint(equalToConstant: constant.size.height),
-        self.profileImageView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
-      ]
-    )
-  }
-
-  private func setupEditProfileImageButtonLayout() {
-    self.view.addSubview(self.editProfileImageButton)
-    self.editProfileImageButton.usingAutolayout()
-
-    NSLayoutConstraint.activate(
-      [
-        self.editProfileImageButton.topAnchor.constraint(
-          equalTo: self.profileImageView.bottomAnchor,
-          constant: Constant.EditProfileImageButton.topMargin
+        self.profileInfoView.widthAnchor.constraint(
+          equalToConstant: Constant.ProfileInfoView.size.width
         ),
-        self.editProfileImageButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
+        self.profileInfoView.heightAnchor.constraint(
+          equalToConstant: Constant.ProfileInfoView.size.height
+        ),
+        self.profileInfoView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
       ]
     )
   }
@@ -251,7 +221,7 @@ extension UserInfoSceneViewController {
     NSLayoutConstraint.activate(
       [
         self.userInfoCollectionView.topAnchor.constraint(
-          equalTo: self.editProfileImageButton.bottomAnchor,
+          equalTo: self.profileInfoView.bottomAnchor,
           constant: constant.topMargin
         ),
         self.userInfoCollectionView.leadingAnchor.constraint(

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -101,11 +101,24 @@ extension UserInfoSceneViewController: ToDoGardenAlertControllerDelegate {
   }
 }
 
+// MARK: Subviews Delegate Functions
+
+extension UserInfoSceneViewController: ManageAccountViewDelegate {
+  func didSelectLogOutButton() {
+    self.showAlertController(for: ToDoGardenAlertView.Configuration.askToLogout)
+  }
+  
+  func didSelectWithdrawMembershipButton() {
+    self.showAlertController(for: ToDoGardenAlertView.Configuration.askToUnsubscribe)
+  }
+}
+
 // MARK: - Private Functions
 
 extension UserInfoSceneViewController {
   private func setup() {
     self.setupMainUI()
+    self.setupSubviewsDelegate()
     self.setupEditProfileImageButton()
     self.setupUserInfoCollectionView()
     self.loadUserInfoCollectionViewData()
@@ -115,6 +128,10 @@ extension UserInfoSceneViewController {
   private func setupMainUI() {
     self.title = UserInfoSceneTheme.StringLiteral.title
     self.view.backgroundColor = UIColor.toDoGardenWhite
+  }
+
+  private func setupSubviewsDelegate() {
+    self.manageAccountView.delegate = self
   }
 
   private func setupEditProfileImageButton() {
@@ -267,6 +284,9 @@ extension UserInfoSceneViewController {
         ),
         self.manageAccountView.trailingAnchor.constraint(
           equalTo: self.userInfoCollectionView.trailingAnchor
+        ),
+        self.manageAccountView.heightAnchor.constraint(
+          equalToConstant: Constant.ManageAccountView.height
         )
       ]
     )

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-import TDUtility
 import ToDoGardenUIAPI
 import ToDoGardenUIComponent
 import ToDoGardenUIConstant

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ManageAccountView.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ManageAccountView.swift
@@ -11,6 +11,8 @@ final class ManageAccountView: UIView {
   private let logOutButton: UIButton
   private let withdrawMembershipButton: UIButton
 
+  weak var delegate: ManageAccountViewDelegate?
+
   init() {
     self.logOutButton = UIButton()
     self.withdrawMembershipButton = UIButton()
@@ -24,12 +26,21 @@ final class ManageAccountView: UIView {
   }
 }
 
+// MARK: ManageAccountView Delegate
+
+protocol ManageAccountViewDelegate: AnyObject {
+  func didSelectLogOutButton()
+  func didSelectWithdrawMembershipButton()
+}
+
 // MARK: Private Functions
 
 extension ManageAccountView {
   private func setup() {
     self.setupLogOutButtonTitle()
+    self.setupLogOutButtonAction()
     self.setupWithdrawMembershipButton()
+    self.setupWithdrawMembershipButtonAction()
     self.setupSubviewsLayout()
   }
 
@@ -48,6 +59,15 @@ extension ManageAccountView {
     self.logOutButton.setAttributedTitle(title, for: UIControl.State.normal)
   }
 
+  private func setupLogOutButtonAction() {
+    let buttonAction = UIAction { _ in
+      print("called")
+      self.delegate?.didSelectLogOutButton()
+    }
+
+    self.logOutButton.addAction(buttonAction, for: UIControl.Event.touchUpInside)
+  }
+
   private func setupWithdrawMembershipButton() {
     let buttonTitle = UserInfoSceneTheme.StringLiteral.WithdrawMembershipButton.title
     let attributedTitle = buttonTitle.applyTextAttributes(
@@ -60,6 +80,15 @@ extension ManageAccountView {
     )
 
     self.withdrawMembershipButton.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
+  }
+
+  private func setupWithdrawMembershipButtonAction() {
+    let buttonAction = UIAction { _ in
+      print("called")
+      self.delegate?.didSelectWithdrawMembershipButton()
+    }
+
+    self.withdrawMembershipButton.addAction(buttonAction, for: UIControl.Event.touchUpInside)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ManageAccountView.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ManageAccountView.swift
@@ -92,6 +92,8 @@ extension ManageAccountView {
   }
 }
 
+// MARK: Auto Layout
+
 extension ManageAccountView {
   private func setupSubviewsLayout() {
     self.setupLogOutButtonLayout()

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ManageAccountView.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ManageAccountView.swift
@@ -1,0 +1,119 @@
+//
+//  ManageAccountView.swift
+//
+//
+//  Created by Wood on 9/3/24.
+//
+
+import UIKit
+
+final class ManageAccountView: UIView {
+  private let logOutButton: UIButton
+  private let withdrawMembershipButton: UIButton
+
+  init() {
+    self.logOutButton = UIButton()
+    self.withdrawMembershipButton = UIButton()
+    super.init(frame: CGRect.zero)
+    self.setup()
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: Private Functions
+
+extension ManageAccountView {
+  private func setup() {
+    self.setupLogOutButtonTitle()
+    self.setupWithdrawMembershipButton()
+    self.setupSubviewsLayout()
+  }
+
+  private func setupLogOutButtonTitle() {
+    self.logOutButton.backgroundColor = UIColor.toDoGardenGreenBackground
+    let cornerRadius = UserInfoSceneViewController.Constant.LogOutButton.Layer.cornerRadius
+    self.logOutButton.layer.cornerRadius = cornerRadius
+    self.logOutButton.setTitleColor(UIColor.toDoGardenEditButtonRed, for: UIControl.State.normal)
+    let title = NSAttributedString(
+      string: UserInfoSceneTheme.StringLiteral.LogOutButton.title,
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardBodyMedium,
+        NSAttributedString.Key.strokeColor: UIColor.toDoGardenEditButtonRed
+      ]
+    )
+    self.logOutButton.setAttributedTitle(title, for: UIControl.State.normal)
+  }
+
+  private func setupWithdrawMembershipButton() {
+    let buttonTitle = UserInfoSceneTheme.StringLiteral.WithdrawMembershipButton.title
+    let attributedTitle = buttonTitle.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardBodySemiBold15,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGray2,
+        NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue,
+        NSAttributedString.Key.underlineColor: UIColor.toDoGardenGray2
+      ]
+    )
+
+    self.withdrawMembershipButton.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
+  }
+}
+
+extension ManageAccountView {
+  private func setupSubviewsLayout() {
+    self.setupLogOutButtonLayout()
+    self.setupLogOutButtonTitleLayout()
+    self.setupWithdrawMembershipButtonLayout()
+  }
+
+  private func setupLogOutButtonLayout() {
+    self.addSubview(self.logOutButton)
+    self.logOutButton.usingAutolayout()
+
+    NSLayoutConstraint.activate(
+      [
+        self.logOutButton.topAnchor.constraint(equalTo: self.topAnchor),
+        self.logOutButton.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.logOutButton.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        self.logOutButton.heightAnchor.constraint(
+          equalToConstant: UserInfoSceneViewController.Constant.LogOutButton.height
+        )
+      ]
+    )
+  }
+
+  private func setupLogOutButtonTitleLayout() {
+    if let titleLabel = self.logOutButton.titleLabel {
+      titleLabel.usingAutolayout()
+
+      NSLayoutConstraint.activate(
+        [
+          titleLabel.leadingAnchor.constraint(
+            equalTo: self.logOutButton.leadingAnchor,
+            constant: UserInfoSceneViewController.Constant.LogOutButton.titleLeadingMargin
+          ),
+          titleLabel.centerYAnchor.constraint(equalTo: self.logOutButton.centerYAnchor)
+        ]
+      )
+    }
+  }
+
+  private func setupWithdrawMembershipButtonLayout() {
+    self.addSubview(self.withdrawMembershipButton)
+    self.withdrawMembershipButton.usingAutolayout()
+
+    NSLayoutConstraint.activate(
+      [
+        self.withdrawMembershipButton.topAnchor.constraint(
+          equalTo: self.logOutButton.bottomAnchor,
+          constant: UserInfoSceneViewController.Constant.WithdrawMembershipButton.topMargin
+        ),
+        self.withdrawMembershipButton.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+      ]
+    )
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ProfileInfoView.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ProfileInfoView.swift
@@ -7,18 +7,14 @@
 
 import UIKit
 
-import ToDoGardenUIComponent
-
 final class ProfileInfoView: UIView {
-  private let profileImageView: ProfileImageView
+  private let profileImageView: UIImageView
   private let editProfileImageButton: UIButton
 
   weak var delegate: ProfileInfoViewDelegate?
 
   init() {
-    self.profileImageView = ProfileImageView(
-      size: UserInfoSceneViewController.Constant.ProfileImageView.size
-    )
+    self.profileImageView = UIImageView()
     self.editProfileImageButton = UIButton()
     super.init(frame: CGRect.zero)
     self.setup()
@@ -27,6 +23,10 @@ final class ProfileInfoView: UIView {
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+
+  func updateImage(_ image: UIImage) {
+    self.profileImageView.image = image
   }
 }
 
@@ -38,9 +38,17 @@ protocol ProfileInfoViewDelegate: AnyObject {
 
 extension ProfileInfoView {
   private func setup() {
+    self.setupProfileImageView()
     self.setupEditProfileImageButton()
     self.setupEditProfileImageButtonAction()
     self.setupSubviewsLayout()
+  }
+
+  private func setupProfileImageView() {
+    let height = UserInfoSceneViewController.Constant.ProfileImageView.size.height
+    self.profileImageView.layer.cornerRadius = height / 2
+    self.profileImageView.contentMode = UIView.ContentMode.scaleAspectFit
+    self.profileImageView.image = UIImage.defaultProfileImage
   }
 
   private func setupEditProfileImageButton() {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ProfileInfoView.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ProfileInfoView.swift
@@ -13,6 +13,8 @@ final class ProfileInfoView: UIView {
   private let profileImageView: ProfileImageView
   private let editProfileImageButton: UIButton
 
+  weak var delegate: ProfileInfoViewDelegate?
+
   init() {
     self.profileImageView = ProfileImageView(
       size: UserInfoSceneViewController.Constant.ProfileImageView.size
@@ -28,11 +30,16 @@ final class ProfileInfoView: UIView {
   }
 }
 
+protocol ProfileInfoViewDelegate: AnyObject {
+  func didSelectEditProfileButton()
+}
+
 // MARK: Private Functions
 
 extension ProfileInfoView {
   private func setup() {
     self.setupEditProfileImageButton()
+    self.setupEditProfileImageButtonAction()
     self.setupSubviewsLayout()
   }
 
@@ -48,6 +55,14 @@ extension ProfileInfoView {
     )
 
     self.editProfileImageButton.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
+  }
+
+  private func setupEditProfileImageButtonAction() {
+    let buttonAction = UIAction { _ in
+      self.delegate?.didSelectEditProfileButton()
+    }
+
+    self.editProfileImageButton.addAction(buttonAction, for: UIControl.Event.touchUpInside)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ProfileInfoView.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ProfileInfoView.swift
@@ -1,0 +1,92 @@
+//
+//  ProfileInfoView.swift
+//
+//
+//  Created by Wood on 9/3/24.
+//
+
+import UIKit
+
+import ToDoGardenUIComponent
+
+final class ProfileInfoView: UIView {
+  private let profileImageView: ProfileImageView
+  private let editProfileImageButton: UIButton
+
+  init() {
+    self.profileImageView = ProfileImageView(
+      size: UserInfoSceneViewController.Constant.ProfileImageView.size
+    )
+    self.editProfileImageButton = UIButton()
+    super.init(frame: CGRect.zero)
+    self.setup()
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: Private Functions
+
+extension ProfileInfoView {
+  private func setup() {
+    self.setupEditProfileImageButton()
+    self.setupSubviewsLayout()
+  }
+
+  private func setupEditProfileImageButton() {
+    let buttonTitle = UserInfoSceneTheme.StringLiteral.EditProfileImageButton.title
+    let attributedTitle = buttonTitle.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardBodyMedium,
+        NSAttributedString.Key.foregroundColor: UserInfoSceneTheme.mainColor,
+        NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue,
+        NSAttributedString.Key.underlineColor: UserInfoSceneTheme.mainColor
+      ]
+    )
+
+    self.editProfileImageButton.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
+  }
+}
+
+// MARK: Auto Layout
+
+extension ProfileInfoView {
+  private func setupSubviewsLayout() {
+    self.setupProfileImageViewLayout()
+    self.setupEditProfileImageButtonLayout()
+  }
+
+  private func setupProfileImageViewLayout() {
+    self.addSubview(self.profileImageView)
+    self.profileImageView.usingAutolayout()
+
+    let constant = UserInfoSceneViewController.Constant.ProfileImageView.size
+    NSLayoutConstraint.activate(
+      [
+        self.profileImageView.topAnchor.constraint(equalTo: self.topAnchor),
+        self.profileImageView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+        self.profileImageView.widthAnchor.constraint(equalToConstant: constant.width),
+        self.profileImageView.heightAnchor.constraint(equalToConstant: constant.height)
+      ]
+    )
+  }
+
+  private func setupEditProfileImageButtonLayout() {
+    self.addSubview(self.editProfileImageButton)
+    self.editProfileImageButton.usingAutolayout()
+
+    let constant = UserInfoSceneViewController.Constant.EditProfileImageButton.self
+    NSLayoutConstraint.activate(
+      [
+        self.editProfileImageButton.topAnchor.constraint(
+          equalTo: self.profileImageView.bottomAnchor,
+          constant: constant.topMargin
+        ),
+        self.editProfileImageButton.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+      ]
+    )
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+Constant.swift
@@ -34,6 +34,7 @@ extension UserInfoSceneViewController.Constant {
 
   enum ManageAccountView {
     static let topMargin: CGFloat = 35
+    static let height: CGFloat = 65
   }
 
   enum LogOutButton {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+Constant.swift
@@ -12,8 +12,12 @@ extension UserInfoSceneViewController {
 }
 
 extension UserInfoSceneViewController.Constant {
-  enum ProfileImageView {
+  enum ProfileInfoView {
     static let topMargin: CGFloat = 10
+    static let size = CGSize(width: 86, height: 106)
+  }
+
+  enum ProfileImageView {
     static let size = CGSize(width: 86, height: 86)
   }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+Constant.swift
@@ -32,12 +32,15 @@ extension UserInfoSceneViewController.Constant {
     static let leadingMargin: CGFloat = 11
   }
 
+  enum ManageAccountView {
+    static let topMargin: CGFloat = 35
+  }
+
   enum LogOutButton {
     enum Layer {
       static let cornerRadius: CGFloat = 10
     }
 
-    static let topMargin: CGFloat = 35
     static let height: CGFloat = 40
     static let titleLeadingMargin: CGFloat = 21
   }


### PR DESCRIPTION
## 💡 관련 이슈
- related: #455
- closed: #458

## 🎉 변경 사항
- UserInfoSceneViewController에 하위 컴포넌트들을 담는 컨테이너 뷰 객체를 추가하였습니다.
- 이외에 새롭게 변경된 코드는 없습니다!

## 📌 PR Point
- 기존에 구현된 UI 컴포넌트들을 담는 `컨테이너 뷰 객체`들을 추가하였습니다.
- 하위 컴포넌트들의 UI 설정을 ViewController 대신 컨테이너 뷰 객체가 담당합니다.

### 추가한 컨테이너 뷰 종류
1. ProfileInfoView: 프로필 이미지 뷰와 이미지 설정 버튼을 가짐.
2. ManageAccountView: 회원탈퇴 버튼과 로그아웃 버튼을 가짐.
- 컨테이너 뷰 내부 버튼의 터치 여부를 ViewController에 전달할 수 있도록 `Delegate 객체`를 추가하였습니다.

<img width="250" alt="스크린샷 2024-09-03 21 45 30" src="https://github.com/user-attachments/assets/1dd8e8ab-5cba-4095-8fb4-fddf56c1adb5">


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?