### PR TITLE
Add Guide Scene Contents View

### DIFF
--- a/ToDo-Garden/ToDo-Garden/GuideScene/Sources/GuideScene/GuideDetailViewController+BottomView.swift
+++ b/ToDo-Garden/ToDo-Garden/GuideScene/Sources/GuideScene/GuideDetailViewController+BottomView.swift
@@ -12,6 +12,7 @@ extension GuideDetailViewController {
     private var rightButton: UIButton!
     
     @Published var currentIndex: Int = 0
+    private var subscription: AnyCancellable?
     private var subviewCount: Int = 0
     
     override init(frame: CGRect) {
@@ -78,16 +79,16 @@ extension GuideDetailViewController {
       self.addSubview(self.rightButton)
       self.layoutContainer(container)
       self.leftButton.isHidden = true
+      self.bindingCurrentIndex()
     }
     
     private func moveTo(forward: Bool) {
-      let count = forward ? 1 : -1
-      let rowWidth = self.scrollView.bounds.width * CGFloat(count)
+      let count = !forward ? 1 : -1
+      guard
+        0..<3 ~= self.currentIndex + count
+      else { return }
       self.currentIndex += count
-      self.scrollView.setContentOffset(
-        .init(x: self.scrollView.contentOffset.x - rowWidth, y: 0),
-        animated: true
-      )
+      self.scrollView.moveTo(index: self.currentIndex)
     }
     
     private func buildContainer() -> UIView {
@@ -188,7 +189,15 @@ extension GuideDetailViewController {
         self.rightButton.widthAnchor.constraint(equalToConstant: 24),
         self.rightButton.heightAnchor.constraint(equalToConstant: 24)
       ])
-      
+    }
+    
+    private func bindingCurrentIndex() {
+      self.subscription = self.$currentIndex
+        .debounce(for: 0.3, scheduler: DispatchQueue.main)
+        .removeDuplicates()
+        .sink { [weak scrollView] index in
+          scrollView?.moveTo(index: index)
+        }
     }
   }
 }
@@ -197,6 +206,7 @@ extension GuideDetailViewController.BottomView: UIScrollViewDelegate {
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
     let viewSize = scrollView.bounds.width
     let index = Int(round(scrollView.contentOffset.x / viewSize))
+    guard self.currentIndex != index else { return }
     self.currentIndex = index
     self.updateStepLabel(currentIndex)
     self.updateButtons()
@@ -217,5 +227,16 @@ extension GuideDetailViewController.BottomView: UIScrollViewDelegate {
       self.leftButton.isHidden = false
       self.rightButton.isHidden = false
     }
+  }
+}
+
+// GuideScene에서만 사용가능한 메소드이기에 공용 컴포넌트로 분리시키지 않겠습니다.
+extension UIScrollView {
+  func moveTo(index: Int) {
+    let offset: CGFloat = CGFloat(index) * (self.bounds.width)
+    self.setContentOffset(
+      .init(x: offset, y: 0),
+      animated: true
+    )
   }
 }

--- a/ToDo-Garden/ToDo-Garden/GuideScene/Sources/GuideScene/GuideDetailViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/GuideScene/Sources/GuideScene/GuideDetailViewController.swift
@@ -4,11 +4,14 @@ import Combine
 import UIKit
 
 final class GuideDetailViewController: UIViewController {
+  private var scrollView: UIScrollView!
+  private var scrollViewContentsView: UIStackView!
   private var bottomView: BottomView!
   
   private var state: Guide.GuideState
   
   private var contensBuilder: GuideSceneContentsBuilder
+  private var subscription: AnyCancellable?
   
   // MARK: - Object lifecycle
   init(
@@ -29,15 +32,52 @@ final class GuideDetailViewController: UIViewController {
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    self.bottomView = BottomView()
-    self.layoutBottomView()
+    self.build()
   }
   
   override func viewIsAppearing(_ animated: Bool) {
     super.viewIsAppearing(animated)
+    self.updateContents(
+      self.contensBuilder.baseContents(self.state)
+    )
     self.bottomView.updateContents(
       self.contensBuilder.bottomContents(self.state)
     )
+  }
+  
+  private func updateContents(_ contents: [UIView]) {
+    for content in contents {
+      self.scrollViewContentsView.addArrangedSubview(content)
+      content.widthAnchor.constraint(equalTo: self.view.widthAnchor).isActive = true
+      content.heightAnchor.constraint(equalTo: self.view.heightAnchor).isActive = true
+    }
+  }
+  
+  private func build() {
+    self.scrollView = buildScrollView()
+    self.scrollView.delegate = self
+    self.scrollViewContentsView = UIHStackView(
+      spacing: 0,
+      arrangedSubviews: []
+    )
+    self.bottomView = BottomView()
+    self.bindingCurrentIndex()
+    self.layoutScrollView()
+    self.layoutBottomView()
+  }
+  
+  private func buildScrollView() -> UIScrollView {
+    let scrollView = UIScrollView()
+    scrollView.isPagingEnabled = true
+    scrollView.showsHorizontalScrollIndicator = false
+    return scrollView
+  }
+  
+  private func layoutScrollView() {
+    self.view.addSubview(self.scrollView)
+    self.scrollView.equalToParent()
+    self.scrollView.addSubview(self.scrollViewContentsView)
+    self.scrollViewContentsView.equalToParent()
   }
   
   private func layoutBottomView() {
@@ -49,6 +89,23 @@ final class GuideDetailViewController: UIViewController {
       self.bottomView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
       self.bottomView.heightAnchor.constraint(equalToConstant: 275)
     ])
+  }
+  
+  private func bindingCurrentIndex() {
+    self.subscription = self.bottomView.$currentIndex
+      .debounce(for: 0.3, scheduler: DispatchQueue.main)
+      .removeDuplicates()
+      .sink { [weak scrollView] index in
+        scrollView?.moveTo(index: index)
+      }
+  }
+}
+
+extension GuideDetailViewController: UIScrollViewDelegate {
+  func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    let viewSize = scrollView.bounds.width
+    let index = Int(round(scrollView.contentOffset.x / viewSize))
+    self.bottomView.currentIndex = index
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/GuideScene/Sources/GuideScene/GuideDetailViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/GuideScene/Sources/GuideScene/GuideDetailViewController.swift
@@ -102,7 +102,11 @@ final class GuideDetailViewController: UIViewController {
 }
 
 extension GuideDetailViewController: UIScrollViewDelegate {
-  func scrollViewDidScroll(_ scrollView: UIScrollView) {
+  func scrollViewWillEndDragging(
+    _ scrollView: UIScrollView,
+    withVelocity velocity: CGPoint,
+    targetContentOffset: UnsafeMutablePointer<CGPoint>
+  ) {
     let viewSize = scrollView.bounds.width
     let index = Int(round(scrollView.contentOffset.x / viewSize))
     self.bottomView.currentIndex = index
@@ -111,5 +115,5 @@ extension GuideDetailViewController: UIScrollViewDelegate {
 
 @available(iOS 17.0, *)
 #Preview {
-  GuideDetailViewController(.todoCreate)
+  GuideDetailViewController(.todoEdit)
 }

--- a/ToDo-Garden/ToDo-Garden/GuideScene/Sources/GuideScene/GuideSceneContentsBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/GuideScene/Sources/GuideScene/GuideSceneContentsBuilder.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 struct GuideSceneContentsBuilder: Sendable {
+  var baseContents: @MainActor @Sendable (Guide.GuideState) -> [UIView]
   var bottomContents: @MainActor @Sendable (Guide.GuideState) -> [UIView]
 }
 
@@ -9,8 +10,18 @@ extension GuideSceneContentsBuilder {
     let bottomBuilder = GuideSceneBottomContentsViewBuilder()
     
     return GuideSceneContentsBuilder(
+      baseContents: { _ in
+        let view1 = UIView()
+        view1.backgroundColor = .systemIndigo
+        let view2 = UIView()
+        view2.backgroundColor = .purple
+        let view3 = UIView()
+        view3.backgroundColor = .orange
+        
+        return [view1, view2, view3]
+      },
       bottomContents: { state in
-        return bottomBuilder
+        bottomBuilder
           .buildSubviews(state)
           .map { $0.wrapVerticallyCentered() }
       }


### PR DESCRIPTION
## 💡 관련 이슈
#412 
## 🎉 변경 사항
가이드 씬 컨텐츠 뷰를 추가할 수 있도록 준비했습니다.

- 버튼을 눌러서 Index 범위를 벗어나는 경우를 수정했습니다.
- 컨텐츠 스크롤 뷰와 바텀 스크롤 뷰를 동기화 처리했습니다.

## 📝 셀프체크리스트
- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?