### PR TITLE
ShareGardenScene 데이터 응답 대기 애니메이션 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import struct UIKit.NSDirectionalEdgeInsets
 
 extension ShareGardenSceneViewController {
   enum Constant {
@@ -53,6 +54,12 @@ extension ShareGardenSceneViewController.Constant.Layout {
     static let profilePlaceholderCornerRadius: CGFloat = 18.0
     static let nicknamePlaceholderHeight: CGFloat = 16.0
     static let nicknamePlaceholderCornerRadius: CGFloat = 8.0
+    static let placeholderContainerDirectionalMargins: NSDirectionalEdgeInsets = NSDirectionalEdgeInsets(
+      top: 6,
+      leading: 25,
+      bottom: 6,
+      trailing: 25
+    )
   }
   
   enum FriendsGardenListView {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -47,6 +47,12 @@ extension ShareGardenSceneViewController.Constant.Layout {
     static let gardenViewTopInsetWhenSelected: CGFloat = 9
   }
   
+  enum FriendsGardenListViewLoadingCell {
+    static let profilePlaceholderWidth: CGFloat = 36.0
+    static let profilePlaceholderHeight: CGFloat = 36.0
+    static let profilePlaceholderCornerRadius: CGFloat = 18.0
+  }
+  
   enum FriendsGardenListView {
     static let fullWidthRatio: CGFloat = 1.0
     static let estimatedItemHeight: CGFloat = 48.0

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -51,6 +51,8 @@ extension ShareGardenSceneViewController.Constant.Layout {
     static let profilePlaceholderWidth: CGFloat = 36.0
     static let profilePlaceholderHeight: CGFloat = 36.0
     static let profilePlaceholderCornerRadius: CGFloat = 18.0
+    static let nicknamePlaceholderHeight: CGFloat = 16.0
+    static let nicknamePlaceholderCornerRadius: CGFloat = 8.0
   }
   
   enum FriendsGardenListView {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -77,5 +77,6 @@ extension ShareGardenSceneViewController.Constant.Layout {
     static let searchGardenButtonTopInset: CGFloat = 8
     static let searchGardenButtonHeight: CGFloat = 24.0
     static let searchGardenButtonHorizontalInsetRatio: CGFloat = 19.0 / 375.0
+    static let numberOfPlaceholderCells: Int = 3
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -67,9 +67,9 @@ extension ShareGardenSceneViewController.FriendsGardenView {
       fatalError("init(coder:) has not been implemented")
     }
     
-    /// FriendsGardenListView에 로딩 상태를 설정합니다.
+    /// FriendsGardenListView에 Shimmering Animation을 적용합니다.
     /// - Parameter numberOfCells: 표시될 placeholder cell의 숫자입니다.
-    func setLoadingState(numberOfCells: Int) {
+    func startShimmeringAnimation(numberOfCells: Int) {
       self.isUserInteractionEnabled = false
       var snapshot = self.friendsGardenListDataSource.snapshot()
       
@@ -88,7 +88,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
       self.friendsGardenListDataSource.apply(snapshot)
     }
     
-    func endLoading() {
+    func stopShimmeringAnimation() {
       self.isUserInteractionEnabled = true
       self.friendsGardenListDataSource.apply(Snapshot())
     }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -99,6 +99,10 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
   }
   
   private typealias DataSource = UICollectionViewDiffableDataSource<Section, ShareGardenScene.FriendsGarden.ID>
+  private enum Item: Hashable {
+    case friendsGarden(ShareGardenScene.FriendsGarden.ID)
+    case loading(UUID)
+  }
   private typealias FriendsGardenListViewCell =
   ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListViewCell
   private typealias Snapshot =

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -98,17 +98,29 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
     case main
   }
   
-  private typealias DataSource = UICollectionViewDiffableDataSource<Section, ShareGardenScene.FriendsGarden.ID>
   private enum Item: Hashable {
     case friendsGarden(ShareGardenScene.FriendsGarden.ID)
     case loading(UUID)
   }
+  
+  private typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
   private typealias FriendsGardenListViewCell =
   ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListViewCell
+  private typealias FriendsGardenListViewLoadingCell =
+  ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListViewLoadingCell
   private typealias Snapshot =
   NSDiffableDataSourceSnapshot<
     ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView.Section,
-    ShareGardenScene.FriendsGarden.ID
+    Item
+  >
+  private typealias FriendsGardenListViewCellRegistration = UICollectionView.CellRegistration<
+    FriendsGardenListViewCell,
+    Item
+  >
+  
+  private typealias LoadingCellRegistration = UICollectionView.CellRegistration<
+    FriendsGardenListViewLoadingCell,
+    Item
   >
 }
 
@@ -147,18 +159,33 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
 
 extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView {
   private func setupDataSource() -> DataSource {
-    let cellRegistration = UICollectionView.CellRegistration<
-      FriendsGardenListViewCell,
-      ShareGardenScene.FriendsGarden.ID
-    > { [weak self] cell, _, identifier in
-      guard let friendsGarden = self?.friendsGardenStore.fetchBy(identifier)
+    let friendsGardenListViewCellRegistration = FriendsGardenListViewCellRegistration { [weak self] cell, _, item in
+      guard case let Item.friendsGarden(identifier) = item,
+        let friendsGarden = self?.friendsGardenStore.fetchBy(identifier)
       else { return }
       
       cell.configure(with: friendsGarden)
     }
     
-    return DataSource(collectionView: self.friendListView) { collectionView, indexPath, identifier in
-      collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: identifier)
+    let loadingCellRegistration = LoadingCellRegistration { cell, _, _ in
+      cell.configure()
+    }
+    
+    return DataSource(collectionView: self.friendListView) { collectionView, indexPath, item in
+      switch item {
+      case Item.loading:
+        return collectionView.dequeueConfiguredReusableCell(
+          using: loadingCellRegistration,
+          for: indexPath,
+          item: item
+        )
+      case Item.friendsGarden(_):
+        return collectionView.dequeueConfiguredReusableCell(
+          using: friendsGardenListViewCellRegistration,
+          for: indexPath,
+          item: item
+        )
+      }
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -72,7 +72,8 @@ extension ShareGardenSceneViewController.FriendsGardenView {
       if snapshot.sectionIdentifiers.contains(Section.main) == false {
         snapshot.appendSections([Section.main])
       }
-      snapshot.appendItems(identifiers, toSection: Section.main)
+      let items = identifiers.map { Item.friendsGarden($0) }
+      snapshot.appendItems(items, toSection: Section.main)
       self.friendsGardenListDataSource.apply(snapshot)
     }
   }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -67,6 +67,27 @@ extension ShareGardenSceneViewController.FriendsGardenView {
       fatalError("init(coder:) has not been implemented")
     }
     
+    
+    /// FriendsGardenListView에 로딩 상태를 설정합니다.
+    /// - Parameter numberOfCells: 표시될 placeholder cell의 숫자입니다.
+    func setLoadingState(numberOfCells: Int) {
+      self.isUserInteractionEnabled = false
+      var snapshot = self.friendsGardenListDataSource.snapshot()
+      
+      if snapshot.sectionIdentifiers.contains(Section.main) == false {
+        snapshot.appendSections([Section.main])
+      }
+      
+      var items = [Item]()
+      
+      for _ in 0 ..< numberOfCells {
+        let uuid = UUID()
+        items.append(Item.loading(uuid))
+      }
+      
+      snapshot.appendItems(items)
+      self.friendsGardenListDataSource.apply(snapshot)
+    }
     func append(_ identifiers: [ShareGardenScene.FriendsGarden.ID]) {
       var snapshot = self.friendsGardenListDataSource.snapshot()
       if snapshot.sectionIdentifiers.contains(Section.main) == false {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -88,6 +88,12 @@ extension ShareGardenSceneViewController.FriendsGardenView {
       snapshot.appendItems(items)
       self.friendsGardenListDataSource.apply(snapshot)
     }
+    
+    func endLoading() {
+      self.isUserInteractionEnabled = true
+      self.friendsGardenListDataSource.apply(Snapshot())
+    }
+    
     func append(_ identifiers: [ShareGardenScene.FriendsGarden.ID]) {
       var snapshot = self.friendsGardenListDataSource.snapshot()
       if snapshot.sectionIdentifiers.contains(Section.main) == false {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -67,7 +67,6 @@ extension ShareGardenSceneViewController.FriendsGardenView {
       fatalError("init(coder:) has not been implemented")
     }
     
-    
     /// FriendsGardenListView에 로딩 상태를 설정합니다.
     /// - Parameter numberOfCells: 표시될 placeholder cell의 숫자입니다.
     func setLoadingState(numberOfCells: Int) {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -19,7 +19,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     private lazy var friendListView: UICollectionView = {
       let friendListView = UICollectionView(
         frame: CGRect.zero,
-        collectionViewLayout: Self.makeFreindsGardenListViewLayout()
+        collectionViewLayout: Self.makeFriendsGardenListViewLayout()
       )
       friendListView.delegate = self
       friendListView.backgroundColor = UIColor.white
@@ -154,7 +154,7 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
 // MARK: - layout
 
 extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView {
-  private static func makeFreindsGardenListViewLayout() -> UICollectionViewCompositionalLayout {
+  private static func makeFriendsGardenListViewLayout() -> UICollectionViewCompositionalLayout {
     let itemSize = NSCollectionLayoutSize(
       widthDimension: NSCollectionLayoutDimension.fractionalWidth(
         Self.layoutConstant.fullWidthRatio

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewLoadingCell.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewLoadingCell.swift
@@ -11,12 +11,21 @@ import ToDoGardenUIComponent
 
 extension ShareGardenSceneViewController.FriendsGardenView {
   final class FriendsGardenListViewLoadingCell: UICollectionViewCell {
+    
+    private static let LayoutConstant = ShareGardenSceneViewController
+      .Constant.Layout.FriendsGardenListViewLoadingCell.self
+    
     private let profilePlaceholder: UIView = {
       let profilePlaceholder = UIView()
       profilePlaceholder.usingAutolayout()
-      profilePlaceholder.widthAnchor.constraint(equalToConstant: 36).isActive = true
-      profilePlaceholder.heightAnchor.constraint(equalToConstant: 36).isActive = true
-      profilePlaceholder.layer.cornerRadius = 18
+      
+      let width = FriendsGardenListViewLoadingCell.LayoutConstant.profilePlaceholderWidth
+      let height = FriendsGardenListViewLoadingCell.LayoutConstant.profilePlaceholderHeight
+      let cornerRadius = FriendsGardenListViewLoadingCell.LayoutConstant.profilePlaceholderCornerRadius
+      
+      profilePlaceholder.widthAnchor.constraint(equalToConstant: width).isActive = true
+      profilePlaceholder.heightAnchor.constraint(equalToConstant: height).isActive = true
+      profilePlaceholder.layer.cornerRadius = cornerRadius
       profilePlaceholder.isShimmering = true
       
       return profilePlaceholder

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewLoadingCell.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewLoadingCell.swift
@@ -62,6 +62,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
       self.setup()
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
     }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewLoadingCell.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewLoadingCell.swift
@@ -1,0 +1,90 @@
+//
+//  FriendsGardenListViewLoadingCell.swift
+//  ShareGardenScene
+//
+//  Created by Noah on 9/6/24.
+//
+
+import UIKit
+
+import ToDoGardenUIComponent
+
+extension ShareGardenSceneViewController.FriendsGardenView {
+  final class FriendsGardenListViewLoadingCell: UICollectionViewCell {
+    private let profilePlaceholder: UIView = {
+      let profilePlaceholder = UIView()
+      profilePlaceholder.usingAutolayout()
+      profilePlaceholder.widthAnchor.constraint(equalToConstant: 36).isActive = true
+      profilePlaceholder.heightAnchor.constraint(equalToConstant: 36).isActive = true
+      profilePlaceholder.layer.cornerRadius = 18
+      profilePlaceholder.isShimmering = true
+      
+      return profilePlaceholder
+    }()
+    
+    private let nicknamePlaceholder: UIView = {
+      let nicknamePlaceholder = UIView()
+      nicknamePlaceholder.usingAutolayout()
+      nicknamePlaceholder.heightAnchor.constraint(equalToConstant: 16).isActive = true
+      nicknamePlaceholder.isShimmering = true
+      nicknamePlaceholder.layer.cornerRadius = 8
+      
+      return nicknamePlaceholder
+    }()
+    
+    private lazy var placeholderContianer: UIStackView = {
+      let placeHolderContainer = UIHStackView(
+        arrangedSubviews: [self.profilePlaceholder, self.nicknamePlaceholder]
+      )
+      placeHolderContainer.isLayoutMarginsRelativeArrangement = true
+      placeHolderContainer.directionalLayoutMargins = NSDirectionalEdgeInsets(
+        top: 6,
+        leading: 25,
+        bottom: 6,
+        trailing: 25
+      )
+      placeHolderContainer.isShimmering = true
+      
+      return placeHolderContainer
+    }()
+    
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+      self.setup()
+    }
+    
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+      super.prepareForReuse()
+      self.stopShimmering()
+    }
+    
+    func configure() {
+      self.startShimmering()
+    }
+  }
+}
+
+extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListViewLoadingCell {
+  private func setup() {
+    self.addSubviews()
+    self.setupLayuotConstraints()
+    self.setupShimmering()
+  }
+  
+  private func addSubviews() {
+    self.contentView.addSubview(self.placeholderContianer)
+  }
+  
+  private func setupLayuotConstraints() {
+    self.contentView.equalToParent()
+    self.placeholderContianer.equalToParent()
+  }
+  
+  private func setupShimmering() {
+    self.contentView.isShimmering = true
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewLoadingCell.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewLoadingCell.swift
@@ -34,9 +34,13 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     private let nicknamePlaceholder: UIView = {
       let nicknamePlaceholder = UIView()
       nicknamePlaceholder.usingAutolayout()
-      nicknamePlaceholder.heightAnchor.constraint(equalToConstant: 16).isActive = true
+      
+      let height = FriendsGardenListViewLoadingCell.LayoutConstant.nicknamePlaceholderHeight
+      let cornerRadius = FriendsGardenListViewLoadingCell.LayoutConstant.nicknamePlaceholderCornerRadius
+      
+      nicknamePlaceholder.heightAnchor.constraint(equalToConstant: height).isActive = true
       nicknamePlaceholder.isShimmering = true
-      nicknamePlaceholder.layer.cornerRadius = 8
+      nicknamePlaceholder.layer.cornerRadius = cornerRadius
       
       return nicknamePlaceholder
     }()

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewLoadingCell.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListViewLoadingCell.swift
@@ -50,12 +50,8 @@ extension ShareGardenSceneViewController.FriendsGardenView {
         arrangedSubviews: [self.profilePlaceholder, self.nicknamePlaceholder]
       )
       placeHolderContainer.isLayoutMarginsRelativeArrangement = true
-      placeHolderContainer.directionalLayoutMargins = NSDirectionalEdgeInsets(
-        top: 6,
-        leading: 25,
-        bottom: 6,
-        trailing: 25
-      )
+      placeHolderContainer.directionalLayoutMargins = FriendsGardenListViewLoadingCell.LayoutConstant
+        .placeholderContainerDirectionalMargins
       placeHolderContainer.isShimmering = true
       
       return placeHolderContainer

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -69,6 +69,11 @@ extension ShareGardenSceneViewController {
         self.setupLayoutConstraints()
       }
     }
+    
+    func setLoadingState() {
+      let numberOfPlaceholderCells = Self.layoutConstant.numberOfPlaceholderCells
+      self.friendsGardenListView.setLoadingState(numberOfCells: numberOfPlaceholderCells)
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -74,13 +74,13 @@ extension ShareGardenSceneViewController {
       self.friendsGardenListView.append(identifiers)
     }
     
-    func setLoadingState() {
+    func startShimmeringAnimation() {
       let numberOfPlaceholderCells = Self.layoutConstant.numberOfPlaceholderCells
-      self.friendsGardenListView.setLoadingState(numberOfCells: numberOfPlaceholderCells)
+      self.friendsGardenListView.startShimmeringAnimation(numberOfCells: numberOfPlaceholderCells)
     }
     
-    func endLoading() {
-      self.friendsGardenListView.endLoading()
+    func stopShimmeringAnimation() {
+      self.friendsGardenListView.stopShimmeringAnimation()
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -74,6 +74,10 @@ extension ShareGardenSceneViewController {
       let numberOfPlaceholderCells = Self.layoutConstant.numberOfPlaceholderCells
       self.friendsGardenListView.setLoadingState(numberOfCells: numberOfPlaceholderCells)
     }
+    
+    func endLoading() {
+      self.friendsGardenListView.endLoading()
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -70,6 +70,10 @@ extension ShareGardenSceneViewController {
       }
     }
     
+    func append(_ identifiers: [ShareGardenScene.FriendsGarden.ID]) {
+      self.friendsGardenListView.append(identifiers)
+    }
+    
     func setLoadingState() {
       let numberOfPlaceholderCells = Self.layoutConstant.numberOfPlaceholderCells
       self.friendsGardenListView.setLoadingState(numberOfCells: numberOfPlaceholderCells)

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -75,6 +75,10 @@ extension ShareGardenSceneViewController {
       }
     }
     
+    func configure(with pomodoroRecordCollection: PomodoroRecordCollection) {
+      self.gardenView.configure(with: pomodoroRecordCollection)
+    }
+    
     func startShimmeringAnimation() {
       self.layoutIfNeeded()
       self.profileInfoView.startShimmering()

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -72,7 +72,6 @@ extension ShareGardenSceneViewController {
       super.layoutSubviews()
       self.setupLayoutIfNeeded = {
         self.setupLayoutConstraints()
-        self.setupShimmering()
       }
     }
   }
@@ -134,24 +133,5 @@ extension ShareGardenSceneViewController.MyGardenView {
       self.profileInfoView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
       self.profileInfoView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
     ])
-  }
-}
-
-// MARK: - Setup shimmer
-
-extension ShareGardenSceneViewController.MyGardenView {
-  private func setupShimmering() {
-    self.setupProfileInfoViewShimmering()
-  }
-  
-  private func setupProfileInfoViewShimmering() {
-    var stack = profileInfoView.subviews
-    
-    while stack.isEmpty == false {
-      let currentView = stack.removeLast()
-      currentView.isShimmering = true
-      
-      stack.append(contentsOf: currentView.subviews)
-    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -74,6 +74,15 @@ extension ShareGardenSceneViewController {
         self.setupLayoutConstraints()
       }
     }
+    
+    func startShimmeringAnimation() {
+      self.layoutIfNeeded()
+      self.profileInfoView.startShimmering()
+    }
+    
+    func stopShimmeringAnimation() {
+      self.profileInfoView.stopShimmering()
+    }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
@@ -11,6 +11,11 @@ extension Styled.Row {
       arrangedSubviews: self.buildProfileSubviews(model: model)
     )
     stack.addInnerPadding(model[style: \.innerPadding])
+    
+    if model.style == Configuration.ProfileModel.Style.shareProfile {
+      stack.isShimmering = true
+    }
+    
     return stack
   }
 
@@ -24,9 +29,8 @@ extension Styled.Row {
     
     let innerStack = self.buildInnerStack(model: model)
     let forwardImage = UIImageView(image: UIImage.forwardButtonImage)
-    if model.style == Configuration.ProfileModel.Style.shareRow {
-      self.bindingForwardImage(imageView: forwardImage)
-    }
+    
+    self.setupViewsBasedOnStyle(style: model.style, profileImageView: profileImageView, forwardImage: forwardImage)
     
     var subviews = [
       profileImageView,
@@ -68,7 +72,43 @@ extension Styled.Row {
       spacing.heightAnchor.constraint(equalToConstant: 3).isActive = true
     }
     
+    if model.style == Configuration.ProfileModel.Style.shareProfile {
+      self.setupShimmeringInnerStack(titleLabel, descriptionLabel, stack)
+    }
+    
     return stack
+  }
+  
+  private func setupViewsBasedOnStyle(
+    style: Configuration.ProfileModel.Style,
+    profileImageView: UIImageView,
+    forwardImage: UIImageView
+  ) {
+    if style == Configuration.ProfileModel.Style.shareRow {
+      self.bindingForwardImage(imageView: forwardImage)
+    }
+    
+    if style == Configuration.ProfileModel.Style.shareProfile {
+      self.setupShimmeringProfileImageView(profileImageView)
+    }
+  }
+  
+  private func setupShimmeringProfileImageView(_ profileImageView: UIImageView) {
+    profileImageView.layer.cornerRadius = profileImageView.bounds.height / 2
+    profileImageView.isShimmering = true
+  }
+  
+  private func setupShimmeringInnerStack(
+    _ titleLabel: UILabel,
+    _ descriptionLabel: UILabel,
+    _ innerStack: UIStackView
+  ) {
+    titleLabel.layer.cornerRadius = 9.0
+    titleLabel.isShimmering = true
+    
+    descriptionLabel.layer.cornerRadius = 7.0
+    descriptionLabel.isShimmering = true
+    innerStack.isShimmering = true
   }
   
   private func bindingProfileImageState(imageView: UIImageView) {


### PR DESCRIPTION
## 💡 관련 이슈
- related: #298 
## 🎉 변경 사항
- ShareGardenScene의 데이터 응답 대기 애니메이션을 추가하였습니다.

## 📌 PR Point

|FirendsGardenListView
|---|
|<img width="600" alt="Screenshot 2024-09-09 at 4 21 17 PM" src="https://github.com/user-attachments/assets/cf00357b-199d-4a66-b424-e0f1ba550e7b">|

친구의 가든의 경우 각각의 데이터 응답 대기와 관련된 상태값을 Cell 내부에 두어 상태값에 따라 UI의 appearnace를 조작하는 것이 아닌, 데이터 로딩 시점에 보여줄 Cell과 데이터를 보여주는 셀을 각각 따로 구현하도록 하여 상위 뷰에서 데이터 응답 상태에 따라 원하는 셀을 보여주도록 함으로써 로딩과 관련된 애니메이션, Appearance 조작이 기존 셀에 영향이 가지 않도록 설계하였습니다.

### 관련 코드

```swift
// 친구의 가든 셀 등록
let friendsGardenListViewCellRegistration = FriendsGardenListViewCellRegistration { [weak self] cell, _, item in
  guard case let Item.friendsGarden(identifier) = item,
             let friendsGarden = self?.friendsGardenStore.fetchBy(identifier)
  else { return }
  
  cell.configure(with: friendsGarden)
}

// 친구의 가든 로딩 전용 셀 등록
let loadingCellRegistration = LoadingCellRegistration { cell, _, _ in
  cell.configure()
}

return DataSource(collectionView: self.friendListView) { collectionView, indexPath, item in
  switch item {
  case Item.loading:
    return collectionView.dequeueConfiguredReusableCell(
      using: loadingCellRegistration,
      for: indexPath,
      item: item
    )
  case Item.friendsGarden(_):
    return collectionView.dequeueConfiguredReusableCell(
      using: friendsGardenListViewCellRegistration,
      for: indexPath,
      item: item
    )
  }
```


### 작동 데모

|Simulator|
|---|
|<img width="300" src="https://github.com/user-attachments/assets/ca043289-58dd-44c1-a48b-1f501536f93e" />|

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?