### PR TITLE
ManageGroupScene Interactor Test추가 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/.swiftpm/xcode/xcshareddata/xcschemes/ManageGroupSceneTests.xcscheme
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/.swiftpm/xcode/xcshareddata/xcschemes/ManageGroupSceneTests.xcscheme
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManageGroupSceneTests"
+               BuildableName = "ManageGroupSceneTests"
+               BlueprintName = "ManageGroupSceneTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -22,7 +22,7 @@ protocol ManageGroupBusinessLogic {
 class ManageGroupInteractor: ManageGroupDataStore {
   var presenter: ManageGroupPresentationLogic?
   private let manageGroupWorker: ManageGroupWorkable
-  private var currentGroups: [ManageGroup.ToDoGroup]
+  var currentGroups: [ManageGroup.ToDoGroup]
   
   init(
     worker: ManageGroupWorkable

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Tests/ManageGroupSceneTests/ManageGroupInteractorTests.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Tests/ManageGroupSceneTests/ManageGroupInteractorTests.swift
@@ -34,7 +34,7 @@ final class ManageGroupInteractorTests: XCTestCase {
   // MARK: Test setup
   func setupManageGroupInteractor() {
     self.mockWorker = MockWorker()
-    self.interactor = ManageGroupInteractor(worker: mockWorker)
+    self.interactor = ManageGroupInteractor(worker: self.mockWorker)
     self.mockPresenter = MockManageGroupPresenter()
     self.interactor.presenter = self.mockPresenter
   }
@@ -43,7 +43,7 @@ final class ManageGroupInteractorTests: XCTestCase {
   func testFetchGroupList() async {
     // Given
     let expectedGroups = ManageGroupMockData.fetchedData
-    self.mockWorker.fetchGroupListResult = .success(expectedGroups)
+    self.mockWorker.setFetchGroupListResultSuccess(groups: expectedGroups)
     
     // When
     await self.interactor.fetchGroupList(request: ManageGroup.FetchGroupList.Request())
@@ -60,7 +60,7 @@ final class ManageGroupInteractorTests: XCTestCase {
       ManageGroup.ToDoGroup(id: "1", groupName: "Group1", progressColor: .red, progressRate: 0.5)
     ]
     let request = ManageGroup.SaveGroupList.Request(with: groupsToSave)
-    self.mockWorker.saveGroupListResult = .success(groupsToSave)
+    self.mockWorker.setSaveGroupListResultSuccess(groups: groupsToSave)
     
     // When
     await self.interactor.saveGroupList(request: request)

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Tests/ManageGroupSceneTests/ManageGroupInteractorTests.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Tests/ManageGroupSceneTests/ManageGroupInteractorTests.swift
@@ -116,8 +116,16 @@ extension ManageGroupInteractorTests {
   }
   
   class MockWorker: ManageGroupWorkable {
-    var fetchGroupListResult: Result<[ManageGroup.ToDoGroup], Error>?
-    var saveGroupListResult: Result<[ManageGroup.ToDoGroup], Error>?
+    private var fetchGroupListResult: Result<[ManageGroup.ToDoGroup], Error>?
+    private var saveGroupListResult: Result<[ManageGroup.ToDoGroup], Error>?
+    
+    func setFetchGroupListResultSuccess(groups: [ManageGroup.ToDoGroup]) {
+      self.fetchGroupListResult = .success(groups)
+    }
+    
+    func setSaveGroupListResultSuccess(groups: [ManageGroup.ToDoGroup]) {
+      self.saveGroupListResult = .success(groups)
+    }
     
     func fetchGroupList(request: ManageGroup.FetchGroupList.Request) async -> Result<[ManageGroup.ToDoGroup], Error> {
       return self.fetchGroupListResult ?? .failure(NSError(domain: "Test", code: 0, userInfo: nil))

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Tests/ManageGroupSceneTests/ManageGroupInteractorTests.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Tests/ManageGroupSceneTests/ManageGroupInteractorTests.swift
@@ -50,8 +50,7 @@ final class ManageGroupInteractorTests: XCTestCase {
     
     // Then
     XCTAssertEqual(self.interactor.currentGroups, expectedGroups)
-    XCTAssertTrue(self.mockPresenter.presentFetchedGroupListCalled)
-    XCTAssertEqual(self.mockPresenter.fetchedGroupListResponse?.data, expectedGroups)
+    XCTAssertEqual(self.mockPresenter.presentedGroups, expectedGroups)
   }
   
   func testSaveGroupList() async {
@@ -67,8 +66,7 @@ final class ManageGroupInteractorTests: XCTestCase {
     
     // Then
     XCTAssertEqual(self.interactor.currentGroups, groupsToSave)
-    XCTAssertTrue(self.mockPresenter.presentSavedGroupListCalled)
-    XCTAssertEqual(self.mockPresenter.savedGroupListResponse?.data, groupsToSave)
+    XCTAssertEqual(self.mockPresenter.presentedGroups, groupsToSave)
   }
   
   func testDeleteGroup() {
@@ -82,36 +80,29 @@ final class ManageGroupInteractorTests: XCTestCase {
     
     // Then
     XCTAssertTrue(self.interactor.currentGroups.isEmpty)
-    XCTAssertTrue(self.mockPresenter.presentDeletedGroupCalled)
-    XCTAssertEqual(self.mockPresenter.deletedGroupResponse?.id, "1")
-    XCTAssertEqual(self.mockPresenter.deletedGroupResponse?.index, 0)
+    XCTAssertEqual(self.mockPresenter.deletedGroupId, "1")
+    XCTAssertEqual(self.mockPresenter.deletedGroupIndex, 0)
   }
 }
 
 // MARK: - Mock
 extension ManageGroupInteractorTests {
   class MockManageGroupPresenter: ManageGroupPresentationLogic {
-    var presentFetchedGroupListCalled = false
-    var presentSavedGroupListCalled = false
-    var presentDeletedGroupCalled = false
-    
-    var fetchedGroupListResponse: ManageGroup.FetchGroupList.Response?
-    var savedGroupListResponse: ManageGroup.SaveGroupList.Response?
-    var deletedGroupResponse: ManageGroup.DeleteGroup.Response?
+    private(set) var presentedGroups: [ManageGroup.ToDoGroup]?
+    private(set) var deletedGroupId: String?
+    private(set) var deletedGroupIndex: Int?
     
     func presentFetchedGroupList(response: ManageGroup.FetchGroupList.Response) {
-      self.presentFetchedGroupListCalled = true
-      self.fetchedGroupListResponse = response
+      self.presentedGroups = response.data
     }
     
     func presentSavedGroupList(response: ManageGroup.SaveGroupList.Response) {
-      self.presentSavedGroupListCalled = true
-      self.savedGroupListResponse = response
+      self.presentedGroups = response.data
     }
     
     func presentDeletedGroup(response: ManageGroup.DeleteGroup.Response) {
-      self.presentDeletedGroupCalled = true
-      self.deletedGroupResponse = response
+      self.deletedGroupId = response.id
+      self.deletedGroupIndex = response.index
     }
   }
   

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Tests/ManageGroupSceneTests/ManageGroupInteractorTests.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Tests/ManageGroupSceneTests/ManageGroupInteractorTests.swift
@@ -1,0 +1,130 @@
+//
+//  ManageGroupInteractorTests.swift
+//
+//
+//  Created by SONG on 9/10/24.
+//  Copyright (c) 2024 ___ORGANIZATIONNAME___. All rights reserved.
+
+import XCTest
+
+@testable import ManageGroupScene
+@testable import ManageGroupSceneAPI
+@testable import ManageGroupSceneEntity
+
+final class ManageGroupInteractorTests: XCTestCase {
+  
+  // MARK: Test Object
+  var interactor: ManageGroupInteractor!
+  var mockPresenter: MockManageGroupPresenter!
+  var mockWorker: MockWorker!
+  
+  // MARK: Test lifecycle
+  override func setUp() {
+    super.setUp()
+    self.setupManageGroupInteractor()
+  }
+  
+  override func tearDown() {
+    self.interactor = nil
+    self.mockPresenter = nil
+    self.mockWorker = nil
+    super.tearDown()
+  }
+  
+  // MARK: Test setup
+  func setupManageGroupInteractor() {
+    self.mockWorker = MockWorker()
+    self.interactor = ManageGroupInteractor(worker: mockWorker)
+    self.mockPresenter = MockManageGroupPresenter()
+    self.interactor.presenter = self.mockPresenter
+  }
+  
+  // MARK: Tests
+  func testFetchGroupList() async {
+    // Given
+    let expectedGroups = ManageGroupMockData.fetchedData
+    self.mockWorker.fetchGroupListResult = .success(expectedGroups)
+    
+    // When
+    await self.interactor.fetchGroupList(request: ManageGroup.FetchGroupList.Request())
+    
+    // Then
+    XCTAssertEqual(self.interactor.currentGroups, expectedGroups)
+    XCTAssertTrue(self.mockPresenter.presentFetchedGroupListCalled)
+    XCTAssertEqual(self.mockPresenter.fetchedGroupListResponse?.data, expectedGroups)
+  }
+  
+  func testSaveGroupList() async {
+    // Given
+    let groupsToSave = [
+      ManageGroup.ToDoGroup(id: "1", groupName: "Group1", progressColor: .red, progressRate: 0.5)
+    ]
+    let request = ManageGroup.SaveGroupList.Request(with: groupsToSave)
+    self.mockWorker.saveGroupListResult = .success(groupsToSave)
+    
+    // When
+    await self.interactor.saveGroupList(request: request)
+    
+    // Then
+    XCTAssertEqual(self.interactor.currentGroups, groupsToSave)
+    XCTAssertTrue(self.mockPresenter.presentSavedGroupListCalled)
+    XCTAssertEqual(self.mockPresenter.savedGroupListResponse?.data, groupsToSave)
+  }
+  
+  func testDeleteGroup() {
+    // Given
+    let groupToDelete = ManageGroup.ToDoGroup(id: "1", groupName: "Group1", progressColor: .red, progressRate: 0.5)
+    self.interactor.currentGroups = [groupToDelete]
+    let request = ManageGroup.DeleteGroup.Request(id: "1", index: 0)
+    
+    // When
+    self.interactor.deleteGroup(request: request)
+    
+    // Then
+    XCTAssertTrue(self.interactor.currentGroups.isEmpty)
+    XCTAssertTrue(self.mockPresenter.presentDeletedGroupCalled)
+    XCTAssertEqual(self.mockPresenter.deletedGroupResponse?.id, "1")
+    XCTAssertEqual(self.mockPresenter.deletedGroupResponse?.index, 0)
+  }
+}
+
+// MARK: - Mock
+extension ManageGroupInteractorTests {
+  class MockManageGroupPresenter: ManageGroupPresentationLogic {
+    var presentFetchedGroupListCalled = false
+    var presentSavedGroupListCalled = false
+    var presentDeletedGroupCalled = false
+    
+    var fetchedGroupListResponse: ManageGroup.FetchGroupList.Response?
+    var savedGroupListResponse: ManageGroup.SaveGroupList.Response?
+    var deletedGroupResponse: ManageGroup.DeleteGroup.Response?
+    
+    func presentFetchedGroupList(response: ManageGroup.FetchGroupList.Response) {
+      self.presentFetchedGroupListCalled = true
+      self.fetchedGroupListResponse = response
+    }
+    
+    func presentSavedGroupList(response: ManageGroup.SaveGroupList.Response) {
+      self.presentSavedGroupListCalled = true
+      self.savedGroupListResponse = response
+    }
+    
+    func presentDeletedGroup(response: ManageGroup.DeleteGroup.Response) {
+      self.presentDeletedGroupCalled = true
+      self.deletedGroupResponse = response
+    }
+  }
+  
+  class MockWorker: ManageGroupWorkable {
+    var fetchGroupListResult: Result<[ManageGroup.ToDoGroup], Error>?
+    var saveGroupListResult: Result<[ManageGroup.ToDoGroup], Error>?
+    
+    func fetchGroupList(request: ManageGroup.FetchGroupList.Request) async -> Result<[ManageGroup.ToDoGroup], Error> {
+      return self.fetchGroupListResult ?? .failure(NSError(domain: "Test", code: 0, userInfo: nil))
+    }
+    
+    func saveGroupList(request: ManageGroup.SaveGroupList.Request) async -> Result<[ManageGroup.ToDoGroup], Error> {
+      return self.saveGroupListResult ?? .failure(NSError(domain: "Test", code: 0, userInfo: nil))
+    }
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Tests/ManageGroupSceneTests/ManageGroupSceneTests.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Tests/ManageGroupSceneTests/ManageGroupSceneTests.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-@testable import ManageGroupScene
-
-final class ManageGroupSceneTests: XCTestCase {
-  
-}


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #478  
## 🎉 변경 사항
- ManageGroupScene Interactor에 대한 테스트코드 추가 
## 📌 PR Point

### 검증하고자 했던 것들 

1) 메서드 호출 후, `currentGroups`이 올바르게 변경되었는가? 
 ManageGroupInteractor는 `currentGroups` 속성을 가지고 있고, 이 속성은 VIP사이클을 한바퀴 돌고 나면 표시되어야 할 그룹들을 나타냅니다. fetchGroupList / saveGroupList / deleteGroup 모두 `currentGroups`에 올바른 변화를 주는가 테스트 하였습니다.
 
2) 프레젠터에 전달되는 response가 올바른가? 
 ManageGroupInteractor는 최종적으로 프레젠터에 Response를 전달합니다. 프레젠터에 전달될 response가 올바른지 테스트 하였습니다. 
 
3) 프레젠터가 호출되었는가? 
인터랙터의 메서드에 의해 프레젠터가 호출되었는가 를 테스트하였습니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?