### PR TITLE
post usecase in manage group scene VIP구현

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -68,10 +68,23 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
   }
   
   func addGroup(request: ManageGroup.AddGroup.Request) {
-    // 다음 PR에 포함예정
+    let group = self.manageGroupWorker.addGroup(request: request)
+    self.currentGroups.append(group)
+    
+    let response = ManageGroup.AddGroup.Response(group: group)
+    self.presenter?.presentAddedGroup(response: response)
   }
   
   func editGroup(request: ManageGroup.EditGroup.Request) {
-    // 다음 PR에 포함예정
+    if let index = self.currentGroups.firstIndex(where: { $0.groupID == request.groupID }) {
+      let progressRate = self.currentGroups[index].progressRate
+      let group = self.manageGroupWorker.editGroup(request: request, progressRate: progressRate)
+      self.currentGroups[index] = group
+      
+      let response = ManageGroup.EditGroup.Response(group: group, editedIndex: index)
+      self.presenter?.presentEditedGroup(response: response)
+    } else {
+      return
+    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
@@ -13,6 +13,8 @@ protocol ManageGroupPresentationLogic {
   func presentFetchedGroupList(response: ManageGroup.FetchGroupList.Response)
   func presentSavedGroupList(response: ManageGroup.SaveGroupList.Response)
   func presentDeletedGroup(response: ManageGroup.DeleteGroup.Response)
+  func presentAddedGroup(response: ManageGroup.AddGroup.Response)
+  func presentEditedGroup(response: ManageGroup.EditGroup.Response)
 }
 
 class ManageGroupPresenter {
@@ -38,5 +40,15 @@ extension ManageGroupPresenter: ManageGroupPresentationLogic {
       index: response.index
     )
     self.viewController?.displayDeletedGroup(viewModel: viewModel)
+  }
+  
+  func presentAddedGroup(response: ManageGroup.AddGroup.Response) {
+    let viewModel = ManageGroup.AddGroup.ViewModel(group: response.group)
+    self.viewController?.displayAddedGroup(viewModel: viewModel)
+  }
+  
+  func presentEditedGroup(response: ManageGroup.EditGroup.Response) {
+    let viewModel = ManageGroup.EditGroup.ViewModel(group: response.group, editedIndex: response.editedIndex)
+    self.viewController?.displayEditedGroup(viewModel: viewModel)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -291,18 +291,13 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     self.rightBarButton.isEnabled = false
     Task { @MainActor in
       self.groupListTableView.performBatchUpdates({
-        self.groupListTableView.insertRows(
-          at: changes.insertions,
-          with: UITableView.RowAnimation.fade
-        )
+        self.groupListTableView.deleteRows(at: changes.deletions, with: UITableView.RowAnimation.fade)
+        self.groupListTableView.insertRows(at: changes.insertions, with: UITableView.RowAnimation.fade)
         changes.moves.forEach { move in
           self.groupListTableView.moveRow(at: move.from, to: move.to)
         }
       }, completion: { _ in
-        self.groupListTableView.reloadRows(
-          at: changes.updates,
-          with: UITableView.RowAnimation.none
-        )
+        self.groupListTableView.reloadRows(at: changes.updates, with: UITableView.RowAnimation.fade)
         self.rightBarButton.isEnabled = true
       })
     }
@@ -313,6 +308,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     oldGroups: [ManageGroup.ToDoGroup],
     newGroups: [ManageGroup.ToDoGroup]
   ) -> (
+    deletions: [IndexPath],
     insertions: [IndexPath],
     moves: [(from: IndexPath, to: IndexPath)],
     updates: [IndexPath]
@@ -320,6 +316,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     let oldIDs = oldGroups.map { $0.groupID }
     let newIDs = newGroups.map { $0.groupID }
     
+    let deletions = calculateDeletions(oldIDs: oldIDs, newIDs: Set(newIDs))
     let insertions = calculateInsertions(newIDs: newIDs, oldIDs: Set(oldIDs))
     let oldIndexMap = createOldIndexMap(oldGroups: oldGroups)
     let (moves, updates) = calculateMovesAndUpdates(
@@ -327,9 +324,15 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
       oldGroups: oldGroups,
       oldIndexMap: oldIndexMap
     )
-    return (insertions, moves, updates)
+    return (deletions, insertions, moves, updates)
   }
   // swiftlint:enable large_tuple
+  
+  private func calculateDeletions(oldIDs: [UUID], newIDs: Set<UUID>) -> [IndexPath] {
+    return oldIDs.enumerated().compactMap { index, groupID in
+      newIDs.contains(groupID) ? nil : IndexPath(row: index, section: 0)
+    }
+  }
   
   private func calculateInsertions(newIDs: [UUID], oldIDs: Set<UUID>) -> [IndexPath] {
     var insertions: [IndexPath] = []

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -18,6 +18,8 @@ protocol ManageGroupDisplayLogic: AnyObject {
   func displayFetchedGroupList(viewModel: ManageGroup.FetchGroupList.ViewModel)
   func displaySavedGroupList(viewModel: ManageGroup.SaveGroupList.ViewModel)
   func displayDeletedGroup(viewModel: ManageGroup.DeleteGroup.ViewModel)
+  func displayAddedGroup(viewModel: ManageGroup.AddGroup.ViewModel)
+  func displayEditedGroup(viewModel: ManageGroup.EditGroup.ViewModel)
 }
 
 public class ManageGroupViewController: UIViewController, ManageGroupViewControllable {
@@ -274,12 +276,36 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
   
   func displayDeletedGroup(viewModel: ManageGroup.DeleteGroup.ViewModel) {
     let index = viewModel.index
+    self.manageGroupTableViewDelegate?.displayedGroups.remove(at: index)
     Task { @MainActor in
-      self.manageGroupTableViewDelegate?.displayedGroups.remove(at: index)
       self.groupListTableView.deleteRows(
         at: [IndexPath(row: index, section: 0)],
         with: UITableView.RowAnimation.fade
       )
+    }
+  }
+  
+  func displayAddedGroup(viewModel: ManageGroup.AddGroup.ViewModel) {
+    let indexPath = IndexPath(
+      row: self.groupListTableView.numberOfRows(inSection: 0),
+      section: 0
+    )
+    self.manageGroupTableViewDelegate?.displayedGroups.append(viewModel.group)
+    Task { @MainActor in
+      self.groupListTableView.insertRows(
+        at: [indexPath],
+        with: UITableView.RowAnimation.fade
+      )
+      self.groupListTableView.scrollToRow(at: indexPath, at: .bottom, animated: true)
+    }
+  }
+  
+  func displayEditedGroup(viewModel: ManageGroup.EditGroup.ViewModel) {
+    self.manageGroupTableViewDelegate?.displayedGroups[viewModel.editedIndex] = viewModel.group
+    Task { @MainActor in
+      self.groupListTableView.reloadRows(
+        at: [IndexPath(row: viewModel.editedIndex, section: Int.zero)],
+        with: UITableView.RowAnimation.fade)
     }
   }
   

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -277,12 +277,10 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
   func displayDeletedGroup(viewModel: ManageGroup.DeleteGroup.ViewModel) {
     let index = viewModel.index
     self.manageGroupTableViewDelegate?.displayedGroups.remove(at: index)
-    Task { @MainActor in
-      self.groupListTableView.deleteRows(
-        at: [IndexPath(row: index, section: 0)],
-        with: UITableView.RowAnimation.fade
-      )
-    }
+    self.groupListTableView.deleteRows(
+      at: [IndexPath(row: index, section: 0)],
+      with: UITableView.RowAnimation.fade
+    )
   }
   
   func displayAddedGroup(viewModel: ManageGroup.AddGroup.ViewModel) {
@@ -291,22 +289,18 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
       section: 0
     )
     self.manageGroupTableViewDelegate?.displayedGroups.append(viewModel.group)
-    Task { @MainActor in
-      self.groupListTableView.insertRows(
-        at: [indexPath],
-        with: UITableView.RowAnimation.fade
-      )
-      self.groupListTableView.scrollToRow(at: indexPath, at: .bottom, animated: true)
-    }
+    self.groupListTableView.insertRows(
+      at: [indexPath],
+      with: UITableView.RowAnimation.fade
+    )
+    self.groupListTableView.scrollToRow(at: indexPath, at: .bottom, animated: true)
   }
   
   func displayEditedGroup(viewModel: ManageGroup.EditGroup.ViewModel) {
     self.manageGroupTableViewDelegate?.displayedGroups[viewModel.editedIndex] = viewModel.group
-    Task { @MainActor in
-      self.groupListTableView.reloadRows(
-        at: [IndexPath(row: viewModel.editedIndex, section: Int.zero)],
-        with: UITableView.RowAnimation.fade)
-    }
+    self.groupListTableView.reloadRows(
+      at: [IndexPath(row: viewModel.editedIndex, section: Int.zero)],
+      with: UITableView.RowAnimation.fade)
   }
   
   private func updateTableViewWithAnimation(

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
@@ -34,6 +34,26 @@ public class ManageGroupWorker: ManageGroupWorkable {
       return .failure(error)
     }
   }
+  
+  public func addGroup(request: ManageGroup.AddGroup.Request) -> ManageGroup.ToDoGroup {
+    let group = ManageGroup.ToDoGroup(
+      groupID: request.groupID,
+      groupName: request.groupName,
+      progressColor: request.groupColor,
+      progressRate: Float.zero
+    )
+    return group
+  }
+  
+  public func editGroup(request: ManageGroup.EditGroup.Request, progressRate: Float) -> ManageGroup.ToDoGroup {
+    let group = ManageGroup.ToDoGroup(
+      groupID: request.groupID,
+      groupName: request.groupName,
+      progressColor: request.groupColor,
+      progressRate: progressRate
+    )
+    return group
+  }
 
   private func fetchGroupsFromDatabase() async throws -> [ManageGroup.ToDoGroup] {
     let fetchedData: [ManageGroup.ToDoGroup] = ManageGroupMockData.fetchedData

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneAPI/ManageGroupWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneAPI/ManageGroupWorkable.swift
@@ -16,4 +16,6 @@ public protocol ManageGroupWorkable {
   func saveGroupList(
     request: ManageGroupSceneEntity.ManageGroup.SaveGroupList.Request
   ) async -> Result<[ManageGroup.ToDoGroup], Error>
+  func addGroup(request: ManageGroup.AddGroup.Request) -> ManageGroup.ToDoGroup
+  func editGroup(request: ManageGroup.EditGroup.Request, progressRate: Float) -> ManageGroup.ToDoGroup
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #491 
## 🎉 변경 사항
 - AddGroup / EditGroup 동작에 대한 VIP사이클을 구현하였습니다. 
 - 편집모드 진입 후, "취소" 버튼에 대한 추가 동작을 구현하였습니다. 
 
## 📌 PR Point

* 488 브랜치로 머지후, develop 브랜치에 머지시킬 예정입니다. 
(많은 files changed + develop에서의 build error 방지 ^^;;)

### AddGroup / EditGroup
- PostGroupScene 에서 `그룹 추가하기`작업이 완료되면 , ManageGroupTableView에 추가한 그룹의 Cell이 추가됩니다. 
- `저장` 버튼을 누르기 전에는 UI만 보여주는 동작이며, `저장`버튼을 눌러야 모든 변경사항에 대한 요청을 보냅니다. 
- `취소` 버튼을 누르면, 편집모드에 진입하여 수행한 모든 변경사항이 원상태로 돌아갑니다. 
   - 편집모드에서 "그룹 추가" 를 하고, `취소`를 누르면, 추가된 그룹을 원상태로 돌리기 위해 "삭제"해야 합니다. 아래 메서드의 반환값에 deletions를 추가하여 구현하였습니다. 
   
```swift
   private func calculateTableViewChanges(
    oldGroups: [ManageGroup.ToDoGroup],
    newGroups: [ManageGroup.ToDoGroup]
  ) -> (
    deletions: [IndexPath],
    insertions: [IndexPath],
    moves: [(from: IndexPath, to: IndexPath)],
    updates: [IndexPath]
  ) {
    let oldIDs = oldGroups.map { $0.groupID }
    let newIDs = newGroups.map { $0.groupID }
...    
    )
    return (deletions, insertions, moves, updates)
  }
```

- 백그라운드 스레드에서 실행되면 안되는 UI업데이트하는 부분은 Task로 묶어 MainActor 마킹을 해주었습니다. 

### 결과화면 (ADD / EDIT 후 `취소`)

![Simulator Screen Recording - iPhone 15 - 2024-09-22 at 17 30 15](https://github.com/user-attachments/assets/63a738fe-0b6c-40c5-abeb-0228481f3060)

![Simulator Screen Recording - iPhone 15 - 2024-09-22 at 17 30 55](https://github.com/user-attachments/assets/c81988e6-c887-4be0-9004-bf648f54a654)


## 📝 셀프체크리스트
- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?