### PR TITLE
UserInfoSceneViewController 사진 접근 권한 설정 로직 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden.xcodeproj/project.pbxproj
+++ b/ToDo-Garden/ToDo-Garden.xcodeproj/project.pbxproj
@@ -469,6 +469,7 @@
 				DEVELOPMENT_TEAM = 7J855UGZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "ToDo-Garden/Resources/Info.plist";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -496,6 +497,7 @@
 				DEVELOPMENT_TEAM = 7J855UGZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "ToDo-Garden/Resources/Info.plist";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/AppServiceWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/AppServiceWorker.swift
@@ -1,0 +1,24 @@
+//
+//  AppServiceWorker.swift
+//
+//
+//  Created by Wood on 9/7/24.
+//
+
+import UIKit
+
+import UserInfoSceneAPI
+
+public struct AppServiceWorker: AppServiceWorkable {
+  public init() {}
+
+  public func openSettingApp() -> Bool {
+    let settingAppURL = URL(string: UIApplication.openSettingsURLString)
+    if let settingAppURL, UIApplication.shared.canOpenURL(settingAppURL) {
+      UIApplication.shared.open(settingAppURL)
+      return true
+    } else {
+      return false
+    }
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/AppServiceWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/AppServiceWorker.swift
@@ -12,13 +12,10 @@ import UserInfoSceneAPI
 public struct AppServiceWorker: AppServiceWorkable {
   public init() {}
 
-  public func openSettingApp() -> Bool {
+  public func openSettingApp() {
     let settingAppURL = URL(string: UIApplication.openSettingsURLString)
     if let settingAppURL, UIApplication.shared.canOpenURL(settingAppURL) {
       UIApplication.shared.open(settingAppURL)
-      return true
-    } else {
-      return false
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -1,6 +1,6 @@
 //
 //  UserInfoSceneInteractor.swift
-//  
+//
 //
 //  Created by Wood on 8/28/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
@@ -15,35 +15,56 @@ protocol UserInfoSceneDataStore {
 }
 
 protocol UserInfoSceneBusinessLogic {
+  func fetchUserPhotoToChange()
   func moveToSettingApp()
   func doSomething(request: UserInfoScene.Something.Request)
 }
 
 class UserInfoSceneInteractor: UserInfoSceneDataStore {
+  private var profileImageLoadTask: Task<Void, Error>?
+
   // var name: String = ""
   var presenter: UserInfoScenePresentationLogic?
   private let userInfoWorker: UserInfoSceneWorkable
   private let appServiceWorker: AppServiceWorkable
+  private let userPhotoWorker: UserPhotoWorker
 
   init(
     userInfoWorker: UserInfoSceneWorkable,
-    appServiceWorker: AppServiceWorkable
+    appServiceWorker: AppServiceWorkable,
+    userPhotoWorker: UserPhotoWorker
   ) {
     self.userInfoWorker = userInfoWorker
     self.appServiceWorker = appServiceWorker
+    self.userPhotoWorker = userPhotoWorker
   }
 }
 
 // MARK: - Request to worker
 
 extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
+  func fetchUserPhotoToChange() {
+    self.profileImageLoadTask = Task {
+      let isPhotoAccessEnabled = await self.userPhotoWorker.fetchPhotoAcess()
+      if isPhotoAccessEnabled {
+        let selectedImage = try await self.userPhotoWorker.requestImage()
+        print(selectedImage)
+      } else {
+        await MainActor.run {
+          self.presenter?.presentSettingAppAlsert()
+        }
+      }
+    }
+  }
+
   func moveToSettingApp() {
     let isSettingAppOpened = self.appServiceWorker.openSettingApp()
+    print(isSettingAppOpened)
   }
 
   func doSomething(request: UserInfoScene.Something.Request) {
     self.userInfoWorker.doSomeWork()
-    
+
     let response = UserInfoScene.Something.Response()
     self.presenter?.presentSomething(response: response)
   }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -15,6 +15,7 @@ protocol UserInfoSceneDataStore {
 }
 
 protocol UserInfoSceneBusinessLogic {
+  func moveToSettingApp()
   func doSomething(request: UserInfoScene.Something.Request)
 }
 
@@ -22,15 +23,24 @@ class UserInfoSceneInteractor: UserInfoSceneDataStore {
   // var name: String = ""
   var presenter: UserInfoScenePresentationLogic?
   private let userInfoWorker: UserInfoSceneWorkable
-  
-  init(userInfoWorker: UserInfoSceneWorkable) {
+  private let appServiceWorker: AppServiceWorkable
+
+  init(
+    userInfoWorker: UserInfoSceneWorkable,
+    appServiceWorker: AppServiceWorkable
+  ) {
     self.userInfoWorker = userInfoWorker
+    self.appServiceWorker = appServiceWorker
   }
 }
 
 // MARK: - Request to worker
 
 extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
+  func moveToSettingApp() {
+    let isSettingAppOpened = self.appServiceWorker.openSettingApp()
+  }
+
   func doSomething(request: UserInfoScene.Something.Request) {
     self.userInfoWorker.doSomeWork()
     

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -58,8 +58,24 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
 
   func changeUserProfileImage() {
     self.requestUserPhotoTask = Task {
-      let photoForEdit = try await self.userPhotoWorker.requestPhoto()
-      // TODO: 서버에 프로필 이미지 변경 요청
+      do {
+        let profileImageToChange = try await self.userPhotoWorker.requestPhoto()
+        if let imageData = profileImageToChange.pngData() {
+          try self.userInfoWorker.requestChangeProfileImage(with: imageData)
+          let response = UserInfoScene.ChangeProfileImage.Response(
+            changeResult: Result.success(profileImageToChange)
+          )
+
+          await MainActor.run {
+            self.presenter?.presentChangedProfileImage(response: response)
+          }
+        }
+      } catch let error {
+        let response = UserInfoScene.ChangeProfileImage.Response(
+          changeResult: Result.failure(error)
+        )
+        self.presenter?.presentChangedProfileImage(response: response)
+      }
     }
   }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -5,7 +5,7 @@
 //  Created by Wood on 8/28/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit.UIImage
 
 import UserInfoSceneAPI
 import UserInfoSceneEntity
@@ -15,13 +15,15 @@ protocol UserInfoSceneDataStore {
 }
 
 protocol UserInfoSceneBusinessLogic {
-  func fetchUserPhotoToChange()
-  func moveToSettingApp()
+  func fetchUserPhotoAccess()
+  func changeUserProfileImage()
+  func openSettingApp()
   func doSomething(request: UserInfoScene.Something.Request)
 }
 
 class UserInfoSceneInteractor: UserInfoSceneDataStore {
-  private var profileImageLoadTask: Task<Void, Error>?
+  private var requestPhotoAccessTask: Task<Void, Error>?
+  private var requestUserPhotoTask: Task<Void, Error>?
 
   // var name: String = ""
   var presenter: UserInfoScenePresentationLogic?
@@ -43,23 +45,26 @@ class UserInfoSceneInteractor: UserInfoSceneDataStore {
 // MARK: - Request to worker
 
 extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
-  func fetchUserPhotoToChange() {
-    self.profileImageLoadTask = Task {
-      let isPhotoAccessEnabled = await self.userPhotoWorker.fetchPhotoAcess()
-      if isPhotoAccessEnabled {
-        let selectedImage = try await self.userPhotoWorker.requestImage()
-        print(selectedImage)
-      } else {
-        await MainActor.run {
-          self.presenter?.presentSettingAppAlsert()
-        }
+  func fetchUserPhotoAccess() {
+    self.requestPhotoAccessTask = Task {
+      let isPhotoAccessible = await self.userPhotoWorker.requestPhotoAccess()
+      let response = UserInfoScene.FetchUserPhotoAccess.Response(isPhotoAccessible: isPhotoAccessible)
+
+      await MainActor.run {
+        self.presenter?.presentUserPhotoAccess(response: response)
       }
     }
   }
 
-  func moveToSettingApp() {
-    let isSettingAppOpened = self.appServiceWorker.openSettingApp()
-    print(isSettingAppOpened)
+  func changeUserProfileImage() {
+    self.requestUserPhotoTask = Task {
+      let photoForEdit = try await self.userPhotoWorker.requestPhoto()
+      // TODO: 서버에 프로필 이미지 변경 요청
+    }
+  }
+
+  func openSettingApp() {
+    self.appServiceWorker.openSettingApp()
   }
 
   func doSomething(request: UserInfoScene.Something.Request) {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -12,6 +12,7 @@ import UserInfoSceneEntity
 protocol UserInfoScenePresentationLogic {
   func presentSomething(response: UserInfoScene.Something.Response)
   func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response)
+  func presentChangedProfileImage(response: UserInfoScene.ChangeProfileImage.Response)
 }
 
 class UserInfoScenePresenter {
@@ -25,6 +26,12 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
     let isPhotoAccessible = response.isPhotoAccessible
     let viewModel = UserInfoScene.FetchUserPhotoAccess.ViewModel(isPhotoAccessible: isPhotoAccessible)
     self.viewController?.displayUserPhotoAccess(viewModel: viewModel)
+  }
+
+  func presentChangedProfileImage(response: UserInfoScene.ChangeProfileImage.Response) {
+    let changeResult = response.changeResult
+    let viewModel = UserInfoScene.ChangeProfileImage.ViewModel(changeResult: changeResult)
+    self.viewController?.displayChangedProfileImage(viewModel: viewModel)
   }
 
   func presentSomething(response: UserInfoScene.Something.Response) {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -11,7 +11,7 @@ import UserInfoSceneEntity
 
 protocol UserInfoScenePresentationLogic {
   func presentSomething(response: UserInfoScene.Something.Response)
-  func presentSettingAppAlsert()
+  func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response)
 }
 
 class UserInfoScenePresenter {
@@ -21,10 +21,12 @@ class UserInfoScenePresenter {
 // MARK: - Request to ViewController
 
 extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
-  func presentSettingAppAlsert() {
-    self.viewController?.displaySettingAppAlert()
+  func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response) {
+    let isPhotoAccessible = response.isPhotoAccessible
+    let viewModel = UserInfoScene.FetchUserPhotoAccess.ViewModel(isPhotoAccessible: isPhotoAccessible)
+    self.viewController?.displayUserPhotoAccess(viewModel: viewModel)
   }
-  
+
   func presentSomething(response: UserInfoScene.Something.Response) {
     let viewModel = UserInfoScene.Something.ViewModel()
     self.viewController?.displaySomething(viewModel: viewModel)

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -11,6 +11,7 @@ import UserInfoSceneEntity
 
 protocol UserInfoScenePresentationLogic {
   func presentSomething(response: UserInfoScene.Something.Response)
+  func presentSettingAppAlsert()
 }
 
 class UserInfoScenePresenter {
@@ -20,6 +21,10 @@ class UserInfoScenePresenter {
 // MARK: - Request to ViewController
 
 extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
+  func presentSettingAppAlsert() {
+    self.viewController?.displaySettingAppAlert()
+  }
+  
   func presentSomething(response: UserInfoScene.Something.Response) {
     let viewModel = UserInfoScene.Something.ViewModel()
     self.viewController?.displaySomething(viewModel: viewModel)

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
@@ -20,9 +20,9 @@ protocol UserInfoSceneDataPassing {
 class UserInfoSceneRouter: UserInfoSceneDataPassing {
   weak var viewController: UserInfoSceneViewController?
   var dataStore: UserInfoSceneDataStore?
-  private let nextSceneBuilder: NextSceneBuildable
-  
-  init(nextSceneBuilder: NextSceneBuildable) {
+  private let nextSceneBuilder: NextSceneBuildable?
+
+  init(nextSceneBuilder: NextSceneBuildable?) {
     self.nextSceneBuilder = nextSceneBuilder
   }
 }
@@ -31,9 +31,9 @@ class UserInfoSceneRouter: UserInfoSceneDataPassing {
 
 extension UserInfoSceneRouter: UserInfoSceneRoutingLogic {
   func routeToSomewhere() {
-    let destinationViewController = self.nextSceneBuilder.build(with: NextScenePayload())
-    
-    self.viewController?.present(destinationViewController, animated: true)
+//    let destinationViewController = self.nextSceneBuilder.build(with: NextScenePayload())
+//    
+//    self.viewController?.present(destinationViewController, animated: true)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
@@ -5,6 +5,7 @@
 //  Created by Wood on 8/28/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
+import PhotosUI
 import UIKit.UIApplication
 
 import UserInfoSceneAPI
@@ -13,17 +14,20 @@ import UserInfoSceneEntity
 public struct UserInfoSceneSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
+    let photoPickerViewController: PHPickerViewController
     let application: UIApplication
     let openSettingsURLString: String
     let userInfoWorker: UserInfoSceneWorkable
     let nextSceneBuilder: NextSceneBuildable
 
     public init(
+      photoPickerViewController: PHPickerViewController,
       application: UIApplication,
       openSettingsURLString: String,
       userInfoWorker: UserInfoSceneWorkable,
       nextSceneBuilder: NextSceneBuildable
     ) {
+      self.photoPickerViewController = photoPickerViewController
       self.application = application
       self.openSettingsURLString = openSettingsURLString
       self.userInfoWorker = userInfoWorker
@@ -44,6 +48,7 @@ extension UserInfoSceneSceneBuilder: UserInfoSceneSceneBuildable {
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
   public func build(with payload: UserInfoSceneScenePayloadable) -> UserInfoSceneViewControllable {
     let userInfoSceneViewController = UserInfoSceneViewController(
+      photoPickerViewController: self.dependency.photoPickerViewController,
       application: self.dependency.application,
       openSettingsURLString: self.dependency.openSettingsURLString
     )

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
@@ -15,21 +15,18 @@ public struct UserInfoSceneSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
     let photoPickerViewController: PHPickerViewController
-    let application: UIApplication
-    let openSettingsURLString: String
+    let appServiceWorker: AppServiceWorkable
     let userInfoWorker: UserInfoSceneWorkable
     let nextSceneBuilder: NextSceneBuildable
 
     public init(
       photoPickerViewController: PHPickerViewController,
-      application: UIApplication,
-      openSettingsURLString: String,
+      appServiceWorker: AppServiceWorkable,
       userInfoWorker: UserInfoSceneWorkable,
       nextSceneBuilder: NextSceneBuildable
     ) {
       self.photoPickerViewController = photoPickerViewController
-      self.application = application
-      self.openSettingsURLString = openSettingsURLString
+      self.appServiceWorker = appServiceWorker
       self.userInfoWorker = userInfoWorker
       self.nextSceneBuilder = nextSceneBuilder
     }
@@ -48,9 +45,7 @@ extension UserInfoSceneSceneBuilder: UserInfoSceneSceneBuildable {
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
   public func build(with payload: UserInfoSceneScenePayloadable) -> UserInfoSceneViewControllable {
     let userInfoSceneViewController = UserInfoSceneViewController(
-      photoPickerViewController: self.dependency.photoPickerViewController,
-      application: self.dependency.application,
-      openSettingsURLString: self.dependency.openSettingsURLString
+      photoPickerViewController: self.dependency.photoPickerViewController
     )
     let configuredVIPCycleViewController = self.configureVIPCycle(for: userInfoSceneViewController)
     self.setPayload(for: configuredVIPCycleViewController, with: payload)
@@ -64,7 +59,10 @@ extension UserInfoSceneSceneBuilder {
   /// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
   private func configureVIPCycle(for viewController: UserInfoSceneViewController) -> UserInfoSceneViewController {
-    let interactor = UserInfoSceneInteractor(userInfoWorker: self.dependency.userInfoWorker)
+    let interactor = UserInfoSceneInteractor(
+      userInfoWorker: self.dependency.userInfoWorker,
+      appServiceWorker: self.dependency.appServiceWorker
+    )
     let presenter = UserInfoScenePresenter()
     let router = UserInfoSceneRouter(nextSceneBuilder: self.dependency.nextSceneBuilder)
     viewController.interactor = interactor

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
@@ -5,7 +5,7 @@
 //  Created by Wood on 8/28/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit.UIApplication
 
 import UserInfoSceneAPI
 import UserInfoSceneEntity
@@ -13,15 +13,24 @@ import UserInfoSceneEntity
 public struct UserInfoSceneSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
+    let application: UIApplication
+    let openSettingsURLString: String
     let userInfoWorker: UserInfoSceneWorkable
     let nextSceneBuilder: NextSceneBuildable
-    
-    public init(userInfoWorker: UserInfoSceneWorkable, nextSceneBuilder: NextSceneBuildable) {
+
+    public init(
+      application: UIApplication,
+      openSettingsURLString: String,
+      userInfoWorker: UserInfoSceneWorkable,
+      nextSceneBuilder: NextSceneBuildable
+    ) {
+      self.application = application
+      self.openSettingsURLString = openSettingsURLString
       self.userInfoWorker = userInfoWorker
       self.nextSceneBuilder = nextSceneBuilder
     }
   }
-  
+
   private let dependency: Dependency
   
   public init(dependency: Dependency) {
@@ -34,10 +43,14 @@ extension UserInfoSceneSceneBuilder: UserInfoSceneSceneBuildable {
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
   public func build(with payload: UserInfoSceneScenePayloadable) -> UserInfoSceneViewControllable {
-    let someViewController = self.configureVIPCycle(for: UserInfoSceneViewController())
-    self.setPayload(for: someViewController, with: payload)
-    
-    return someViewController
+    let userInfoSceneViewController = UserInfoSceneViewController(
+      application: self.dependency.application,
+      openSettingsURLString: self.dependency.openSettingsURLString
+    )
+    let configuredVIPCycleViewController = self.configureVIPCycle(for: userInfoSceneViewController)
+    self.setPayload(for: configuredVIPCycleViewController, with: payload)
+
+    return configuredVIPCycleViewController
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
@@ -14,17 +14,20 @@ import UserInfoSceneEntity
 public struct UserInfoSceneSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
+    let photoPicker: PHPickerViewController
     let appServiceWorker: AppServiceWorkable
     let userPhotoWorker: UserPhotoWorker
     let userInfoWorker: UserInfoSceneWorkable
     let nextSceneBuilder: NextSceneBuildable?
 
     public init(
+      photoPicker: PHPickerViewController,
       appServiceWorker: AppServiceWorkable,
       userPhotoWorker: UserPhotoWorker,
       userInfoWorker: UserInfoSceneWorkable,
       nextSceneBuilder: NextSceneBuildable?
     ) {
+      self.photoPicker = photoPicker
       self.appServiceWorker = appServiceWorker
       self.userPhotoWorker = userPhotoWorker
       self.userInfoWorker = userInfoWorker
@@ -44,7 +47,10 @@ extension UserInfoSceneSceneBuilder: UserInfoSceneSceneBuildable {
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
   public func build(with payload: UserInfoSceneScenePayloadable) -> UserInfoSceneViewControllable {
-    let userInfoSceneViewController = UserInfoSceneViewController()
+    self.dependency.photoPicker.delegate = self.dependency.userPhotoWorker
+    let userInfoSceneViewController = UserInfoSceneViewController(
+      photoPicker: self.dependency.photoPicker
+    )
     let configuredVIPCycleViewController = self.configureVIPCycle(for: userInfoSceneViewController)
     self.setPayload(for: configuredVIPCycleViewController, with: payload)
 
@@ -57,7 +63,6 @@ extension UserInfoSceneSceneBuilder {
   /// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
   private func configureVIPCycle(for viewController: UserInfoSceneViewController) -> UserInfoSceneViewController {
-    self.dependency.userPhotoWorker.baseViewController = viewController
     let interactor = UserInfoSceneInteractor(
       userInfoWorker: self.dependency.userInfoWorker,
       appServiceWorker: self.dependency.appServiceWorker,

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
@@ -14,19 +14,19 @@ import UserInfoSceneEntity
 public struct UserInfoSceneSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
-    let photoPickerViewController: PHPickerViewController
     let appServiceWorker: AppServiceWorkable
+    let userPhotoWorker: UserPhotoWorker
     let userInfoWorker: UserInfoSceneWorkable
-    let nextSceneBuilder: NextSceneBuildable
+    let nextSceneBuilder: NextSceneBuildable?
 
     public init(
-      photoPickerViewController: PHPickerViewController,
       appServiceWorker: AppServiceWorkable,
+      userPhotoWorker: UserPhotoWorker,
       userInfoWorker: UserInfoSceneWorkable,
-      nextSceneBuilder: NextSceneBuildable
+      nextSceneBuilder: NextSceneBuildable?
     ) {
-      self.photoPickerViewController = photoPickerViewController
       self.appServiceWorker = appServiceWorker
+      self.userPhotoWorker = userPhotoWorker
       self.userInfoWorker = userInfoWorker
       self.nextSceneBuilder = nextSceneBuilder
     }
@@ -44,9 +44,7 @@ extension UserInfoSceneSceneBuilder: UserInfoSceneSceneBuildable {
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
   public func build(with payload: UserInfoSceneScenePayloadable) -> UserInfoSceneViewControllable {
-    let userInfoSceneViewController = UserInfoSceneViewController(
-      photoPickerViewController: self.dependency.photoPickerViewController
-    )
+    let userInfoSceneViewController = UserInfoSceneViewController()
     let configuredVIPCycleViewController = self.configureVIPCycle(for: userInfoSceneViewController)
     self.setPayload(for: configuredVIPCycleViewController, with: payload)
 
@@ -59,9 +57,11 @@ extension UserInfoSceneSceneBuilder {
   /// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
   private func configureVIPCycle(for viewController: UserInfoSceneViewController) -> UserInfoSceneViewController {
+    self.dependency.userPhotoWorker.baseViewController = viewController
     let interactor = UserInfoSceneInteractor(
       userInfoWorker: self.dependency.userInfoWorker,
-      appServiceWorker: self.dependency.appServiceWorker
+      appServiceWorker: self.dependency.appServiceWorker,
+      userPhotoWorker: self.dependency.userPhotoWorker
     )
     let presenter = UserInfoScenePresenter()
     let router = UserInfoSceneRouter(nextSceneBuilder: self.dependency.nextSceneBuilder)

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneTheme.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneTheme.swift
@@ -45,5 +45,11 @@ extension UserInfoSceneTheme.StringLiteral {
     static let title = "회원 탈퇴"
   }
 
+  enum SettingAppAlert {
+    static let message = "프로필 이미지를 변경하려면\n사진 접근 권한을 허용해야 합니다."
+    static let leftActionTitle = "취소"
+    static let rightActionTitle = "설정으로 이동"
+  }
+
   static let title = "프로필"
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -18,6 +18,7 @@ import UserInfoSceneEntity
 protocol UserInfoSceneDisplayLogic: AnyObject {
   func displaySomething(viewModel: UserInfoScene.Something.ViewModel)
   func displayUserPhotoAccess(viewModel: UserInfoScene.FetchUserPhotoAccess.ViewModel)
+  func displayChangedProfileImage(viewModel: UserInfoScene.ChangeProfileImage.ViewModel)
 }
 
 final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewControllable {
@@ -68,6 +69,16 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
       self.interactor?.changeUserProfileImage()
     } else {
       self.showMovingToSettingAppAlert()
+    }
+  }
+
+  func displayChangedProfileImage(viewModel: UserInfoScene.ChangeProfileImage.ViewModel) {
+    switch viewModel.changeResult {
+    case .success(let changedProfileImage):
+      self.profileInfoView.updateImage(changedProfileImage)
+    case .failure(let error):
+      // TODO: - 에러 내용이 명시된 ToDoGardenAlert을 띄울 예정이며, 해당 알럿 컴포넌트 제작 후에 반영할 예정입니다.
+      return
     }
   }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -26,9 +26,10 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   private let manageAccountView: ManageAccountView
 
   // MARK: Dependency
-  
-  private let application: UIApplication
-  private let openSettingsURLString: String
+
+  let photoPickerViewController: PHPickerViewController
+  let application: UIApplication
+  let openSettingsURLString: String
 
   // MARK: - VIP Properties
   
@@ -37,13 +38,18 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   
   // MARK: - Object lifecycle
   
-  init(application: UIApplication, openSettingsURLString: String) {
+  init(
+    photoPickerViewController: PHPickerViewController,
+    application: UIApplication,
+    openSettingsURLString: String
+  ) {
     self.profileInfoView = ProfileInfoView()
     self.userInfoCollectionView = UICollectionView(
       frame: CGRect.zero,
       collectionViewLayout: UICollectionViewLayout()
     )
     self.manageAccountView = ManageAccountView()
+    self.photoPickerViewController = photoPickerViewController
     self.application = application
     self.openSettingsURLString = openSettingsURLString
     super.init(nibName: nil, bundle: nil)
@@ -147,19 +153,11 @@ extension UserInfoSceneViewController: PHPickerViewControllerDelegate {
       case .notDetermined, .denied, .restricted:
         self.showMovingToSettingAppAlert()
       case .authorized, .limited:
-        self.showPhotoPicker()
+        self.present(self.photoPickerViewController, animated: true)
       @unknown default:
         break
       }
     }
-  }
-
-  private func showPhotoPicker() {
-    var configuration = PHPickerConfiguration()
-    configuration.filter = PHPickerFilter.images
-    let phpickerViewController = PHPickerViewController(configuration: configuration)
-    phpickerViewController.delegate = self
-    self.present(phpickerViewController, animated: true)
   }
 
   private func showMovingToSettingAppAlert() {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Wood on 8/28/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
+import PhotosUI
 import UIKit
 
 import ToDoGardenUIAPI
@@ -102,7 +103,7 @@ extension UserInfoSceneViewController: ToDoGardenAlertControllerDelegate {
 
 extension UserInfoSceneViewController: ManageAccountViewDelegate, ProfileInfoViewDelegate {
   func didSelectEditProfileButton() {
-    // TODO: 이미지 선택 로직 구현 예정
+    self.handlePhotoAuthorizationStatus()
   }
 
   func didSelectLogOutButton() {
@@ -111,6 +112,24 @@ extension UserInfoSceneViewController: ManageAccountViewDelegate, ProfileInfoVie
   
   func didSelectWithdrawMembershipButton() {
     self.showAlertController(for: ToDoGardenAlertView.Configuration.askToUnsubscribe)
+  }
+}
+
+// MARK: User Image Handling Functions
+
+extension UserInfoSceneViewController {
+  private func handlePhotoAuthorizationStatus() {
+    Task {
+      let status = await PHPhotoLibrary.requestAuthorization(for: PHAccessLevel.readWrite)
+      switch status {
+      case .notDetermined, .denied, .restricted:
+        break
+      case .authorized, .limited:
+        break
+      @unknown default:
+        break
+      }
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -117,7 +117,11 @@ extension UserInfoSceneViewController: ManageAccountViewDelegate, ProfileInfoVie
 
 // MARK: User Image Handling Functions
 
-extension UserInfoSceneViewController {
+extension UserInfoSceneViewController: PHPickerViewControllerDelegate {
+  func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+    
+  }
+
   private func handlePhotoAuthorizationStatus() {
     Task {
       let status = await PHPhotoLibrary.requestAuthorization(for: PHAccessLevel.readWrite)
@@ -125,11 +129,19 @@ extension UserInfoSceneViewController {
       case .notDetermined, .denied, .restricted:
         break
       case .authorized, .limited:
-        break
+        self.showPhotoPicker()
       @unknown default:
         break
       }
     }
+  }
+
+  private func showPhotoPicker() {
+    var configuration = PHPickerConfiguration()
+    configuration.filter = PHPickerFilter.images
+    let phpickerViewController = PHPickerViewController(configuration: configuration)
+    phpickerViewController.delegate = self
+    self.present(phpickerViewController, animated: true)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -119,7 +119,18 @@ extension UserInfoSceneViewController: ManageAccountViewDelegate, ProfileInfoVie
 
 extension UserInfoSceneViewController: PHPickerViewControllerDelegate {
   func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
-    
+    picker.dismiss(animated: true)
+
+    if let itemProvider = results.first?.itemProvider, itemProvider.canLoadObject(ofClass: UIImage.self) {
+      itemProvider.loadObject(ofClass: UIImage.self) { (loadedObject, error) in
+        if let newProfileImage = loadedObject as? UIImage {
+          // TODO: Change Profile Image Request - VIP Cycle
+          print(newProfileImage)
+        } else {
+          print("\(error.debugDescription) ocurred")
+        }
+      }
+    }
   }
 
   private func handlePhotoAuthorizationStatus() {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Wood on 8/28/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
+import PhotosUI
 import UIKit
 
 import ToDoGardenUIAPI
@@ -16,7 +17,7 @@ import UserInfoSceneEntity
 
 protocol UserInfoSceneDisplayLogic: AnyObject {
   func displaySomething(viewModel: UserInfoScene.Something.ViewModel)
-  func displaySettingAppAlert()
+  func displayUserPhotoAccess(viewModel: UserInfoScene.FetchUserPhotoAccess.ViewModel)
 }
 
 final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewControllable {
@@ -24,6 +25,7 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   private let userInfoCollectionView: UICollectionView
   private var userInfoCollectionViewDataSource: DiffableDataSource?
   private let manageAccountView: ManageAccountView
+  private let photoPicker: PHPickerViewController
 
   // MARK: - VIP Properties
   
@@ -32,13 +34,14 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   
   // MARK: - Object lifecycle
   
-  init() {
+  init(photoPicker: PHPickerViewController) {
     self.profileInfoView = ProfileInfoView()
     self.userInfoCollectionView = UICollectionView(
       frame: CGRect.zero,
       collectionViewLayout: UICollectionViewLayout()
     )
     self.manageAccountView = ManageAccountView()
+    self.photoPicker = photoPicker
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -59,8 +62,13 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
 // MARK: - Confirm display logic protocol
 
 extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
-  func displaySettingAppAlert() {
-    self.showMovingToSettingAppAlert()
+  func displayUserPhotoAccess(viewModel: UserInfoScene.FetchUserPhotoAccess.ViewModel) {
+    if viewModel.isPhotoAccessible {
+      self.present(self.photoPicker, animated: true)
+      self.interactor?.changeUserProfileImage()
+    } else {
+      self.showMovingToSettingAppAlert()
+    }
   }
 
   func displaySomething(viewModel: UserInfoScene.Something.ViewModel) {
@@ -71,6 +79,10 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
 // MARK: - Request to interactor
 
 extension UserInfoSceneViewController {
+  func didSelectEditProfileButton() {
+    self.interactor?.fetchUserPhotoAccess()
+  }
+
   func doSomething() {
     let request = UserInfoScene.Something.Request()
     self.interactor?.doSomething(request: request)
@@ -106,10 +118,6 @@ extension UserInfoSceneViewController: ToDoGardenAlertControllerDelegate {
 // MARK: Subviews Delegate Functions
 
 extension UserInfoSceneViewController: ManageAccountViewDelegate, ProfileInfoViewDelegate {
-  func didSelectEditProfileButton() {
-    self.interactor?.fetchUserPhotoToChange()
-  }
-
   func didSelectLogOutButton() {
     self.showAlertController(for: ToDoGardenAlertView.Configuration.askToLogout)
   }
@@ -124,7 +132,6 @@ extension UserInfoSceneViewController: ManageAccountViewDelegate, ProfileInfoVie
 extension UserInfoSceneViewController {
   @MainActor
   private func showMovingToSettingAppAlert() {
-    print(Thread.isMainThread)
     let stringLiteral = UserInfoSceneTheme.StringLiteral.SettingAppAlert.self
     let alert = UIAlertController(
       title: nil,
@@ -152,7 +159,7 @@ extension UserInfoSceneViewController {
       title: UserInfoSceneTheme.StringLiteral.SettingAppAlert.rightActionTitle,
       style: UIAlertAction.Style.default
     ) { _ in
-      self.interactor?.moveToSettingApp()
+      self.interactor?.openSettingApp()
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -147,15 +147,16 @@ extension UserInfoSceneViewController: PHPickerViewControllerDelegate {
   }
 
   private func handlePhotoAuthorizationStatus() {
-    Task {
-      let status = await PHPhotoLibrary.requestAuthorization(for: PHAccessLevel.readWrite)
-      switch status {
-      case .notDetermined, .denied, .restricted:
-        self.showMovingToSettingAppAlert()
-      case .authorized, .limited:
-        self.present(self.photoPickerViewController, animated: true)
-      @unknown default:
-        break
+    PHPhotoLibrary.requestAuthorization(for: PHAccessLevel.readWrite) { status in
+      DispatchQueue.main.async {
+        switch status {
+        case .notDetermined, .denied, .restricted:
+          self.showMovingToSettingAppAlert()
+        case .authorized, .limited:
+          self.present(self.photoPickerViewController, animated: true)
+        @unknown default:
+          break
+        }
       }
     }
   }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -5,7 +5,6 @@
 //  Created by Wood on 8/28/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import PhotosUI
 import UIKit
 
 import ToDoGardenUIAPI
@@ -17,6 +16,7 @@ import UserInfoSceneEntity
 
 protocol UserInfoSceneDisplayLogic: AnyObject {
   func displaySomething(viewModel: UserInfoScene.Something.ViewModel)
+  func displaySettingAppAlert()
 }
 
 final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewControllable {
@@ -25,10 +25,6 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   private var userInfoCollectionViewDataSource: DiffableDataSource?
   private let manageAccountView: ManageAccountView
 
-  // MARK: Dependency
-
-  let photoPickerViewController: PHPickerViewController
-
   // MARK: - VIP Properties
   
   var interactor: UserInfoSceneBusinessLogic?
@@ -36,14 +32,13 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   
   // MARK: - Object lifecycle
   
-  init(photoPickerViewController: PHPickerViewController) {
+  init() {
     self.profileInfoView = ProfileInfoView()
     self.userInfoCollectionView = UICollectionView(
       frame: CGRect.zero,
       collectionViewLayout: UICollectionViewLayout()
     )
     self.manageAccountView = ManageAccountView()
-    self.photoPickerViewController = photoPickerViewController
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -64,6 +59,10 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
 // MARK: - Confirm display logic protocol
 
 extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
+  func displaySettingAppAlert() {
+    self.showMovingToSettingAppAlert()
+  }
+
   func displaySomething(viewModel: UserInfoScene.Something.ViewModel) {
     // self.nameTextField.text = viewModel.name
   }
@@ -108,7 +107,7 @@ extension UserInfoSceneViewController: ToDoGardenAlertControllerDelegate {
 
 extension UserInfoSceneViewController: ManageAccountViewDelegate, ProfileInfoViewDelegate {
   func didSelectEditProfileButton() {
-    self.handlePhotoAuthorizationStatus()
+    self.interactor?.fetchUserPhotoToChange()
   }
 
   func didSelectLogOutButton() {
@@ -122,38 +121,10 @@ extension UserInfoSceneViewController: ManageAccountViewDelegate, ProfileInfoVie
 
 // MARK: User Image Handling Functions
 
-extension UserInfoSceneViewController: PHPickerViewControllerDelegate {
-  func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
-    picker.dismiss(animated: true)
-
-    if let itemProvider = results.first?.itemProvider, itemProvider.canLoadObject(ofClass: UIImage.self) {
-      itemProvider.loadObject(ofClass: UIImage.self) { (loadedObject, error) in
-        if let newProfileImage = loadedObject as? UIImage {
-          // TODO: Change Profile Image Request - VIP Cycle
-          print(newProfileImage)
-        } else {
-          print("\(error.debugDescription) ocurred")
-        }
-      }
-    }
-  }
-
-  private func handlePhotoAuthorizationStatus() {
-    PHPhotoLibrary.requestAuthorization(for: PHAccessLevel.readWrite) { status in
-      DispatchQueue.main.async {
-        switch status {
-        case .notDetermined, .denied, .restricted:
-          self.showMovingToSettingAppAlert()
-        case .authorized, .limited:
-          self.present(self.photoPickerViewController, animated: true)
-        @unknown default:
-          break
-        }
-      }
-    }
-  }
-
+extension UserInfoSceneViewController {
+  @MainActor
   private func showMovingToSettingAppAlert() {
+    print(Thread.isMainThread)
     let stringLiteral = UserInfoSceneTheme.StringLiteral.SettingAppAlert.self
     let alert = UIAlertController(
       title: nil,

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -25,6 +25,11 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   private var userInfoCollectionViewDataSource: DiffableDataSource?
   private let manageAccountView: ManageAccountView
 
+  // MARK: Dependency
+  
+  private let application: UIApplication
+  private let openSettingsURLString: String
+
   // MARK: - VIP Properties
   
   var interactor: UserInfoSceneBusinessLogic?
@@ -32,13 +37,15 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   
   // MARK: - Object lifecycle
   
-  init() {
+  init(application: UIApplication, openSettingsURLString: String) {
     self.profileInfoView = ProfileInfoView()
     self.userInfoCollectionView = UICollectionView(
       frame: CGRect.zero,
       collectionViewLayout: UICollectionViewLayout()
     )
     self.manageAccountView = ManageAccountView()
+    self.application = application
+    self.openSettingsURLString = openSettingsURLString
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -183,9 +190,9 @@ extension UserInfoSceneViewController: PHPickerViewControllerDelegate {
       title: UserInfoSceneTheme.StringLiteral.SettingAppAlert.rightActionTitle,
       style: UIAlertAction.Style.default
     ) { _ in
-      let settingAppURL = URL(string: UIApplication.openSettingsURLString)
-      if let settingAppURL, UIApplication.shared.canOpenURL(settingAppURL) {
-        UIApplication.shared.open(settingAppURL)
+      let settingAppURL = URL(string: self.openSettingsURLString)
+      if let settingAppURL, self.application.canOpenURL(settingAppURL) {
+        self.application.open(settingAppURL)
       } else {
         self.closeAlert()
       }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -28,8 +28,6 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   // MARK: Dependency
 
   let photoPickerViewController: PHPickerViewController
-  let application: UIApplication
-  let openSettingsURLString: String
 
   // MARK: - VIP Properties
   
@@ -38,11 +36,7 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   
   // MARK: - Object lifecycle
   
-  init(
-    photoPickerViewController: PHPickerViewController,
-    application: UIApplication,
-    openSettingsURLString: String
-  ) {
+  init(photoPickerViewController: PHPickerViewController) {
     self.profileInfoView = ProfileInfoView()
     self.userInfoCollectionView = UICollectionView(
       frame: CGRect.zero,
@@ -50,8 +44,6 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
     )
     self.manageAccountView = ManageAccountView()
     self.photoPickerViewController = photoPickerViewController
-    self.application = application
-    self.openSettingsURLString = openSettingsURLString
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -189,12 +181,7 @@ extension UserInfoSceneViewController: PHPickerViewControllerDelegate {
       title: UserInfoSceneTheme.StringLiteral.SettingAppAlert.rightActionTitle,
       style: UIAlertAction.Style.default
     ) { _ in
-      let settingAppURL = URL(string: self.openSettingsURLString)
-      if let settingAppURL, self.application.canOpenURL(settingAppURL) {
-        self.application.open(settingAppURL)
-      } else {
-        self.closeAlert()
-      }
+      self.interactor?.moveToSettingApp()
     }
   }
 }
@@ -352,15 +339,15 @@ extension UserInfoSceneViewController {
   }
 }
 
-#if DEBUG
-@available(iOS 17.0, *)
-#Preview {
-  return UINavigationController(
-    rootViewController: UserInfoSceneViewController(
-      photoPickerViewController: PHPickerViewController(configuration: PHPickerConfiguration()),
-      application: UIApplication.shared,
-      openSettingsURLString: UIApplication.openSettingsURLString
-    )
-  )
-}
-#endif
+//  #if DEBUG
+//  @available(iOS 17.0, *)
+//  #Preview {
+//    return UINavigationController(
+//      rootViewController: UserInfoSceneViewController(
+//        photoPickerViewController: PHPickerViewController(configuration: PHPickerConfiguration()),
+//        application: UIApplication.shared,
+//        openSettingsURLString: UIApplication.openSettingsURLString
+//      )
+//    )
+//  }
+//  #endif

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -127,7 +127,7 @@ extension UserInfoSceneViewController: PHPickerViewControllerDelegate {
       let status = await PHPhotoLibrary.requestAuthorization(for: PHAccessLevel.readWrite)
       switch status {
       case .notDetermined, .denied, .restricted:
-        break
+        self.showMovingToSettingAppAlert()
       case .authorized, .limited:
         self.showPhotoPicker()
       @unknown default:
@@ -142,6 +142,43 @@ extension UserInfoSceneViewController: PHPickerViewControllerDelegate {
     let phpickerViewController = PHPickerViewController(configuration: configuration)
     phpickerViewController.delegate = self
     self.present(phpickerViewController, animated: true)
+  }
+
+  private func showMovingToSettingAppAlert() {
+    let stringLiteral = UserInfoSceneTheme.StringLiteral.SettingAppAlert.self
+    let alert = UIAlertController(
+      title: nil,
+      message: stringLiteral.message,
+      preferredStyle: UIAlertController.Style.alert
+    )
+
+    alert.addAction(self.makeCancelAction())
+    alert.addAction(self.makeMovingToSettingAppAction())
+
+    self.present(alert, animated: true)
+  }
+
+  private func makeCancelAction() -> UIAlertAction {
+    return UIAlertAction(
+      title: UserInfoSceneTheme.StringLiteral.SettingAppAlert.leftActionTitle,
+      style: UIAlertAction.Style.cancel
+    ) { _ in
+      self.closeAlert()
+    }
+  }
+
+  private func makeMovingToSettingAppAction() -> UIAlertAction {
+    return UIAlertAction(
+      title: UserInfoSceneTheme.StringLiteral.SettingAppAlert.rightActionTitle,
+      style: UIAlertAction.Style.default
+    ) { _ in
+      let settingAppURL = URL(string: UIApplication.openSettingsURLString)
+      if let settingAppURL, UIApplication.shared.canOpenURL(settingAppURL) {
+        UIApplication.shared.open(settingAppURL)
+      } else {
+        self.closeAlert()
+      }
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -355,6 +355,12 @@ extension UserInfoSceneViewController {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-  return UINavigationController(rootViewController: UserInfoSceneViewController())
+  return UINavigationController(
+    rootViewController: UserInfoSceneViewController(
+      photoPickerViewController: PHPickerViewController(configuration: PHPickerConfiguration()),
+      application: UIApplication.shared,
+      openSettingsURLString: UIApplication.openSettingsURLString
+    )
+  )
 }
 #endif

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
@@ -14,4 +14,8 @@ public struct UserInfoSceneWorker: UserInfoSceneWorkable {
 
   public func doSomeWork() {
   }
+
+  public func requestChangeProfileImage(with data: Data) throws {
+    return
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
@@ -9,7 +9,9 @@ import Foundation
 
 import UserInfoSceneAPI
 
-struct UserInfoSceneWorker: UserInfoSceneWorkable {
-  func doSomeWork() {
+public struct UserInfoSceneWorker: UserInfoSceneWorkable {
+  public init() {}
+
+  public func doSomeWork() {
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserPhotoWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserPhotoWorker.swift
@@ -1,0 +1,57 @@
+//
+//  UserPhotoWorker.swift
+//
+//
+//  Created by Wood on 9/8/24.
+//
+
+import PhotosUI
+
+public final class UserPhotoWorker: PHPickerViewControllerDelegate {
+  private let photoPicker: PHPickerViewController
+  private var selectedImagesHandler: ((UIImage?, Error?) -> Void)?
+  weak var baseViewController: UIViewController?
+
+  public init(photoPicker: PHPickerViewController) {
+    self.photoPicker = photoPicker
+    self.photoPicker.delegate = self
+  }
+
+  public func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+    picker.dismiss(animated: true)
+
+    if let itemProvider = results.first?.itemProvider, itemProvider.canLoadObject(ofClass: UIImage.self) {
+      itemProvider.loadObject(ofClass: UIImage.self) { (loadedObject, error) in
+        let newProfileImage = loadedObject as? UIImage
+        self.selectedImagesHandler?(newProfileImage, error)
+      }
+    }
+  }
+
+  func fetchPhotoAcess() async -> Bool {
+    let status = await PHPhotoLibrary.requestAuthorization(for: PHAccessLevel.readWrite)
+    if status == PHAuthorizationStatus.authorized || status == PHAuthorizationStatus.limited {
+      return true
+    } else {
+      return false
+    }
+  }
+
+  func requestImage() async throws -> UIImage {
+    try await withCheckedThrowingContinuation { continuation in
+      self.selectedImagesHandler = { image, error in
+        if let image {
+          continuation.resume(returning: image)
+        } else {
+          let error = error ?? UserPhotoworkerError.unknownError
+          continuation.resume(throwing: error)
+        }
+      }
+      self.baseViewController?.present(self.photoPicker, animated: true)
+    }
+  }
+}
+
+public enum UserPhotoworkerError: Error {
+  case unknownError
+}

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserPhotoWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserPhotoWorker.swift
@@ -8,14 +8,9 @@
 import PhotosUI
 
 public final class UserPhotoWorker: PHPickerViewControllerDelegate {
-  private let photoPicker: PHPickerViewController
   private var selectedImagesHandler: ((UIImage?, Error?) -> Void)?
-  weak var baseViewController: UIViewController?
 
-  public init(photoPicker: PHPickerViewController) {
-    self.photoPicker = photoPicker
-    self.photoPicker.delegate = self
-  }
+  public init() {}
 
   public func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
     picker.dismiss(animated: true)
@@ -28,7 +23,7 @@ public final class UserPhotoWorker: PHPickerViewControllerDelegate {
     }
   }
 
-  func fetchPhotoAcess() async -> Bool {
+  func requestPhotoAccess() async -> Bool {
     let status = await PHPhotoLibrary.requestAuthorization(for: PHAccessLevel.readWrite)
     if status == PHAuthorizationStatus.authorized || status == PHAuthorizationStatus.limited {
       return true
@@ -37,7 +32,7 @@ public final class UserPhotoWorker: PHPickerViewControllerDelegate {
     }
   }
 
-  func requestImage() async throws -> UIImage {
+  func requestPhoto() async throws -> UIImage {
     try await withCheckedThrowingContinuation { continuation in
       self.selectedImagesHandler = { image, error in
         if let image {
@@ -47,7 +42,6 @@ public final class UserPhotoWorker: PHPickerViewControllerDelegate {
           continuation.resume(throwing: error)
         }
       }
-      self.baseViewController?.present(self.photoPicker, animated: true)
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ProfileInfoView.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ProfileInfoView.swift
@@ -47,7 +47,8 @@ extension ProfileInfoView {
   private func setupProfileImageView() {
     let height = UserInfoSceneViewController.Constant.ProfileImageView.size.height
     self.profileImageView.layer.cornerRadius = height / 2
-    self.profileImageView.contentMode = UIView.ContentMode.scaleAspectFit
+    self.profileImageView.contentMode = UIView.ContentMode.scaleAspectFill
+    self.profileImageView.clipsToBounds = true
     self.profileImageView.image = UIImage.defaultProfileImage
   }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/AppServiceWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/AppServiceWorkable.swift
@@ -1,0 +1,12 @@
+//
+//  AppServiceWorkable.swift
+//
+//
+//  Created by Wood on 9/7/24.
+//
+
+import Foundation
+
+public protocol AppServiceWorkable {
+  func openSettingApp() -> Bool
+}

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/AppServiceWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/AppServiceWorkable.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 public protocol AppServiceWorkable {
-  func openSettingApp() -> Bool
+  func openSettingApp()
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/UserInfoSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/UserInfoSceneWorkable.swift
@@ -9,4 +9,5 @@ import Foundation
 
 public protocol UserInfoSceneWorkable {
   func doSomeWork()
+  func requestChangeProfileImage(with data: Data) throws
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -5,7 +5,7 @@
 //  Created by Wood on 8/28/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit.UIImage
 
 public enum UserInfoScene {
 
@@ -25,6 +25,24 @@ public enum UserInfoScene {
 
       public init(isPhotoAccessible: Bool) {
         self.isPhotoAccessible = isPhotoAccessible
+      }
+    }
+  }
+
+  public enum ChangeProfileImage {
+    public struct Response {
+      public let changeResult: Result<UIImage, Error>
+
+      public init(changeResult: Result<UIImage, Error>) {
+        self.changeResult = changeResult
+      }
+    }
+
+    public struct ViewModel {
+      public let changeResult: Result<UIImage, Error>
+
+      public init(changeResult: Result<UIImage, Error>) {
+        self.changeResult = changeResult
       }
     }
   }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -11,6 +11,24 @@ public enum UserInfoScene {
 
   // MARK: Use cases
 
+  public enum FetchUserPhotoAccess {
+    public struct Response {
+      public let isPhotoAccessible: Bool
+
+      public init(isPhotoAccessible: Bool) {
+        self.isPhotoAccessible = isPhotoAccessible
+      }
+    }
+
+    public struct ViewModel {
+      public let isPhotoAccessible: Bool
+
+      public init(isPhotoAccessible: Bool) {
+        self.isPhotoAccessible = isPhotoAccessible
+      }
+    }
+  }
+
   public enum Something {
     public struct Request {
       public init() { }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #466 

## 🎉 변경 사항
- UserInfoSceneViewController에서 사용자의 앨범에서 이미지를 선택할 수 있는 로직을 추가하였습니다.
- info.plist에 NSPhotoLibraryUsageDescription Key 값을 추가하였습니다.

## 📌 PR Point
- 프로필 변경 버튼 클릭시 `앨범에서 이미지를 선택`하도록 `PHPicker`를 present합니다.
  - 현재 이미지 선택시 이미지가 변경되지는 않습니다. 
  - 이미지 변경은 서버로의 요청이 필요하기에 VIP 사이클 구현 PR에서 진행할 예정입니다!

- 권한이 없는 경우에는, `설정 앱으로 이동`하는 알럿을 present합니다.

|권한이 없는 경우|권한이 있는 경우|
|--|--|
|<img width="250" src="https://github.com/user-attachments/assets/045d427b-2c3d-43e2-a9f5-28e075f81982">|<img width="250" src="https://github.com/user-attachments/assets/1ab83c85-5a75-4bac-b2ac-147ba14a23ca">|

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?