### PR TITLE
ManageGroupScene & PostGroupScene 라우팅 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Package.swift
@@ -21,7 +21,8 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(name: "ToDoGardenUI", path: "../ToDoGardenUI")
+    .package(name: "ToDoGardenUI", path: "../ToDoGardenUI"),
+    .package(name: "PostGroupScene", path: "./PostGroupScene")
   ],
   targets: [
     .target(
@@ -38,6 +39,7 @@ let package = Package(
       name: "ManageGroupScene",
       dependencies: [
         .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
+        .product(name: "PostGroupSceneAPI", package: "PostGroupScene"),
         "ManageGroupSceneAPI",
         "ManageGroupSceneEntity"
       ]

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import ManageGroupSceneAPI
+import PostGroupSceneAPI
 
 protocol ManageGroupRoutingLogic {
   func routeToSomewhere()
@@ -40,7 +41,9 @@ extension ManageGroupRouter: ManageGroupRoutingLogic {
 // MARK: - Declare Payload for scene
 
 extension ManageGroupRouter {
-  struct NextScenePayload: NextScenePayloadable {
-    // var name: String
+  struct PostGroupScenePayload: PostGroupScenePayloadable {
+    var groupID: String?
+    var groupName: String?
+    var groupColor: UIColor?
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
@@ -37,9 +37,9 @@ class ManageGroupRouter: ManageGroupDataPassing {
 
 extension ManageGroupRouter: ManageGroupRoutingLogic {
   func routeToPostGroupScene(
-    groupId: String? = nil,
-    groupName: String? = nil,
-    groupColor: UIColor? = nil
+    groupId: String?,
+    groupName: String?,
+    groupColor: UIColor?
   ) {
     let payload = PostGroupScenePayload(
       groupID: groupId,

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
@@ -5,13 +5,17 @@
 //  Created by SONG on 6/26/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit.UIColor
 
 import ManageGroupSceneAPI
 import PostGroupSceneAPI
 
 protocol ManageGroupRoutingLogic {
-  func routeToSomewhere()
+  func routeToPostGroupScene(
+    groupId: String?,
+    groupName: String?,
+    groupColor: UIColor?
+  )
 }
 
 protocol ManageGroupDataPassing {
@@ -21,20 +25,32 @@ protocol ManageGroupDataPassing {
 class ManageGroupRouter: ManageGroupDataPassing {
   weak var viewController: ManageGroupViewController?
   var dataStore: ManageGroupDataStore?
-  private let nextSceneBuilder: NextSceneBuildable?
+  private let postSceneBuilder: PostGroupSceneBuildable?
   
-  init(nextSceneBuilder: NextSceneBuildable?) {
-    self.nextSceneBuilder = nextSceneBuilder
+  init(postSceneBuilder: PostGroupSceneBuildable?) {
+    self.postSceneBuilder = postSceneBuilder
+  
   }
 }
 
 // MARK: - Routing
 
 extension ManageGroupRouter: ManageGroupRoutingLogic {
-  func routeToSomewhere() {
-    guard let destinationViewController = self.nextSceneBuilder?.build(with: NextScenePayload()) else { return }
+  func routeToPostGroupScene(
+    groupId: String? = nil,
+    groupName: String? = nil,
+    groupColor: UIColor? = nil
+  ) {
+    let payload = PostGroupScenePayload(
+      groupID: groupId,
+      groupName: groupName,
+      groupColor: groupColor
+    )
+    guard let destinationViewController = self.postSceneBuilder?.build(with: payload) else {
+      return
+    }
     
-    self.viewController?.present(destinationViewController, animated: true)
+    self.viewController?.navigationController?.pushViewController(destinationViewController, animated: true)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
@@ -8,14 +8,11 @@
 import UIKit.UIColor
 
 import ManageGroupSceneAPI
+import ManageGroupSceneEntity
 import PostGroupSceneAPI
 
 protocol ManageGroupRoutingLogic {
-  func routeToPostGroupScene(
-    groupId: String?,
-    groupName: String?,
-    groupColor: UIColor?
-  )
+  func routeToPostGroupScene(groupInfo: ManageGroup.ToDoGroup?)
 }
 
 protocol ManageGroupDataPassing {
@@ -36,15 +33,11 @@ class ManageGroupRouter: ManageGroupDataPassing {
 // MARK: - Routing
 
 extension ManageGroupRouter: ManageGroupRoutingLogic {
-  func routeToPostGroupScene(
-    groupId: String?,
-    groupName: String?,
-    groupColor: UIColor?
-  ) {
+  func routeToPostGroupScene(groupInfo: ManageGroup.ToDoGroup?) {
     let payload = PostGroupScenePayload(
-      groupID: groupId,
-      groupName: groupName,
-      groupColor: groupColor
+      groupID: groupInfo?.id,
+      groupName: groupInfo?.groupName,
+      groupColor: groupInfo?.progressColor
     )
     guard let destinationViewController = self.postSceneBuilder?.build(with: payload) else {
       return

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneBuilder.swift
@@ -8,20 +8,21 @@
 import UIKit
 
 import ManageGroupSceneAPI
+import PostGroupSceneAPI
 import ToDoGardenUIAPI
 
 public struct ManageGroupSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
     let manageGroupWorker: ManageGroupWorkable
-    let nextSceneBuilder: NextSceneBuildable?
+    let postSceneBuilder: PostGroupSceneBuildable?
     
     public init(
       manageGroupWorker: ManageGroupWorkable,
-      nextSceneBuilder: NextSceneBuildable?
+      postSceneBuilder: PostGroupSceneBuildable?
     ) {
       self.manageGroupWorker = manageGroupWorker
-      self.nextSceneBuilder = nextSceneBuilder
+      self.postSceneBuilder = postSceneBuilder
     }
   }
   
@@ -37,12 +38,12 @@ extension ManageGroupSceneBuilder: ManageGroupSceneBuildable {
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
   public func build(with payload: ManageGroupScenePayloadable?) -> ManageGroupViewControllable {
-    let someViewController = self.configureVIPCycle(
+    let manageGroupSceneViewController = self.configureVIPCycle(
       for: ManageGroupViewController()
     )
-    self.setPayload(for: someViewController, with: payload ?? nil )
+    self.setPayload(for: manageGroupSceneViewController, with: payload ?? nil )
     
-    return someViewController
+    return manageGroupSceneViewController
   }
 }
 
@@ -56,7 +57,7 @@ extension ManageGroupSceneBuilder {
     )
     
     let presenter = ManageGroupPresenter()
-    let router = ManageGroupRouter(nextSceneBuilder: nil)
+    let router = ManageGroupRouter(postSceneBuilder: self.dependency.postSceneBuilder)
     viewController.interactor = interactor
     viewController.router = router
     interactor.presenter = presenter

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneBuilder.swift
@@ -15,14 +15,14 @@ public struct ManageGroupSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
     let manageGroupWorker: ManageGroupWorkable
-    let postSceneBuilder: PostGroupSceneBuildable?
+    let postGroupSceneBuilder: PostGroupSceneBuildable?
     
     public init(
       manageGroupWorker: ManageGroupWorkable,
-      postSceneBuilder: PostGroupSceneBuildable?
+      postGroupSceneBuilder: PostGroupSceneBuildable?
     ) {
       self.manageGroupWorker = manageGroupWorker
-      self.postSceneBuilder = postSceneBuilder
+      self.postGroupSceneBuilder = postGroupSceneBuilder
     }
   }
   
@@ -57,7 +57,7 @@ extension ManageGroupSceneBuilder {
     )
     
     let presenter = ManageGroupPresenter()
-    let router = ManageGroupRouter(postSceneBuilder: self.dependency.postSceneBuilder)
+    let router = ManageGroupRouter(postSceneBuilder: self.dependency.postGroupSceneBuilder)
     viewController.interactor = interactor
     viewController.router = router
     interactor.presenter = presenter

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -164,7 +164,13 @@ extension ManageGroupViewController {
   
   private func setupTouchActions() {
     self.manageGroupTableViewDelegate?.setOnPostGroup { [weak self] groupId, groupName, groupColor in
-      self?.routeToPostGroupScene(groupId: groupId, groupName: groupName, groupColor: groupColor)
+      let groupInfo = ManageGroup.ToDoGroup(
+        id: groupId,
+        groupName: groupName,
+        progressColor: groupColor,
+        progressRate: Float.zero
+      )
+      self?.routeToPostGroupScene(groupInfo: groupInfo)
     }
     
     self.manageGroupTableViewDelegate?.setOnDeleteGroup { [weak self] id, index in
@@ -240,7 +246,7 @@ extension ManageGroupViewController {
   private func setupFooterButtonAction(_ button: UIButton) {
     button.addAction(
       UIAction { _ in
-        self.routeToPostGroupScene(groupId: nil, groupName: nil, groupColor: nil)
+        self.routeToPostGroupScene(groupInfo: nil)
       },
       for: UIControl.Event.touchUpInside
     )
@@ -367,15 +373,13 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
 }
 
 extension ManageGroupViewController {
-  func routeToPostGroupScene(groupId: String?, groupName: String?, groupColor: UIColor?) {
-    guard let groupId = groupId,
-    let groupName = groupName,
-    let groupColor = groupColor else {
-      self.router?.routeToPostGroupScene(groupId: nil, groupName: nil, groupColor: nil)
+  func routeToPostGroupScene(groupInfo: ManageGroup.ToDoGroup?) {
+    guard let groupInfo = groupInfo else {
+      self.router?.routeToPostGroupScene(groupInfo: nil)
       return
     }
     
-    self.router?.routeToPostGroupScene(groupId: groupId, groupName: groupName, groupColor: groupColor)
+    self.router?.routeToPostGroupScene(groupInfo: groupInfo)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -384,7 +384,7 @@ extension ManageGroupViewController {
 #Preview {
   let worker = ManageGroupWorker()
   let sceneBuilder = ManageGroupSceneBuilder(
-    dependency: .init(manageGroupWorker: worker, postSceneBuilder: nil)
+    dependency: .init(manageGroupWorker: worker, postGroupSceneBuilder: nil)
   )
   let naviController = UINavigationController(rootViewController: sceneBuilder.build(with: nil))
   return naviController

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -24,13 +24,10 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
   
   var interactor: ManageGroupBusinessLogic?
   var router: (ManageGroupRoutingLogic & ManageGroupDataPassing)?
-  
-  public var rightBarButton: UIBarButtonItem
-  public var footerView: UIView
-  
   var manageGroupTableViewDelegate: ManageGroupTableViewDelegate?
   let groupListTableView: ManageGroupTableView
-  
+  public var rightBarButton: UIBarButtonItem
+  public var footerView: UIView
   private let groupListTableViewCell: ManageGroupTableViewCell
   private var editModeLeftBarButton: UIBarButtonItem
   // MARK: - Object lifecycle
@@ -324,7 +321,6 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     return (insertions, moves, updates)
   }
   // swiftlint:enable large_tuple
-  
   private func calculateInsertions(newIDs: [String], oldIDs: Set<String>) -> [IndexPath] {
     var insertions: [IndexPath] = []
     for (newIndex, newID) in newIDs.enumerated() where !oldIDs.contains(newID) {
@@ -384,7 +380,7 @@ extension ManageGroupViewController {
 #Preview {
   let worker = ManageGroupWorker()
   let sceneBuilder = ManageGroupSceneBuilder(
-    dependency: .init(manageGroupWorker: worker, nextSceneBuilder: nil)
+    dependency: .init(manageGroupWorker: worker, postSceneBuilder: nil)
   )
   let naviController = UINavigationController(rootViewController: sceneBuilder.build(with: nil))
   return naviController

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -163,8 +163,8 @@ extension ManageGroupViewController {
   }
   
   private func setupTouchActions() {
-    self.manageGroupTableViewDelegate?.setOnPostGroup { [weak self] _, groupName, groupColor in
-      self?.routeToPostGroupScene(groupName: groupName, color: groupColor)
+    self.manageGroupTableViewDelegate?.setOnPostGroup { [weak self] groupId, groupName, groupColor in
+      self?.routeToPostGroupScene(groupId: groupId, groupName: groupName, groupColor: groupColor)
     }
     
     self.manageGroupTableViewDelegate?.setOnDeleteGroup { [weak self] id, index in
@@ -240,7 +240,7 @@ extension ManageGroupViewController {
   private func setupFooterButtonAction(_ button: UIButton) {
     button.addAction(
       UIAction { _ in
-        self.routeToPostGroupScene(groupName: nil, color: nil)
+        self.routeToPostGroupScene(groupId: nil, groupName: nil, groupColor: nil)
       },
       for: UIControl.Event.touchUpInside
     )
@@ -367,13 +367,15 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
 }
 
 extension ManageGroupViewController {
-  func routeToPostGroupScene(groupName: String?, color: UIColor?) {
-    guard let groupName = groupName, let color = color else {
-      print("route To AddGroup")
+  func routeToPostGroupScene(groupId: String?, groupName: String?, groupColor: UIColor?) {
+    guard let groupId = groupId,
+    let groupName = groupName,
+    let groupColor = groupColor else {
+      self.router?.routeToPostGroupScene(groupId: nil, groupName: nil, groupColor: nil)
       return
     }
     
-    print("route To EditGroup with \(groupName), \(color)")
+    self.router?.routeToPostGroupScene(groupId: groupId, groupName: groupName, groupColor: groupColor)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -191,7 +191,9 @@ extension ManageGroupViewController {
         ),
         self.groupListTableView.trailingAnchor.constraint(
           equalTo: self.view.trailingAnchor,
-          constant: -Constant.Layout.TableView.sideMargin)
+          constant: -Constant.Layout.TableView.sideMargin
+        ),
+        self.groupListTableView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor)
       ]
     )
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #464 
## 🎉 변경 사항
- 그룹추가하기를 누르면 `그룹추가`화면으로 이동합니다.
- 편집모드 진입 후 , 각 그룹의 우측 화살표를 누르면, `그룹편집`화면으로 이동합니다. 
## 📌 PR Point

ManageGroup -> PostGroup(ADD + EDIT) 으로 넘어갈 때, 
페이로드로 3가지를 옵셔널타입으로 전달합니다. 
- 그룹ID (현재는 String으로 쓰고있지만, 변경가능)
- 그룹이름 
- 그룹색상 

`그룹편집` 화면은 위 데이터를 적용시킨 상태로 표시됩니다. 
![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-09-09 at 13 51 49](https://github.com/user-attachments/assets/5895bbce-be5d-49c9-8413-108eb57ce3eb)

`그룹추가` 화면은 위 세가지 데이터가 없으므로, 그룹명과 컬러가 비어있는 채로 표시됩니다. 
![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-09-09 at 13 49 51](https://github.com/user-attachments/assets/70f41725-f583-4838-b7c6-7d003511281c)

### 발견한 이슈 
- Scene간의 연결에는 딱히 문제가 없다고 느낍니다만, PostScene에 포함된 TextInputView가 키보드를 표시하는 과정에서 뭔가 문제가 있어보입니다. 키보드관련 워닝이 많이 표시되네요. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?