### PR TITLE
SettingScene VIP 구현

### DIFF
--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/ApplicationServiceWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/ApplicationServiceWorker.swift
@@ -10,9 +10,19 @@ import Foundation
 // 앱스토어 이동 및 Info.plist의 정보를 받아오는 Worker입니다.
 // 해당 Domain Context Worker 구현이 완료되면 삭제될 예정입니다.
 public struct ApplicationServiceWorker {
-  func fetchAppVersion() -> String? {
+  func fetchCurrentAppVersion() -> String? {
     return Bundle.main.infoDictionary?[ApplicationServiceWorker.bundleVersionKey] as? String
   }
+
+  /// 버전 업데이트 필요 여부를 반환하는 메서드입니다.
+  /// 서버 요청이 필요하므로, Network Service 레이어 구현이 완료되면 추가 구현할 예정입니다.
+  func isUpdateAvailable() async -> Bool {
+    return false
+  }
+
+  /// 업데이트를 위해 앱스토어로 이동하는 메서드입니다.
+  /// 앱스토어에 앱이 등재된 이후, 내부 구현을 할 예정입니다.
+  func openAppStore() {}
 }
 
 extension ApplicationServiceWorker {

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/ApplicationServiceWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/ApplicationServiceWorker.swift
@@ -1,0 +1,20 @@
+//
+//  ApplicationServiceWorker.swift
+//
+//
+//  Created by Wood on 9/13/24.
+//
+
+import Foundation
+
+// 앱스토어 이동 및 Info.plist의 정보를 받아오는 Worker입니다.
+// 해당 Domain Context Worker 구현이 완료되면 삭제될 예정입니다.
+struct ApplicationServiceWorker {
+  func fetchAppVersion() -> String? {
+    return Bundle.main.infoDictionary?[ApplicationServiceWorker.bundleVersionKey] as? String
+  }
+}
+
+extension ApplicationServiceWorker {
+  static let bundleVersionKey = "CFBundleShortVersionString"
+}

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/ApplicationServiceWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/ApplicationServiceWorker.swift
@@ -15,7 +15,7 @@ public struct ApplicationServiceWorker {
   }
 
   /// 버전 업데이트 필요 여부를 반환하는 메서드입니다.
-  /// 서버 요청이 필요하므로, Network Service 레이어 구현이 완료되면 추가 구현할 예정입니다.
+  /// 네트워크 통신이 필요하므로, Network Service 레이어 구현이 완료되면 추가 구현할 예정입니다.
   func isUpdateAvailable() async -> Bool {
     return false
   }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/ApplicationServiceWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/ApplicationServiceWorker.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // 앱스토어 이동 및 Info.plist의 정보를 받아오는 Worker입니다.
 // 해당 Domain Context Worker 구현이 완료되면 삭제될 예정입니다.
-struct ApplicationServiceWorker {
+public struct ApplicationServiceWorker {
   func fetchAppVersion() -> String? {
     return Bundle.main.infoDictionary?[ApplicationServiceWorker.bundleVersionKey] as? String
   }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
@@ -17,6 +17,7 @@ protocol SettingDataStore {
 
 protocol SettingBusinessLogic {
   func fetchUserNickname()
+  func fetchUserProfileImage()
   func fetchAppVersion()
 }
 
@@ -25,6 +26,7 @@ class SettingInteractor: SettingDataStore {
   var profileImageData: Data?
   
   private var fetchUserNicknameTask: Task<Void, Never>?
+  private var fetchUserProfileImageTask: Task<Void, Never>?
   private var fetchAppVersionTask: Task<Void, Never>?
 
   var presenter: SettingPresentationLogic?
@@ -48,6 +50,15 @@ extension SettingInteractor: SettingBusinessLogic {
       self.nickName = nickName
       let response = Setting.FetchUserNickName.Response(nickName: nickName)
       await self.presenter?.presentUserNickName(response: response)
+    }
+  }
+
+  func fetchUserProfileImage() {
+    self.fetchUserProfileImageTask = Task {
+      let profileImageData = await self.settingWorker.requestUserProfileImage()
+      self.profileImageData = profileImageData
+      let response = Setting.FetchUserProfileImage.Response(imageData: profileImageData)
+      await self.presenter?.presentUserProfileImage(response: response)
     }
   }
 

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
@@ -21,7 +21,7 @@ protocol SettingBusinessLogic {
   func fetchAppVersion()
 }
 
-class SettingInteractor: SettingDataStore {
+final class SettingInteractor: SettingDataStore {
   var nickName: String?
   var profileImageData: Data?
   

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
@@ -11,15 +11,20 @@ import SettingSceneAPI
 import SettingSceneEntity
 
 protocol SettingDataStore {
-  // var name: String { get set }
+  var nickName: String? { get }
+  var profileImageData: Data? { get }
 }
 
 protocol SettingBusinessLogic {
+  func fetchUserNickname()
   func fetchAppVersion()
 }
 
 class SettingInteractor: SettingDataStore {
-  // var name: String = ""
+  var nickName: String?
+  var profileImageData: Data?
+  
+  private var fetchUserNicknameTask: Task<Void, Never>?
   private var fetchAppVersionTask: Task<Void, Never>?
 
   var presenter: SettingPresentationLogic?
@@ -37,6 +42,15 @@ class SettingInteractor: SettingDataStore {
 // MARK: - Request to worker
 
 extension SettingInteractor: SettingBusinessLogic {
+  func fetchUserNickname() {
+    self.fetchUserNicknameTask = Task {
+      let nickName = await self.settingWorker.requestUserNickName()
+      self.nickName = nickName
+      let response = Setting.FetchUserNickName.Response(nickName: nickName)
+      await self.presenter?.presentUserNickName(response: response)
+    }
+  }
+
   func fetchAppVersion() {
     self.fetchAppVersionTask = Task {
       let currentAppVersion = self.appServiceWorker.fetchAppVersion()

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
@@ -65,12 +65,10 @@ extension SettingInteractor: SettingBusinessLogic {
 
   func fetchAppVersion() {
     self.fetchAppVersionTask = Task {
-      let currentAppVersion = self.appServiceWorker.fetchCurrentAppVersion()
-      let isLatestVersion = await self.appServiceWorker.isUpdateAvailable()
-      let response = Setting.FetchAppVersion.Response(
-        currentAppVersion: currentAppVersion,
-        isLatestVersion: isLatestVersion
-      )
+      let versionNumber = self.appServiceWorker.fetchCurrentAppVersion()
+      let isUpdateAvailable = await self.appServiceWorker.isUpdateAvailable()
+      let appVersionStatus: Setting.AppVersionStatus = isUpdateAvailable ? .outdated : .latest
+      let response = Setting.FetchAppVersion.Response(versionNumber: versionNumber, appVersionStatus: appVersionStatus)
       await self.presenter?.presentAppVersion(response: response)
     }
   }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
@@ -15,7 +15,6 @@ protocol SettingDataStore {
 }
 
 protocol SettingBusinessLogic {
-  func doSomething(request: Setting.Something.Request)
 }
 
 class SettingInteractor: SettingDataStore {
@@ -31,10 +30,4 @@ class SettingInteractor: SettingDataStore {
 // MARK: - Request to worker
 
 extension SettingInteractor: SettingBusinessLogic {
-  func doSomething(request: Setting.Something.Request) {
-    self.someWorker.doSomeWork()
-    
-    let response = Setting.Something.Response()
-    self.presenter?.presentSomething(response: response)
-  }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
@@ -15,19 +15,27 @@ protocol SettingDataStore {
 }
 
 protocol SettingBusinessLogic {
+  func fetchAppVersion()
 }
 
 class SettingInteractor: SettingDataStore {
   // var name: String = ""
   var presenter: SettingPresentationLogic?
-  private let someWorker: SettingWorkable
-  
-  init(someWorker: SettingWorkable) {
-    self.someWorker = someWorker
+  private let settingWorker: SettingWorkable
+
+  // MARK: Dependency
+  private let appServiceWorker: ApplicationServiceWorker
+
+  init(settingWorker: SettingWorkable, appServiceWorker: ApplicationServiceWorker) {
+    self.settingWorker = settingWorker
+    self.appServiceWorker = appServiceWorker
   }
 }
 
 // MARK: - Request to worker
 
 extension SettingInteractor: SettingBusinessLogic {
+  func fetchAppVersion() {
+    
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
@@ -16,9 +16,7 @@ protocol SettingDataStore {
 }
 
 protocol SettingBusinessLogic {
-  func fetchUserNickname()
-  func fetchUserProfileImage()
-  func fetchAppVersion()
+  func prepareSettingSceneData()
   func openAppStore()
 }
 
@@ -45,7 +43,21 @@ final class SettingInteractor: SettingDataStore {
 // MARK: - Request to worker
 
 extension SettingInteractor: SettingBusinessLogic {
-  func fetchUserNickname() {
+  func prepareSettingSceneData() {
+    self.fetchUserNickname()
+    self.fetchUserProfileImage()
+    self.fetchAppVersion()
+  }
+
+  func openAppStore() {
+    self.appServiceWorker.openAppStore()
+  }
+}
+
+// MARK: - Private Functions
+
+extension SettingInteractor {
+  private func fetchUserNickname() {
     self.fetchUserNicknameTask = Task {
       let nickName = await self.settingWorker.requestUserNickName()
       self.nickName = nickName
@@ -53,7 +65,7 @@ extension SettingInteractor: SettingBusinessLogic {
     }
   }
 
-  func fetchUserProfileImage() {
+  private func fetchUserProfileImage() {
     self.fetchUserProfileImageTask = Task {
       let profileImageData = await self.settingWorker.requestUserProfileImage()
       self.profileImageData = profileImageData
@@ -61,7 +73,7 @@ extension SettingInteractor: SettingBusinessLogic {
     }
   }
 
-  func fetchAppVersion() {
+  private func fetchAppVersion() {
     self.fetchAppVersionTask = Task {
       let versionNumber = self.appServiceWorker.fetchCurrentAppVersion()
       let isUpdateAvailable = await self.appServiceWorker.isUpdateAvailable()
@@ -71,9 +83,5 @@ extension SettingInteractor: SettingBusinessLogic {
       )
       await self.presenter?.presentAppVersion(response: response)
     }
-  }
-
-  func openAppStore() {
-    self.appServiceWorker.openAppStore()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
@@ -65,8 +65,10 @@ extension SettingInteractor: SettingBusinessLogic {
     self.fetchAppVersionTask = Task {
       let versionNumber = self.appServiceWorker.fetchCurrentAppVersion()
       let isUpdateAvailable = await self.appServiceWorker.isUpdateAvailable()
-      let appVersionStatus: Setting.AppVersionStatus = isUpdateAvailable ? .outdated : .latest
-      let response = Setting.FetchAppVersion.Response(versionNumber: versionNumber, appVersionStatus: appVersionStatus)
+      let response = Setting.FetchAppVersion.Response(
+        versionNumber: versionNumber,
+        isLatestVersion: !isUpdateAvailable
+      )
       await self.presenter?.presentAppVersion(response: response)
     }
   }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
@@ -20,6 +20,8 @@ protocol SettingBusinessLogic {
 
 class SettingInteractor: SettingDataStore {
   // var name: String = ""
+  private var fetchAppVersionTask: Task<Void, Never>?
+
   var presenter: SettingPresentationLogic?
   private let settingWorker: SettingWorkable
 
@@ -36,6 +38,15 @@ class SettingInteractor: SettingDataStore {
 
 extension SettingInteractor: SettingBusinessLogic {
   func fetchAppVersion() {
-    
+    self.fetchAppVersionTask = Task {
+      let currentAppVersion = self.appServiceWorker.fetchAppVersion()
+      let latestVersion = await self.settingWorker.requestLatestAppVersion()
+      let isLatestVersion = latestVersion == currentAppVersion
+      let response = Setting.FetchAppVersion.Response(
+        currentAppVersion: currentAppVersion,
+        isLatestVersion: isLatestVersion
+      )
+      await self.presenter?.presentAppVersion(response: response)
+    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
@@ -49,8 +49,7 @@ extension SettingInteractor: SettingBusinessLogic {
     self.fetchUserNicknameTask = Task {
       let nickName = await self.settingWorker.requestUserNickName()
       self.nickName = nickName
-      let response = Setting.FetchUserNickName.Response(nickName: nickName)
-      await self.presenter?.presentUserNickName(response: response)
+      await self.presenter?.presentUserNickName(nickName)
     }
   }
 
@@ -58,8 +57,7 @@ extension SettingInteractor: SettingBusinessLogic {
     self.fetchUserProfileImageTask = Task {
       let profileImageData = await self.settingWorker.requestUserProfileImage()
       self.profileImageData = profileImageData
-      let response = Setting.FetchUserProfileImage.Response(imageData: profileImageData)
-      await self.presenter?.presentUserProfileImage(response: response)
+      await self.presenter?.presentUserProfileImage(profileImageData)
     }
   }
 

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingInteractor.swift
@@ -19,6 +19,7 @@ protocol SettingBusinessLogic {
   func fetchUserNickname()
   func fetchUserProfileImage()
   func fetchAppVersion()
+  func openAppStore()
 }
 
 final class SettingInteractor: SettingDataStore {
@@ -64,14 +65,17 @@ extension SettingInteractor: SettingBusinessLogic {
 
   func fetchAppVersion() {
     self.fetchAppVersionTask = Task {
-      let currentAppVersion = self.appServiceWorker.fetchAppVersion()
-      let latestVersion = await self.settingWorker.requestLatestAppVersion()
-      let isLatestVersion = latestVersion == currentAppVersion
+      let currentAppVersion = self.appServiceWorker.fetchCurrentAppVersion()
+      let isLatestVersion = await self.appServiceWorker.isUpdateAvailable()
       let response = Setting.FetchAppVersion.Response(
         currentAppVersion: currentAppVersion,
         isLatestVersion: isLatestVersion
       )
       await self.presenter?.presentAppVersion(response: response)
     }
+  }
+
+  func openAppStore() {
+    self.appServiceWorker.openAppStore()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
@@ -1,6 +1,6 @@
 //
 //  SettingPresenter.swift
-//  
+//
 //
 //  Created by Wood on 8/5/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
@@ -14,12 +14,34 @@ protocol SettingPresentationLogic {
   func presentAppVersion(response: Setting.FetchAppVersion.Response)
 }
 
-class SettingPresenter {
-	weak var viewController: SettingDisplayLogic?
+final class SettingPresenter {
+  weak var viewController: SettingDisplayLogic?
 }
 
 // MARK: - Request to ViewController
 
 extension SettingPresenter: SettingPresentationLogic {
-  func presentAppVersion(response: Setting.FetchAppVersion.Response) {}
+  func presentAppVersion(response: Setting.FetchAppVersion.Response) {
+    let appVersion = self.formatVersionString(response.currentAppVersion)
+    let isLatestVersion = response.isLatestVersion
+    let viewModel = Setting.FetchAppVersion.ViewModel(
+      appVersion: appVersion,
+      isLatestVersion: isLatestVersion
+    )
+    self.viewController?.displayFetchedAppVersion(viewModel: viewModel)
+  }
+}
+
+// MARK: - Private Functions
+
+extension SettingPresenter {
+  private func formatVersionString(_ version: String?) -> String {
+    if let version {
+      let versionNumbers = version.split(separator: ".")
+      let versions = versionNumbers + Array(repeating: "0", count: 3 - versionNumbers.count)
+      return "v " + versions.joined(separator: ".") + "."
+    } else {
+      return "v 0.0.0."
+    }
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
@@ -22,7 +22,11 @@ final class SettingPresenter {
 // MARK: - Request to ViewController
 
 extension SettingPresenter: SettingPresentationLogic {
-  func presentUserNickName(response: Setting.FetchUserNickName.Response) {}
+  func presentUserNickName(response: Setting.FetchUserNickName.Response) {
+    let nickName = response.nickName
+    let viewModel = Setting.FetchUserNickName.ViewModel(nickName: nickName)
+    self.viewController?.displayFetchedUserNickname(viewModel: viewModel)
+  }
 
   func presentAppVersion(response: Setting.FetchAppVersion.Response) {
     let appVersion = self.formatVersionString(response.currentAppVersion)

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
@@ -23,7 +23,6 @@ final class SettingPresenter {
 // MARK: - Request to ViewController
 
 extension SettingPresenter: SettingPresentationLogic {
-  
   func presentUserNickName(_ nickName: String) {
     self.viewController?.displayFetchedUserNickname(nickName)
   }
@@ -33,10 +32,12 @@ extension SettingPresenter: SettingPresentationLogic {
   }
 
   func presentAppVersion(response: Setting.FetchAppVersion.Response) {
-    let versionNumber = self.formatVersionString(response.versionNumber)
-    let appVersionStatus = response.appVersionStatus
-    let viewModel = Setting.FetchAppVersion.ViewModel(versionNumber: versionNumber, appVersionStatus: appVersionStatus)
-    self.viewController?.displayFetchedAppVersion(viewModel: viewModel)
+    let formattedVersionNumber = self.formatVersionString(response.versionNumber)
+    if response.isLatestVersion {
+      self.viewController?.displayLatestAppVersion(formattedVersionNumber)
+    } else {
+      self.viewController?.displayOutdatedAppVersion(formattedVersionNumber)
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
@@ -11,8 +11,8 @@ import SettingSceneEntity
 
 @MainActor
 protocol SettingPresentationLogic {
-  func presentUserNickName(response: Setting.FetchUserNickName.Response)
-  func presentUserProfileImage(response: Setting.FetchUserProfileImage.Response)
+  func presentUserNickName(_ nickName: String)
+  func presentUserProfileImage(_ profileImageData: Data)
   func presentAppVersion(response: Setting.FetchAppVersion.Response)
 }
 
@@ -23,16 +23,13 @@ final class SettingPresenter {
 // MARK: - Request to ViewController
 
 extension SettingPresenter: SettingPresentationLogic {
-  func presentUserNickName(response: Setting.FetchUserNickName.Response) {
-    let nickName = response.nickName
-    let viewModel = Setting.FetchUserNickName.ViewModel(nickName: nickName)
-    self.viewController?.displayFetchedUserNickname(viewModel: viewModel)
+  
+  func presentUserNickName(_ nickName: String) {
+    self.viewController?.displayFetchedUserNickname(nickName)
   }
 
-  func presentUserProfileImage(response: Setting.FetchUserProfileImage.Response) {
-    let imageData = response.imageData
-    let viewModel = Setting.FetchUserProfileImage.ViewModel(imageData: imageData)
-    self.viewController?.displayFetchedUserProfileImage(viewModel: viewModel)
+  func presentUserProfileImage(_ profileImageData: Data) {
+    self.viewController?.displayFetchedUserProfileImage(profileImageData)
   }
 
   func presentAppVersion(response: Setting.FetchAppVersion.Response) {

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
@@ -11,6 +11,7 @@ import SettingSceneEntity
 
 @MainActor
 protocol SettingPresentationLogic {
+  func presentUserNickName(response: Setting.FetchUserNickName.Response)
   func presentAppVersion(response: Setting.FetchAppVersion.Response)
 }
 
@@ -21,6 +22,8 @@ final class SettingPresenter {
 // MARK: - Request to ViewController
 
 extension SettingPresenter: SettingPresentationLogic {
+  func presentUserNickName(response: Setting.FetchUserNickName.Response) {}
+
   func presentAppVersion(response: Setting.FetchAppVersion.Response) {
     let appVersion = self.formatVersionString(response.currentAppVersion)
     let isLatestVersion = response.isLatestVersion

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
@@ -12,6 +12,7 @@ import SettingSceneEntity
 @MainActor
 protocol SettingPresentationLogic {
   func presentUserNickName(response: Setting.FetchUserNickName.Response)
+  func presentUserProfileImage(response: Setting.FetchUserProfileImage.Response)
   func presentAppVersion(response: Setting.FetchAppVersion.Response)
 }
 
@@ -27,6 +28,8 @@ extension SettingPresenter: SettingPresentationLogic {
     let viewModel = Setting.FetchUserNickName.ViewModel(nickName: nickName)
     self.viewController?.displayFetchedUserNickname(viewModel: viewModel)
   }
+
+  func presentUserProfileImage(response: Setting.FetchUserProfileImage.Response) {}
 
   func presentAppVersion(response: Setting.FetchAppVersion.Response) {
     let appVersion = self.formatVersionString(response.currentAppVersion)

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
@@ -10,7 +10,6 @@ import Foundation
 import SettingSceneEntity
 
 protocol SettingPresentationLogic {
-	func presentSomething(response: Setting.Something.Response)
 }
 
 class SettingPresenter {
@@ -20,8 +19,4 @@ class SettingPresenter {
 // MARK: - Request to ViewController
 
 extension SettingPresenter: SettingPresentationLogic {
-	func presentSomething(response: Setting.Something.Response) {
-		let viewModel = Setting.Something.ViewModel()
-		self.viewController?.displaySomething(viewModel: viewModel)
-	}
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
@@ -36,12 +36,9 @@ extension SettingPresenter: SettingPresentationLogic {
   }
 
   func presentAppVersion(response: Setting.FetchAppVersion.Response) {
-    let appVersion = self.formatVersionString(response.currentAppVersion)
-    let isLatestVersion = response.isLatestVersion
-    let viewModel = Setting.FetchAppVersion.ViewModel(
-      appVersion: appVersion,
-      isLatestVersion: isLatestVersion
-    )
+    let versionNumber = self.formatVersionString(response.versionNumber)
+    let appVersionStatus = response.appVersionStatus
+    let viewModel = Setting.FetchAppVersion.ViewModel(versionNumber: versionNumber, appVersionStatus: appVersionStatus)
     self.viewController?.displayFetchedAppVersion(viewModel: viewModel)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
@@ -29,7 +29,11 @@ extension SettingPresenter: SettingPresentationLogic {
     self.viewController?.displayFetchedUserNickname(viewModel: viewModel)
   }
 
-  func presentUserProfileImage(response: Setting.FetchUserProfileImage.Response) {}
+  func presentUserProfileImage(response: Setting.FetchUserProfileImage.Response) {
+    let imageData = response.imageData
+    let viewModel = Setting.FetchUserProfileImage.ViewModel(imageData: imageData)
+    self.viewController?.displayFetchedUserProfileImage(viewModel: viewModel)
+  }
 
   func presentAppVersion(response: Setting.FetchAppVersion.Response) {
     let appVersion = self.formatVersionString(response.currentAppVersion)

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingPresenter.swift
@@ -9,7 +9,9 @@ import Foundation
 
 import SettingSceneEntity
 
+@MainActor
 protocol SettingPresentationLogic {
+  func presentAppVersion(response: Setting.FetchAppVersion.Response)
 }
 
 class SettingPresenter {
@@ -19,4 +21,5 @@ class SettingPresenter {
 // MARK: - Request to ViewController
 
 extension SettingPresenter: SettingPresentationLogic {
+  func presentAppVersion(response: Setting.FetchAppVersion.Response) {}
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingRouter.swift
@@ -10,7 +10,6 @@ import Foundation
 import SettingSceneAPI
 
 protocol SettingRoutingLogic {
-	func routeToSomewhere()
 }
 
 protocol SettingDataPassing {
@@ -20,21 +19,11 @@ protocol SettingDataPassing {
 class SettingRouter: SettingDataPassing {
 	weak var viewController: SettingViewController?
 	var dataStore: SettingDataStore?
-	private let nextSceneBuilder: NextSceneBuildable
-	
-	init(nextSceneBuilder: NextSceneBuildable) {
-		self.nextSceneBuilder = nextSceneBuilder
-	}
 }
 
 // MARK: - Routing
 
 extension SettingRouter: SettingRoutingLogic {
-	func routeToSomewhere() {
-		let destinationViewController = self.nextSceneBuilder.build(with: NextScenePayload())
-		
-		self.viewController?.present(destinationViewController, animated: true)
-	}
 }
 
 // MARK: - Declare Payload for scene

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingSceneBuilder.swift
@@ -13,9 +13,11 @@ public struct SettingSceneBuilder {
 	/// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
 	public struct Dependency {
     let settingWorker: SettingWorkable
+    let appServiceWorker: ApplicationServiceWorker
 
-		public init(settingWorker: SettingWorkable) {
+    public init(settingWorker: SettingWorkable, appServiceWorker: ApplicationServiceWorker) {
 			self.settingWorker = settingWorker
+      self.appServiceWorker = appServiceWorker
 		}
 	}
 	
@@ -43,7 +45,10 @@ extension SettingSceneBuilder {
 	/// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
 	/// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
 	private func configureVIPCycle(for viewController: SettingViewController) -> SettingViewController {
-    let interactor = SettingInteractor(someWorker: self.dependency.settingWorker)
+    let interactor = SettingInteractor(
+      settingWorker: self.dependency.settingWorker,
+      appServiceWorker: self.dependency.appServiceWorker
+    )
 		let presenter = SettingPresenter()
 		let router = SettingRouter()
 		viewController.interactor = interactor

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingSceneBuilder.swift
@@ -13,11 +13,9 @@ public struct SettingSceneBuilder {
 	/// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
 	public struct Dependency {
     let settingWorker: SettingWorkable
-		let nextSceneBuilder: NextSceneBuildable
-		
-		public init(settingWorker: SettingWorkable, nextSceneBuilder: NextSceneBuildable) {
+
+		public init(settingWorker: SettingWorkable) {
 			self.settingWorker = settingWorker
-			self.nextSceneBuilder = nextSceneBuilder
 		}
 	}
 	
@@ -47,7 +45,7 @@ extension SettingSceneBuilder {
 	private func configureVIPCycle(for viewController: SettingViewController) -> SettingViewController {
     let interactor = SettingInteractor(someWorker: self.dependency.settingWorker)
 		let presenter = SettingPresenter()
-		let router = SettingRouter(nextSceneBuilder: self.dependency.nextSceneBuilder)
+		let router = SettingRouter()
 		viewController.interactor = interactor
 		viewController.router = router
 		interactor.presenter = presenter

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -99,11 +99,11 @@ extension SettingViewController: SettingDisplayLogic {
   }
 
   func displayFetchedAppVersion(viewModel: Setting.FetchAppVersion.ViewModel) {
-    let appVersion = viewModel.appVersion
-    if viewModel.isLatestVersion {
-      self.versionInfoView.updateToLatestVersion(appVersion)
-    } else {
-      self.versionInfoView.updateToPriorVersion(appVersion)
+    switch viewModel.appVersionStatus {
+    case Setting.AppVersionStatus.outdated:
+      self.versionInfoView.updateToPriorVersion(viewModel.versionNumber)
+    case Setting.AppVersionStatus.latest:
+      self.versionInfoView.updateToLatestVersion(viewModel.versionNumber)
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -13,6 +13,7 @@ import ToDoGardenUIComponent
 
 protocol SettingDisplayLogic: AnyObject {
   func displayFetchedUserNickname(viewModel: Setting.FetchUserNickName.ViewModel)
+  func displayFetchedUserProfileImage(viewModel: Setting.FetchUserProfileImage.ViewModel)
   func displayFetchedAppVersion(viewModel: Setting.FetchAppVersion.ViewModel)
 }
 
@@ -82,6 +83,11 @@ extension SettingViewController: SettingDisplayLogic {
         description: SettingSceneTheme.StringLiteral.ProfileRow.description
       )
     )
+  }
+
+  func displayFetchedUserProfileImage(viewModel: Setting.FetchUserProfileImage.ViewModel) {
+    let imageData = viewModel.imageData
+    self.profileRow.iconImage = UIImage(data: imageData)
   }
 
   func displayFetchedAppVersion(viewModel: Setting.FetchAppVersion.ViewModel) {

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -14,7 +14,8 @@ import ToDoGardenUIComponent
 protocol SettingDisplayLogic: AnyObject {
   func displayFetchedUserNickname(_ nickName: String)
   func displayFetchedUserProfileImage(_ profileImageData: Data)
-  func displayFetchedAppVersion(viewModel: Setting.FetchAppVersion.ViewModel)
+  func displayOutdatedAppVersion(_ versionNumber: String)
+  func displayLatestAppVersion(_ versionNumber: String)
 }
 
 final class SettingViewController: UIViewController, SettingViewControllable {
@@ -97,13 +98,12 @@ extension SettingViewController: SettingDisplayLogic {
     self.profileRow.iconImage = UIImage(data: profileImageData)
   }
 
-  func displayFetchedAppVersion(viewModel: Setting.FetchAppVersion.ViewModel) {
-    switch viewModel.appVersionStatus {
-    case Setting.AppVersionStatus.outdated:
-      self.versionInfoView.updateToPriorVersion(viewModel.versionNumber)
-    case Setting.AppVersionStatus.latest:
-      self.versionInfoView.updateToLatestVersion(viewModel.versionNumber)
-    }
+  func displayOutdatedAppVersion(_ versionNumber: String) {
+    self.versionInfoView.updateToPriorVersion(versionNumber)
+  }
+
+  func displayLatestAppVersion(_ versionNumber: String) {
+    self.versionInfoView.updateToLatestVersion(versionNumber)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -290,9 +290,18 @@ extension SettingViewController {
   }
 }
 
+extension SettingViewController {
+  struct SomePayload: SettingScenePayloadable {}
+}
+
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-  return SettingViewController()
+  return SettingSceneBuilder(
+    dependency: SettingSceneBuilder.Dependency(
+      settingWorker: SettingWorker(),
+      appServiceWorker: ApplicationServiceWorker()
+    )
+  ).build(with: SettingViewController.SomePayload())
 }
 #endif

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -12,7 +12,6 @@ import SettingSceneEntity
 import ToDoGardenUIComponent
 
 protocol SettingDisplayLogic: AnyObject {
-  func displaySomething(viewModel: Setting.Something.ViewModel)
 }
 
 final class SettingViewController: UIViewController, SettingViewControllable {
@@ -66,18 +65,11 @@ final class SettingViewController: UIViewController, SettingViewControllable {
 // MARK: - Confirm display logic protocol
 
 extension SettingViewController: SettingDisplayLogic {
-  func displaySomething(viewModel: Setting.Something.ViewModel) {
-    // self.nameTextField.text = viewModel.name
-  }
 }
 
 // MARK: - Request to interactor
 
 extension SettingViewController {
-  func doSomething() {
-    let request = Setting.Something.Request()
-    self.interactor?.doSomething(request: request)
-  }
 }
 
 // MARK: Private Functions

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -12,8 +12,8 @@ import SettingSceneEntity
 import ToDoGardenUIComponent
 
 protocol SettingDisplayLogic: AnyObject {
-  func displayFetchedUserNickname(viewModel: Setting.FetchUserNickName.ViewModel)
-  func displayFetchedUserProfileImage(viewModel: Setting.FetchUserProfileImage.ViewModel)
+  func displayFetchedUserNickname(_ nickName: String)
+  func displayFetchedUserProfileImage(_ profileImageData: Data)
   func displayFetchedAppVersion(viewModel: Setting.FetchAppVersion.ViewModel)
 }
 
@@ -82,20 +82,19 @@ extension SettingViewController {
 // MARK: - Confirm display logic protocol
 
 extension SettingViewController: SettingDisplayLogic {
-  func displayFetchedUserNickname(viewModel: Setting.FetchUserNickName.ViewModel) {
+  func displayFetchedUserNickname(_ nickName: String) {
     let rowConfiguration = Styled.Row.Configuration.self
     self.profileRow.configuration = rowConfiguration.profile(
       rowConfiguration.ProfileModel(
         style: rowConfiguration.ProfileModel.Style.setting,
-        title: viewModel.nickName,
+        title: nickName,
         description: SettingSceneTheme.StringLiteral.ProfileRow.description
       )
     )
   }
 
-  func displayFetchedUserProfileImage(viewModel: Setting.FetchUserProfileImage.ViewModel) {
-    let imageData = viewModel.imageData
-    self.profileRow.iconImage = UIImage(data: imageData)
+  func displayFetchedUserProfileImage(_ profileImageData: Data) {
+    self.profileRow.iconImage = UIImage(data: profileImageData)
   }
 
   func displayFetchedAppVersion(viewModel: Setting.FetchAppVersion.ViewModel) {

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -66,17 +66,7 @@ final class SettingViewController: UIViewController, SettingViewControllable {
 
   override func viewIsAppearing(_ animated: Bool) {
     super.viewIsAppearing(animated)
-    self.prepareSettingSceneData()
-  }
-}
-
-// MARK: - Request to Interactor
-
-extension SettingViewController {
-  private func prepareSettingSceneData() {
-    self.interactor?.fetchUserNickname()
-    self.interactor?.fetchUserProfileImage()
-    self.interactor?.fetchAppVersion()
+    self.interactor?.prepareSettingSceneData()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -67,7 +67,7 @@ final class SettingViewController: UIViewController, SettingViewControllable {
     super.viewIsAppearing(animated)
     self.interactor?.fetchUserNickname()
     self.interactor?.fetchUserProfileImage()
-    self.fetchAppVersion()
+    self.interactor?.fetchAppVersion()
   }
 }
 
@@ -100,11 +100,11 @@ extension SettingViewController: SettingDisplayLogic {
   }
 }
 
-// MARK: - Request to interactor
+// MARK: Subviews Delegate Functions
 
-extension SettingViewController {
-  private func fetchAppVersion() {
-    self.interactor?.fetchAppVersion()
+extension SettingViewController: VersionInfoViewDelegate {
+  func didSelectUpdateButton() {
+    self.interactor?.openAppStore()
   }
 }
 
@@ -115,6 +115,7 @@ extension SettingViewController {
     self.view.backgroundColor = UIColor.toDoGardenWhite
     self.setupSettingLabel()
     self.setupProfileRowUI()
+    self.setupSubviewDeleagte()
     self.setupSettingCollectionView()
     self.setupSubviewsLayout()
   }
@@ -129,6 +130,10 @@ extension SettingViewController {
     self.profileRow.layer.cornerRadius = Constant.ProfileRow.Layer.cornerRadius
     self.profileRow.layer.borderWidth = Constant.ProfileRow.Layer.borderWidth
     self.profileRow.layer.borderColor = UIColor.toDoGardenGreenBackground.cgColor
+  }
+
+  private func setupSubviewDeleagte() {
+    self.versionInfoView.delegate = self
   }
 
   private func setupSettingCollectionView() {

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -70,7 +70,14 @@ final class SettingViewController: UIViewController, SettingViewControllable {
 // MARK: - Confirm display logic protocol
 
 extension SettingViewController: SettingDisplayLogic {
-  func displayFetchedAppVersion(viewModel: Setting.FetchAppVersion.ViewModel) {}
+  func displayFetchedAppVersion(viewModel: Setting.FetchAppVersion.ViewModel) {
+    let appVersion = viewModel.appVersion
+    if viewModel.isLatestVersion {
+      self.versionInfoView.updateToLatestVersion(appVersion)
+    } else {
+      self.versionInfoView.updateToPriorVersion(appVersion)
+    }
+  }
 }
 
 // MARK: - Request to interactor

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -29,11 +29,12 @@ final class SettingViewController: UIViewController, SettingViewControllable {
 
   init() {
     self.settingLabel = UILabel()
-    // TODO: 프로필 UI를 확인하기 위해 "울버린" 사용자명을 임시로 추가했으며, VIP 로직 구현 이후에 삭제할 예정입니다.
+    let rowConfiguration = Styled.Row.Configuration.self
     self.profileRow = Styled.Row(
-      configuration: Styled.Row.Configuration.profile(
-        Styled.Row.Configuration.ProfileModel.primary(
-          title: "울버린",
+      configuration: rowConfiguration.profile(
+        rowConfiguration.ProfileModel(
+          style: rowConfiguration.ProfileModel.Style.setting,
+          title: " ",
           description: SettingSceneTheme.StringLiteral.ProfileRow.description
         )
       )
@@ -57,8 +58,11 @@ final class SettingViewController: UIViewController, SettingViewControllable {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.setupUI()
-    // TODO: VersionInfoView의 UI를 확인하기 위해 임시로 추가한 로직으로, VIP 로직 구현 이후에 삭제할 예정입니다.
-    self.versionInfoView.updateToPriorVersion("v 0.1.2")
+  }
+
+  override func viewIsAppearing(_ animated: Bool) {
+    super.viewIsAppearing(animated)
+    self.fetchAppVersion()
   }
 }
 
@@ -70,6 +74,9 @@ extension SettingViewController: SettingDisplayLogic {
 // MARK: - Request to interactor
 
 extension SettingViewController {
+  private func fetchAppVersion() {
+    self.interactor?.fetchAppVersion()
+  }
 }
 
 // MARK: Private Functions

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -65,6 +65,7 @@ final class SettingViewController: UIViewController, SettingViewControllable {
   override func viewIsAppearing(_ animated: Bool) {
     super.viewIsAppearing(animated)
     self.interactor?.fetchUserNickname()
+    self.interactor?.fetchUserProfileImage()
     self.fetchAppVersion()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -12,6 +12,7 @@ import SettingSceneEntity
 import ToDoGardenUIComponent
 
 protocol SettingDisplayLogic: AnyObject {
+  func displayFetchedUserNickname(viewModel: Setting.FetchUserNickName.ViewModel)
   func displayFetchedAppVersion(viewModel: Setting.FetchAppVersion.ViewModel)
 }
 
@@ -63,6 +64,7 @@ final class SettingViewController: UIViewController, SettingViewControllable {
 
   override func viewIsAppearing(_ animated: Bool) {
     super.viewIsAppearing(animated)
+    self.interactor?.fetchUserNickname()
     self.fetchAppVersion()
   }
 }
@@ -70,6 +72,17 @@ final class SettingViewController: UIViewController, SettingViewControllable {
 // MARK: - Confirm display logic protocol
 
 extension SettingViewController: SettingDisplayLogic {
+  func displayFetchedUserNickname(viewModel: Setting.FetchUserNickName.ViewModel) {
+    let rowConfiguration = Styled.Row.Configuration.self
+    self.profileRow.configuration = rowConfiguration.profile(
+      rowConfiguration.ProfileModel(
+        style: rowConfiguration.ProfileModel.Style.setting,
+        title: viewModel.nickName,
+        description: SettingSceneTheme.StringLiteral.ProfileRow.description
+      )
+    )
+  }
+
   func displayFetchedAppVersion(viewModel: Setting.FetchAppVersion.ViewModel) {
     let appVersion = viewModel.appVersion
     if viewModel.isLatestVersion {

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -12,6 +12,7 @@ import SettingSceneEntity
 import ToDoGardenUIComponent
 
 protocol SettingDisplayLogic: AnyObject {
+  func displayFetchedAppVersion(viewModel: Setting.FetchAppVersion.ViewModel)
 }
 
 final class SettingViewController: UIViewController, SettingViewControllable {
@@ -69,6 +70,7 @@ final class SettingViewController: UIViewController, SettingViewControllable {
 // MARK: - Confirm display logic protocol
 
 extension SettingViewController: SettingDisplayLogic {
+  func displayFetchedAppVersion(viewModel: Setting.FetchAppVersion.ViewModel) {}
 }
 
 // MARK: - Request to interactor

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -65,6 +65,14 @@ final class SettingViewController: UIViewController, SettingViewControllable {
 
   override func viewIsAppearing(_ animated: Bool) {
     super.viewIsAppearing(animated)
+    self.prepareSettingSceneData()
+  }
+}
+
+// MARK: - Request to Interactor
+
+extension SettingViewController {
+  private func prepareSettingSceneData() {
     self.interactor?.fetchUserNickname()
     self.interactor?.fetchUserProfileImage()
     self.interactor?.fetchAppVersion()

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingWorker.swift
@@ -10,6 +10,10 @@ import Foundation
 import SettingSceneAPI
 
 struct SettingWorker: SettingWorkable {
+  func requestUserNickName() async -> String {
+    return MockData.nickName
+  }
+
   /// 서버로부터 앱의 최신버전을 받아오는 메서드입니다.
   func requestLatestAppVersion() -> String {
     return MockData.latestVersion
@@ -18,6 +22,7 @@ struct SettingWorker: SettingWorkable {
 
 extension SettingWorker {
   private enum MockData {
+    static let nickName = "울버린"
     static let latestVersion = "0.1.2"
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingWorker.swift
@@ -17,17 +17,11 @@ struct SettingWorker: SettingWorkable {
   func requestUserProfileImage() async -> Data {
     return MockData.imageData
   }
-
-  /// 서버로부터 앱의 최신버전을 받아오는 메서드입니다.
-  func requestLatestAppVersion() -> String {
-    return MockData.latestVersion
-  }
 }
 
 extension SettingWorker {
   private enum MockData {
     static let nickName = "울버린"
     static let imageData = Data()
-    static let latestVersion = "0.1.2"
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingWorker.swift
@@ -14,6 +14,10 @@ struct SettingWorker: SettingWorkable {
     return MockData.nickName
   }
 
+  func requestUserProfileImage() async -> Data {
+    return MockData.imageData
+  }
+
   /// 서버로부터 앱의 최신버전을 받아오는 메서드입니다.
   func requestLatestAppVersion() -> String {
     return MockData.latestVersion
@@ -23,6 +27,7 @@ struct SettingWorker: SettingWorkable {
 extension SettingWorker {
   private enum MockData {
     static let nickName = "울버린"
+    static let imageData = Data()
     static let latestVersion = "0.1.2"
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingWorker.swift
@@ -10,6 +10,4 @@ import Foundation
 import SettingSceneAPI
 
 struct SettingWorker: SettingWorkable {
-  func doSomeWork() {
-  }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingWorker.swift
@@ -10,4 +10,14 @@ import Foundation
 import SettingSceneAPI
 
 struct SettingWorker: SettingWorkable {
+  /// 서버로부터 앱의 최신버전을 받아오는 메서드입니다.
+  func requestLatestAppVersion() -> String {
+    return MockData.latestVersion
+  }
+}
+
+extension SettingWorker {
+  private enum MockData {
+    static let latestVersion = "0.1.2"
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneAPI/SettingWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneAPI/SettingWorkable.swift
@@ -10,5 +10,4 @@ import Foundation
 public protocol SettingWorkable {
   func requestUserNickName() async -> String
   func requestUserProfileImage() async -> Data
-  func requestLatestAppVersion() async -> String
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneAPI/SettingWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneAPI/SettingWorkable.swift
@@ -8,5 +8,4 @@
 import Foundation
 
 public protocol SettingWorkable {
-	func doSomeWork()
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneAPI/SettingWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneAPI/SettingWorkable.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 public protocol SettingWorkable {
+  func requestUserNickName() async -> String
   func requestLatestAppVersion() async -> String
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneAPI/SettingWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneAPI/SettingWorkable.swift
@@ -8,4 +8,5 @@
 import Foundation
 
 public protocol SettingWorkable {
+  func requestLatestAppVersion() async -> String
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneAPI/SettingWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneAPI/SettingWorkable.swift
@@ -9,5 +9,6 @@ import Foundation
 
 public protocol SettingWorkable {
   func requestUserNickName() async -> String
+  func requestUserProfileImage() async -> Data
   func requestLatestAppVersion() async -> String
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
@@ -11,13 +11,21 @@ public enum Setting {
   
   // MARK: Use cases
   
-  public enum Something {
+  public enum FetchAppVersion {
     public struct Request {
       public init() { }
     }
+
     public struct Response {
-      public init() { }
+      public let currentAppVersion: String?
+      public let isLatestVersion: Bool
+
+      public init(currentAppVersion: String?, isLatestVersion: Bool) {
+        self.currentAppVersion = currentAppVersion
+        self.isLatestVersion = isLatestVersion
+      }
     }
+
     public struct ViewModel {
       public init() { }
     }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
@@ -19,6 +19,14 @@ public enum Setting {
         self.nickName = nickName
       }
     }
+
+    public struct ViewModel {
+      public let nickName: String
+
+      public init(nickName: String) {
+        self.nickName = nickName
+      }
+    }
   }
 
   public enum FetchAppVersion {

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
@@ -53,23 +53,30 @@ public enum Setting {
     }
 
     public struct Response {
-      public let currentAppVersion: String?
-      public let isLatestVersion: Bool
+      public let versionNumber: String?
+      public let appVersionStatus: AppVersionStatus
 
-      public init(currentAppVersion: String?, isLatestVersion: Bool) {
-        self.currentAppVersion = currentAppVersion
-        self.isLatestVersion = isLatestVersion
+      public init(versionNumber: String?, appVersionStatus: AppVersionStatus) {
+        self.versionNumber = versionNumber
+        self.appVersionStatus = appVersionStatus
       }
     }
 
     public struct ViewModel {
-      public let appVersion: String
-      public let isLatestVersion: Bool
+      public let versionNumber: String
+      public let appVersionStatus: AppVersionStatus
 
-      public init(appVersion: String, isLatestVersion: Bool) {
-        self.appVersion = appVersion
-        self.isLatestVersion = isLatestVersion
+      public init(versionNumber: String, appVersionStatus: AppVersionStatus) {
+        self.versionNumber = versionNumber
+        self.appVersionStatus = appVersionStatus
       }
     }
+  }
+}
+
+public extension Setting {
+  enum AppVersionStatus {
+    case outdated
+    case latest
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
@@ -37,6 +37,14 @@ public enum Setting {
         self.imageData = imageData
       }
     }
+
+    public struct ViewModel {
+      public let imageData: Data
+
+      public init(imageData: Data) {
+        self.imageData = imageData
+      }
+    }
   }
 
   public enum FetchAppVersion {

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
@@ -29,6 +29,16 @@ public enum Setting {
     }
   }
 
+  public enum FetchUserProfileImage {
+    public struct Response {
+      public let imageData: Data
+
+      public init(imageData: Data) {
+        self.imageData = imageData
+      }
+    }
+  }
+
   public enum FetchAppVersion {
     public struct Request {
       public init() { }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
@@ -14,29 +14,12 @@ public enum Setting {
   public enum FetchAppVersion {
     public struct Response {
       public let versionNumber: String?
-      public let appVersionStatus: AppVersionStatus
+      public let isLatestVersion: Bool
 
-      public init(versionNumber: String?, appVersionStatus: AppVersionStatus) {
+      public init(versionNumber: String?, isLatestVersion: Bool) {
         self.versionNumber = versionNumber
-        self.appVersionStatus = appVersionStatus
+        self.isLatestVersion = isLatestVersion
       }
     }
-
-    public struct ViewModel {
-      public let versionNumber: String
-      public let appVersionStatus: AppVersionStatus
-
-      public init(versionNumber: String, appVersionStatus: AppVersionStatus) {
-        self.versionNumber = versionNumber
-        self.appVersionStatus = appVersionStatus
-      }
-    }
-  }
-}
-
-public extension Setting {
-  enum AppVersionStatus {
-    case outdated
-    case latest
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
@@ -27,7 +27,13 @@ public enum Setting {
     }
 
     public struct ViewModel {
-      public init() { }
+      public let appVersion: String
+      public let isLatestVersion: Bool
+
+      public init(appVersion: String, isLatestVersion: Bool) {
+        self.appVersion = appVersion
+        self.isLatestVersion = isLatestVersion
+      }
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
@@ -11,47 +11,7 @@ public enum Setting {
   
   // MARK: Use cases
 
-  public enum FetchUserNickName {
-    public struct Response {
-      public let nickName: String
-
-      public init(nickName: String) {
-        self.nickName = nickName
-      }
-    }
-
-    public struct ViewModel {
-      public let nickName: String
-
-      public init(nickName: String) {
-        self.nickName = nickName
-      }
-    }
-  }
-
-  public enum FetchUserProfileImage {
-    public struct Response {
-      public let imageData: Data
-
-      public init(imageData: Data) {
-        self.imageData = imageData
-      }
-    }
-
-    public struct ViewModel {
-      public let imageData: Data
-
-      public init(imageData: Data) {
-        self.imageData = imageData
-      }
-    }
-  }
-
   public enum FetchAppVersion {
-    public struct Request {
-      public init() { }
-    }
-
     public struct Response {
       public let versionNumber: String?
       public let appVersionStatus: AppVersionStatus

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingSceneEntity/SettingModels.swift
@@ -10,7 +10,17 @@ import Foundation
 public enum Setting {
   
   // MARK: Use cases
-  
+
+  public enum FetchUserNickName {
+    public struct Response {
+      public let nickName: String
+
+      public init(nickName: String) {
+        self.nickName = nickName
+      }
+    }
+  }
+
   public enum FetchAppVersion {
     public struct Request {
       public init() { }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #441

## 🎉 변경 사항
- SettingScene에 필요한 VIP 사이클을 구현하였습니다.
- 앱 번들 및 앱스토어 이동을 담당하는 ApplicationServiceWorker 객체를 추가하였습니다.

## 📌 PR Point
- 알림 설정, 공지사항 등 Routing이 필요한 메서드들은 미구현 상태입니다.
- 설명이 기술된 [화면 기술서](https://www.notion.so/671d7067e25649b19e8b7831dbcc64a7?pvs=4)를 첨부합니다!

### 1. 유저 기본 정보 VIP
- 유저의 기본 정보(`프로필 이미지, 닉네임`)를 받아오는 VIP를 구현하였습니다.
- 이미지를 받아오는 Task가 오래 걸릴것으로 예상되어, `각각 별도의 VIP 사이클로 분리`하였습니다.
- 해당 데이터들은 `UserInfoScenePayload`로 전달될 예정이기에, DataStore에 선언하였습니다.

<img width="250" src="https://github.com/user-attachments/assets/a9af135d-e5dd-411f-adf8-81d614c83388">

### 2. 앱 업데이트 확인 VIP
현재 사용자의 앱 버전과 최신 버전을 비교하는 VIP를 구현하였습니다.
1. 이전 버전인 경우에는, 앱스토어 이동 버튼을 활성화합니다.
2. 최신 버전인 경우에는, 앱스토어 이동 버튼을 보여주지 않습니다.
- `Preview에서는 버전이 16.0`으로 나오는데, Preview 번들의 버전이 나오는 문제로 `Simulator에서는 정상적으로 1.0.0`이 표시됩니다.
- [관련 문제해결 노트](https://www.notion.so/f1d50f0bee864173a5573e1b75d2c40a?pvs=4)

|최신 버전|업데이트 필요|
|--|--|
|<img width="250" src="https://github.com/user-attachments/assets/a9af135d-e5dd-411f-adf8-81d614c83388">|<img width="250" src="https://github.com/user-attachments/assets/4af56726-d359-4d69-8dac-0d7953c28632">|

### ApplicationServiceWorker
- 앱 번들 및 앱스토어 이동을 담당하는 객체입니다.
- 여러 Scene에서 사용되고, UIApplication에 접근하기에 `추후에 Domain Context 레이어`로 Builder에서 주입받을 예정입니다!
  - [관련 PR](https://github.com/ToDo-Garden/ToDo-Garden/pull/470#discussion_r1745915024)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?