### PR TITLE
ManageGroup <-> PostGroup 연결 전 사전작업 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneBuilder.swift
@@ -56,7 +56,7 @@ extension ManageGroupSceneBuilder {
     )
     
     let presenter = ManageGroupPresenter()
-    let router = ManageGroupRouter(nextSceneBuilder: self.dependency.nextSceneBuilder)
+    let router = ManageGroupRouter(nextSceneBuilder: nil)
     viewController.interactor = interactor
     viewController.router = router
     interactor.presenter = presenter

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupTableViewDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupTableViewDelegate.swift
@@ -17,7 +17,7 @@ final class ManageGroupTableViewDelegate: NSObject {
   var displayedGroupsBeforeEditing: [ManageGroup.ToDoGroup]
   private let footerView: UIView
   
-  private var onPostGroup: ((String, UIColor) -> Void)?
+  private var onPostGroup: ((String, String, UIColor) -> Void)?
   private var onDeleteGroup: ((String, Int) -> Void)?
   private var onReorderingStateChange: ((Bool) -> Void)?
   
@@ -36,7 +36,7 @@ final class ManageGroupTableViewDelegate: NSObject {
     self.footerView = footerView
   }
   
-  func setOnPostGroup(_ handler: @escaping (String, UIColor) -> Void) {
+  func setOnPostGroup(_ handler: @escaping (String, String, UIColor) -> Void) {
     self.onPostGroup = handler
   }
   
@@ -90,8 +90,8 @@ extension ManageGroupTableViewDelegate: UITableViewDataSource {
     } else {
       cell.leaveEditingMode()
     }
-    cell.setupRightButtonAction { [weak self] color, name in
-      self?.onPostGroup?(name, color)
+    cell.setupRightButtonAction { [weak self] groupId, groupName, groupColor in
+      self?.onPostGroup?(groupId, groupName, groupColor)
     }
     return cell
   }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -166,8 +166,8 @@ extension ManageGroupViewController {
   }
   
   private func setupTouchActions() {
-    self.manageGroupTableViewDelegate?.setOnPostGroup { [weak self] groupName, color in
-      self?.routeToPostGroupScene(groupName: groupName, color: color)
+    self.manageGroupTableViewDelegate?.setOnPostGroup { [weak self] _, groupName, groupColor in
+      self?.routeToPostGroupScene(groupName: groupName, color: groupColor)
     }
     
     self.manageGroupTableViewDelegate?.setOnDeleteGroup { [weak self] id, index in

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -61,12 +61,14 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
   }
   
   func loadGroupData() {
-    let isButtonEnable: Bool = self.isButtonEnable(groupName: payload?.groupName, groupColor: payload?.groupColor)
-    
+    let isDoneBottomButtonEnable: Bool = self.isDoneBottomButtonEnable(
+      groupName: payload?.groupName,
+      groupColor: payload?.groupColor
+    )
     let response = PostGroup.LoadGroupData.Response(
       groupName: payload?.groupName ?? "",
       groupColor: payload?.groupColor,
-      isDoneBottomButtonEnable: isButtonEnable
+      isDoneBottomButtonEnable: isDoneBottomButtonEnable
     )
     self.presenter?.presentLoadGroupData(response: response)
   }
@@ -74,7 +76,7 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
 
 extension PostGroupInteractor {
   
-  private func isButtonEnable(groupName: String?, groupColor: UIColor?) -> Bool {
+  private func isDoneBottomButtonEnable(groupName: String?, groupColor: UIColor?) -> Bool {
     var isButtonEnable: Bool
     if (groupName == nil) || (groupColor == nil) {
       isButtonEnable = false

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupPresenter.swift
@@ -28,7 +28,16 @@ extension PostGroupPresenter: PostGroupPresentationLogic {
   }
   
   func presentLoadGroupData(response: PostGroup.LoadGroupData.Response) {
+    var sceneTitle: String
+    let isEditGroupMode = response.isDoneBottomButtonEnable
+    if isEditGroupMode {
+      sceneTitle = Constant.StringLiteral.titleEditGroup
+    } else {
+      sceneTitle = Constant.StringLiteral.titleAddGroup
+    }
+    
     let viewModel = PostGroup.LoadGroupData.ViewModel(
+      sceneTitle: sceneTitle,
       groupName: response.groupName,
       groupColor: response.groupColor,
       isDoneBottomButtonEnable: response.isDoneBottomButtonEnable

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneConstants.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 enum Constant {
+  enum StringLiteral {
+    static let titleAddGroup: String = "그룹추가"
+    static let titleEditGroup: String = "그룹편집"
+    static let done: String = "완료"
+    static let cancel: String = "취소"
+  }
+  
   enum TextInputView {
     static let margin: CGFloat = 30.0
   }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneConstants.swift
@@ -11,8 +11,8 @@ enum Constant {
   enum StringLiteral {
     static let titleAddGroup: String = "그룹추가"
     static let titleEditGroup: String = "그룹편집"
-    static let done: String = "완료"
-    static let cancel: String = "취소"
+    static let titleBottomButtonDone: String = "완료"
+    static let titleBottomButtonCancel: String = "취소"
   }
   
   enum TextInputView {

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -72,20 +72,7 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
   private func setupBottomSheet() {
     let subject = CurrentValueSubject<Int?, Never>(nil)
     let colorPickerList = ColorPickerList(
-      colors: [
-        UIColor.toDoGardenRed,
-        UIColor.toDoGardenOrange,
-        UIColor.toDoGardenYellow,
-        UIColor.toDoGardenLeaf,
-        UIColor.toDoGardenOlive,
-        UIColor.toDoGardenMint,
-        UIColor.toDoGardenBlue,
-        UIColor.toDoGardenPink,
-        UIColor.toDoGardenPurple,
-        UIColor.toDoGardenBrown,
-        UIColor.toDoGardenBlack,
-        UIColor.toDoGardenGray
-      ],
+      colors: ColorPickerList.primaryColorList,
       itemsPerRow: Constant.ColorPickerRow.itemsPerRow,
       selected: subject
     )

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -41,7 +41,7 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
     self.postGroupColorPickerRow = PostGroupColorPickerRow()
     self.colorPickButton = UIButton()
     self.doneBottomButton = ToDoGardenBoxButton(
-      title: Constant.StringLiteral.done,
+      title: Constant.StringLiteral.titleBottomButtonDone,
       buttonType: ToDoGardenBoxButton.Configuration.primaryRoundRectButton
     )
     super.init(nibName: nil, bundle: nil)
@@ -92,7 +92,10 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
     
     self.postGroupBottomSheet = PostGroupBottomSheet(
       colorPickerList: colorPickerList,
-      bottomButton: ToDoGardenBoxButton(title: Constant.StringLiteral.done, buttonType: .primaryRoundRectButton)
+      bottomButton: ToDoGardenBoxButton(
+        title: Constant.StringLiteral.titleBottomButtonDone,
+        buttonType: .primaryRoundRectButton
+      )
     )
     
     self.postGroupBottomSheet?.delegate = self

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -41,7 +41,7 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
     self.postGroupColorPickerRow = PostGroupColorPickerRow()
     self.colorPickButton = UIButton()
     self.doneBottomButton = ToDoGardenBoxButton(
-      title: "완료",
+      title: Constant.StringLiteral.done,
       buttonType: ToDoGardenBoxButton.Configuration.primaryRoundRectButton
     )
     super.init(nibName: nil, bundle: nil)
@@ -92,7 +92,7 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
     
     self.postGroupBottomSheet = PostGroupBottomSheet(
       colorPickerList: colorPickerList,
-      bottomButton: ToDoGardenBoxButton(title: "완료", buttonType: .primaryRoundRectButton)
+      bottomButton: ToDoGardenBoxButton(title: Constant.StringLiteral.done, buttonType: .primaryRoundRectButton)
     )
     
     self.postGroupBottomSheet?.delegate = self
@@ -230,6 +230,7 @@ extension PostGroupViewController: PostGroupDisplayLogic {
   }
   
   func displayPayload(viewModel: PostGroupSceneEntity.PostGroup.LoadGroupData.ViewModel) {
+    self.title = viewModel.sceneTitle
     self.textInputView.setBeginEditing(with: viewModel.groupName)
     self.postGroupColorPickerRow.updateColor(with: viewModel.groupColor ?? UIColor.toDoGardenGrassNone)
     self.doneBottomButton.isEnabled = viewModel.isDoneBottomButtonEnable

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneEntity/PostGroupModels.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneEntity/PostGroupModels.swift
@@ -56,15 +56,18 @@ public enum PostGroup {
     }
     
     public struct ViewModel {
+      public let sceneTitle: String
       public let groupName: String
       public let groupColor: UIColor?
       public let isDoneBottomButtonEnable: Bool
       
       public init(
+        sceneTitle: String,
         groupName: String,
         groupColor: UIColor?,
         isDoneBottomButtonEnable: Bool
       ) {
+        self.sceneTitle = sceneTitle
         self.groupName = groupName
         self.groupColor = groupColor
         self.isDoneBottomButtonEnable = isDoneBottomButtonEnable

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/ManageGroupTableViewCellAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/ManageGroupTableViewCellAPI.swift
@@ -29,7 +29,7 @@ public protocol ManageGroupTableViewCellAPI: UITableViewCell {
   
   func update(color: UIColor?, progressRate: Float?, groupName: String?)
 
-  func setupRightButtonAction(handler: @escaping (UIColor, String) -> Void)
+  func setupRightButtonAction(handler: @escaping (String, String, UIColor) -> Void)
   
   func setupGroupNameButtonAction(handler: @escaping (String) -> Void)
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ColorPickerList.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ColorPickerList.swift
@@ -174,6 +174,23 @@ private extension Array {
   }
 }
 
+public extension ColorPickerList {
+  static let primaryColorList = [
+    UIColor.toDoGardenRed,
+    UIColor.toDoGardenOrange,
+    UIColor.toDoGardenYellow,
+    UIColor.toDoGardenLeaf,
+    UIColor.toDoGardenOlive,
+    UIColor.toDoGardenMint,
+    UIColor.toDoGardenBlue,
+    UIColor.toDoGardenPink,
+    UIColor.toDoGardenPurple,
+    UIColor.toDoGardenBrown,
+    UIColor.toDoGardenBlack,
+    UIColor.toDoGardenGray
+  ]
+}
+
 @available(iOS 17.0, *)
 #Preview {
   let subject =  CurrentValueSubject<Int?, Never>(nil)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableViewCell.swift
@@ -17,7 +17,7 @@ public final class ManageGroupTableViewCell: UITableViewCell, ManageGroupTableVi
   private var groupNameButton: UIButton?
   private var rightImageButton: UIButton?
   
-  private var rightButtonActionHandler: ((UIColor, String) -> Void)?
+  private var rightButtonActionHandler: ((String, String, UIColor) -> Void)?
   private var groupNameButtonActionHandler: ((String) -> Void)?
   
   public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -120,7 +120,7 @@ public final class ManageGroupTableViewCell: UITableViewCell, ManageGroupTableVi
     self.startAnimation()
   }
   
-  public func setupRightButtonAction(handler: @escaping (UIColor, String) -> Void) {
+  public func setupRightButtonAction(handler: @escaping (String, String, UIColor) -> Void) {
     self.rightButtonActionHandler = handler
     self.rightImageButton?.addAction(UIAction { [weak self] _ in
       self?.handleRightButtonAction()
@@ -138,9 +138,10 @@ public final class ManageGroupTableViewCell: UITableViewCell, ManageGroupTableVi
   }
   
   private func handleRightButtonAction() {
-    if let color = self.configuration?.model?.progressCircle.progressColor.value,
+    if let groupId = self.configuration?.model?.id,
+    let groupColor = self.configuration?.model?.progressCircle.progressColor.value,
     let groupName = self.configuration?.model?.groupNameButton.groupName.value {
-      self.rightButtonActionHandler?(color, groupName)
+      self.rightButtonActionHandler?(groupId, groupName, groupColor)
     }
   }
   


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #471 
## 🎉 변경 사항
- ManageGroup <-> PostGroup 연결 전 사전작업 
## 📌 PR Point

### 1) 메서드 명 변경 
- isButtonEnable() -> isDoneBottomButtonEnable() 로 메서드명이 수행하는 역할을 명확하게 알 수 있게 변경

### 2) 페이로드로 전달될 파라미터 추가 
- 기존: groupName , groupColor 
- 변경후 : groupId, groupName, groupColor 
-> 파이어베이스 명세에 맞춰 변경될 예정 . 현재는 String , String, UIColor 로 전달하고 있습니다. 

### 3) StringLitteral 상수 선언 
- PostGroupScene 의 내비게이션 바에 표시될 title 
- 하단 버튼에 표시될 "완료" / " 취소" 

* 이외의 로직 변경은 없습니다. 파일체인지가 10개로 상당히 많긴 합니다만, 같은 맥락의 사소한 변화들이라 보는데 무리는 없을거라 생각됩니다! 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?