### PR TITLE
UserInfoScene VIP 구현

### DIFF
--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -53,11 +53,10 @@ final class UserInfoSceneInteractor: UserInfoSceneDataStore {
 
 extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
   func configureCollectionView() {
-    let userInfoSections = [UserInfoScene.profileSection, UserInfoScene.accountSection]
-    let response = UserInfoScene.ConfigureCollectionView.Response(userInfoSections: userInfoSections)
-    self.presenter?.presentCollectionViewSections(response: response)
+    self.presenter?.presentCollectionViewSections()
   }
 
+  // TODO: - TaskGroup > async-let
   func fetchUserProfile() async {
     self.userProfile = await withTaskGroup(
       of: (UserInfoScene.UserInfoItem.Title, String).self,
@@ -157,6 +156,8 @@ extension UserInfoSceneInteractor {
     return (item.title, value)
   }
 
+  // TODO: TaskGroup을 전달하고 있는 행위 자체가 금기됨
+  // childTask를 추가하고 있지 않지만, 그럴 우려가 높아짐.
   private func makeUserProfile(
     with taskGroup: TaskGroup<(UserInfoScene.UserInfoItem.Title, String)>
   ) async -> UserInfoScene.UserProfile {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -15,6 +15,7 @@ protocol UserInfoSceneDataStore {
 }
 
 protocol UserInfoSceneBusinessLogic {
+  func configureCollectionView()
   func fetchUserPhotoAccess()
   func changeUserProfileImage()
   func openSettingApp()
@@ -44,6 +45,12 @@ class UserInfoSceneInteractor: UserInfoSceneDataStore {
 // MARK: - Request to worker
 
 extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
+  func configureCollectionView() {
+    let userInfoSections = [UserInfoScene.profileSection, UserInfoScene.accountSection]
+    let response = UserInfoScene.ConfigureCollectionView.Response(userInfoSections: userInfoSections)
+    self.presenter?.presentCollectionViewSections(response: response)
+  }
+
   func fetchUserPhotoAccess() {
     self.requestPhotoAccessTask = Task {
       let isPhotoAccessible = await self.userPhotoWorker.requestPhotoAccess()

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -176,7 +176,8 @@ extension UserInfoSceneInteractor {
 
     return UserInfoScene.UserProfile(
       nickName: profileData[UserInfoScene.UserInfoItem.Title.nickName] ?? "",
-      introduction: profileData[UserInfoScene.UserInfoItem.Title.introduction] ?? "",
+      introduction: profileData[UserInfoScene.UserInfoItem.Title.introduction] 
+      ?? UserInfoSceneTheme.StringLiteral.UserInfoCollectionView.introductionNotExisted,
       id: profileData[UserInfoScene.UserInfoItem.Title.id] ?? "",
       email: profileData[UserInfoScene.UserInfoItem.Title.email] ?? ""
     )

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -16,12 +16,15 @@ protocol UserInfoSceneDataStore {
 
 protocol UserInfoSceneBusinessLogic {
   func configureCollectionView()
+  func fetchUserProfile() async
   func fetchUserPhotoAccess()
   func changeUserProfileImage()
   func openSettingApp()
 }
 
 final class UserInfoSceneInteractor: UserInfoSceneDataStore {
+  private var userProfile: UserInfoScene.UserProfile?
+
   private var requestPhotoAccessTask: Task<Void, Error>?
   private var requestUserPhotoTask: Task<Void, Error>?
 
@@ -49,6 +52,23 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
     let userInfoSections = [UserInfoScene.profileSection, UserInfoScene.accountSection]
     let response = UserInfoScene.ConfigureCollectionView.Response(userInfoSections: userInfoSections)
     self.presenter?.presentCollectionViewSections(response: response)
+  }
+
+  func fetchUserProfile() async {
+    self.userProfile = await withTaskGroup(
+      of: (UserInfoScene.UserInfoItem.Title, String).self,
+      returning: UserInfoScene.UserProfile.self
+    ) { taskGroup in
+      for section in [UserInfoScene.profileSection, UserInfoScene.accountSection] {
+        for item in section.items {
+          taskGroup.addTask {
+            await self.callPresenterWhenRequestArrived(for: item)
+          }
+        }
+      }
+
+      return await self.makeUserProfile(with: taskGroup)
+    }
   }
 
   func fetchUserPhotoAccess() {
@@ -87,5 +107,40 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
 
   func openSettingApp() {
     self.appServiceWorker.openSettingApp()
+  }
+}
+
+// MARK: - Private Functions
+
+extension UserInfoSceneInteractor {
+  private func callPresenterWhenRequestArrived(
+    for item: UserInfoScene.UserInfoItem
+  ) async -> (UserInfoScene.UserInfoItem.Title, String) {
+    let urlParameter = item.title.rawValue
+    let value = await self.userInfoWorker.requestUserProfile(urlString: urlParameter)
+
+    await MainActor.run {
+      let response = UserInfoScene.FetchProfile.Response(description: value, item: item)
+      self.presenter?.presentUserProfile(response: response)
+    }
+
+    return (item.title, value)
+  }
+
+  private func makeUserProfile(
+    with taskGroup: TaskGroup<(UserInfoScene.UserInfoItem.Title, String)>
+  ) async -> UserInfoScene.UserProfile {
+    var profileData = [UserInfoScene.UserInfoItem.Title: String]()
+
+    for await (itemTitle, value) in taskGroup {
+      profileData[itemTitle] = value
+    }
+
+    return UserInfoScene.UserProfile(
+      nickName: profileData[UserInfoScene.UserInfoItem.Title.nickName] ?? "",
+      introduction: profileData[UserInfoScene.UserInfoItem.Title.introduction] ?? "",
+      id: profileData[UserInfoScene.UserInfoItem.Title.id] ?? "",
+      email: profileData[UserInfoScene.UserInfoItem.Title.email] ?? ""
+    )
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -80,9 +80,7 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
       let isPhotoAccessible = await self.userPhotoWorker.requestPhotoAccess()
       let response = UserInfoScene.FetchUserPhotoAccess.Response(isPhotoAccessible: isPhotoAccessible)
 
-      await MainActor.run {
-        self.presenter?.presentUserPhotoAccess(response: response)
-      }
+      await self.presenter?.presentUserPhotoAccess(response: response)
     }
   }
 
@@ -96,15 +94,13 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
             changeResult: Result.success(profileImageToChange)
           )
 
-          await MainActor.run {
-            self.presenter?.presentChangedProfileImage(response: response)
-          }
+          await self.presenter?.presentChangedProfileImage(response: response)
         }
       } catch let error {
         let response = UserInfoScene.ChangeProfileImage.Response(
           changeResult: Result.failure(error)
         )
-        self.presenter?.presentChangedProfileImage(response: response)
+        await self.presenter?.presentChangedProfileImage(response: response)
       }
     }
   }
@@ -123,10 +119,8 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
         withdrawError = error
       }
 
-      await MainActor.run {
-        let response = UserInfoScene.WithdrawMembership.Response(withdrawError: withdrawError)
-        self.presenter?.presentWithdrawResult(response: response)
-      }
+      let response = UserInfoScene.WithdrawMembership.Response(withdrawError: withdrawError)
+      await self.presenter?.presentWithdrawResult(response: response)
     }
   }
 
@@ -140,10 +134,8 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
         signOutError = error
       }
 
-      await MainActor.run {
-        let response = UserInfoScene.SignOut.Response(signOutError: signOutError)
-        self.presenter?.presentSignOutResult(response: response)
-      }
+      let response = UserInfoScene.SignOut.Response(signOutError: signOutError)
+      await self.presenter?.presentSignOutResult(response: response)
     }
   }
 }
@@ -176,7 +168,7 @@ extension UserInfoSceneInteractor {
 
     return UserInfoScene.UserProfile(
       nickName: profileData[UserInfoScene.UserInfoItem.Title.nickName] ?? "",
-      introduction: profileData[UserInfoScene.UserInfoItem.Title.introduction] 
+      introduction: profileData[UserInfoScene.UserInfoItem.Title.introduction]
       ?? UserInfoSceneTheme.StringLiteral.UserInfoCollectionView.introductionNotExisted,
       id: profileData[UserInfoScene.UserInfoItem.Title.id] ?? "",
       email: profileData[UserInfoScene.UserInfoItem.Title.email] ?? ""

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -21,7 +21,7 @@ protocol UserInfoSceneBusinessLogic {
   func openSettingApp()
 }
 
-class UserInfoSceneInteractor: UserInfoSceneDataStore {
+final class UserInfoSceneInteractor: UserInfoSceneDataStore {
   private var requestPhotoAccessTask: Task<Void, Error>?
   private var requestUserPhotoTask: Task<Void, Error>?
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -21,6 +21,7 @@ protocol UserInfoSceneBusinessLogic {
   func changeUserProfileImage()
   func openSettingApp()
   func withdrawMembership()
+  func signOut()
 }
 
 final class UserInfoSceneInteractor: UserInfoSceneDataStore {
@@ -29,6 +30,7 @@ final class UserInfoSceneInteractor: UserInfoSceneDataStore {
   private var requestPhotoAccessTask: Task<Void, Error>?
   private var requestUserPhotoTask: Task<Void, Error>?
   private var requestWithdrawTask: Task<Void, Error>?
+  private var requestSignOutTask: Task<Void, Error>?
 
   // var name: String = ""
   var presenter: UserInfoScenePresentationLogic?
@@ -124,6 +126,23 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
       await MainActor.run {
         let response = UserInfoScene.WithdrawMembership.Response(withdrawError: withdrawError)
         self.presenter?.presentWithdrawResult(response: response)
+      }
+    }
+  }
+
+  func signOut() {
+    self.requestSignOutTask = Task {
+      let signOutError: Error?
+      do {
+        try await self.userInfoWorker.requestSignOut()
+        signOutError = nil
+      } catch let error {
+        signOutError = error
+      }
+
+      await MainActor.run {
+        let response = UserInfoScene.SignOut.Response(signOutError: signOutError)
+        self.presenter?.presentSignOutResult(response: response)
       }
     }
   }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -16,7 +16,6 @@ protocol UserInfoSceneDataStore {
 
 protocol UserInfoSceneBusinessLogic {
   func configureCollectionView()
-  func fetchUserProfile() async
   func fetchUserPhotoAccess()
   func changeUserProfileImage()
   func openSettingApp()
@@ -24,8 +23,20 @@ protocol UserInfoSceneBusinessLogic {
   func signOut()
 }
 
+actor UserInfoDataManager {
+  private var userInfoData: [UserInfoScene.UserInfo: String]
+
+  init() {
+    self.userInfoData = [:]
+  }
+
+  func updateUserInfoData(for userInfo: UserInfoScene.UserInfo, with value: String) {
+    self.userInfoData[userInfo] = value
+  }
+}
+
 final class UserInfoSceneInteractor: UserInfoSceneDataStore {
-  private var userProfile: UserInfoScene.UserProfile?
+  private var userInfoDataManager: UserInfoDataManager
 
   private var requestPhotoAccessTask: Task<Void, Error>?
   private var requestUserPhotoTask: Task<Void, Error>?
@@ -43,6 +54,7 @@ final class UserInfoSceneInteractor: UserInfoSceneDataStore {
     appServiceWorker: AppServiceWorkable,
     userPhotoWorker: UserPhotoWorker
   ) {
+    self.userInfoDataManager = UserInfoDataManager()
     self.userInfoWorker = userInfoWorker
     self.appServiceWorker = appServiceWorker
     self.userPhotoWorker = userPhotoWorker
@@ -54,24 +66,6 @@ final class UserInfoSceneInteractor: UserInfoSceneDataStore {
 extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
   func configureCollectionView() {
     self.presenter?.presentCollectionViewSections()
-  }
-
-  // TODO: - TaskGroup > async-let
-  func fetchUserProfile() async {
-    self.userProfile = await withTaskGroup(
-      of: (UserInfoScene.UserInfoItem.Title, String).self,
-      returning: UserInfoScene.UserProfile.self
-    ) { taskGroup in
-      for section in [UserInfoScene.profileSection, UserInfoScene.accountSection] {
-        for item in section.items {
-          taskGroup.addTask {
-            await self.callPresenterWhenRequestArrived(for: item)
-          }
-        }
-      }
-
-      return await self.makeUserProfile(with: taskGroup)
-    }
   }
 
   func fetchUserPhotoAccess() {
@@ -139,40 +133,10 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
   }
 }
 
-// MARK: - Private Functions
-
-extension UserInfoSceneInteractor {
-  private func callPresenterWhenRequestArrived(
-    for item: UserInfoScene.UserInfoItem
-  ) async -> (UserInfoScene.UserInfoItem.Title, String) {
-    let urlParameter = item.title.rawValue
-    let value = await self.userInfoWorker.requestUserProfile(urlString: urlParameter)
-
-    await MainActor.run {
-      let response = UserInfoScene.FetchProfile.Response(description: value, item: item)
-      self.presenter?.presentUserProfile(response: response)
-    }
-
-    return (item.title, value)
-  }
-
-  // TODO: TaskGroup을 전달하고 있는 행위 자체가 금기됨
-  // childTask를 추가하고 있지 않지만, 그럴 우려가 높아짐.
-  private func makeUserProfile(
-    with taskGroup: TaskGroup<(UserInfoScene.UserInfoItem.Title, String)>
-  ) async -> UserInfoScene.UserProfile {
-    var profileData = [UserInfoScene.UserInfoItem.Title: String]()
-
-    for await (itemTitle, value) in taskGroup {
-      profileData[itemTitle] = value
-    }
-
-    return UserInfoScene.UserProfile(
-      nickName: profileData[UserInfoScene.UserInfoItem.Title.nickName] ?? "",
-      introduction: profileData[UserInfoScene.UserInfoItem.Title.introduction]
-      ?? UserInfoSceneTheme.StringLiteral.UserInfoCollectionView.introductionNotExisted,
-      id: profileData[UserInfoScene.UserInfoItem.Title.id] ?? "",
-      email: profileData[UserInfoScene.UserInfoItem.Title.email] ?? ""
-    )
+extension UserInfoSceneInteractor: UserInfoLoadable {
+  func requestDescription(for userInfo: UserInfoScene.UserInfo) async -> String {
+    let description = await self.userInfoWorker.requestUserProfile(urlString: userInfo.rawValue)
+    await self.userInfoDataManager.updateUserInfoData(for: userInfo, with: description)
+    return description
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -20,6 +20,7 @@ protocol UserInfoSceneBusinessLogic {
   func fetchUserPhotoAccess()
   func changeUserProfileImage()
   func openSettingApp()
+  func withdrawMembership()
 }
 
 final class UserInfoSceneInteractor: UserInfoSceneDataStore {
@@ -27,6 +28,7 @@ final class UserInfoSceneInteractor: UserInfoSceneDataStore {
 
   private var requestPhotoAccessTask: Task<Void, Error>?
   private var requestUserPhotoTask: Task<Void, Error>?
+  private var requestWithdrawTask: Task<Void, Error>?
 
   // var name: String = ""
   var presenter: UserInfoScenePresentationLogic?
@@ -107,6 +109,23 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
 
   func openSettingApp() {
     self.appServiceWorker.openSettingApp()
+  }
+
+  func withdrawMembership() {
+    self.requestWithdrawTask = Task {
+      let withdrawError: Error?
+      do {
+        try await self.userInfoWorker.requestWithdraw()
+        withdrawError = nil
+      } catch let error {
+        withdrawError = error
+      }
+
+      await MainActor.run {
+        let response = UserInfoScene.WithdrawMembership.Response(withdrawError: withdrawError)
+        self.presenter?.presentWithdrawResult(response: response)
+      }
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -18,7 +18,6 @@ protocol UserInfoSceneBusinessLogic {
   func fetchUserPhotoAccess()
   func changeUserProfileImage()
   func openSettingApp()
-  func doSomething(request: UserInfoScene.Something.Request)
 }
 
 class UserInfoSceneInteractor: UserInfoSceneDataStore {
@@ -81,12 +80,5 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
 
   func openSettingApp() {
     self.appServiceWorker.openSettingApp()
-  }
-
-  func doSomething(request: UserInfoScene.Something.Request) {
-    self.userInfoWorker.doSomeWork()
-
-    let response = UserInfoScene.Something.Response()
-    self.presenter?.presentSomething(response: response)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -15,6 +15,7 @@ protocol UserInfoScenePresentationLogic {
   func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response)
   func presentChangedProfileImage(response: UserInfoScene.ChangeProfileImage.Response)
   func presentWithdrawResult(response: UserInfoScene.WithdrawMembership.Response)
+  func presentSignOutResult(response: UserInfoScene.SignOut.Response)
 }
 
 final class UserInfoScenePresenter {
@@ -53,5 +54,9 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
     let withdrawError = response.withdrawError
     let viewModel = UserInfoScene.WithdrawMembership.ViewModel(withdrawError: withdrawError)
     self.viewController?.displayWithdrawResult(viewModel: viewModel)
+  }
+
+  func presentSignOutResult(response: UserInfoScene.SignOut.Response) {
+    
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -57,6 +57,8 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
   }
 
   func presentSignOutResult(response: UserInfoScene.SignOut.Response) {
-    
+    let signOutError = response.signOutError
+    let viewModel = UserInfoScene.SignOut.ViewModel(signOutError: signOutError)
+    self.viewController?.displaySignOutResult(viewModel: viewModel)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -50,5 +50,8 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
   }
 
   func presentWithdrawResult(response: UserInfoScene.WithdrawMembership.Response) {
+    let withdrawError = response.withdrawError
+    let viewModel = UserInfoScene.WithdrawMembership.ViewModel(withdrawError: withdrawError)
+    self.viewController?.displayWithdrawResult(viewModel: viewModel)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -14,6 +14,7 @@ protocol UserInfoScenePresentationLogic {
   func presentUserProfile(response: UserInfoScene.FetchProfile.Response)
   func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response)
   func presentChangedProfileImage(response: UserInfoScene.ChangeProfileImage.Response)
+  func presentWithdrawResult(response: UserInfoScene.WithdrawMembership.Response)
 }
 
 final class UserInfoScenePresenter {
@@ -46,5 +47,8 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
     let changeResult = response.changeResult
     let viewModel = UserInfoScene.ChangeProfileImage.ViewModel(changeResult: changeResult)
     self.viewController?.displayChangedProfileImage(viewModel: viewModel)
+  }
+
+  func presentWithdrawResult(response: UserInfoScene.WithdrawMembership.Response) {
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -1,6 +1,6 @@
 //
 //  UserInfoScenePresenter.swift
-//  
+//
 //
 //  Created by Wood on 8/28/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
@@ -27,8 +27,8 @@ final class UserInfoScenePresenter {
 
 extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
   nonisolated func presentCollectionViewSections() {
-    let userInfoSections = [UserInfoScene.profileSection, UserInfoScene.accountSection]
-    let viewModel = UserInfoScene.ConfigureCollectionView.ViewModel(userInfoSections: userInfoSections)
+    let collectionViewSections = self.makeCollectionViewSections()
+    let viewModel = UserInfoScene.ConfigureCollectionView.ViewModel(userInfoSections: collectionViewSections)
     self.viewController?.displayCollectionViewSections(viewModel: viewModel)
   }
 
@@ -61,5 +61,29 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
     let signOutError = response.signOutError
     let viewModel = UserInfoScene.SignOut.ViewModel(signOutError: signOutError)
     self.viewController?.displaySignOutResult(viewModel: viewModel)
+  }
+}
+
+extension UserInfoScenePresenter {
+  private func makeCollectionViewSections() -> [UserInfoScene.UserInfoSection] {
+    let sectionTitle = UserInfoSceneTheme.StringLiteral.UserInfoCollectionView.Section.self
+    let itemTitle = UserInfoSceneTheme.StringLiteral.UserInfoCollectionView.Item.self
+    let profileSection = UserInfoScene.UserInfoSection(
+      title: sectionTitle.profileSetting,
+      items: [
+        UserInfoScene.UserInfoItem(userInfo: .nickName, title: itemTitle.nickName, isRightImageExisted: true),
+        UserInfoScene.UserInfoItem(userInfo: .introduction, title: itemTitle.introduction, isRightImageExisted: true)
+      ]
+    )
+
+    let accountSection = UserInfoScene.UserInfoSection(
+      title: sectionTitle.accountSetting,
+      items: [
+        UserInfoScene.UserInfoItem(userInfo: .id, title: itemTitle.id, isRightImageExisted: true),
+        UserInfoScene.UserInfoItem(userInfo: .email, title: itemTitle.email, isRightImageExisted: false)
+      ]
+    )
+
+    return [profileSection, accountSection]
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -10,6 +10,7 @@ import Foundation
 import UserInfoSceneEntity
 
 protocol UserInfoScenePresentationLogic {
+  func presentCollectionViewSections(response: UserInfoScene.ConfigureCollectionView.Response)
   func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response)
   func presentChangedProfileImage(response: UserInfoScene.ChangeProfileImage.Response)
 }
@@ -21,6 +22,10 @@ class UserInfoScenePresenter {
 // MARK: - Request to ViewController
 
 extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
+  func presentCollectionViewSections(response: UserInfoScene.ConfigureCollectionView.Response) {
+    
+  }
+
   func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response) {
     let isPhotoAccessible = response.isPhotoAccessible
     let viewModel = UserInfoScene.FetchUserPhotoAccess.ViewModel(isPhotoAccessible: isPhotoAccessible)

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -11,7 +11,7 @@ import UserInfoSceneEntity
 
 @MainActor
 protocol UserInfoScenePresentationLogic {
-  nonisolated func presentCollectionViewSections(response: UserInfoScene.ConfigureCollectionView.Response)
+  nonisolated func presentCollectionViewSections()
   func presentUserProfile(response: UserInfoScene.FetchProfile.Response)
   func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response)
   func presentChangedProfileImage(response: UserInfoScene.ChangeProfileImage.Response)
@@ -26,10 +26,8 @@ final class UserInfoScenePresenter {
 // MARK: - Request to ViewController
 
 extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
-  nonisolated func presentCollectionViewSections(
-    response: UserInfoScene.ConfigureCollectionView.Response
-  ) {
-    let userInfoSections = response.userInfoSections
+  nonisolated func presentCollectionViewSections() {
+    let userInfoSections = [UserInfoScene.profileSection, UserInfoScene.accountSection]
     let viewModel = UserInfoScene.ConfigureCollectionView.ViewModel(userInfoSections: userInfoSections)
     self.viewController?.displayCollectionViewSections(viewModel: viewModel)
   }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -9,8 +9,9 @@ import Foundation
 
 import UserInfoSceneEntity
 
+@MainActor
 protocol UserInfoScenePresentationLogic {
-  func presentCollectionViewSections(response: UserInfoScene.ConfigureCollectionView.Response)
+  nonisolated func presentCollectionViewSections(response: UserInfoScene.ConfigureCollectionView.Response)
   func presentUserProfile(response: UserInfoScene.FetchProfile.Response)
   func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response)
   func presentChangedProfileImage(response: UserInfoScene.ChangeProfileImage.Response)
@@ -25,7 +26,9 @@ final class UserInfoScenePresenter {
 // MARK: - Request to ViewController
 
 extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
-  func presentCollectionViewSections(response: UserInfoScene.ConfigureCollectionView.Response) {
+  nonisolated func presentCollectionViewSections(
+    response: UserInfoScene.ConfigureCollectionView.Response
+  ) {
     let userInfoSections = response.userInfoSections
     let viewModel = UserInfoScene.ConfigureCollectionView.ViewModel(userInfoSections: userInfoSections)
     self.viewController?.displayCollectionViewSections(viewModel: viewModel)

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -30,7 +30,10 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
   }
 
   func presentUserProfile(response: UserInfoScene.FetchProfile.Response) {
-
+    let description = response.description
+    let item = response.item
+    let viewModel = UserInfoScene.FetchProfile.ViewModel(description: description, item: item)
+    self.viewController?.displayFetchedProfile(viewModel: viewModel)
   }
 
   func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response) {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -11,6 +11,7 @@ import UserInfoSceneEntity
 
 protocol UserInfoScenePresentationLogic {
   func presentCollectionViewSections(response: UserInfoScene.ConfigureCollectionView.Response)
+  func presentUserProfile(response: UserInfoScene.FetchProfile.Response)
   func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response)
   func presentChangedProfileImage(response: UserInfoScene.ChangeProfileImage.Response)
 }
@@ -26,6 +27,10 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
     let userInfoSections = response.userInfoSections
     let viewModel = UserInfoScene.ConfigureCollectionView.ViewModel(userInfoSections: userInfoSections)
     self.viewController?.displayCollectionViewSections(viewModel: viewModel)
+  }
+
+  func presentUserProfile(response: UserInfoScene.FetchProfile.Response) {
+
   }
 
   func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response) {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -10,7 +10,6 @@ import Foundation
 import UserInfoSceneEntity
 
 protocol UserInfoScenePresentationLogic {
-  func presentSomething(response: UserInfoScene.Something.Response)
   func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response)
   func presentChangedProfileImage(response: UserInfoScene.ChangeProfileImage.Response)
 }
@@ -32,10 +31,5 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
     let changeResult = response.changeResult
     let viewModel = UserInfoScene.ChangeProfileImage.ViewModel(changeResult: changeResult)
     self.viewController?.displayChangedProfileImage(viewModel: viewModel)
-  }
-
-  func presentSomething(response: UserInfoScene.Something.Response) {
-    let viewModel = UserInfoScene.Something.ViewModel()
-    self.viewController?.displaySomething(viewModel: viewModel)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -15,7 +15,7 @@ protocol UserInfoScenePresentationLogic {
   func presentChangedProfileImage(response: UserInfoScene.ChangeProfileImage.Response)
 }
 
-class UserInfoScenePresenter {
+final class UserInfoScenePresenter {
   weak var viewController: UserInfoSceneDisplayLogic?
 }
 
@@ -23,7 +23,9 @@ class UserInfoScenePresenter {
 
 extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
   func presentCollectionViewSections(response: UserInfoScene.ConfigureCollectionView.Response) {
-    
+    let userInfoSections = response.userInfoSections
+    let viewModel = UserInfoScene.ConfigureCollectionView.ViewModel(userInfoSections: userInfoSections)
+    self.viewController?.displayCollectionViewSections(viewModel: viewModel)
   }
 
   func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response) {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
@@ -10,6 +10,7 @@ import Foundation
 import UserInfoSceneAPI
 
 protocol UserInfoSceneRoutingLogic {
+  func routeToSettingScene()
 }
 
 protocol UserInfoSceneDataPassing {
@@ -29,6 +30,9 @@ class UserInfoSceneRouter: UserInfoSceneDataPassing {
 // MARK: - Routing
 
 extension UserInfoSceneRouter: UserInfoSceneRoutingLogic {
+  func routeToSettingScene() {
+    self.viewController?.navigationController?.popViewController(animated: true)
+  }
 }
 
 // MARK: - Declare Payload for scene

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
@@ -10,7 +10,7 @@ import Foundation
 import UserInfoSceneAPI
 
 protocol UserInfoSceneRoutingLogic {
-  func routeToSettingScene()
+  func routeToLoginScene()
 }
 
 protocol UserInfoSceneDataPassing {
@@ -30,8 +30,8 @@ class UserInfoSceneRouter: UserInfoSceneDataPassing {
 // MARK: - Routing
 
 extension UserInfoSceneRouter: UserInfoSceneRoutingLogic {
-  func routeToSettingScene() {
-    self.viewController?.navigationController?.popViewController(animated: true)
+  func routeToLoginScene() {
+    // TODO: LoginSceneBuilder가 구현되면 해당 화면으로 라우팅할 예정입니다.
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
@@ -10,7 +10,6 @@ import Foundation
 import UserInfoSceneAPI
 
 protocol UserInfoSceneRoutingLogic {
-  func routeToSomewhere()
 }
 
 protocol UserInfoSceneDataPassing {
@@ -30,11 +29,6 @@ class UserInfoSceneRouter: UserInfoSceneDataPassing {
 // MARK: - Routing
 
 extension UserInfoSceneRouter: UserInfoSceneRoutingLogic {
-  func routeToSomewhere() {
-//    let destinationViewController = self.nextSceneBuilder.build(with: NextScenePayload())
-//    
-//    self.viewController?.present(destinationViewController, animated: true)
-  }
 }
 
 // MARK: - Declare Payload for scene

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneTheme.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneTheme.swift
@@ -24,6 +24,8 @@ extension UserInfoSceneTheme.StringLiteral {
   }
 
   enum UserInfoCollectionView {
+    static let introductionNotExisted = "소개글을 입력해주세요"
+
     enum Section {
       static let profileSetting = "프로필 설정"
       static let accountSetting = "계정 설정"

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -175,7 +175,6 @@ extension UserInfoSceneViewController: ManageAccountViewDelegate, ProfileInfoVie
 // MARK: User Image Handling Functions
 
 extension UserInfoSceneViewController {
-  @MainActor
   private func showMovingToSettingAppAlert() {
     let stringLiteral = UserInfoSceneTheme.StringLiteral.SettingAppAlert.self
     let alert = UIAlertController(

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -17,6 +17,7 @@ import UserInfoSceneEntity
 
 protocol UserInfoSceneDisplayLogic: AnyObject {
   func displayCollectionViewSections(viewModel: UserInfoScene.ConfigureCollectionView.ViewModel)
+  func displayFetchedProfile(viewModel: UserInfoScene.FetchProfile.ViewModel)
   func displayUserPhotoAccess(viewModel: UserInfoScene.FetchUserPhotoAccess.ViewModel)
   func displayChangedProfileImage(viewModel: UserInfoScene.ChangeProfileImage.ViewModel)
 }
@@ -75,6 +76,15 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
     }
 
     self.userInfoCollectionViewDataSource?.apply(snapshot)
+  }
+
+  func displayFetchedProfile(viewModel: UserInfoScene.FetchProfile.ViewModel) {
+    guard let indexPath = self.userInfoCollectionViewDataSource?.indexPath(for: viewModel.item)
+    else { return }
+
+    let cell = self.userInfoCollectionView.cellForItem(at: indexPath) as? SettingCollectionViewCell
+    let description = viewModel.description
+    cell?.updateDescription(description)
   }
 
   func displayUserPhotoAccess(viewModel: UserInfoScene.FetchUserPhotoAccess.ViewModel) {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -326,15 +326,20 @@ extension UserInfoSceneViewController {
   }
 }
 
-//  #if DEBUG
-//  @available(iOS 17.0, *)
-//  #Preview {
-//    return UINavigationController(
-//      rootViewController: UserInfoSceneViewController(
-//        photoPickerViewController: PHPickerViewController(configuration: PHPickerConfiguration()),
-//        application: UIApplication.shared,
-//        openSettingsURLString: UIApplication.openSettingsURLString
-//      )
-//    )
-//  }
-//  #endif
+struct SomePayload: UserInfoSceneScenePayloadable {}
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let userInfoScene = UserInfoSceneSceneBuilder(
+    dependency: UserInfoSceneSceneBuilder.Dependency(
+      photoPicker: PHPickerViewController(configuration: PHPickerConfiguration()),
+      appServiceWorker: AppServiceWorker(),
+      userPhotoWorker: UserPhotoWorker(),
+      userInfoWorker: UserInfoSceneWorker(),
+      nextSceneBuilder: nil
+    )
+  ).build(with: SomePayload())
+  return userInfoScene
+}
+#endif

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -16,7 +16,6 @@ import UserInfoSceneAPI
 import UserInfoSceneEntity
 
 protocol UserInfoSceneDisplayLogic: AnyObject {
-  func displaySomething(viewModel: UserInfoScene.Something.ViewModel)
   func displayUserPhotoAccess(viewModel: UserInfoScene.FetchUserPhotoAccess.ViewModel)
   func displayChangedProfileImage(viewModel: UserInfoScene.ChangeProfileImage.ViewModel)
 }
@@ -56,7 +55,6 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   override func viewDidLoad() {
     super.viewDidLoad()
     self.setup()
-    self.doSomething()
   }
 }
 
@@ -81,10 +79,6 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
       return
     }
   }
-
-  func displaySomething(viewModel: UserInfoScene.Something.ViewModel) {
-    // self.nameTextField.text = viewModel.name
-  }
 }
 
 // MARK: - Request to interactor
@@ -92,11 +86,6 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
 extension UserInfoSceneViewController {
   func didSelectEditProfileButton() {
     self.interactor?.fetchUserPhotoAccess()
-  }
-
-  func doSomething() {
-    let request = UserInfoScene.Something.Request()
-    self.interactor?.doSomething(request: request)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -59,6 +59,13 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
     self.setup()
     self.interactor?.configureCollectionView()
   }
+
+  override func viewIsAppearing(_ animated: Bool) {
+    super.viewIsAppearing(animated)
+    Task {
+      await self.interactor?.fetchUserProfile()
+    }
+  }
 }
 
 // MARK: - Confirm display logic protocol
@@ -127,8 +134,7 @@ extension UserInfoSceneViewController: ToDoGardenAlertControllerDelegate {
       // TODO: 로그아웃 Interactor 메서드 호출 예정
       return
     case ToDoGardenUIConstant.Constant.ToDoGardenAlertView.Content.ButtonActionType.unsubscribe:
-      // TODO: 회원 탈퇴 Interactor 메서드 호출 예정
-      return
+      self.interactor?.withdrawMembership()
     default:
       break
     }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -231,15 +231,6 @@ extension UserInfoSceneViewController {
 
   private func setupUserInfoCollectionView() {
     self.userInfoCollectionView.isScrollEnabled = false
-    self.userInfoCollectionView.register(
-      SettingCollectionViewCell.self,
-      forCellWithReuseIdentifier: SettingCollectionViewCell.identifier
-    )
-    self.userInfoCollectionView.register(
-      SectionHeaderView.self,
-      forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
-      withReuseIdentifier: SectionHeaderView.identifier
-    )
     self.userInfoCollectionViewDataSource = self.makeDiffableDataSource(with: self.userInfoCollectionView)
     self.userInfoCollectionView.dataSource = self.userInfoCollectionViewDataSource
     self.userInfoCollectionView.collectionViewLayout = self.makeCompositionalLayout()

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -138,8 +138,7 @@ extension UserInfoSceneViewController: ToDoGardenAlertControllerDelegate {
     self.closeAlert()
     switch buttonType {
     case ToDoGardenUIConstant.Constant.ToDoGardenAlertView.Content.ButtonActionType.logout:
-      // TODO: 로그아웃 Interactor 메서드 호출 예정
-      return
+      self.interactor?.signOut()
     case ToDoGardenUIConstant.Constant.ToDoGardenAlertView.Content.ButtonActionType.unsubscribe:
       self.interactor?.withdrawMembership()
     default:

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -55,6 +55,7 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   override func viewDidLoad() {
     super.viewDidLoad()
     self.setup()
+    self.interactor?.configureCollectionView()
   }
 }
 
@@ -74,7 +75,7 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
     switch viewModel.changeResult {
     case .success(let changedProfileImage):
       self.profileInfoView.updateImage(changedProfileImage)
-    case .failure(let error):
+    case .failure:
       // TODO: - 에러 내용이 명시된 ToDoGardenAlert을 띄울 예정이며, 해당 알럿 컴포넌트 제작 후에 반영할 예정입니다.
       return
     }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -33,7 +33,7 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
 
   // MARK: - VIP Properties
   
-  var interactor: UserInfoSceneBusinessLogic?
+  var interactor: (UserInfoSceneBusinessLogic & UserInfoLoadable)?
   var router: (UserInfoSceneRoutingLogic & UserInfoSceneDataPassing)?
   
   // MARK: - Object lifecycle
@@ -60,13 +60,6 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
     super.viewDidLoad()
     self.setup()
     self.interactor?.configureCollectionView()
-  }
-
-  override func viewIsAppearing(_ animated: Bool) {
-    super.viewIsAppearing(animated)
-    Task {
-      await self.interactor?.fetchUserProfile()
-    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -16,6 +16,7 @@ import UserInfoSceneAPI
 import UserInfoSceneEntity
 
 protocol UserInfoSceneDisplayLogic: AnyObject {
+  func displayCollectionViewSections(viewModel: UserInfoScene.ConfigureCollectionView.ViewModel)
   func displayUserPhotoAccess(viewModel: UserInfoScene.FetchUserPhotoAccess.ViewModel)
   func displayChangedProfileImage(viewModel: UserInfoScene.ChangeProfileImage.ViewModel)
 }
@@ -62,6 +63,20 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
 // MARK: - Confirm display logic protocol
 
 extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
+  typealias UserInfoSection = UserInfoScene.UserInfoSection
+  typealias UserInfoItem = UserInfoScene.UserInfoItem
+
+  func displayCollectionViewSections(viewModel: UserInfoScene.ConfigureCollectionView.ViewModel) {
+    var snapshot = NSDiffableDataSourceSnapshot<UserInfoSection, UserInfoItem>()
+    snapshot.appendSections(viewModel.userInfoSections)
+
+    snapshot.sectionIdentifiers.forEach { (section: UserInfoSection) in
+      snapshot.appendItems(section.items, toSection: section)
+    }
+
+    self.userInfoCollectionViewDataSource?.apply(snapshot)
+  }
+
   func displayUserPhotoAccess(viewModel: UserInfoScene.FetchUserPhotoAccess.ViewModel) {
     if viewModel.isPhotoAccessible {
       self.present(self.photoPicker, animated: true)
@@ -172,7 +187,6 @@ extension UserInfoSceneViewController {
     self.setupMainUI()
     self.setupSubviewsDelegate()
     self.setupUserInfoCollectionView()
-    self.loadUserInfoCollectionViewData()
     self.setupSubviewsLayout()
   }
 
@@ -200,41 +214,6 @@ extension UserInfoSceneViewController {
     self.userInfoCollectionViewDataSource = self.makeDiffableDataSource(with: self.userInfoCollectionView)
     self.userInfoCollectionView.dataSource = self.userInfoCollectionViewDataSource
     self.userInfoCollectionView.collectionViewLayout = self.makeCompositionalLayout()
-  }
-
-  private func loadUserInfoCollectionViewData() {
-    var snapshot = NSDiffableDataSourceSnapshot<UserInfoSection, UserInfoItem>()
-    snapshot.appendSections(self.makeSections())
-
-    snapshot.sectionIdentifiers.forEach { (section: UserInfoSection) in
-      snapshot.appendItems(section.items, toSection: section)
-    }
-
-    self.userInfoCollectionViewDataSource?.apply(snapshot)
-  }
-
-  private func makeSections() -> [UserInfoSection] {
-    let sectionTitle = UserInfoSceneTheme.StringLiteral.UserInfoCollectionView.Section.self
-    let itemTitle = UserInfoSceneTheme.StringLiteral.UserInfoCollectionView.Item.self
-    let position = SettingCollectionViewCell.Position.self
-
-    let profileSettingSection = UserInfoSection(
-      title: sectionTitle.profileSetting,
-      items: [
-        UserInfoItem(title: itemTitle.nickName, isRightImageExisted: true, position: position.top),
-        UserInfoItem(title: itemTitle.introduction, isRightImageExisted: true, position: position.bottom)
-      ]
-    )
-
-    let accountSettingSection = UserInfoSection(
-      title: sectionTitle.accountSetting,
-      items: [
-        UserInfoItem(title: itemTitle.id, isRightImageExisted: true, position: position.top),
-        UserInfoItem(title: itemTitle.email, isRightImageExisted: false, position: position.bottom)
-      ]
-    )
-
-    return [profileSettingSection, accountSettingSection]
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -20,6 +20,7 @@ protocol UserInfoSceneDisplayLogic: AnyObject {
   func displayFetchedProfile(viewModel: UserInfoScene.FetchProfile.ViewModel)
   func displayUserPhotoAccess(viewModel: UserInfoScene.FetchUserPhotoAccess.ViewModel)
   func displayChangedProfileImage(viewModel: UserInfoScene.ChangeProfileImage.ViewModel)
+  func displayWithdrawResult(viewModel: UserInfoScene.WithdrawMembership.ViewModel)
 }
 
 final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewControllable {
@@ -110,6 +111,12 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
     case .failure:
       // TODO: - 에러 내용이 명시된 ToDoGardenAlert을 띄울 예정이며, 해당 알럿 컴포넌트 제작 후에 반영할 예정입니다.
       return
+    }
+  }
+
+  func displayWithdrawResult(viewModel: UserInfoScene.WithdrawMembership.ViewModel) {
+    if viewModel.withdrawError == nil {
+      self.router?.routeToSettingScene()
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -21,6 +21,7 @@ protocol UserInfoSceneDisplayLogic: AnyObject {
   func displayUserPhotoAccess(viewModel: UserInfoScene.FetchUserPhotoAccess.ViewModel)
   func displayChangedProfileImage(viewModel: UserInfoScene.ChangeProfileImage.ViewModel)
   func displayWithdrawResult(viewModel: UserInfoScene.WithdrawMembership.ViewModel)
+  func displaySignOutResult(viewModel: UserInfoScene.SignOut.ViewModel)
 }
 
 final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewControllable {
@@ -116,7 +117,13 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
 
   func displayWithdrawResult(viewModel: UserInfoScene.WithdrawMembership.ViewModel) {
     if viewModel.withdrawError == nil {
-      self.router?.routeToSettingScene()
+      self.router?.routeToLoginScene()
+    }
+  }
+
+  func displaySignOutResult(viewModel: UserInfoScene.SignOut.ViewModel) {
+    if viewModel.signOutError == nil {
+      self.router?.routeToLoginScene()
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
@@ -19,4 +19,6 @@ public struct UserInfoSceneWorker: UserInfoSceneWorkable {
   public func requestUserProfile(urlString: String) async -> String {
     return ""
   }
+
+  public func requestWithdraw() async throws {}
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
@@ -12,10 +12,11 @@ import UserInfoSceneAPI
 public struct UserInfoSceneWorker: UserInfoSceneWorkable {
   public init() {}
 
-  public func doSomeWork() {
-  }
-
   public func requestChangeProfileImage(with data: Data) throws {
     return
+  }
+
+  public func requestUserProfile(urlString: String) async -> String {
+    return ""
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import UserInfoSceneAPI
+import UserInfoSceneEntity
 
 public struct UserInfoSceneWorker: UserInfoSceneWorkable {
   public init() {}
@@ -17,10 +18,32 @@ public struct UserInfoSceneWorker: UserInfoSceneWorkable {
   }
 
   public func requestUserProfile(urlString: String) async -> String {
-    return ""
+    let data = UserInfoScene.UserInfoItem.Title.self
+    if urlString == data.nickName.rawValue {
+      try? await Task.sleep(nanoseconds: 1_000_000_000)
+      return MockData.nickName
+    } else if urlString == data.introduction.rawValue {
+      try? await Task.sleep(nanoseconds: 1_000_000_000)
+      return MockData.introduction
+    } else if urlString == data.id.rawValue {
+      try? await Task.sleep(nanoseconds: 2_000_000_000)
+      return MockData.id
+    } else {
+      try? await Task.sleep(nanoseconds: 3_000_000_000)
+      return MockData.email
+    }
   }
 
   public func requestWithdraw() async throws {}
 
   public func requestSignOut() async throws {}
+}
+
+extension UserInfoSceneWorker {
+  private enum MockData {
+    static let nickName = "울버린"
+    static let introduction = "나는 나뭇잎 마을의"
+    static let id = "@noah0316"
+    static let email = "dev.noah0316@gmail.com"
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
@@ -18,7 +18,7 @@ public struct UserInfoSceneWorker: UserInfoSceneWorkable {
   }
 
   public func requestUserProfile(urlString: String) async -> String {
-    let data = UserInfoScene.UserInfoItem.Title.self
+    let data = UserInfoScene.UserInfo.self
     if urlString == data.nickName.rawValue {
       try? await Task.sleep(nanoseconds: 1_000_000_000)
       return MockData.nickName

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
@@ -21,4 +21,6 @@ public struct UserInfoSceneWorker: UserInfoSceneWorkable {
   }
 
   public func requestWithdraw() async throws {}
+
+  public func requestSignOut() async throws {}
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ManageAccountView.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ManageAccountView.swift
@@ -137,10 +137,7 @@ extension ManageAccountView {
 
     NSLayoutConstraint.activate(
       [
-        self.withdrawMembershipButton.topAnchor.constraint(
-          equalTo: self.logOutButton.bottomAnchor,
-          constant: UserInfoSceneViewController.Constant.WithdrawMembershipButton.topMargin
-        ),
+        self.withdrawMembershipButton.topAnchor.constraint(equalTo: self.logOutButton.bottomAnchor),
         self.withdrawMembershipButton.centerXAnchor.constraint(equalTo: self.centerXAnchor)
       ]
     )

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ManageAccountView.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ManageAccountView.swift
@@ -61,7 +61,6 @@ extension ManageAccountView {
 
   private func setupLogOutButtonAction() {
     let buttonAction = UIAction { _ in
-      print("called")
       self.delegate?.didSelectLogOutButton()
     }
 
@@ -84,7 +83,6 @@ extension ManageAccountView {
 
   private func setupWithdrawMembershipButtonAction() {
     let buttonAction = UIAction { _ in
-      print("called")
       self.delegate?.didSelectWithdrawMembershipButton()
     }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ProfileInfoView.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/ProfileInfoView.swift
@@ -102,13 +102,9 @@ extension ProfileInfoView {
     self.addSubview(self.editProfileImageButton)
     self.editProfileImageButton.usingAutolayout()
 
-    let constant = UserInfoSceneViewController.Constant.EditProfileImageButton.self
     NSLayoutConstraint.activate(
       [
-        self.editProfileImageButton.topAnchor.constraint(
-          equalTo: self.profileImageView.bottomAnchor,
-          constant: constant.topMargin
-        ),
+        self.editProfileImageButton.topAnchor.constraint(equalTo: self.profileImageView.bottomAnchor),
         self.editProfileImageButton.centerXAnchor.constraint(equalTo: self.centerXAnchor)
       ]
     )

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoCollectionViewCell.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoCollectionViewCell.swift
@@ -1,0 +1,32 @@
+//
+//  UserInfoCollectionViewCell.swift
+//
+//
+//  Created by Wood on 9/12/24.
+//
+
+import UIKit
+
+import ToDoGardenUIComponent
+import UserInfoSceneEntity
+
+protocol UserInfoLoadable: AnyObject {
+  func requestDescription(for userInfo: UserInfoScene.UserInfo) async -> String
+}
+
+final class UserInfoCollectionViewCell: SettingCollectionViewCell {
+  private var requestDescriptionTask: Task<Void, Error>?
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+  }
+
+  func updateUserInfo(_ userInfo: UserInfoScene.UserInfo, with userInfoLoader: UserInfoLoadable?) {
+    self.requestDescriptionTask = Task {
+      let description = await userInfoLoader?.requestDescription(for: userInfo)
+      await MainActor.run {
+        self.updateDescription(description)
+      }
+    }
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+Constant.swift
@@ -14,7 +14,7 @@ extension UserInfoSceneViewController {
 extension UserInfoSceneViewController.Constant {
   enum ProfileInfoView {
     static let topMargin: CGFloat = 10
-    static let size = CGSize(width: 86, height: 106)
+    static let size = CGSize(width: 86, height: 114)
   }
 
   enum ProfileImageView {
@@ -38,7 +38,7 @@ extension UserInfoSceneViewController.Constant {
 
   enum ManageAccountView {
     static let topMargin: CGFloat = 35
-    static let height: CGFloat = 65
+    static let height: CGFloat = 70
   }
 
   enum LogOutButton {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+makeDiffableDataSource.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+makeDiffableDataSource.swift
@@ -12,28 +12,33 @@ import ToDoGardenUIResource
 
 extension UserInfoSceneViewController {
   typealias DiffableDataSource = UICollectionViewDiffableDataSource<UserInfoSection, UserInfoItem>
+  typealias CellRegistration = UICollectionView.CellRegistration<SettingCollectionViewCell, UserInfoItem>
   typealias HeaderRegistration = UICollectionView.SupplementaryRegistration<SectionHeaderView>
 
   func makeDiffableDataSource(with collectionView: UICollectionView) -> DiffableDataSource {
+    let cellRegistration = self.makeCellRegistration()
     let dataSource = DiffableDataSource(collectionView: collectionView) { collectionView, indexPath, itemIdentifier in
-      guard let cell = collectionView.dequeueReusableCell(
-        withReuseIdentifier: SettingCollectionViewCell.identifier,
-        for: indexPath
-      ) as? SettingCollectionViewCell else { return UICollectionViewCell() }
-
-      let cellPosition = self.getCellPosition(of: itemIdentifier.position)
-      cell.setupUI(
-        title: itemIdentifier.title.rawValue,
-        titleFont: UIFont.pretendardBodyMedium,
-        isShowingModal: itemIdentifier.isRightImageExisted,
-        position: cellPosition
+      return collectionView.dequeueConfiguredReusableCell(
+        using: cellRegistration,
+        for: indexPath,
+        item: itemIdentifier
       )
-
-      return cell
     }
 
     dataSource.supplementaryViewProvider = self.makeSupplementaryViewProvider(with: dataSource)
     return dataSource
+  }
+
+  private func makeCellRegistration() -> CellRegistration {
+    return CellRegistration { cell, _, item in
+      let cellPosition = self.getCellPosition(of: item.position)
+      cell.setupUI(
+        title: item.title.rawValue,
+        titleFont: UIFont.pretendardBodyMedium,
+        isShowingModal: item.isRightImageExisted,
+        position: cellPosition
+      )
+    }
   }
 
   private func getCellPosition(of position: UserInfoItem.Position) -> SettingCollectionViewCell.Position {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+makeDiffableDataSource.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+makeDiffableDataSource.swift
@@ -12,7 +12,7 @@ import ToDoGardenUIResource
 
 extension UserInfoSceneViewController {
   typealias DiffableDataSource = UICollectionViewDiffableDataSource<UserInfoSection, UserInfoItem>
-  typealias CellRegistration = UICollectionView.CellRegistration<SettingCollectionViewCell, UserInfoItem>
+  typealias CellRegistration = UICollectionView.CellRegistration<UserInfoCollectionViewCell, UserInfoItem>
   typealias HeaderRegistration = UICollectionView.SupplementaryRegistration<SectionHeaderView>
 
   func makeDiffableDataSource(with collectionView: UICollectionView) -> DiffableDataSource {
@@ -31,7 +31,6 @@ extension UserInfoSceneViewController {
 
   private func makeCellRegistration(with collectionView: UICollectionView) -> CellRegistration {
     return CellRegistration { cell, indexPath, item in
-
       let cellPosition = self.getCellPosition(of: indexPath, collectionView: collectionView)
       cell.setupUI(
         title: item.title.rawValue,
@@ -39,6 +38,7 @@ extension UserInfoSceneViewController {
         isShowingModal: item.isRightImageExisted,
         position: cellPosition
       )
+      cell.updateUserInfo(item.userInfo, with: self.interactor)
     }
   }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+makeDiffableDataSource.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+makeDiffableDataSource.swift
@@ -33,7 +33,7 @@ extension UserInfoSceneViewController {
     return CellRegistration { cell, indexPath, item in
       let cellPosition = self.getCellPosition(of: indexPath, collectionView: collectionView)
       cell.setupUI(
-        title: item.title.rawValue,
+        title: item.title,
         titleFont: UIFont.pretendardBodyMedium,
         isShowingModal: item.isRightImageExisted,
         position: cellPosition
@@ -71,7 +71,7 @@ extension UserInfoSceneViewController {
     ) { supplementaryView, _, indexPath in
       let snapshot = dataSource.snapshot()
       let section = snapshot.sectionIdentifiers[indexPath.section]
-      supplementaryView.updateUI(title: section.title.rawValue)
+      supplementaryView.updateUI(title: section.title)
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+makeDiffableDataSource.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+makeDiffableDataSource.swift
@@ -16,7 +16,7 @@ extension UserInfoSceneViewController {
   typealias HeaderRegistration = UICollectionView.SupplementaryRegistration<SectionHeaderView>
 
   func makeDiffableDataSource(with collectionView: UICollectionView) -> DiffableDataSource {
-    let cellRegistration = self.makeCellRegistration()
+    let cellRegistration = self.makeCellRegistration(with: collectionView)
     let dataSource = DiffableDataSource(collectionView: collectionView) { collectionView, indexPath, itemIdentifier in
       return collectionView.dequeueConfiguredReusableCell(
         using: cellRegistration,
@@ -29,9 +29,10 @@ extension UserInfoSceneViewController {
     return dataSource
   }
 
-  private func makeCellRegistration() -> CellRegistration {
-    return CellRegistration { cell, _, item in
-      let cellPosition = self.getCellPosition(of: item.position)
+  private func makeCellRegistration(with collectionView: UICollectionView) -> CellRegistration {
+    return CellRegistration { cell, indexPath, item in
+
+      let cellPosition = self.getCellPosition(of: indexPath, collectionView: collectionView)
       cell.setupUI(
         title: item.title.rawValue,
         titleFont: UIFont.pretendardBodyMedium,
@@ -41,14 +42,17 @@ extension UserInfoSceneViewController {
     }
   }
 
-  private func getCellPosition(of position: UserInfoItem.Position) -> SettingCollectionViewCell.Position {
-    switch position {
-    case UserInfoItem.Position.top:
+  private func getCellPosition(
+    of indexPath: IndexPath,
+    collectionView: UICollectionView
+  ) -> SettingCollectionViewCell.Position {
+    let rowCount = collectionView.numberOfItems(inSection: indexPath.section)
+    if indexPath.item == 0 {
       return SettingCollectionViewCell.Position.top
-    case UserInfoItem.Position.middle:
-      return SettingCollectionViewCell.Position.middle
-    case UserInfoItem.Position.bottom:
+    } else if indexPath.item == rowCount - 1 {
       return SettingCollectionViewCell.Position.bottom
+    } else {
+      return SettingCollectionViewCell.Position.middle
     }
   }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+makeDiffableDataSource.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+makeDiffableDataSource.swift
@@ -11,19 +11,6 @@ import ToDoGardenUIComponent
 import ToDoGardenUIResource
 
 extension UserInfoSceneViewController {
-  struct UserInfoSection: Hashable {
-    let title: String
-    let items: [UserInfoItem]
-  }
-
-  struct UserInfoItem: Hashable {
-    let title: String
-    let isRightImageExisted: Bool
-    let position: SettingCollectionViewCell.Position
-  }
-}
-
-extension UserInfoSceneViewController {
   typealias DiffableDataSource = UICollectionViewDiffableDataSource<UserInfoSection, UserInfoItem>
   typealias HeaderRegistration = UICollectionView.SupplementaryRegistration<SectionHeaderView>
 
@@ -34,11 +21,12 @@ extension UserInfoSceneViewController {
         for: indexPath
       ) as? SettingCollectionViewCell else { return UICollectionViewCell() }
 
+      let cellPosition = self.getCellPosition(of: itemIdentifier.position)
       cell.setupUI(
-        title: itemIdentifier.title,
+        title: itemIdentifier.title.rawValue,
         titleFont: UIFont.pretendardBodyMedium,
         isShowingModal: itemIdentifier.isRightImageExisted,
-        position: itemIdentifier.position
+        position: cellPosition
       )
 
       return cell
@@ -46,6 +34,17 @@ extension UserInfoSceneViewController {
 
     dataSource.supplementaryViewProvider = self.makeSupplementaryViewProvider(with: dataSource)
     return dataSource
+  }
+
+  private func getCellPosition(of position: UserInfoItem.Position) -> SettingCollectionViewCell.Position {
+    switch position {
+    case UserInfoItem.Position.top:
+      return SettingCollectionViewCell.Position.top
+    case UserInfoItem.Position.middle:
+      return SettingCollectionViewCell.Position.middle
+    case UserInfoItem.Position.bottom:
+      return SettingCollectionViewCell.Position.bottom
+    }
   }
 
   private func makeSupplementaryViewProvider(
@@ -63,7 +62,7 @@ extension UserInfoSceneViewController {
     ) { supplementaryView, _, indexPath in
       let snapshot = dataSource.snapshot()
       let section = snapshot.sectionIdentifiers[indexPath.section]
-      supplementaryView.updateUI(title: section.title)
+      supplementaryView.updateUI(title: section.title.rawValue)
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/UserInfoSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/UserInfoSceneWorkable.swift
@@ -10,4 +10,5 @@ import Foundation
 public protocol UserInfoSceneWorkable {
   func requestChangeProfileImage(with data: Data) throws
   func requestUserProfile(urlString: String) async -> String
+  func requestWithdraw() async throws
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/UserInfoSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/UserInfoSceneWorkable.swift
@@ -8,6 +8,5 @@
 import Foundation
 
 public protocol UserInfoSceneWorkable {
-  func doSomeWork()
   func requestChangeProfileImage(with data: Data) throws
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/UserInfoSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/UserInfoSceneWorkable.swift
@@ -9,4 +9,5 @@ import Foundation
 
 public protocol UserInfoSceneWorkable {
   func requestChangeProfileImage(with data: Data) throws
+  func requestUserProfile(urlString: String) async -> String
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/UserInfoSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/UserInfoSceneWorkable.swift
@@ -11,4 +11,5 @@ public protocol UserInfoSceneWorkable {
   func requestChangeProfileImage(with data: Data) throws
   func requestUserProfile(urlString: String) async -> String
   func requestWithdraw() async throws
+  func requestSignOut() async throws
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -55,6 +55,14 @@ public enum UserInfoScene {
         self.userInfoSections = userInfoSections
       }
     }
+
+    public struct ViewModel {
+      public let userInfoSections: [UserInfoSection]
+
+      public init(userInfoSections: [UserInfoSection]) {
+        self.userInfoSections = userInfoSections
+      }
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -46,4 +46,79 @@ public enum UserInfoScene {
       }
     }
   }
+
+  public enum ConfigureCollectionView {
+    public struct Response {
+      public let userInfoSections: [UserInfoSection]
+
+      public init(userInfoSections: [UserInfoSection]) {
+        self.userInfoSections = userInfoSections
+      }
+    }
+  }
+}
+
+// MARK: - Configure CollectionView
+
+public extension UserInfoScene {
+  struct UserInfoSection: Hashable {
+    public enum Title: String {
+      case profileSetting = "프로필 설정"
+      case accountSetting = "계정 설정"
+    }
+
+    public let title: Title
+    public let items: [UserInfoItem]
+  }
+
+  struct UserInfoItem: Hashable {
+    public enum Title: String {
+      case nickName = "닉네임"
+      case introduction = "소개"
+      case id = "아이디"
+      case email = "이메일"
+    }
+
+    public enum Position {
+      case top
+      case middle
+      case bottom
+    }
+
+    public let title: Title
+    public let isRightImageExisted: Bool
+    public let position: UserInfoItem.Position
+  }
+
+  static let profileSection = UserInfoSection(
+    title: UserInfoSection.Title.profileSetting,
+    items: [
+      UserInfoItem(
+        title: UserInfoItem.Title.nickName,
+        isRightImageExisted: true,
+        position: UserInfoItem.Position.top
+      ),
+      UserInfoItem(
+        title: UserInfoItem.Title.introduction,
+        isRightImageExisted: true,
+        position: UserInfoItem.Position.bottom
+      )
+    ]
+  )
+
+  static let accountSection = UserInfoSection(
+    title: UserInfoSection.Title.accountSetting,
+    items: [
+      UserInfoItem(
+        title: UserInfoItem.Title.id,
+        isRightImageExisted: true,
+        position: UserInfoItem.Position.top
+      ),
+      UserInfoItem(
+        title: UserInfoItem.Title.email,
+        isRightImageExisted: false,
+        position: UserInfoItem.Position.bottom
+      )
+    ]
+  )
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -46,16 +46,4 @@ public enum UserInfoScene {
       }
     }
   }
-
-  public enum Something {
-    public struct Request {
-      public init() { }
-    }
-    public struct Response {
-      public init() { }
-    }
-    public struct ViewModel {
-      public init() { }
-    }
-  }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -104,6 +104,16 @@ public enum UserInfoScene {
       }
     }
   }
+
+  public enum SignOut {
+    public struct Response {
+      public let signOutError: Error?
+
+      public init(signOutError: Error?) {
+        self.signOutError = signOutError
+      }
+    }
+  }
 }
 
 // MARK: - Data Objects

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -64,6 +64,36 @@ public enum UserInfoScene {
       }
     }
   }
+
+  public enum FetchProfile {
+    public struct Response {
+      public let description: String
+      public let item: UserInfoItem
+
+      public init(description: String, item: UserInfoItem) {
+        self.description = description
+        self.item = item
+      }
+    }
+  }
+}
+
+// MARK: - Data Objects
+
+public extension UserInfoScene {
+  struct UserProfile {
+    public let nickName: String
+    public let introduction: String
+    public let id: String
+    public let email: String
+
+    public init(nickName: String, introduction: String, id: String, email: String) {
+      self.nickName = nickName
+      self.introduction = introduction
+      self.id = id
+      self.email = email
+    }
+  }
 }
 
 // MARK: - Configure CollectionView

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -131,41 +131,24 @@ public extension UserInfoScene {
 
 public extension UserInfoScene {
   struct UserInfoSection: Hashable {
-    public enum Title: String {
-      case profileSetting = "프로필 설정"
-      case accountSetting = "계정 설정"
-    }
-
-    public let title: Title
+    public let title: String
     public let items: [UserInfoItem]
+
+    public init(title: String, items: [UserInfoItem]) {
+      self.title = title
+      self.items = items
+    }
   }
 
   struct UserInfoItem: Hashable {
-    public enum Title: String {
-      case nickName = "닉네임"
-      case introduction = "소개"
-      case id = "아이디"
-      case email = "이메일"
-    }
-
     public let userInfo: UserInfo
-    public let title: Title
+    public let title: String
     public let isRightImageExisted: Bool
+
+    public init(userInfo: UserInfo, title: String, isRightImageExisted: Bool) {
+      self.userInfo = userInfo
+      self.title = title
+      self.isRightImageExisted = isRightImageExisted
+    }
   }
-
-  static let profileSection = UserInfoSection(
-    title: UserInfoSection.Title.profileSetting,
-    items: [
-      UserInfoItem(userInfo: .nickName, title: UserInfoItem.Title.nickName, isRightImageExisted: true),
-      UserInfoItem(userInfo: .introduction, title: UserInfoItem.Title.introduction, isRightImageExisted: true)
-    ]
-  )
-
-  static let accountSection = UserInfoSection(
-    title: UserInfoSection.Title.accountSetting,
-    items: [
-      UserInfoItem(userInfo: .id, title: UserInfoItem.Title.id, isRightImageExisted: true),
-      UserInfoItem(userInfo: .email, title: UserInfoItem.Title.email, isRightImageExisted: false)
-    ]
-  )
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -48,14 +48,6 @@ public enum UserInfoScene {
   }
 
   public enum ConfigureCollectionView {
-    public struct Response {
-      public let userInfoSections: [UserInfoSection]
-
-      public init(userInfoSections: [UserInfoSection]) {
-        self.userInfoSections = userInfoSections
-      }
-    }
-
     public struct ViewModel {
       public let userInfoSections: [UserInfoSection]
 
@@ -163,46 +155,23 @@ public extension UserInfoScene {
       case email = "이메일"
     }
 
-    public enum Position {
-      case top
-      case middle
-      case bottom
-    }
-
     public let title: Title
     public let isRightImageExisted: Bool
-    public let position: UserInfoItem.Position
   }
 
   static let profileSection = UserInfoSection(
     title: UserInfoSection.Title.profileSetting,
     items: [
-      UserInfoItem(
-        title: UserInfoItem.Title.nickName,
-        isRightImageExisted: true,
-        position: UserInfoItem.Position.top
-      ),
-      UserInfoItem(
-        title: UserInfoItem.Title.introduction,
-        isRightImageExisted: true,
-        position: UserInfoItem.Position.bottom
-      )
+      UserInfoItem(title: UserInfoItem.Title.nickName, isRightImageExisted: true),
+      UserInfoItem(title: UserInfoItem.Title.introduction, isRightImageExisted: true)
     ]
   )
 
   static let accountSection = UserInfoSection(
     title: UserInfoSection.Title.accountSetting,
     items: [
-      UserInfoItem(
-        title: UserInfoItem.Title.id,
-        isRightImageExisted: true,
-        position: UserInfoItem.Position.top
-      ),
-      UserInfoItem(
-        title: UserInfoItem.Title.email,
-        isRightImageExisted: false,
-        position: UserInfoItem.Position.bottom
-      )
+      UserInfoItem(title: UserInfoItem.Title.id, isRightImageExisted: true),
+      UserInfoItem(title: UserInfoItem.Title.email, isRightImageExisted: false)
     ]
   )
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -86,6 +86,16 @@ public enum UserInfoScene {
       }
     }
   }
+
+  public enum WithdrawMembership {
+    public struct Response {
+      public let withdrawError: Error?
+
+      public init(withdrawError: Error?) {
+        self.withdrawError = withdrawError
+      }
+    }
+  }
 }
 
 // MARK: - Data Objects

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -95,6 +95,14 @@ public enum UserInfoScene {
         self.withdrawError = withdrawError
       }
     }
+
+    public struct ViewModel {
+      public let withdrawError: Error?
+
+      public init(withdrawError: Error?) {
+        self.withdrawError = withdrawError
+      }
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -113,6 +113,14 @@ public enum UserInfoScene {
         self.signOutError = signOutError
       }
     }
+
+    public struct ViewModel {
+      public let signOutError: Error?
+
+      public init(signOutError: Error?) {
+        self.signOutError = signOutError
+      }
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -119,18 +119,11 @@ public enum UserInfoScene {
 // MARK: - Data Objects
 
 public extension UserInfoScene {
-  struct UserProfile {
-    public let nickName: String
-    public let introduction: String
-    public let id: String
-    public let email: String
-
-    public init(nickName: String, introduction: String, id: String, email: String) {
-      self.nickName = nickName
-      self.introduction = introduction
-      self.id = id
-      self.email = email
-    }
+  enum UserInfo: String {
+    case nickName
+    case introduction
+    case id
+    case email
   }
 }
 
@@ -155,6 +148,7 @@ public extension UserInfoScene {
       case email = "이메일"
     }
 
+    public let userInfo: UserInfo
     public let title: Title
     public let isRightImageExisted: Bool
   }
@@ -162,16 +156,16 @@ public extension UserInfoScene {
   static let profileSection = UserInfoSection(
     title: UserInfoSection.Title.profileSetting,
     items: [
-      UserInfoItem(title: UserInfoItem.Title.nickName, isRightImageExisted: true),
-      UserInfoItem(title: UserInfoItem.Title.introduction, isRightImageExisted: true)
+      UserInfoItem(userInfo: .nickName, title: UserInfoItem.Title.nickName, isRightImageExisted: true),
+      UserInfoItem(userInfo: .introduction, title: UserInfoItem.Title.introduction, isRightImageExisted: true)
     ]
   )
 
   static let accountSection = UserInfoSection(
     title: UserInfoSection.Title.accountSetting,
     items: [
-      UserInfoItem(title: UserInfoItem.Title.id, isRightImageExisted: true),
-      UserInfoItem(title: UserInfoItem.Title.email, isRightImageExisted: false)
+      UserInfoItem(userInfo: .id, title: UserInfoItem.Title.id, isRightImageExisted: true),
+      UserInfoItem(userInfo: .email, title: UserInfoItem.Title.email, isRightImageExisted: false)
     ]
   )
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -75,6 +75,16 @@ public enum UserInfoScene {
         self.item = item
       }
     }
+
+    public struct ViewModel {
+      public let description: String
+      public let item: UserInfoItem
+
+      public init(description: String, item: UserInfoItem) {
+        self.description = description
+        self.item = item
+      }
+    }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingCollectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingCollectionViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import TDUtility
 
-public final class SettingCollectionViewCell: UICollectionViewCell, ReusableIdentifier {
+open class SettingCollectionViewCell: UICollectionViewCell, ReusableIdentifier {
   public enum Position {
     case top
     case middle
@@ -33,7 +33,7 @@ public final class SettingCollectionViewCell: UICollectionViewCell, ReusableIden
   }
 
   @available(*, unavailable)
-  required init?(coder: NSCoder) {
+  required public init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #481 

## 🎉 변경 사항
- 유저정보 Scene에 VIP Cycle을 구현하였습니다.
- VIP 구현으로 인해 File Changed 수가 많습니다.

## 📌 PR Point
### 1. 프로필 정보 가져오기
- 유저의 프로필 정보(닉네임, 소개, 아이디, 이메일)를 가져오는 VIP 입니다.
- 프로필 정보 요청을 병렬적으로 수행하도록 구현하였습니다.
- 프로필 데이터가 `빨리 도착하는대로 UI를 업데이트` 합니다.
  - related: https://github.com/ToDo-Garden/ToDo-Garden/pull/449#discussion_r1740300705

아래는 위에서 설명한 동작을 GIF로 첨부하였습니다.
<img width="250" src="https://github.com/user-attachments/assets/a27e9c72-8b45-46e7-b717-80595db91186">

### 2. 로그아웃, 회원탈퇴 VIP
- 회원탈퇴와 로그아웃 관련 VIP를 구현하였습니다.
- TODO: 성공시에는 로그인 화면으로 이동할 예정입니다. `(LoginSceneBuilder가 구현되면 구현할 예정)`
- TODO: 실패시에는 Alert을 발생시킬 예정입니다. `(관련 알럿 Compnent 구현 후 새로운 PR에서 진행)`

|회원탈퇴|로그아웃|
|--|--|
<img width="250" src="https://github.com/user-attachments/assets/5f3515bc-7cc3-4463-8461-314d587a7ddd">|<img width="250" src="https://github.com/user-attachments/assets/b25d9374-590a-4b36-9934-7527c57a23b8">|

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?