### PR TITLE
ShareGardenSceneViewController 초기 레이아웃 설정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneInteractor.swift
@@ -29,3 +29,9 @@ final class ShareGardenSceneInteractor: ShareGardenSceneDataStore {
 
 extension ShareGardenSceneInteractor: ShareGardenSceneBusinessLogic {
 }
+
+extension ShareGardenSceneInteractor: FriendsGardenStore {
+  func fetchBy(_ id: ShareGardenSceneEntity.ShareGardenScene.FriendsGarden.ID) -> ShareGardenScene.FriendsGarden? {
+    return nil
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneSceneBuilder.swift
@@ -33,7 +33,7 @@ extension ShareGardenSceneSceneBuilder: ShareGardenSceneSceneBuildable {
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
   public func build(with payload: ShareGardenSceneScenePayloadable) -> ShareGardenSceneViewControllable {
-    let shareGardenScene = self.configureVIPCycle(for: ShareGardenSceneViewController())
+    let shareGardenScene = self.configuredVIPCycleShareGardenScene()
     self.setPayload(for: shareGardenScene, with: payload)
     
     return shareGardenScene
@@ -42,10 +42,10 @@ extension ShareGardenSceneSceneBuilder: ShareGardenSceneSceneBuildable {
 
 extension ShareGardenSceneSceneBuilder {
   /// VIP Cycle을 설정합니다.
-  /// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
-  private func configureVIPCycle(for viewController: ShareGardenSceneViewController) -> ShareGardenSceneViewController {
+  private func configuredVIPCycleShareGardenScene() -> ShareGardenSceneViewController {
     let interactor = ShareGardenSceneInteractor(shareGardenSceneWorker: self.dependency.shareGardenSceneWorker)
+    let viewController = ShareGardenSceneViewController(friendsGardenStore: interactor)
     let presenter = ShareGardenScenePresenter()
     let router = ShareGardenSceneRouter()
     viewController.interactor = interactor

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -53,7 +53,7 @@ extension ShareGardenSceneViewController.Constant.Layout {
   enum FriendsGardenView {
     static let editButtonWidth: CGFloat = 35.0
     static let editButtonHeight: CGFloat = 35.0
-    static let stackViewSpacing = 15.0
+    static let stackViewSpacing: CGFloat = 14.0
     static let sectionHeaderViewLeftInsetRatio: CGFloat = 28.0 / 375.0
     static let sectionHeaderViewRightInsetRatio: CGFloat = 22.0 / 375.0
     static let searchGardenButtonTopInset: CGFloat = 8

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -35,7 +35,7 @@ extension ShareGardenSceneViewController.Constant.StringLiteral {
 // MARK: - Layout
 
 extension ShareGardenSceneViewController.Constant.Layout {
-  static let myGardenViewTopInsetRatio: CGFloat = 21 / 812
+  static let myGardenViewTopInsetRatio: CGFloat = 19 / 812
   static let friendsGardenViewTopInsetRatio: CGFloat = 26 / 812
   
   enum SectionHeaderView {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -56,6 +56,7 @@ extension ShareGardenSceneViewController.Constant.Layout {
     static let stackViewSpacing = 15.0
     static let sectionHeaderViewLeftInsetRatio: CGFloat = 28.0 / 375.0
     static let sectionHeaderViewRightInsetRatio: CGFloat = 22.0 / 375.0
+    static let searchGardenButtonTopInset: CGFloat = 8
     static let searchGardenButtonHorizontalInsetRatio: CGFloat = 19.0 / 375.0
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -35,6 +35,9 @@ extension ShareGardenSceneViewController.Constant.StringLiteral {
 // MARK: - Layout
 
 extension ShareGardenSceneViewController.Constant.Layout {
+  static let myGardenViewTopInsetRatio: CGFloat = 21 / 812
+  static let friendsGardenViewTopInsetRatio: CGFloat = 26 / 812
+  
   enum SectionHeaderView {
     static let spacingRatio: CGFloat = 100 / 323
   }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -60,6 +60,7 @@ extension ShareGardenSceneViewController.Constant.Layout {
     static let sectionHeaderViewLeftInsetRatio: CGFloat = 28.0 / 375.0
     static let sectionHeaderViewRightInsetRatio: CGFloat = 15.0 / 375.0
     static let searchGardenButtonTopInset: CGFloat = 8
+    static let searchGardenButtonHeight: CGFloat = 24.0
     static let searchGardenButtonHorizontalInsetRatio: CGFloat = 19.0 / 375.0
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -55,7 +55,7 @@ extension ShareGardenSceneViewController.Constant.Layout {
     static let editButtonHeight: CGFloat = 35.0
     static let stackViewSpacing: CGFloat = 14.0
     static let sectionHeaderViewLeftInsetRatio: CGFloat = 28.0 / 375.0
-    static let sectionHeaderViewRightInsetRatio: CGFloat = 22.0 / 375.0
+    static let sectionHeaderViewRightInsetRatio: CGFloat = 15.0 / 375.0
     static let searchGardenButtonTopInset: CGFloat = 8
     static let searchGardenButtonHorizontalInsetRatio: CGFloat = 19.0 / 375.0
   }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -37,6 +37,13 @@ final class ShareGardenSceneViewController: UIViewController, ShareGardenSceneVi
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+ 
+  // MARK: - View life cycle
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.setup()
+  }
   
   // MARK: - View lifecycle
 }
@@ -49,4 +56,59 @@ extension ShareGardenSceneViewController: ShareGardenSceneDisplayLogic {
 // MARK: - Request to interactor
 
 extension ShareGardenSceneViewController {
+}
+
+// MARK: - Setup
+
+extension ShareGardenSceneViewController {
+  private func setup() {
+    self.setupViewAppearance()
+    self.addSubviews()
+    self.setupLayoutConstraints()
+  }
+  
+  private func setupViewAppearance() {
+    self.view.backgroundColor = UIColor.white
+  }
+  
+  private func addSubviews() {
+    self.view.addSubview(self.myGardenView)
+    self.view.addSubview(self.friendsGardenView)
+  }
+  
+  private func setupLayoutConstraints() {
+    self.setupMyGardenViewLayoutConstraints()
+    self.setupFriendsGardenViewLayoutConstraints()
+  }
+}
+
+// MARK: - Layout constraints
+
+extension ShareGardenSceneViewController {
+  private func setupMyGardenViewLayoutConstraints() {
+    let topInsetRatio = Constant.Layout.myGardenViewTopInsetRatio
+    let topInset: CGFloat = self.view.bounds.height * topInsetRatio
+    
+    self.myGardenView.usingAutolayout()
+    
+    NSLayoutConstraint.activate([
+      self.myGardenView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: topInset),
+      self.myGardenView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+      self.myGardenView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
+    ])
+  }
+  
+  private func setupFriendsGardenViewLayoutConstraints() {
+    let topInsetRatio = Constant.Layout.friendsGardenViewTopInsetRatio
+    let topInset: CGFloat = self.view.bounds.height * topInsetRatio
+    
+    self.friendsGardenView.usingAutolayout()
+    
+    NSLayoutConstraint.activate([
+      self.friendsGardenView.topAnchor.constraint(equalTo: self.myGardenView.bottomAnchor, constant: topInset),
+      self.friendsGardenView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+      self.friendsGardenView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+      self.friendsGardenView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
+    ])
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -17,12 +17,19 @@ final class ShareGardenSceneViewController: UIViewController, ShareGardenSceneVi
   
   // MARK: - VIP Properties
   
-  var interactor: ShareGardenSceneBusinessLogic?
+  var interactor: (ShareGardenSceneBusinessLogic & FriendsGardenStore)?
   var router: (ShareGardenSceneRoutingLogic & ShareGardenSceneDataPassing)?
+  
+  // MARK: - UI Properties
+  
+  private let myGardenView: MyGardenView
+  private let friendsGardenView: FriendsGardenView
   
   // MARK: - Object lifecycle
   
-  init() {
+  init(friendsGardenStore: FriendsGardenStore) {
+    self.myGardenView = MyGardenView()
+    self.friendsGardenView = FriendsGardenView(friendsGardenStore: friendsGardenStore)
     super.init(nibName: nil, bundle: nil)
   }
   

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -187,5 +187,6 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
       height: Self.layoutConstant.gradientLayerHeight
     )
     self.layer.addSublayer(self.gradientLayer)
+    self.isGradientLayerAdded = true
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -81,7 +81,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
 // MARK: - Setup
 
 extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView {
-  private func setup () {
+  private func setup() {
     self.addSubviews()
     self.setupLayoutCosntraints()
   }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -164,7 +164,7 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
     if collectionView.indexPathsForSelectedItems?.contains(indexPath) ?? false {
       collectionView.deselectItem(at: indexPath, animated: true)
     } else {
-      collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
+      collectionView.selectItem(at: indexPath, animated: true, scrollPosition: [])
     }
     
     return false

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewCell.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewCell.swift
@@ -21,10 +21,11 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     ///
     /// [이슈 링크](https://github.com/ToDo-Garden/ToDo-Garden/issues/439)
     private let profileInfoView: Styled.Row = {
+      let profileInfoViewConfiguration = Styled.Row.Configuration.self
       let profileInfoView = Styled.Row(
-        configuration: Styled.Row.Configuration.profile(
-          Styled.Row.Configuration.ProfileModel.gardenInfo(
-            image: UIImage.defaultFriendProfileImage,
+        configuration: profileInfoViewConfiguration.profile(
+          profileInfoViewConfiguration.ProfileModel(
+            style: profileInfoViewConfiguration.ProfileModel.Style.shareRow,
             title: "이인우",
             description: "연속 19일 집중!"
           )
@@ -45,6 +46,9 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     override var isSelected: Bool {
       didSet {
         self.toggleConstraintsForSelectionState()
+        if let collectionView = self.superview as? UICollectionView {
+          collectionView.layoutIfNeeded()
+        }
         self.invalidateIntrinsicContentSize()
       }
     }
@@ -129,6 +133,8 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
     self.deSelectedConstraints.forEach {
       $0.isActive = !self.isSelected
     }
+    
+    self.profileInfoView.isSelected = self.isSelected
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -126,12 +126,14 @@ extension ShareGardenSceneViewController.FriendsGardenView {
   
   private func setupSearchGardenButtonLayoutConstraints() {
     let horizontalInset: CGFloat = self.bounds.width * Self.layoutConstant.searchGardenButtonHorizontalInsetRatio
+    let height: CGFloat = Self.layoutConstant.searchGardenButtonHeight
     
     self.searchGardenButton.usingAutolayout()
     
     NSLayoutConstraint.activate([
       self.searchGardenButton.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: horizontalInset),
-      self.searchGardenButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -horizontalInset)
+      self.searchGardenButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -horizontalInset),
+      self.searchGardenButton.heightAnchor.constraint(equalToConstant: height)
     ])
   }
   

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -78,6 +78,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
   private func setup() {
     self.setupStackView()
     self.addSubviews()
+    self.setCustomSpacing()
   }
   
   private func setupStackView() {
@@ -141,5 +142,10 @@ extension ShareGardenSceneViewController.FriendsGardenView {
       self.friendsGardenListView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
       self.friendsGardenListView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
     ])
+  }
+  
+  private func setCustomSpacing() {
+    let searchGardenButtonTopInset = Self.layoutConstant.searchGardenButtonTopInset
+    self.setCustomSpacing(searchGardenButtonTopInset, after: self.sectionHeaderView)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -20,6 +20,9 @@ extension ShareGardenSceneViewController {
       let shareButton = UIButton()
       shareButton.setImage(UIImage.shareIconImage, for: UIControl.State.normal)
       let title = ShareGardenSceneViewController.Constant.StringLiteral.MyGardenSectionHeaderView.title
+      shareButton.usingAutolayout()
+      shareButton.widthAnchor.constraint(equalToConstant: 25).isActive = true
+      shareButton.heightAnchor.constraint(equalToConstant: 25).isActive = true
       
       let sectionHeaderView = SectionHeaderView(
         sectionTitle: title,

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -88,7 +88,7 @@ extension ShareGardenSceneViewController.MyGardenView {
   
   private func setupStackView() {
     self.spacing = 14
-    self.distribution = UIStackView.Distribution.fillProportionally
+    self.distribution = UIStackView.Distribution.fill
     self.axis = NSLayoutConstraint.Axis.vertical
     self.alignment = UIStackView.Alignment.center
   }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -23,6 +23,7 @@ extension ShareGardenSceneViewController {
       shareButton.usingAutolayout()
       shareButton.widthAnchor.constraint(equalToConstant: 25).isActive = true
       shareButton.heightAnchor.constraint(equalToConstant: 25).isActive = true
+      shareButton.setTitleColor(UIColor.darkGray, for: UIControl.State.highlighted)
       
       let sectionHeaderView = SectionHeaderView(
         sectionTitle: title,

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
@@ -119,8 +119,8 @@ extension Styled.Row.Configuration.ProfileModel {
     
     var defaultImage: UIImage {
       self == Self.shareRow
-      ? UIImage.defaultProfileImage
-      : UIImage.defaultFriendProfileImage
+      ? UIImage.defaultFriendProfileImage
+      : UIImage.defaultProfileImage
     }
     
     var imageSize: CGSize {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
@@ -142,7 +142,7 @@ extension Styled.Row.Configuration.ProfileModel {
     
     var titleFont: UIFont {
       self == Self.shareRow
-      ? UIFont.pretendardBodyBold
+      ? UIFont.pretendardBodySemiBold15
       : UIFont.pretendardHeadBold
     }
     


### PR DESCRIPTION
## 💡 관련 이슈
- related: #298 
## 🎉 변경 사항
- ShareGardenSceneViewController의 초기 레이아웃을 설정하였습니다.

|Demo|Design|
|---|---|
|<img width="230" src="https://github.com/user-attachments/assets/93905705-cd78-4405-ba60-86a0775c26a7" /> | <img width="230" src="https://github.com/user-attachments/assets/f9e48a0e-67e8-4f4a-9e6a-72eb8a48125a" />|

## 📌 PR Point

- 디자인 가이드에 맞추어 수치를 조정하였습니다.
- FriendsGardenView를 그리기 위해 필요한 의존성인 FriendsGardenStore를 주입 시키기 위해 SceneBuilder를 수정하였습니다.
- Interactor가 FriendsGardenStore 프로토콜을 채택하도록 하여, 친구의 가든 데이터를 관리할 수 있도록 설계하였습니다!

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?