### PR TITLE
PostGroup -> ManageGroup 로의 이벤트 전달 구현 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -17,6 +17,8 @@ protocol ManageGroupBusinessLogic {
   func fetchGroupList(request: ManageGroup.FetchGroupList.Request) async
   func saveGroupList(request: ManageGroup.SaveGroupList.Request) async
   func deleteGroup(request: ManageGroup.DeleteGroup.Request)
+  func addGroup(request: ManageGroup.AddGroup.Request)
+  func editGroup(request: ManageGroup.EditGroup.Request)
 }
 
 class ManageGroupInteractor: ManageGroupDataStore {
@@ -63,5 +65,11 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
     self.currentGroups.remove(at: request.index)
     let response = ManageGroup.DeleteGroup.Response(groupID: request.groupID, index: request.index)
     self.presenter?.presentDeletedGroup(response: response)
+  }
+  
+  func addGroup(request: ManageGroup.AddGroup.Request) {
+  }
+  
+  func editGroup(request: ManageGroup.EditGroup.Request) {
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -68,8 +68,10 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
   }
   
   func addGroup(request: ManageGroup.AddGroup.Request) {
+    // 다음 PR에 포함예정
   }
   
   func editGroup(request: ManageGroup.EditGroup.Request) {
+    // 다음 PR에 포함예정
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -68,10 +68,23 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
   }
   
   func addGroup(request: ManageGroup.AddGroup.Request) {
-    // 다음 PR에 포함예정
+    let group = self.manageGroupWorker.addGroup(request: request)
+    self.currentGroups.append(group)
+    
+    let response = ManageGroup.AddGroup.Response(group: group)
+    self.presenter?.presentAddedGroup(response: response)
   }
   
   func editGroup(request: ManageGroup.EditGroup.Request) {
-    // 다음 PR에 포함예정
+    if let index = self.currentGroups.firstIndex(where: { $0.groupID == request.groupID }) {
+      let progressRate = self.currentGroups[index].progressRate
+      let group = self.manageGroupWorker.editGroup(request: request, progressRate: progressRate)
+      self.currentGroups[index] = group
+      
+      let response = ManageGroup.EditGroup.Response(group: group, editedIndex: index)
+      self.presenter?.presentEditedGroup(response: response)
+    } else {
+      return
+    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
@@ -13,6 +13,8 @@ protocol ManageGroupPresentationLogic {
   func presentFetchedGroupList(response: ManageGroup.FetchGroupList.Response)
   func presentSavedGroupList(response: ManageGroup.SaveGroupList.Response)
   func presentDeletedGroup(response: ManageGroup.DeleteGroup.Response)
+  func presentAddedGroup(response: ManageGroup.AddGroup.Response)
+  func presentEditedGroup(response: ManageGroup.EditGroup.Response)
 }
 
 class ManageGroupPresenter {
@@ -38,5 +40,15 @@ extension ManageGroupPresenter: ManageGroupPresentationLogic {
       index: response.index
     )
     self.viewController?.displayDeletedGroup(viewModel: viewModel)
+  }
+  
+  func presentAddedGroup(response: ManageGroup.AddGroup.Response) {
+    let viewModel = ManageGroup.AddGroup.ViewModel(group: response.group)
+    self.viewController?.displayAddedGroup(viewModel: viewModel)
+  }
+  
+  func presentEditedGroup(response: ManageGroup.EditGroup.Response) {
+    let viewModel = ManageGroup.EditGroup.ViewModel(group: response.group, editedIndex: response.editedIndex)
+    self.viewController?.displayEditedGroup(viewModel: viewModel)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
@@ -10,6 +10,7 @@ import UIKit.UIColor
 import ManageGroupSceneAPI
 import ManageGroupSceneEntity
 import PostGroupSceneAPI
+import PostGroupSceneEntity
 
 protocol ManageGroupRoutingLogic {
   func routeToPostGroupScene(groupInfo: ManageGroup.ToDoGroup?)
@@ -37,9 +38,11 @@ extension ManageGroupRouter: ManageGroupRoutingLogic {
     var payload: PostGroupScenePayload?
     if let groupInfo {
       payload = PostGroupScenePayload(
-        groupID: groupInfo.groupID,
-        groupName: groupInfo.groupName,
-        groupColor: groupInfo.progressColor
+        group: PostGroup.ToDoGroup(
+          groupID: groupInfo.groupID,
+          groupName: groupInfo.groupName,
+          groupColor: groupInfo.progressColor
+        )
       )
     } else {
       payload = nil
@@ -60,8 +63,6 @@ extension ManageGroupRouter: ManageGroupRoutingLogic {
 
 extension ManageGroupRouter {
   struct PostGroupScenePayload: PostGroupScenePayloadable {
-    var groupID: UUID
-    var groupName: String
-    var groupColor: UIColor
+    var group: PostGroup.ToDoGroup
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController+PostGroupSceneDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController+PostGroupSceneDelegate.swift
@@ -1,0 +1,38 @@
+//
+//  ManageGroupViewController+PostGroupSceneDelegate.swift
+//
+//
+//  Created by SONG on 9/12/24.
+//
+
+import UIKit.UIColor
+
+import ManageGroupSceneEntity
+import PostGroupSceneAPI
+import PostGroupSceneEntity
+
+extension ManageGroupViewController: PostGroupSceneDelegate {
+  public func addGroup(group: PostGroup.ToDoGroup) {
+    let request = ManageGroup.AddGroup.Request(
+      groupID: group.groupID ?? UUID(),
+      groupName: group.groupName ?? "",
+      groupColor: group.groupColor ?? UIColor.toDoGardenGrassNone
+    )
+    
+    self.interactor?.addGroup(request: request)
+  }
+  
+  public func editGroup(group: PostGroup.ToDoGroup) {
+    guard let groupID = group.groupID else {
+      return
+    }
+    
+    let request = ManageGroup.EditGroup.Request(
+      groupID: groupID,
+      groupName: group.groupName ?? "",
+      groupColor: group.groupColor ?? UIColor.toDoGardenGrassNone
+    )
+    
+    self.interactor?.editGroup(request: request)
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController+PostGroupSceneDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController+PostGroupSceneDelegate.swift
@@ -15,8 +15,8 @@ extension ManageGroupViewController: PostGroupSceneDelegate {
   public func addGroup(group: PostGroup.ToDoGroup) {
     let request = ManageGroup.AddGroup.Request(
       groupID: group.groupID ?? UUID(),
-      groupName: group.groupName ?? "",
-      groupColor: group.groupColor ?? UIColor.toDoGardenGrassNone
+      groupName: group.groupName,
+      groupColor: group.groupColor
     )
     
     self.interactor?.addGroup(request: request)
@@ -29,8 +29,8 @@ extension ManageGroupViewController: PostGroupSceneDelegate {
     
     let request = ManageGroup.EditGroup.Request(
       groupID: groupID,
-      groupName: group.groupName ?? "",
-      groupColor: group.groupColor ?? UIColor.toDoGardenGrassNone
+      groupName: group.groupName,
+      groupColor: group.groupColor
     )
     
     self.interactor?.editGroup(request: request)

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -291,18 +291,13 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     self.rightBarButton.isEnabled = false
     Task { @MainActor in
       self.groupListTableView.performBatchUpdates({
-        self.groupListTableView.insertRows(
-          at: changes.insertions,
-          with: UITableView.RowAnimation.fade
-        )
+        self.groupListTableView.deleteRows(at: changes.deletions, with: UITableView.RowAnimation.fade)
+        self.groupListTableView.insertRows(at: changes.insertions, with: UITableView.RowAnimation.fade)
         changes.moves.forEach { move in
           self.groupListTableView.moveRow(at: move.from, to: move.to)
         }
       }, completion: { _ in
-        self.groupListTableView.reloadRows(
-          at: changes.updates,
-          with: UITableView.RowAnimation.none
-        )
+        self.groupListTableView.reloadRows(at: changes.updates, with: UITableView.RowAnimation.fade)
         self.rightBarButton.isEnabled = true
       })
     }
@@ -313,6 +308,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     oldGroups: [ManageGroup.ToDoGroup],
     newGroups: [ManageGroup.ToDoGroup]
   ) -> (
+    deletions: [IndexPath],
     insertions: [IndexPath],
     moves: [(from: IndexPath, to: IndexPath)],
     updates: [IndexPath]
@@ -320,6 +316,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     let oldIDs = oldGroups.map { $0.groupID }
     let newIDs = newGroups.map { $0.groupID }
     
+    let deletions = calculateDeletions(oldIDs: oldIDs, newIDs: Set(newIDs))
     let insertions = calculateInsertions(newIDs: newIDs, oldIDs: Set(oldIDs))
     let oldIndexMap = createOldIndexMap(oldGroups: oldGroups)
     let (moves, updates) = calculateMovesAndUpdates(
@@ -327,9 +324,15 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
       oldGroups: oldGroups,
       oldIndexMap: oldIndexMap
     )
-    return (insertions, moves, updates)
+    return (deletions, insertions, moves, updates)
   }
   // swiftlint:enable large_tuple
+  
+  private func calculateDeletions(oldIDs: [UUID], newIDs: Set<UUID>) -> [IndexPath] {
+    return oldIDs.enumerated().compactMap { index, groupID in
+      newIDs.contains(groupID) ? nil : IndexPath(row: index, section: 0)
+    }
+  }
   
   private func calculateInsertions(newIDs: [UUID], oldIDs: Set<UUID>) -> [IndexPath] {
     var insertions: [IndexPath] = []

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -18,6 +18,8 @@ protocol ManageGroupDisplayLogic: AnyObject {
   func displayFetchedGroupList(viewModel: ManageGroup.FetchGroupList.ViewModel)
   func displaySavedGroupList(viewModel: ManageGroup.SaveGroupList.ViewModel)
   func displayDeletedGroup(viewModel: ManageGroup.DeleteGroup.ViewModel)
+  func displayAddedGroup(viewModel: ManageGroup.AddGroup.ViewModel)
+  func displayEditedGroup(viewModel: ManageGroup.EditGroup.ViewModel)
 }
 
 public class ManageGroupViewController: UIViewController, ManageGroupViewControllable {
@@ -274,12 +276,36 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
   
   func displayDeletedGroup(viewModel: ManageGroup.DeleteGroup.ViewModel) {
     let index = viewModel.index
+    self.manageGroupTableViewDelegate?.displayedGroups.remove(at: index)
     Task { @MainActor in
-      self.manageGroupTableViewDelegate?.displayedGroups.remove(at: index)
       self.groupListTableView.deleteRows(
         at: [IndexPath(row: index, section: 0)],
         with: UITableView.RowAnimation.fade
       )
+    }
+  }
+  
+  func displayAddedGroup(viewModel: ManageGroup.AddGroup.ViewModel) {
+    let indexPath = IndexPath(
+      row: self.groupListTableView.numberOfRows(inSection: 0),
+      section: 0
+    )
+    self.manageGroupTableViewDelegate?.displayedGroups.append(viewModel.group)
+    Task { @MainActor in
+      self.groupListTableView.insertRows(
+        at: [indexPath],
+        with: UITableView.RowAnimation.fade
+      )
+      self.groupListTableView.scrollToRow(at: indexPath, at: .bottom, animated: true)
+    }
+  }
+  
+  func displayEditedGroup(viewModel: ManageGroup.EditGroup.ViewModel) {
+    self.manageGroupTableViewDelegate?.displayedGroups[viewModel.editedIndex] = viewModel.group
+    Task { @MainActor in
+      self.groupListTableView.reloadRows(
+        at: [IndexPath(row: viewModel.editedIndex, section: Int.zero)],
+        with: UITableView.RowAnimation.fade)
     }
   }
   

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -277,12 +277,10 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
   func displayDeletedGroup(viewModel: ManageGroup.DeleteGroup.ViewModel) {
     let index = viewModel.index
     self.manageGroupTableViewDelegate?.displayedGroups.remove(at: index)
-    Task { @MainActor in
-      self.groupListTableView.deleteRows(
-        at: [IndexPath(row: index, section: 0)],
-        with: UITableView.RowAnimation.fade
-      )
-    }
+    self.groupListTableView.deleteRows(
+      at: [IndexPath(row: index, section: 0)],
+      with: UITableView.RowAnimation.fade
+    )
   }
   
   func displayAddedGroup(viewModel: ManageGroup.AddGroup.ViewModel) {
@@ -291,22 +289,18 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
       section: 0
     )
     self.manageGroupTableViewDelegate?.displayedGroups.append(viewModel.group)
-    Task { @MainActor in
-      self.groupListTableView.insertRows(
-        at: [indexPath],
-        with: UITableView.RowAnimation.fade
-      )
-      self.groupListTableView.scrollToRow(at: indexPath, at: .bottom, animated: true)
-    }
+    self.groupListTableView.insertRows(
+      at: [indexPath],
+      with: UITableView.RowAnimation.fade
+    )
+    self.groupListTableView.scrollToRow(at: indexPath, at: .bottom, animated: true)
   }
   
   func displayEditedGroup(viewModel: ManageGroup.EditGroup.ViewModel) {
     self.manageGroupTableViewDelegate?.displayedGroups[viewModel.editedIndex] = viewModel.group
-    Task { @MainActor in
-      self.groupListTableView.reloadRows(
-        at: [IndexPath(row: viewModel.editedIndex, section: Int.zero)],
-        with: UITableView.RowAnimation.fade)
-    }
+    self.groupListTableView.reloadRows(
+      at: [IndexPath(row: viewModel.editedIndex, section: Int.zero)],
+      with: UITableView.RowAnimation.fade)
   }
   
   private func updateTableViewWithAnimation(

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -5,7 +5,6 @@
 //  Created by SONG on 6/26/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-// swiftlint:disable file_length
 import UIKit
 
 import ManageGroupSceneAPI

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
@@ -34,6 +34,26 @@ public class ManageGroupWorker: ManageGroupWorkable {
       return .failure(error)
     }
   }
+  
+  public func addGroup(request: ManageGroup.AddGroup.Request) -> ManageGroup.ToDoGroup {
+    let group = ManageGroup.ToDoGroup(
+      groupID: request.groupID,
+      groupName: request.groupName,
+      progressColor: request.groupColor,
+      progressRate: Float.zero
+    )
+    return group
+  }
+  
+  public func editGroup(request: ManageGroup.EditGroup.Request, progressRate: Float) -> ManageGroup.ToDoGroup {
+    let group = ManageGroup.ToDoGroup(
+      groupID: request.groupID,
+      groupName: request.groupName,
+      progressColor: request.groupColor,
+      progressRate: progressRate
+    )
+    return group
+  }
 
   private func fetchGroupsFromDatabase() async throws -> [ManageGroup.ToDoGroup] {
     let fetchedData: [ManageGroup.ToDoGroup] = ManageGroupMockData.fetchedData

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneAPI/ManageGroupWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneAPI/ManageGroupWorkable.swift
@@ -16,4 +16,6 @@ public protocol ManageGroupWorkable {
   func saveGroupList(
     request: ManageGroupSceneEntity.ManageGroup.SaveGroupList.Request
   ) async -> Result<[ManageGroup.ToDoGroup], Error>
+  func addGroup(request: ManageGroup.AddGroup.Request) -> ManageGroup.ToDoGroup
+  func editGroup(request: ManageGroup.EditGroup.Request, progressRate: Float) -> ManageGroup.ToDoGroup
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneEntity/ManageGroupModels.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneEntity/ManageGroupModels.swift
@@ -107,4 +107,68 @@ public enum ManageGroup {
       }
     }
   }
+  
+  public enum AddGroup {
+    public struct Request {
+      public let groupID: UUID
+      public let groupName: String
+      public let groupColor: UIColor
+      
+      public init(groupID: UUID, groupName: String, groupColor: UIColor) {
+        self.groupID = groupID
+        self.groupName = groupName
+        self.groupColor = groupColor
+      }
+    }
+    
+    public struct Response {
+      public let group: ToDoGroup
+      
+      public init(group: ToDoGroup) {
+        self.group = group
+      }
+    }
+    
+    public struct ViewModel {
+      public let group: ToDoGroup
+      
+      public init(group: ToDoGroup) {
+        self.group = group
+      }
+    }
+  }
+  
+  public enum EditGroup {
+    public struct Request {
+      public let groupID: UUID
+      public let groupName: String
+      public let groupColor: UIColor
+      
+      public init(groupID: UUID, groupName: String, groupColor: UIColor) {
+        self.groupID = groupID
+        self.groupName = groupName
+        self.groupColor = groupColor
+      }
+    }
+    
+    public struct Response {
+      public let group: ToDoGroup
+      public let editedIndex: Int
+      
+      public init(group: ToDoGroup, editedIndex: Int) {
+        self.group = group
+        self.editedIndex = editedIndex
+      }
+    }
+    
+    public struct ViewModel {
+      public let group: ToDoGroup
+      public let editedIndex: Int
+      
+      public init(group: ToDoGroup, editedIndex: Int) {
+        self.group = group
+        self.editedIndex = editedIndex
+      }
+    }
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -25,7 +25,12 @@ class PostGroupInteractor: PostGroupDataStore {
   var delegate: PostGroupSceneDelegate?
   var presenter: PostGroupPresentationLogic?
   private let postGroupWorker: PostGroupWorkable
-  var payload: PostGroupScenePayloadable?
+  var payload: PostGroupScenePayloadable? {
+    didSet {
+      self.setCurrentGroup()
+    }
+  }
+  var currentGroup: PostGroup.ToDoGroup?
   
   init(postGroupWorker: PostGroupWorkable) {
     self.postGroupWorker = postGroupWorker
@@ -78,6 +83,22 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
 }
 
 extension PostGroupInteractor {
+  private func setCurrentGroup() {
+    guard let payload = self.payload else {
+      self.currentGroup = PostGroup.ToDoGroup(
+        groupID: nil,
+        groupName: nil,
+        groupColor: nil
+      )
+      return
+    }
+    
+    self.currentGroup = PostGroup.ToDoGroup(
+      groupID: payload.groupID,
+      groupName: payload.groupName,
+      groupColor: payload.groupColor
+    )
+  }
   
   private func isDoneBottomButtonEnable(groupName: String?, groupColor: UIColor?) -> Bool {
     var isButtonEnable: Bool

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -59,7 +59,7 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
     
     let response = PostGroup.TouchDoneButton.Response(group: result)
     self.currentGroup = response.group
-    self.presenter?.presentTouchedDoneButton(response: response)
+    self.presenter?.presentAfterTouchingDoneButton(response: response)
   }
   
   func changeColor(request: PostGroup.ChangeColor.Request) {

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -12,6 +12,7 @@ import PostGroupSceneEntity
 
 protocol PostGroupDataStore {
   var payload: PostGroupScenePayloadable? { get set }
+  var delegate: PostGroupSceneDelegate? { get set }
 }
 
 protocol PostGroupBusinessLogic {
@@ -21,6 +22,7 @@ protocol PostGroupBusinessLogic {
 }
 
 class PostGroupInteractor: PostGroupDataStore {
+  var delegate: PostGroupSceneDelegate?
   var presenter: PostGroupPresentationLogic?
   private let postGroupWorker: PostGroupWorkable
   var payload: PostGroupScenePayloadable?

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -11,7 +11,7 @@ import PostGroupSceneAPI
 import PostGroupSceneEntity
 
 protocol PostGroupDataStore {
-  var payload: PostGroupScenePayloadable? { get set }
+  var currentGroup: PostGroup.ToDoGroup? { get set }
   var delegate: PostGroupSceneDelegate? { get set }
 }
 
@@ -25,11 +25,7 @@ class PostGroupInteractor: PostGroupDataStore {
   var delegate: PostGroupSceneDelegate?
   var presenter: PostGroupPresentationLogic?
   private let postGroupWorker: PostGroupWorkable
-  var payload: PostGroupScenePayloadable? {
-    didSet {
-      self.setCurrentGroup()
-    }
-  }
+  
   var currentGroup: PostGroup.ToDoGroup?
   
   init(postGroupWorker: PostGroupWorkable) {
@@ -69,14 +65,11 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
   }
   
   func loadGroupData() {
-    let isDoneBottomButtonEnable: Bool = self.isDoneBottomButtonEnable(
-      groupName: self.payload?.groupName,
-      groupColor: self.payload?.groupColor
-    )
+    let isDoneBottomButtonEnable: Bool = self.isDoneBottomButtonEnable(with: self.currentGroup)
     
     let response = PostGroup.LoadGroupData.Response(
-      groupName: self.payload?.groupName ?? "",
-      groupColor: self.payload?.groupColor,
+      groupName: self.currentGroup?.groupName ?? "",
+      groupColor: self.currentGroup?.groupColor,
       isDoneBottomButtonEnable: isDoneBottomButtonEnable
     )
     self.presenter?.presentLoadGroupData(response: response)
@@ -84,26 +77,9 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
 }
 
 extension PostGroupInteractor {
-  private func setCurrentGroup() {
-    guard let payload = self.payload else {
-      self.currentGroup = PostGroup.ToDoGroup(
-        groupID: nil,
-        groupName: nil,
-        groupColor: nil
-      )
-      return
-    }
-    
-    self.currentGroup = PostGroup.ToDoGroup(
-      groupID: payload.groupID,
-      groupName: payload.groupName,
-      groupColor: payload.groupColor
-    )
-  }
-  
-  private func isDoneBottomButtonEnable(groupName: String?, groupColor: UIColor?) -> Bool {
+  private func isDoneBottomButtonEnable(with currentGroup: PostGroup.ToDoGroup?) -> Bool {
     var isButtonEnable: Bool
-    if (groupName == nil) || (groupColor == nil) {
+    if currentGroup == nil {
       isButtonEnable = false
     } else {
       isButtonEnable = true

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -64,12 +64,13 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
   
   func loadGroupData() {
     let isDoneBottomButtonEnable: Bool = self.isDoneBottomButtonEnable(
-      groupName: payload?.groupName,
-      groupColor: payload?.groupColor
+      groupName: self.payload?.groupName,
+      groupColor: self.payload?.groupColor
     )
+    
     let response = PostGroup.LoadGroupData.Response(
-      groupName: payload?.groupName ?? "",
-      groupColor: payload?.groupColor,
+      groupName: self.payload?.groupName ?? "",
+      groupColor: self.payload?.groupColor,
       isDoneBottomButtonEnable: isDoneBottomButtonEnable
     )
     self.presenter?.presentLoadGroupData(response: response)

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -41,29 +41,30 @@ class PostGroupInteractor: PostGroupDataStore {
 
 extension PostGroupInteractor: PostGroupBusinessLogic {
   func touchDoneButton(request: PostGroupSceneEntity.PostGroup.TouchDoneButton.Request) {
-    guard let groupID = payload?.groupID else {
-      return
+    let groupID: UUID? = self.currentGroup?.groupID
+    
+    let result = self.postGroupWorker.touchDoneButton(
+      groupID: groupID,
+      groupName: request.groupName,
+      groupColor: request.groupColor
+    )
+    
+    let isAddGroup = result.groupID == nil
+    
+    if isAddGroup {
+      self.delegate?.addGroup(group: result)
+    } else {
+      self.delegate?.editGroup(group: result)
     }
     
-    self.postGroupWorker.touchDoneButton(
-      groupID: groupID,
-      groupName: request.groupName,
-      groupColor: request.groupColor
-    )
-    
-    let response = PostGroup.TouchDoneButton.Response(
-      groupID: groupID,
-      groupName: request.groupName,
-      groupColor: request.groupColor
-    )
-    
+    let response = PostGroup.TouchDoneButton.Response(group: result)
+    self.currentGroup = response.group
     self.presenter?.presentTouchedDoneButton(response: response)
   }
   
   func changeColor(request: PostGroup.ChangeColor.Request) {
-    self.postGroupWorker.changeColor(groupColor: request.groupColor)
-    // 성공했다고 가정
-    let response = PostGroup.ChangeColor.Response(groupID: "ID", groupColor: request.groupColor)
+    self.currentGroup?.groupColor = request.groupColor
+    let response = PostGroup.ChangeColor.Response(groupColor: request.groupColor)
     self.presenter?.presentChangedColor(response: response)
   }
   

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupPresenter.swift
@@ -12,7 +12,7 @@ import PostGroupSceneEntity
 protocol PostGroupPresentationLogic {
   func presentChangedColor(response: PostGroup.ChangeColor.Response)
   func presentLoadGroupData(response: PostGroup.LoadGroupData.Response)
-  func presentTouchedDoneButton(response: PostGroup.TouchDoneButton.Response)
+  func presentAfterTouchingDoneButton(response: PostGroup.TouchDoneButton.Response)
 }
 
 class PostGroupPresenter {
@@ -45,8 +45,8 @@ extension PostGroupPresenter: PostGroupPresentationLogic {
     self.viewController?.displayPayload(viewModel: viewModel)
   }
   
-  func presentTouchedDoneButton(response: PostGroup.TouchDoneButton.Response) {
+  func presentAfterTouchingDoneButton(response: PostGroup.TouchDoneButton.Response) {
     let viewModel = PostGroup.TouchDoneButton.ViewModel()
-    self.viewController?.displayTouchedDondButton(viewModel: viewModel)
+    self.viewController?.displayAfterTouchingDoneButton(viewModel: viewModel)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupRouter.swift
@@ -8,9 +8,12 @@
 import Foundation
 
 import PostGroupSceneAPI
+import PostGroupSceneEntity
 
 protocol PostGroupDataPassing {
   var dataStore: PostGroupDataStore? { get set }
+  
+  func routeToManageGroupScene()
 }
 
 class PostGroupRouter: PostGroupDataPassing {
@@ -18,5 +21,11 @@ class PostGroupRouter: PostGroupDataPassing {
   var dataStore: PostGroupDataStore?
   
   init() {
+  }
+  
+  // TODO: delegate 호출도 라우터에서 처리하자
+  
+  func routeToManageGroupScene() {
+    self.viewController?.navigationController?.popViewController(animated: true)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
@@ -74,7 +74,7 @@ extension PostGroupSceneBuilder {
     with payload: PostGroupScenePayloadable?,
     delegate: PostGroupSceneDelegate?
   ) {
-    viewController.router?.dataStore?.payload = payload
+    viewController.router?.dataStore?.currentGroup = payload?.group
     viewController.router?.dataStore?.delegate = delegate
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
@@ -34,11 +34,14 @@ extension PostGroupSceneBuilder: PostGroupSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
-  public func build(with payload: PostGroupScenePayloadable?) -> PostGroupViewControllable {
+  public func build(
+    with payload: PostGroupScenePayloadable?,
+    delegate: PostGroupSceneDelegate?
+  ) -> PostGroupViewControllable {
     let postGroupViewController = self.configureVIPCycle(
       for: PostGroupViewController()
     )
-    self.loadGroupData(for: postGroupViewController, with: payload)
+    self.setPayload(for: postGroupViewController, with: payload, delegate: delegate)
     
     return postGroupViewController
   }
@@ -66,7 +69,12 @@ extension PostGroupSceneBuilder {
   /// - Parameters:
   ///   - viewController: 런타임 의존성을 설정할 ViewController 객체입니다.
   ///   - payload: 런타임에 전달할 의존성입니다.
-  private func loadGroupData(for viewController: PostGroupViewController, with payload: PostGroupScenePayloadable?) {
+  private func setPayload(
+    for viewController: PostGroupViewController,
+    with payload: PostGroupScenePayloadable?,
+    delegate: PostGroupSceneDelegate?
+  ) {
     viewController.router?.dataStore?.payload = payload
+    viewController.router?.dataStore?.delegate = delegate
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -227,7 +227,7 @@ extension PostGroupViewController: PostGroupDisplayLogic {
   }
   
   func displayAfterTouchingDoneButton(viewModel: PostGroup.TouchDoneButton.ViewModel) {
-    self.navigationController?.popViewController(animated: true)
+    self.router?.routeToManageGroupScene()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -18,7 +18,7 @@ import ToDoGardenUIResource
 protocol PostGroupDisplayLogic: AnyObject {
   func displayChangedColor(viewModel: PostGroup.ChangeColor.ViewModel)
   func displayPayload(viewModel: PostGroup.LoadGroupData.ViewModel)
-  func displayTouchedDondButton(viewModel: PostGroup.TouchDoneButton.ViewModel)
+  func displayAfterTouchingDoneButton(viewModel: PostGroup.TouchDoneButton.ViewModel)
 }
 
 final class PostGroupViewController: UIViewController, PostGroupViewControllable {
@@ -226,8 +226,8 @@ extension PostGroupViewController: PostGroupDisplayLogic {
     self.doneBottomButton.isEnabled = viewModel.isDoneBottomButtonEnable
   }
   
-  func displayTouchedDondButton(viewModel: PostGroup.TouchDoneButton.ViewModel) {
-    print("Route to ManageGroupScene")
+  func displayAfterTouchingDoneButton(viewModel: PostGroup.TouchDoneButton.ViewModel) {
+    self.navigationController?.popViewController(animated: true)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -154,7 +154,11 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
       ]
     )
     
-    self.colorPickButton.addAction( UIAction { _ in
+    self.colorPickButton.addAction( UIAction { [weak self] _ in
+      guard let self = self else {
+        return
+      }
+      
       postGroupBottomSheet.setupCurrentColor(color: self.postGroupColorPickerRow.getColor())
       self.present(postGroupBottomSheet, animated: true)
     }, for: UIControl.Event.touchUpInside)
@@ -177,13 +181,14 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
     
     self.doneBottomButton.addAction(
       UIAction { [weak self] _ in
-        guard let groupName = self?.textInputView.getEditingText(),
-          let groupColor = self?.postGroupColorPickerRow.getColor() else {
+        guard let self = self,
+          let groupName = self.textInputView.getEditingText(),
+          let groupColor = self.postGroupColorPickerRow.getColor() else {
           return
         }
         
         let request = PostGroup.TouchDoneButton.Request(groupName: groupName, groupColor: groupColor)
-        self?.interactor?.touchDoneButton(request: request)
+        self.interactor?.touchDoneButton(request: request)
       },
       for: UIControl.Event.touchUpInside
     )

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneBuildable.swift
@@ -7,11 +7,11 @@
 
 import UIKit.UIColor
 
+import PostGroupSceneEntity
+
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
 public protocol PostGroupScenePayloadable {
-  var groupID: UUID { get }
-  var groupName: String { get }
-  var groupColor: UIColor { get }
+  var group: PostGroup.ToDoGroup { get }
 }
 
 public protocol PostGroupSceneBuildable {

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneBuildable.swift
@@ -18,5 +18,5 @@ public protocol PostGroupSceneBuildable {
   ///  VIP Cycle, 런타임 파라미터가 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 파라미터입니다.
   /// - Returns: 런타임 파라미터, VIP Cycle이 설정된 ViewController가 반환되도록 구현합니다.
-  func build(with payload: PostGroupScenePayloadable?) -> PostGroupViewControllable
+  func build(with payload: PostGroupScenePayloadable?, delegate: PostGroupSceneDelegate?) -> PostGroupViewControllable
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneDelegate.swift
@@ -1,0 +1,14 @@
+//
+//  PostGroupSceneDelegate.swift
+//
+//
+//  Created by SONG on 9/12/24.
+//
+
+import Foundation
+import PostGroupSceneEntity
+
+public protocol PostGroupSceneDelegate: AnyObject {
+  func addGroup(group: PostGroup.ToDoGroup)
+  func editGroup(group: PostGroup.ToDoGroup)
+}

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneEntity/PostGroupModels.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneEntity/PostGroupModels.swift
@@ -10,10 +10,10 @@ import UIKit.UIColor
 public enum PostGroup {
   public struct ToDoGroup: Sendable {
     public let groupID: UUID?
-    public var groupName: String?
-    public var groupColor: UIColor?
+    public var groupName: String
+    public var groupColor: UIColor
     
-    public init(groupID: UUID?, groupName: String?, groupColor: UIColor?) {
+    public init(groupID: UUID?, groupName: String, groupColor: UIColor) {
       self.groupID = groupID
       self.groupName = groupName
       self.groupColor = groupColor


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #488
   - #491 이 해당 브랜치에 머지 된 후 머지버튼 누를 것
## 🎉 변경 사항
PostGroup -> ManageGroup 로의 이벤트 전달 구현 

## 📌 PR Point

### 변경사항이 많아 분리하여 PR하려면, 빌드에러 가능성이 있습니다. develop 에서의 빌드에러를 피하기 위해 #485에 먼저 머지 시킨후, 이상없음을 확인하고 #485를 develop에 머지하여 일괄적으로 머지시킬 예정입니다. 

### 주요 작업 

- ManageGroup 에서 Push로 화면에 띄워진 PostGroup에서의 작업을 마치고, 완료버튼을 눌렀을때, 기존의 ManageGroup에 표시된 테이블뷰에 UI 업데이트를 하기위한 작업입니다. 

- PostGroupDelegate 프로토콜을 선언하여, PostGroup에서 진행된 그룹변경사항에 대한 UI업데이트를 ManageGroupVC가 대신수행합니다. payload와 함께 delegate가 PostGroup에 전달되어 장착됩니다. 

- 수정/추가 되고있는 상태정보를 저장하는 속성을 PostGroupInteractor에 추가하였습니다. `완료` 버튼을 누르면, delegate를 통해 해당 정보가 ManageGroup으로 넘어가게 됩니다. 

- (다음 PR포함 예정) 그 상태정보를 토대로 ManageGroupList에 UI업데이트가 이루어집니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?