### PR TITLE
가이드 씬에서 사용될 뷰 - 그룹관리 씬 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneConstants.swift
@@ -19,6 +19,7 @@ enum Constant {
     
     enum Cell {
       static let height: CGFloat = 45.0
+      static let cornerRadius: CGFloat = 18.0
     }
     enum FooterView {
       static let height: CGFloat = 50.0

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupTableViewDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupTableViewDelegate.swift
@@ -81,6 +81,27 @@ extension ManageGroupTableViewDelegate: UITableViewDataSource {
     cell.setupRightButtonAction { [weak self] color, name in
       self?.onPostGroup?(name, color)
     }
+    return self.applyCornerRadius(to: cell, at: indexPath, in: tableView)
+  }
+  
+  private func applyCornerRadius(
+    to cell: ManageGroupTableViewCell,
+    at indexPath: IndexPath,
+    in tableView: UITableView
+  ) -> UITableViewCell {
+    let isFirstCell = indexPath.row == 0
+    let isLastCell = indexPath.row == tableView.numberOfRows(inSection: 0) - 1
+    
+    cell.backgroundColor = .white
+    if isFirstCell {
+      cell.layer.cornerRadius = Constant.Layout.Cell.cornerRadius
+      cell.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+      cell.layer.masksToBounds = true
+    } else if isLastCell {
+      cell.layer.cornerRadius = Constant.Layout.Cell.cornerRadius
+      cell.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+      cell.layer.masksToBounds = true
+    }
     return cell
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -127,12 +127,20 @@ extension ManageGroupViewController {
     }
   }
   
-  func setupTableView() {
+  func setupTableView(isForGuide: Bool = false) {
+    self.groupListTableView.backgroundColor = .clear
     self.footerView = self.buildAddGroupFooterButton()
-    self.manageGroupTableViewDelegate = ManageGroupTableViewDelegate(
-      displayedGroups: self.displayedGroups,
-      footerView: self.footerView
-    )
+    if !isForGuide {
+      self.manageGroupTableViewDelegate = ManageGroupTableViewDelegate(
+        displayedGroups: self.displayedGroups,
+        footerView: self.footerView
+      )
+    } else {
+      self.manageGroupTableViewDelegate = ManageGroupTableViewDelegate(
+        displayedGroups: self.displayedGroups,
+        footerView: UIView()
+      )
+    }
     
     self.groupListTableView.delegate = self.manageGroupTableViewDelegate
     self.groupListTableView.dataSource = self.manageGroupTableViewDelegate

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -25,13 +25,13 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
   
   var interactor: ManageGroupBusinessLogic?
   var router: (ManageGroupRoutingLogic & ManageGroupDataPassing)?
-
+  
   public var rightBarButton: UIBarButtonItem
   public var footerView: UIView
   
   var displayedGroups: [ManageGroup.ToDoGroup]
   var manageGroupTableViewDelegate: ManageGroupTableViewDelegate?
-  let groupListTableView: ManageGroupTableView
+  public let groupListTableView: ManageGroupTableView
   
   private let groupListTableViewCell: ManageGroupTableViewCell
   
@@ -106,7 +106,7 @@ extension ManageGroupViewController {
     self.navigationItem.setRightBarButton(self.rightBarButton, animated: true)
   }
   
-  @objc private func setEditingMode() {
+  @objc public func setEditingMode() {
     self.rightBarButton.isEnabled = false
     let isEditingMode = self.groupListTableView.isEditing
     self.groupListTableView.setEditingMode(!isEditingMode, animated: true)

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
@@ -14,10 +14,10 @@ public final class ManageGroupViewControllerForGuide: ManageGroupViewController 
   public override init() {
     super.init()
   }
-
+  
   public override func viewDidLoad() {
     self.view.backgroundColor = UIColor.white
-    self.setupTableView()
+    self.setupTableView(isForGuide: true)
     self.setupNavigationBar()
     self.fetchGroupList()
   }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import ToDoGardenUIComponent
+import ToDoGardenUIConstant
 
 public final class ManageGroupViewControllerForGuide: ManageGroupViewController {
   
@@ -20,6 +21,8 @@ public final class ManageGroupViewControllerForGuide: ManageGroupViewController 
     self.setupTableView(isForGuide: true)
     self.setupNavigationBar()
     self.fetchGroupList()
+    self.setFooterViewForGuide()
+    self.view.isUserInteractionEnabled = false
   }
   
   override func fetchGroupList() {
@@ -27,6 +30,24 @@ public final class ManageGroupViewControllerForGuide: ManageGroupViewController 
     self.displayedGroups = fetchedData
     self.manageGroupTableViewDelegate?.displayedGroups = fetchedData
   }
+  
+  private func setFooterViewForGuide() {
+    self.footerView.layer.cornerRadius = Constant.Layout.Cell.cornerRadius
+    self.footerView.layer.masksToBounds = true
+    self.footerView.usingAutolayout()
+    self.view.addSubview(self.footerView)
+    
+    NSLayoutConstraint.activate(
+      [
+        self.footerView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+        self.footerView.topAnchor.constraint(
+          equalTo: self.groupListTableView.topAnchor,
+          constant: Constant.Layout.Cell.height * 3
+        ),
+        self.footerView.leadingAnchor.constraint(equalTo: self.groupListTableView.leadingAnchor),
+        self.footerView.heightAnchor.constraint(equalToConstant: Constant.Layout.FooterView.height)
+      ]
+    )
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
@@ -61,5 +61,24 @@ public final class ManageGroupViewControllerForGuide: ManageGroupViewController 
   dimmedView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
   viewController.view.addSubview(dimmedView)
   
+  // rightBarButton 특정
+  viewController.rightBarButton.tintColor = .systemBlue
+  
+  // front로 끄집어내기
+  
+  // viewController.view.bringSubviewToFront(viewController.footerView)
+  viewController.view.bringSubviewToFront(viewController.groupListTableView)
+  
+  // 편집모드 진입
+  DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+    viewController.setEditingMode()
+  }
+  // 한번더 하면 편집모드 탈출
+  DispatchQueue.main.asyncAfter(deadline: .now() + 6.0) {
+    viewController.setEditingMode()
+  }
+
+  let navi = UINavigationController(rootViewController: viewController)
+  return navi
 }
 #endif

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
@@ -11,12 +11,6 @@ import ToDoGardenUIComponent
 
 public final class ManageGroupViewControllerForGuide: ManageGroupViewController {
   
-  public lazy var groupCells: [UITableViewCell] = {
-    self.groupListTableView.layoutIfNeeded()
-    let cells = self.groupListTableView.visibleCells
-    return cells
-  }()
-  
   public override init() {
     super.init()
   }
@@ -32,20 +26,19 @@ public final class ManageGroupViewControllerForGuide: ManageGroupViewController 
     let fetchedData = ManageGroupMockData.guideSceneData
     self.displayedGroups = fetchedData
     self.manageGroupTableViewDelegate?.displayedGroups = fetchedData
-    self.groupListTableView.reloadData()
+  }
   }
 }
 
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-  
   let viewController = ManageGroupViewControllerForGuide()
-  viewController.loadViewIfNeeded()
-  viewController.footerView.backgroundColor = .red
-  viewController.groupCells.forEach { cell in
-    cell.backgroundColor = .green
-  }
-  return viewController
+  
+  // 실험용 dimmedView 추가
+  let dimmedView = UIView(frame: viewController.view.bounds)
+  dimmedView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+  viewController.view.addSubview(dimmedView)
+  
 }
 #endif


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #443 
## 🎉 변경 사항
- 가이드씬에서 활용될 수 있게 일부 view들을 개조하였습니다. 

## 📌 PR Point

### I ) 가이드씬 뷰를 준비하다가 든 생각
<img width="974" alt="스크린샷 2024-09-04 오후 4 30 00" src="https://github.com/user-attachments/assets/4c3856f0-bf84-4621-8da4-10f900c8baa9">

____________

### II ) 개조시작
<img width="970" alt="스크린샷 2024-09-04 오후 4 32 20" src="https://github.com/user-attachments/assets/fb37e17a-55b9-4398-be59-d6b3080d31a5">

<img width="571" alt="스크린샷 2024-09-04 오후 4 33 53" src="https://github.com/user-attachments/assets/44c8bd1f-e6ad-4075-82b7-e4666ee6e187">

____________

### III ) 문득 그냥 써도 되겠다는 생각이 듦
<img width="930" alt="스크린샷 2024-09-04 오후 4 57 02" src="https://github.com/user-attachments/assets/fa25f786-862f-4a58-83dc-bead27d5ccde">


-> 가이드씬을 구성할때 추가적인 까다로운 변경이 없도록 살짝만 다듬으려 했는데, 이렇게 되어버렸습니다. 
-> 프리뷰를 통해 직접적으로 확인이 가능합니다. 
______

### 구상해두신 방법이 분명 있을것이라 생각합니다. 
그대로 써도 되겠는데? 싶어서 이렇게 PR합니다 ! 
만약 ManageGroupViewControllerForGuide를 그대로 갖다 쓰는것 때문에 그 방법에 제한이 생기거나, 마음에 안드는 느낌이라면,
말씀만 주시면 이 PR에서 CommonViews에 
- ManageGroupTableViewCell
- ManageGroupTableViewFooter (새로 생성) 
- (필요하다면 우측상단 버튼도)
작업진행 하곘습니다. 의견을 알려주세요 ! 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?