### PR TITLE
 implement updating groups after posting groups

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -17,6 +17,8 @@ protocol ManageGroupBusinessLogic {
   func fetchGroupList(request: ManageGroup.FetchGroupList.Request) async
   func saveGroupList(request: ManageGroup.SaveGroupList.Request) async
   func deleteGroup(request: ManageGroup.DeleteGroup.Request)
+  func addGroup(request: ManageGroup.AddGroup.Request)
+  func editGroup(request: ManageGroup.EditGroup.Request)
 }
 
 class ManageGroupInteractor: ManageGroupDataStore {
@@ -63,5 +65,11 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
     self.currentGroups.remove(at: request.index)
     let response = ManageGroup.DeleteGroup.Response(groupID: request.groupID, index: request.index)
     self.presenter?.presentDeletedGroup(response: response)
+  }
+  
+  func addGroup(request: ManageGroup.AddGroup.Request) {
+  }
+  
+  func editGroup(request: ManageGroup.EditGroup.Request) {
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -68,8 +68,10 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
   }
   
   func addGroup(request: ManageGroup.AddGroup.Request) {
+    // 다음 PR에 포함예정
   }
   
   func editGroup(request: ManageGroup.EditGroup.Request) {
+    // 다음 PR에 포함예정
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -68,10 +68,23 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
   }
   
   func addGroup(request: ManageGroup.AddGroup.Request) {
-    // 다음 PR에 포함예정
+    let group = self.manageGroupWorker.addGroup(request: request)
+    self.currentGroups.append(group)
+    
+    let response = ManageGroup.AddGroup.Response(group: group)
+    self.presenter?.presentAddedGroup(response: response)
   }
   
   func editGroup(request: ManageGroup.EditGroup.Request) {
-    // 다음 PR에 포함예정
+    if let index = self.currentGroups.firstIndex(where: { $0.groupID == request.groupID }) {
+      let progressRate = self.currentGroups[index].progressRate
+      let group = self.manageGroupWorker.editGroup(request: request, progressRate: progressRate)
+      self.currentGroups[index] = group
+      
+      let response = ManageGroup.EditGroup.Response(group: group, editedIndex: index)
+      self.presenter?.presentEditedGroup(response: response)
+    } else {
+      return
+    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -61,7 +61,7 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
   
   func deleteGroup(request: ManageGroup.DeleteGroup.Request) {
     self.currentGroups.remove(at: request.index)
-    let response = ManageGroup.DeleteGroup.Response(id: request.id, index: request.index)
+    let response = ManageGroup.DeleteGroup.Response(groupID: request.groupID, index: request.index)
     self.presenter?.presentDeletedGroup(response: response)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupMockData.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupMockData.swift
@@ -13,31 +13,31 @@ import ToDoGardenUIResource
 struct ManageGroupMockData {
   
   static let guideSceneData: [ManageGroup.ToDoGroup] = [
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "영어 독해", progressColor: .toDoGardenYellow, progressRate: 0.5),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "역사와 문화 이해", progressColor: .toDoGardenRed, progressRate: 0.5),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "디자인 창작", progressColor: .toDoGardenOlive, progressRate: 0.5)
+    ManageGroup.ToDoGroup(groupName: "영어 독해", progressColor: .toDoGardenYellow, progressRate: 0.5),
+    ManageGroup.ToDoGroup(groupName: "역사와 문화 이해", progressColor: .toDoGardenRed, progressRate: 0.5),
+    ManageGroup.ToDoGroup(groupName: "디자인 창작", progressColor: .toDoGardenOlive, progressRate: 0.5)
   ]
   
   static let fetchedData: [ManageGroup.ToDoGroup] = [
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "수학 공부", progressColor: .red, progressRate: 0.5),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "영어 학습 및 연습", progressColor: .blue, progressRate: 0.3),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "과학과 기술 분야 탐구", progressColor: .green, progressRate: 0.7),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "프로그래밍과 코딩 도전", progressColor: .purple, progressRate: 0.2),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "역사와 문화 이해", progressColor: .orange, progressRate: 0.9),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "음악과 예술 감상", progressColor: .yellow, progressRate: 0.4),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "미술과 디자인 창작", progressColor: .cyan, progressRate: 0.6),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "체육 운동과 스포츠", progressColor: .magenta, progressRate: 0.8),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "경제와 금융의 기초 이해", progressColor: .brown, progressRate: 0.3),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "사회 문제 탐구", progressColor: .black, progressRate: 0.7),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "컴퓨터 과학의 기본 개념", progressColor: .systemPink, progressRate: 0.5),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "문학과 시 이해와 해석", progressColor: .systemIndigo, progressRate: 0.2),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "요리와 조리 기술 연마", progressColor: .systemBrown, progressRate: 0.9),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "자동차 수리와 정비", progressColor: .systemPurple, progressRate: 0.6),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "정치와 법의 기본 개념", progressColor: .systemOrange, progressRate: 0.4),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "화학 실험과 실험실 작업", progressColor: .red, progressRate: 0.3),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "언어 학습과 외국어 구사", progressColor: .blue, progressRate: 0.6),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "생물학 연구와 생명 과학", progressColor: .green, progressRate: 0.8),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "디지털 아트와 그래픽 디자인", progressColor: .purple, progressRate: 0.1),
-    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "건강과 웰빙의 기본 지식", progressColor: .orange, progressRate: 0.5)
+    ManageGroup.ToDoGroup(groupName: "수학 공부", progressColor: .red, progressRate: 0.5),
+    ManageGroup.ToDoGroup(groupName: "영어 학습 및 연습", progressColor: .blue, progressRate: 0.3),
+    ManageGroup.ToDoGroup(groupName: "과학과 기술 분야 탐구", progressColor: .green, progressRate: 0.7),
+    ManageGroup.ToDoGroup(groupName: "프로그래밍과 코딩 도전", progressColor: .purple, progressRate: 0.2),
+    ManageGroup.ToDoGroup(groupName: "역사와 문화 이해", progressColor: .orange, progressRate: 0.9),
+    ManageGroup.ToDoGroup(groupName: "음악과 예술 감상", progressColor: .yellow, progressRate: 0.4),
+    ManageGroup.ToDoGroup(groupName: "미술과 디자인 창작", progressColor: .cyan, progressRate: 0.6),
+    ManageGroup.ToDoGroup(groupName: "체육 운동과 스포츠", progressColor: .magenta, progressRate: 0.8),
+    ManageGroup.ToDoGroup(groupName: "경제와 금융의 기초 이해", progressColor: .brown, progressRate: 0.3),
+    ManageGroup.ToDoGroup(groupName: "사회 문제 탐구", progressColor: .black, progressRate: 0.7),
+    ManageGroup.ToDoGroup(groupName: "컴퓨터 과학의 기본 개념", progressColor: .systemPink, progressRate: 0.5),
+    ManageGroup.ToDoGroup(groupName: "문학과 시 이해와 해석", progressColor: .systemIndigo, progressRate: 0.2),
+    ManageGroup.ToDoGroup(groupName: "요리와 조리 기술 연마", progressColor: .systemBrown, progressRate: 0.9),
+    ManageGroup.ToDoGroup(groupName: "자동차 수리와 정비", progressColor: .systemPurple, progressRate: 0.6),
+    ManageGroup.ToDoGroup(groupName: "정치와 법의 기본 개념", progressColor: .systemOrange, progressRate: 0.4),
+    ManageGroup.ToDoGroup(groupName: "화학 실험과 실험실 작업", progressColor: .red, progressRate: 0.3),
+    ManageGroup.ToDoGroup(groupName: "언어 학습과 외국어 구사", progressColor: .blue, progressRate: 0.6),
+    ManageGroup.ToDoGroup(groupName: "생물학 연구와 생명 과학", progressColor: .green, progressRate: 0.8),
+    ManageGroup.ToDoGroup(groupName: "디지털 아트와 그래픽 디자인", progressColor: .purple, progressRate: 0.1),
+    ManageGroup.ToDoGroup(groupName: "건강과 웰빙의 기본 지식", progressColor: .orange, progressRate: 0.5)
   ]
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupMockData.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupMockData.swift
@@ -13,31 +13,31 @@ import ToDoGardenUIResource
 struct ManageGroupMockData {
   
   static let guideSceneData: [ManageGroup.ToDoGroup] = [
-    ManageGroup.ToDoGroup(id: "1", groupName: "영어 독해", progressColor: .toDoGardenYellow, progressRate: 0.5),
-    ManageGroup.ToDoGroup(id: "2", groupName: "역사와 문화 이해", progressColor: .toDoGardenRed, progressRate: 0.5),
-    ManageGroup.ToDoGroup(id: "3", groupName: "디자인 창작", progressColor: .toDoGardenOlive, progressRate: 0.5)
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "영어 독해", progressColor: .toDoGardenYellow, progressRate: 0.5),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "역사와 문화 이해", progressColor: .toDoGardenRed, progressRate: 0.5),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "디자인 창작", progressColor: .toDoGardenOlive, progressRate: 0.5)
   ]
   
   static let fetchedData: [ManageGroup.ToDoGroup] = [
-    ManageGroup.ToDoGroup(id: "1", groupName: "수학 공부", progressColor: .red, progressRate: 0.5),
-    ManageGroup.ToDoGroup(id: "2", groupName: "영어 학습 및 연습", progressColor: .blue, progressRate: 0.3),
-    ManageGroup.ToDoGroup(id: "3", groupName: "과학과 기술 분야 탐구", progressColor: .green, progressRate: 0.7),
-    ManageGroup.ToDoGroup(id: "4", groupName: "프로그래밍과 코딩 도전", progressColor: .purple, progressRate: 0.2),
-    ManageGroup.ToDoGroup(id: "5", groupName: "역사와 문화 이해", progressColor: .orange, progressRate: 0.9),
-    ManageGroup.ToDoGroup(id: "6", groupName: "음악과 예술 감상", progressColor: .yellow, progressRate: 0.4),
-    ManageGroup.ToDoGroup(id: "7", groupName: "미술과 디자인 창작", progressColor: .cyan, progressRate: 0.6),
-    ManageGroup.ToDoGroup(id: "8", groupName: "체육 운동과 스포츠", progressColor: .magenta, progressRate: 0.8),
-    ManageGroup.ToDoGroup(id: "9", groupName: "경제와 금융의 기초 이해", progressColor: .brown, progressRate: 0.3),
-    ManageGroup.ToDoGroup(id: "10", groupName: "사회 문제 탐구", progressColor: .black, progressRate: 0.7),
-    ManageGroup.ToDoGroup(id: "11", groupName: "컴퓨터 과학의 기본 개념", progressColor: .systemPink, progressRate: 0.5),
-    ManageGroup.ToDoGroup(id: "12", groupName: "문학과 시 이해와 해석", progressColor: .systemIndigo, progressRate: 0.2),
-    ManageGroup.ToDoGroup(id: "13", groupName: "요리와 조리 기술 연마", progressColor: .systemBrown, progressRate: 0.9),
-    ManageGroup.ToDoGroup(id: "14", groupName: "자동차 수리와 정비", progressColor: .systemPurple, progressRate: 0.6),
-    ManageGroup.ToDoGroup(id: "15", groupName: "정치와 법의 기본 개념", progressColor: .systemOrange, progressRate: 0.4),
-    ManageGroup.ToDoGroup(id: "16", groupName: "화학 실험과 실험실 작업", progressColor: .red, progressRate: 0.3),
-    ManageGroup.ToDoGroup(id: "17", groupName: "언어 학습과 외국어 구사", progressColor: .blue, progressRate: 0.6),
-    ManageGroup.ToDoGroup(id: "18", groupName: "생물학 연구와 생명 과학", progressColor: .green, progressRate: 0.8),
-    ManageGroup.ToDoGroup(id: "19", groupName: "디지털 아트와 그래픽 디자인", progressColor: .purple, progressRate: 0.1),
-    ManageGroup.ToDoGroup(id: "20", groupName: "건강과 웰빙의 기본 지식", progressColor: .orange, progressRate: 0.5)
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "수학 공부", progressColor: .red, progressRate: 0.5),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "영어 학습 및 연습", progressColor: .blue, progressRate: 0.3),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "과학과 기술 분야 탐구", progressColor: .green, progressRate: 0.7),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "프로그래밍과 코딩 도전", progressColor: .purple, progressRate: 0.2),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "역사와 문화 이해", progressColor: .orange, progressRate: 0.9),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "음악과 예술 감상", progressColor: .yellow, progressRate: 0.4),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "미술과 디자인 창작", progressColor: .cyan, progressRate: 0.6),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "체육 운동과 스포츠", progressColor: .magenta, progressRate: 0.8),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "경제와 금융의 기초 이해", progressColor: .brown, progressRate: 0.3),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "사회 문제 탐구", progressColor: .black, progressRate: 0.7),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "컴퓨터 과학의 기본 개념", progressColor: .systemPink, progressRate: 0.5),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "문학과 시 이해와 해석", progressColor: .systemIndigo, progressRate: 0.2),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "요리와 조리 기술 연마", progressColor: .systemBrown, progressRate: 0.9),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "자동차 수리와 정비", progressColor: .systemPurple, progressRate: 0.6),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "정치와 법의 기본 개념", progressColor: .systemOrange, progressRate: 0.4),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "화학 실험과 실험실 작업", progressColor: .red, progressRate: 0.3),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "언어 학습과 외국어 구사", progressColor: .blue, progressRate: 0.6),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "생물학 연구와 생명 과학", progressColor: .green, progressRate: 0.8),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "디지털 아트와 그래픽 디자인", progressColor: .purple, progressRate: 0.1),
+    ManageGroup.ToDoGroup(groupID: UUID(), groupName: "건강과 웰빙의 기본 지식", progressColor: .orange, progressRate: 0.5)
   ]
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
@@ -13,6 +13,8 @@ protocol ManageGroupPresentationLogic {
   func presentFetchedGroupList(response: ManageGroup.FetchGroupList.Response)
   func presentSavedGroupList(response: ManageGroup.SaveGroupList.Response)
   func presentDeletedGroup(response: ManageGroup.DeleteGroup.Response)
+  func presentAddedGroup(response: ManageGroup.AddGroup.Response)
+  func presentEditedGroup(response: ManageGroup.EditGroup.Response)
 }
 
 class ManageGroupPresenter {
@@ -38,5 +40,15 @@ extension ManageGroupPresenter: ManageGroupPresentationLogic {
       index: response.index
     )
     self.viewController?.displayDeletedGroup(viewModel: viewModel)
+  }
+  
+  func presentAddedGroup(response: ManageGroup.AddGroup.Response) {
+    let viewModel = ManageGroup.AddGroup.ViewModel(group: response.group)
+    self.viewController?.displayAddedGroup(viewModel: viewModel)
+  }
+  
+  func presentEditedGroup(response: ManageGroup.EditGroup.Response) {
+    let viewModel = ManageGroup.EditGroup.ViewModel(group: response.group, editedIndex: response.editedIndex)
+    self.viewController?.displayEditedGroup(viewModel: viewModel)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
@@ -34,7 +34,7 @@ extension ManageGroupPresenter: ManageGroupPresentationLogic {
   
   func presentDeletedGroup(response: ManageGroup.DeleteGroup.Response) {
     let viewModel = ManageGroup.DeleteGroup.ViewModel(
-      id: response.id,
+      groupID: response.groupID,
       index: response.index
     )
     self.viewController?.displayDeletedGroup(viewModel: viewModel)

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
@@ -35,7 +35,7 @@ class ManageGroupRouter: ManageGroupDataPassing {
 extension ManageGroupRouter: ManageGroupRoutingLogic {
   func routeToPostGroupScene(groupInfo: ManageGroup.ToDoGroup?) {
     var payload: PostGroupScenePayload?
-    if let groupInfo = groupInfo {
+    if let groupInfo {
       payload = PostGroupScenePayload(
         groupID: groupInfo.groupID,
         groupName: groupInfo.groupName,

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
@@ -10,6 +10,7 @@ import UIKit.UIColor
 import ManageGroupSceneAPI
 import ManageGroupSceneEntity
 import PostGroupSceneAPI
+import PostGroupSceneEntity
 
 protocol ManageGroupRoutingLogic {
   func routeToPostGroupScene(groupInfo: ManageGroup.ToDoGroup?)
@@ -37,9 +38,11 @@ extension ManageGroupRouter: ManageGroupRoutingLogic {
     var payload: PostGroupScenePayload?
     if let groupInfo {
       payload = PostGroupScenePayload(
-        groupID: groupInfo.groupID,
-        groupName: groupInfo.groupName,
-        groupColor: groupInfo.progressColor
+        group: PostGroup.ToDoGroup(
+          groupID: groupInfo.groupID,
+          groupName: groupInfo.groupName,
+          groupColor: groupInfo.progressColor
+        )
       )
     } else {
       payload = nil
@@ -60,8 +63,6 @@ extension ManageGroupRouter: ManageGroupRoutingLogic {
 
 extension ManageGroupRouter {
   struct PostGroupScenePayload: PostGroupScenePayloadable {
-    var groupID: UUID
-    var groupName: String
-    var groupColor: UIColor
+    var group: PostGroup.ToDoGroup
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupRouter.swift
@@ -34,12 +34,21 @@ class ManageGroupRouter: ManageGroupDataPassing {
 
 extension ManageGroupRouter: ManageGroupRoutingLogic {
   func routeToPostGroupScene(groupInfo: ManageGroup.ToDoGroup?) {
-    let payload = PostGroupScenePayload(
-      groupID: groupInfo?.id,
-      groupName: groupInfo?.groupName,
-      groupColor: groupInfo?.progressColor
-    )
-    guard let destinationViewController = self.postSceneBuilder?.build(with: payload) else {
+    var payload: PostGroupScenePayload?
+    if let groupInfo = groupInfo {
+      payload = PostGroupScenePayload(
+        groupID: groupInfo.groupID,
+        groupName: groupInfo.groupName,
+        groupColor: groupInfo.progressColor
+      )
+    } else {
+      payload = nil
+    }
+
+    guard let destinationViewController = self.postSceneBuilder?.build(
+      with: payload,
+      delegate: self.viewController
+    ) else {
       return
     }
     
@@ -51,8 +60,8 @@ extension ManageGroupRouter: ManageGroupRoutingLogic {
 
 extension ManageGroupRouter {
   struct PostGroupScenePayload: PostGroupScenePayloadable {
-    var groupID: String?
-    var groupName: String?
-    var groupColor: UIColor?
+    var groupID: UUID
+    var groupName: String
+    var groupColor: UIColor
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupTableViewDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupTableViewDelegate.swift
@@ -17,8 +17,8 @@ final class ManageGroupTableViewDelegate: NSObject {
   var displayedGroupsBeforeEditing: [ManageGroup.ToDoGroup]
   private let footerView: UIView
   
-  private var onPostGroup: ((String, String, UIColor) -> Void)?
-  private var onDeleteGroup: ((String, Int) -> Void)?
+  private var onPostGroup: ((UUID, String, UIColor) -> Void)?
+  private var onDeleteGroup: ((UUID, Int) -> Void)?
   private var onReorderingStateChange: ((Bool) -> Void)?
   
   private var isReordering: Bool = false {
@@ -36,11 +36,11 @@ final class ManageGroupTableViewDelegate: NSObject {
     self.footerView = footerView
   }
   
-  func setOnPostGroup(_ handler: @escaping (String, String, UIColor) -> Void) {
+  func setOnPostGroup(_ handler: @escaping (UUID, String, UIColor) -> Void) {
     self.onPostGroup = handler
   }
   
-  func setOnDeleteGroup(_ handler: @escaping (String, Int) -> Void) {
+  func setOnDeleteGroup(_ handler: @escaping (UUID, Int) -> Void) {
     self.onDeleteGroup = handler
   }
   
@@ -78,7 +78,7 @@ extension ManageGroupTableViewDelegate: UITableViewDataSource {
     let singleGroup = self.displayedGroups[indexPath.row]
     
     cell.applyModelPrimary(
-      id: singleGroup.id,
+      id: singleGroup.groupID,
       groupName: singleGroup.groupName,
       progressColor: singleGroup.progressColor,
       progressRate: singleGroup.progressRate,
@@ -90,8 +90,8 @@ extension ManageGroupTableViewDelegate: UITableViewDataSource {
     } else {
       cell.leaveEditingMode()
     }
-    cell.setupRightButtonAction { [weak self] groupId, groupName, groupColor in
-      self?.onPostGroup?(groupId, groupName, groupColor)
+    cell.setupRightButtonAction { [weak self] groupID, groupName, groupColor in
+      self?.onPostGroup?(groupID, groupName, groupColor)
     }
     return cell
   }
@@ -107,10 +107,10 @@ extension ManageGroupTableViewDelegate: UITableViewDelegate {
     guard !isReordering else { return }
     
     let index = indexPath.row
-    let id = self.displayedGroups[index].id
+    let groupID = self.displayedGroups[index].groupID
     
     if editingStyle == UITableViewCell.EditingStyle.delete {
-      self.onDeleteGroup?(id, index)
+      self.onDeleteGroup?(groupID, index)
     }
   }
   
@@ -143,7 +143,7 @@ extension ManageGroupTableViewDelegate: UITableViewDragDelegate {
     at indexPath: IndexPath
   ) -> [UIDragItem] {
     let item = displayedGroups[indexPath.row]
-    let itemProvider = NSItemProvider(object: item.id as NSString)
+    let itemProvider = NSItemProvider(object: item.groupID.uuidString as NSString)
     return [UIDragItem(itemProvider: itemProvider)]
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController+PostGroupSceneDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController+PostGroupSceneDelegate.swift
@@ -1,0 +1,38 @@
+//
+//  ManageGroupViewController+PostGroupSceneDelegate.swift
+//
+//
+//  Created by SONG on 9/12/24.
+//
+
+import UIKit.UIColor
+
+import ManageGroupSceneEntity
+import PostGroupSceneAPI
+import PostGroupSceneEntity
+
+extension ManageGroupViewController: PostGroupSceneDelegate {
+  public func addGroup(group: PostGroup.ToDoGroup) {
+    let request = ManageGroup.AddGroup.Request(
+      groupID: group.groupID ?? UUID(),
+      groupName: group.groupName ?? "",
+      groupColor: group.groupColor ?? UIColor.toDoGardenGrassNone
+    )
+    
+    self.interactor?.addGroup(request: request)
+  }
+  
+  public func editGroup(group: PostGroup.ToDoGroup) {
+    guard let groupID = group.groupID else {
+      return
+    }
+    
+    let request = ManageGroup.EditGroup.Request(
+      groupID: groupID,
+      groupName: group.groupName ?? "",
+      groupColor: group.groupColor ?? UIColor.toDoGardenGrassNone
+    )
+    
+    self.interactor?.editGroup(request: request)
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController+PostGroupSceneDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController+PostGroupSceneDelegate.swift
@@ -15,8 +15,8 @@ extension ManageGroupViewController: PostGroupSceneDelegate {
   public func addGroup(group: PostGroup.ToDoGroup) {
     let request = ManageGroup.AddGroup.Request(
       groupID: group.groupID ?? UUID(),
-      groupName: group.groupName ?? "",
-      groupColor: group.groupColor ?? UIColor.toDoGardenGrassNone
+      groupName: group.groupName,
+      groupColor: group.groupColor
     )
     
     self.interactor?.addGroup(request: request)
@@ -29,8 +29,8 @@ extension ManageGroupViewController: PostGroupSceneDelegate {
     
     let request = ManageGroup.EditGroup.Request(
       groupID: groupID,
-      groupName: group.groupName ?? "",
-      groupColor: group.groupColor ?? UIColor.toDoGardenGrassNone
+      groupName: group.groupName,
+      groupColor: group.groupColor
     )
     
     self.interactor?.editGroup(request: request)

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -291,18 +291,13 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     self.rightBarButton.isEnabled = false
     Task { @MainActor in
       self.groupListTableView.performBatchUpdates({
-        self.groupListTableView.insertRows(
-          at: changes.insertions,
-          with: UITableView.RowAnimation.fade
-        )
+        self.groupListTableView.deleteRows(at: changes.deletions, with: UITableView.RowAnimation.fade)
+        self.groupListTableView.insertRows(at: changes.insertions, with: UITableView.RowAnimation.fade)
         changes.moves.forEach { move in
           self.groupListTableView.moveRow(at: move.from, to: move.to)
         }
       }, completion: { _ in
-        self.groupListTableView.reloadRows(
-          at: changes.updates,
-          with: UITableView.RowAnimation.none
-        )
+        self.groupListTableView.reloadRows(at: changes.updates, with: UITableView.RowAnimation.fade)
         self.rightBarButton.isEnabled = true
       })
     }
@@ -313,6 +308,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     oldGroups: [ManageGroup.ToDoGroup],
     newGroups: [ManageGroup.ToDoGroup]
   ) -> (
+    deletions: [IndexPath],
     insertions: [IndexPath],
     moves: [(from: IndexPath, to: IndexPath)],
     updates: [IndexPath]
@@ -320,6 +316,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     let oldIDs = oldGroups.map { $0.groupID }
     let newIDs = newGroups.map { $0.groupID }
     
+    let deletions = calculateDeletions(oldIDs: oldIDs, newIDs: Set(newIDs))
     let insertions = calculateInsertions(newIDs: newIDs, oldIDs: Set(oldIDs))
     let oldIndexMap = createOldIndexMap(oldGroups: oldGroups)
     let (moves, updates) = calculateMovesAndUpdates(
@@ -327,9 +324,15 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
       oldGroups: oldGroups,
       oldIndexMap: oldIndexMap
     )
-    return (insertions, moves, updates)
+    return (deletions, insertions, moves, updates)
   }
   // swiftlint:enable large_tuple
+  
+  private func calculateDeletions(oldIDs: [UUID], newIDs: Set<UUID>) -> [IndexPath] {
+    return oldIDs.enumerated().compactMap { index, groupID in
+      newIDs.contains(groupID) ? nil : IndexPath(row: index, section: 0)
+    }
+  }
   
   private func calculateInsertions(newIDs: [UUID], oldIDs: Set<UUID>) -> [IndexPath] {
     var insertions: [IndexPath] = []

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -5,6 +5,7 @@
 //  Created by SONG on 6/26/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
+// swiftlint:disable file_length
 import UIKit
 
 import ManageGroupSceneAPI

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -18,6 +18,8 @@ protocol ManageGroupDisplayLogic: AnyObject {
   func displayFetchedGroupList(viewModel: ManageGroup.FetchGroupList.ViewModel)
   func displaySavedGroupList(viewModel: ManageGroup.SaveGroupList.ViewModel)
   func displayDeletedGroup(viewModel: ManageGroup.DeleteGroup.ViewModel)
+  func displayAddedGroup(viewModel: ManageGroup.AddGroup.ViewModel)
+  func displayEditedGroup(viewModel: ManageGroup.EditGroup.ViewModel)
 }
 
 public class ManageGroupViewController: UIViewController, ManageGroupViewControllable {
@@ -274,12 +276,36 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
   
   func displayDeletedGroup(viewModel: ManageGroup.DeleteGroup.ViewModel) {
     let index = viewModel.index
+    self.manageGroupTableViewDelegate?.displayedGroups.remove(at: index)
     Task { @MainActor in
-      self.manageGroupTableViewDelegate?.displayedGroups.remove(at: index)
       self.groupListTableView.deleteRows(
         at: [IndexPath(row: index, section: 0)],
         with: UITableView.RowAnimation.fade
       )
+    }
+  }
+  
+  func displayAddedGroup(viewModel: ManageGroup.AddGroup.ViewModel) {
+    let indexPath = IndexPath(
+      row: self.groupListTableView.numberOfRows(inSection: 0),
+      section: 0
+    )
+    self.manageGroupTableViewDelegate?.displayedGroups.append(viewModel.group)
+    Task { @MainActor in
+      self.groupListTableView.insertRows(
+        at: [indexPath],
+        with: UITableView.RowAnimation.fade
+      )
+      self.groupListTableView.scrollToRow(at: indexPath, at: .bottom, animated: true)
+    }
+  }
+  
+  func displayEditedGroup(viewModel: ManageGroup.EditGroup.ViewModel) {
+    self.manageGroupTableViewDelegate?.displayedGroups[viewModel.editedIndex] = viewModel.group
+    Task { @MainActor in
+      self.groupListTableView.reloadRows(
+        at: [IndexPath(row: viewModel.editedIndex, section: Int.zero)],
+        with: UITableView.RowAnimation.fade)
     }
   }
   

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -76,8 +76,8 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
     }
   }
   
-  func deleteGroup(id: String, index: Int) {
-    let request = ManageGroup.DeleteGroup.Request(id: id, index: index)
+  func deleteGroup(groupID: UUID, index: Int) {
+    let request = ManageGroup.DeleteGroup.Request(groupID: groupID, index: index)
     self.interactor?.deleteGroup(request: request)
   }
   
@@ -163,9 +163,9 @@ extension ManageGroupViewController {
   }
   
   private func setupTouchActions() {
-    self.manageGroupTableViewDelegate?.setOnPostGroup { [weak self] groupId, groupName, groupColor in
+    self.manageGroupTableViewDelegate?.setOnPostGroup { [weak self] groupID, groupName, groupColor in
       let groupInfo = ManageGroup.ToDoGroup(
-        id: groupId,
+        groupID: groupID,
         groupName: groupName,
         progressColor: groupColor,
         progressRate: Float.zero
@@ -173,8 +173,8 @@ extension ManageGroupViewController {
       self?.routeToPostGroupScene(groupInfo: groupInfo)
     }
     
-    self.manageGroupTableViewDelegate?.setOnDeleteGroup { [weak self] id, index in
-      self?.deleteGroup(id: id, index: index)
+    self.manageGroupTableViewDelegate?.setOnDeleteGroup { [weak self] groupID, index in
+      self?.deleteGroup(groupID: groupID, index: index)
     }
   }
   
@@ -316,8 +316,8 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     moves: [(from: IndexPath, to: IndexPath)],
     updates: [IndexPath]
   ) {
-    let oldIDs = oldGroups.map { $0.id }
-    let newIDs = newGroups.map { $0.id }
+    let oldIDs = oldGroups.map { $0.groupID }
+    let newIDs = newGroups.map { $0.groupID }
     
     let insertions = calculateInsertions(newIDs: newIDs, oldIDs: Set(oldIDs))
     let oldIndexMap = createOldIndexMap(oldGroups: oldGroups)
@@ -329,7 +329,8 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     return (insertions, moves, updates)
   }
   // swiftlint:enable large_tuple
-  private func calculateInsertions(newIDs: [String], oldIDs: Set<String>) -> [IndexPath] {
+  
+  private func calculateInsertions(newIDs: [UUID], oldIDs: Set<UUID>) -> [IndexPath] {
     var insertions: [IndexPath] = []
     for (newIndex, newID) in newIDs.enumerated() where !oldIDs.contains(newID) {
       insertions.append(IndexPath(row: newIndex, section: 0))
@@ -337,10 +338,10 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     return insertions
   }
   
-  private func createOldIndexMap(oldGroups: [ManageGroup.ToDoGroup]) -> [String: Int] {
-    var oldIndexMap = [String: Int]()
+  private func createOldIndexMap(oldGroups: [ManageGroup.ToDoGroup]) -> [UUID: Int] {
+    var oldIndexMap = [UUID: Int]()
     for (index, group) in oldGroups.enumerated() {
-      oldIndexMap[group.id] = index
+      oldIndexMap[group.groupID] = index
     }
     return oldIndexMap
   }
@@ -348,7 +349,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
   private func calculateMovesAndUpdates(
     newGroups: [ManageGroup.ToDoGroup],
     oldGroups: [ManageGroup.ToDoGroup],
-    oldIndexMap: [String: Int]
+    oldIndexMap: [UUID: Int]
   ) -> (
     moves: [(from: IndexPath, to: IndexPath)],
     updates: [IndexPath]
@@ -356,7 +357,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     var moves: [(from: IndexPath, to: IndexPath)] = []
     var updates: [IndexPath] = []
     for (newIndex, newGroup) in newGroups.enumerated() {
-      if let oldIndex = oldIndexMap[newGroup.id] {
+      if let oldIndex = oldIndexMap[newGroup.groupID] {
         if oldIndex != newIndex {
           moves.append(
             (from: IndexPath(row: oldIndex, section: 0),

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -277,12 +277,10 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
   func displayDeletedGroup(viewModel: ManageGroup.DeleteGroup.ViewModel) {
     let index = viewModel.index
     self.manageGroupTableViewDelegate?.displayedGroups.remove(at: index)
-    Task { @MainActor in
-      self.groupListTableView.deleteRows(
-        at: [IndexPath(row: index, section: 0)],
-        with: UITableView.RowAnimation.fade
-      )
-    }
+    self.groupListTableView.deleteRows(
+      at: [IndexPath(row: index, section: 0)],
+      with: UITableView.RowAnimation.fade
+    )
   }
   
   func displayAddedGroup(viewModel: ManageGroup.AddGroup.ViewModel) {
@@ -291,22 +289,18 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
       section: 0
     )
     self.manageGroupTableViewDelegate?.displayedGroups.append(viewModel.group)
-    Task { @MainActor in
-      self.groupListTableView.insertRows(
-        at: [indexPath],
-        with: UITableView.RowAnimation.fade
-      )
-      self.groupListTableView.scrollToRow(at: indexPath, at: .bottom, animated: true)
-    }
+    self.groupListTableView.insertRows(
+      at: [indexPath],
+      with: UITableView.RowAnimation.fade
+    )
+    self.groupListTableView.scrollToRow(at: indexPath, at: .bottom, animated: true)
   }
   
   func displayEditedGroup(viewModel: ManageGroup.EditGroup.ViewModel) {
     self.manageGroupTableViewDelegate?.displayedGroups[viewModel.editedIndex] = viewModel.group
-    Task { @MainActor in
-      self.groupListTableView.reloadRows(
-        at: [IndexPath(row: viewModel.editedIndex, section: Int.zero)],
-        with: UITableView.RowAnimation.fade)
-    }
+    self.groupListTableView.reloadRows(
+      at: [IndexPath(row: viewModel.editedIndex, section: Int.zero)],
+      with: UITableView.RowAnimation.fade)
   }
   
   private func updateTableViewWithAnimation(

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -5,7 +5,6 @@
 //  Created by SONG on 6/26/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-// swiftlint:disable file_length
 import UIKit
 
 import ManageGroupSceneAPI

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
@@ -34,6 +34,26 @@ public class ManageGroupWorker: ManageGroupWorkable {
       return .failure(error)
     }
   }
+  
+  public func addGroup(request: ManageGroup.AddGroup.Request) -> ManageGroup.ToDoGroup {
+    let group = ManageGroup.ToDoGroup(
+      groupID: request.groupID,
+      groupName: request.groupName,
+      progressColor: request.groupColor,
+      progressRate: Float.zero
+    )
+    return group
+  }
+  
+  public func editGroup(request: ManageGroup.EditGroup.Request, progressRate: Float) -> ManageGroup.ToDoGroup {
+    let group = ManageGroup.ToDoGroup(
+      groupID: request.groupID,
+      groupName: request.groupName,
+      progressColor: request.groupColor,
+      progressRate: progressRate
+    )
+    return group
+  }
 
   private func fetchGroupsFromDatabase() async throws -> [ManageGroup.ToDoGroup] {
     let fetchedData: [ManageGroup.ToDoGroup] = ManageGroupMockData.fetchedData

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneAPI/ManageGroupWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneAPI/ManageGroupWorkable.swift
@@ -16,4 +16,6 @@ public protocol ManageGroupWorkable {
   func saveGroupList(
     request: ManageGroupSceneEntity.ManageGroup.SaveGroupList.Request
   ) async -> Result<[ManageGroup.ToDoGroup], Error>
+  func addGroup(request: ManageGroup.AddGroup.Request) -> ManageGroup.ToDoGroup
+  func editGroup(request: ManageGroup.EditGroup.Request, progressRate: Float) -> ManageGroup.ToDoGroup
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneEntity/ManageGroupModels.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneEntity/ManageGroupModels.swift
@@ -14,7 +14,7 @@ public enum ManageGroup {
     public let progressColor: UIColor
     public let progressRate: Float
     
-    public init(groupID: UUID, groupName: String, progressColor: UIColor, progressRate: Float) {
+    public init(groupID: UUID = UUID(), groupName: String, progressColor: UIColor, progressRate: Float) {
       self.groupID = groupID
       self.groupName = groupName
       self.progressColor = progressColor

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneEntity/ManageGroupModels.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneEntity/ManageGroupModels.swift
@@ -107,4 +107,68 @@ public enum ManageGroup {
       }
     }
   }
+  
+  public enum AddGroup {
+    public struct Request {
+      public let groupID: UUID
+      public let groupName: String
+      public let groupColor: UIColor
+      
+      public init(groupID: UUID, groupName: String, groupColor: UIColor) {
+        self.groupID = groupID
+        self.groupName = groupName
+        self.groupColor = groupColor
+      }
+    }
+    
+    public struct Response {
+      public let group: ToDoGroup
+      
+      public init(group: ToDoGroup) {
+        self.group = group
+      }
+    }
+    
+    public struct ViewModel {
+      public let group: ToDoGroup
+      
+      public init(group: ToDoGroup) {
+        self.group = group
+      }
+    }
+  }
+  
+  public enum EditGroup {
+    public struct Request {
+      public let groupID: UUID
+      public let groupName: String
+      public let groupColor: UIColor
+      
+      public init(groupID: UUID, groupName: String, groupColor: UIColor) {
+        self.groupID = groupID
+        self.groupName = groupName
+        self.groupColor = groupColor
+      }
+    }
+    
+    public struct Response {
+      public let group: ToDoGroup
+      public let editedIndex: Int
+      
+      public init(group: ToDoGroup, editedIndex: Int) {
+        self.group = group
+        self.editedIndex = editedIndex
+      }
+    }
+    
+    public struct ViewModel {
+      public let group: ToDoGroup
+      public let editedIndex: Int
+      
+      public init(group: ToDoGroup, editedIndex: Int) {
+        self.group = group
+        self.editedIndex = editedIndex
+      }
+    }
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneEntity/ManageGroupModels.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneEntity/ManageGroupModels.swift
@@ -9,20 +9,20 @@ import UIKit.UIColor
 
 public enum ManageGroup {
   public struct ToDoGroup: Equatable {
-    public let id: String
+    public let groupID: UUID
     public let groupName: String
     public let progressColor: UIColor
     public let progressRate: Float
     
-    public init(id: String, groupName: String, progressColor: UIColor, progressRate: Float) {
-      self.id = id
+    public init(groupID: UUID, groupName: String, progressColor: UIColor, progressRate: Float) {
+      self.groupID = groupID
       self.groupName = groupName
       self.progressColor = progressColor
       self.progressRate = progressRate
     }
     
     public static func == (lhs: ToDoGroup, rhs: ToDoGroup) -> Bool {
-      return lhs.id == rhs.id &&
+      return lhs.groupID == rhs.groupID &&
       lhs.groupName == rhs.groupName &&
       lhs.progressColor == rhs.progressColor &&
       lhs.progressRate == rhs.progressRate
@@ -75,34 +75,34 @@ public enum ManageGroup {
   
   public enum DeleteGroup {
     public struct Request {
-      public let id: String
+      public let groupID: UUID
       public let index: Int
       
-      public init(id: String, index: Int) {
-        self.id = id
+      public init(groupID: UUID, index: Int) {
+        self.groupID = groupID
         self.index = index
       }
     }
     
     public struct Response {
-      public let id: String
+      public let groupID: UUID
       public let index: Int
       
-      public init(id: String, index: Int) {
-        self.id = id
+      public init(groupID: UUID, index: Int) {
+        self.groupID = groupID
         self.index = index
       }
     }
     
     public struct ViewModel {
-      public let id: String
+      public let groupID: UUID
       public let index: Int
       
       public init(
-        id: String,
+        groupID: UUID,
         index: Int
       ) {
-        self.id = id
+        self.groupID = groupID
         self.index = index
       }
     }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -25,7 +25,12 @@ class PostGroupInteractor: PostGroupDataStore {
   var delegate: PostGroupSceneDelegate?
   var presenter: PostGroupPresentationLogic?
   private let postGroupWorker: PostGroupWorkable
-  var payload: PostGroupScenePayloadable?
+  var payload: PostGroupScenePayloadable? {
+    didSet {
+      self.setCurrentGroup()
+    }
+  }
+  var currentGroup: PostGroup.ToDoGroup?
   
   init(postGroupWorker: PostGroupWorkable) {
     self.postGroupWorker = postGroupWorker
@@ -78,6 +83,22 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
 }
 
 extension PostGroupInteractor {
+  private func setCurrentGroup() {
+    guard let payload = self.payload else {
+      self.currentGroup = PostGroup.ToDoGroup(
+        groupID: nil,
+        groupName: nil,
+        groupColor: nil
+      )
+      return
+    }
+    
+    self.currentGroup = PostGroup.ToDoGroup(
+      groupID: payload.groupID,
+      groupName: payload.groupName,
+      groupColor: payload.groupColor
+    )
+  }
   
   private func isDoneBottomButtonEnable(groupName: String?, groupColor: UIColor?) -> Bool {
     var isButtonEnable: Bool

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -59,7 +59,7 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
     
     let response = PostGroup.TouchDoneButton.Response(group: result)
     self.currentGroup = response.group
-    self.presenter?.presentTouchedDoneButton(response: response)
+    self.presenter?.presentAfterTouchingDoneButton(response: response)
   }
   
   func changeColor(request: PostGroup.ChangeColor.Request) {

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -12,6 +12,7 @@ import PostGroupSceneEntity
 
 protocol PostGroupDataStore {
   var payload: PostGroupScenePayloadable? { get set }
+  var delegate: PostGroupSceneDelegate? { get set }
 }
 
 protocol PostGroupBusinessLogic {
@@ -21,6 +22,7 @@ protocol PostGroupBusinessLogic {
 }
 
 class PostGroupInteractor: PostGroupDataStore {
+  var delegate: PostGroupSceneDelegate?
   var presenter: PostGroupPresentationLogic?
   private let postGroupWorker: PostGroupWorkable
   var payload: PostGroupScenePayloadable?

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -11,7 +11,7 @@ import PostGroupSceneAPI
 import PostGroupSceneEntity
 
 protocol PostGroupDataStore {
-  var payload: PostGroupScenePayloadable? { get set }
+  var currentGroup: PostGroup.ToDoGroup? { get set }
   var delegate: PostGroupSceneDelegate? { get set }
 }
 
@@ -25,11 +25,7 @@ class PostGroupInteractor: PostGroupDataStore {
   var delegate: PostGroupSceneDelegate?
   var presenter: PostGroupPresentationLogic?
   private let postGroupWorker: PostGroupWorkable
-  var payload: PostGroupScenePayloadable? {
-    didSet {
-      self.setCurrentGroup()
-    }
-  }
+  
   var currentGroup: PostGroup.ToDoGroup?
   
   init(postGroupWorker: PostGroupWorkable) {
@@ -69,14 +65,11 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
   }
   
   func loadGroupData() {
-    let isDoneBottomButtonEnable: Bool = self.isDoneBottomButtonEnable(
-      groupName: self.payload?.groupName,
-      groupColor: self.payload?.groupColor
-    )
+    let isDoneBottomButtonEnable: Bool = self.isDoneBottomButtonEnable(with: self.currentGroup)
     
     let response = PostGroup.LoadGroupData.Response(
-      groupName: self.payload?.groupName ?? "",
-      groupColor: self.payload?.groupColor,
+      groupName: self.currentGroup?.groupName ?? "",
+      groupColor: self.currentGroup?.groupColor,
       isDoneBottomButtonEnable: isDoneBottomButtonEnable
     )
     self.presenter?.presentLoadGroupData(response: response)
@@ -84,26 +77,9 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
 }
 
 extension PostGroupInteractor {
-  private func setCurrentGroup() {
-    guard let payload = self.payload else {
-      self.currentGroup = PostGroup.ToDoGroup(
-        groupID: nil,
-        groupName: nil,
-        groupColor: nil
-      )
-      return
-    }
-    
-    self.currentGroup = PostGroup.ToDoGroup(
-      groupID: payload.groupID,
-      groupName: payload.groupName,
-      groupColor: payload.groupColor
-    )
-  }
-  
-  private func isDoneBottomButtonEnable(groupName: String?, groupColor: UIColor?) -> Bool {
+  private func isDoneBottomButtonEnable(with currentGroup: PostGroup.ToDoGroup?) -> Bool {
     var isButtonEnable: Bool
-    if (groupName == nil) || (groupColor == nil) {
+    if currentGroup == nil {
       isButtonEnable = false
     } else {
       isButtonEnable = true

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -64,12 +64,13 @@ extension PostGroupInteractor: PostGroupBusinessLogic {
   
   func loadGroupData() {
     let isDoneBottomButtonEnable: Bool = self.isDoneBottomButtonEnable(
-      groupName: payload?.groupName,
-      groupColor: payload?.groupColor
+      groupName: self.payload?.groupName,
+      groupColor: self.payload?.groupColor
     )
+    
     let response = PostGroup.LoadGroupData.Response(
-      groupName: payload?.groupName ?? "",
-      groupColor: payload?.groupColor,
+      groupName: self.payload?.groupName ?? "",
+      groupColor: self.payload?.groupColor,
       isDoneBottomButtonEnable: isDoneBottomButtonEnable
     )
     self.presenter?.presentLoadGroupData(response: response)

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupInteractor.swift
@@ -41,29 +41,30 @@ class PostGroupInteractor: PostGroupDataStore {
 
 extension PostGroupInteractor: PostGroupBusinessLogic {
   func touchDoneButton(request: PostGroupSceneEntity.PostGroup.TouchDoneButton.Request) {
-    guard let groupID = payload?.groupID else {
-      return
+    let groupID: UUID? = self.currentGroup?.groupID
+    
+    let result = self.postGroupWorker.touchDoneButton(
+      groupID: groupID,
+      groupName: request.groupName,
+      groupColor: request.groupColor
+    )
+    
+    let isAddGroup = result.groupID == nil
+    
+    if isAddGroup {
+      self.delegate?.addGroup(group: result)
+    } else {
+      self.delegate?.editGroup(group: result)
     }
     
-    self.postGroupWorker.touchDoneButton(
-      groupID: groupID,
-      groupName: request.groupName,
-      groupColor: request.groupColor
-    )
-    
-    let response = PostGroup.TouchDoneButton.Response(
-      groupID: groupID,
-      groupName: request.groupName,
-      groupColor: request.groupColor
-    )
-    
+    let response = PostGroup.TouchDoneButton.Response(group: result)
+    self.currentGroup = response.group
     self.presenter?.presentTouchedDoneButton(response: response)
   }
   
   func changeColor(request: PostGroup.ChangeColor.Request) {
-    self.postGroupWorker.changeColor(groupColor: request.groupColor)
-    // 성공했다고 가정
-    let response = PostGroup.ChangeColor.Response(groupID: "ID", groupColor: request.groupColor)
+    self.currentGroup?.groupColor = request.groupColor
+    let response = PostGroup.ChangeColor.Response(groupColor: request.groupColor)
     self.presenter?.presentChangedColor(response: response)
   }
   

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupPresenter.swift
@@ -12,7 +12,7 @@ import PostGroupSceneEntity
 protocol PostGroupPresentationLogic {
   func presentChangedColor(response: PostGroup.ChangeColor.Response)
   func presentLoadGroupData(response: PostGroup.LoadGroupData.Response)
-  func presentTouchedDoneButton(response: PostGroup.TouchDoneButton.Response)
+  func presentAfterTouchingDoneButton(response: PostGroup.TouchDoneButton.Response)
 }
 
 class PostGroupPresenter {
@@ -45,8 +45,8 @@ extension PostGroupPresenter: PostGroupPresentationLogic {
     self.viewController?.displayPayload(viewModel: viewModel)
   }
   
-  func presentTouchedDoneButton(response: PostGroup.TouchDoneButton.Response) {
+  func presentAfterTouchingDoneButton(response: PostGroup.TouchDoneButton.Response) {
     let viewModel = PostGroup.TouchDoneButton.ViewModel()
-    self.viewController?.displayTouchedDondButton(viewModel: viewModel)
+    self.viewController?.displayAfterTouchingDoneButton(viewModel: viewModel)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupRouter.swift
@@ -8,9 +8,12 @@
 import Foundation
 
 import PostGroupSceneAPI
+import PostGroupSceneEntity
 
 protocol PostGroupDataPassing {
   var dataStore: PostGroupDataStore? { get set }
+  
+  func routeToManageGroupScene()
 }
 
 class PostGroupRouter: PostGroupDataPassing {
@@ -18,5 +21,11 @@ class PostGroupRouter: PostGroupDataPassing {
   var dataStore: PostGroupDataStore?
   
   init() {
+  }
+  
+  // TODO: delegate 호출도 라우터에서 처리하자
+  
+  func routeToManageGroupScene() {
+    self.viewController?.navigationController?.popViewController(animated: true)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
@@ -74,7 +74,7 @@ extension PostGroupSceneBuilder {
     with payload: PostGroupScenePayloadable?,
     delegate: PostGroupSceneDelegate?
   ) {
-    viewController.router?.dataStore?.payload = payload
+    viewController.router?.dataStore?.currentGroup = payload?.group
     viewController.router?.dataStore?.delegate = delegate
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupSceneBuilder.swift
@@ -34,11 +34,14 @@ extension PostGroupSceneBuilder: PostGroupSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
-  public func build(with payload: PostGroupScenePayloadable?) -> PostGroupViewControllable {
+  public func build(
+    with payload: PostGroupScenePayloadable?,
+    delegate: PostGroupSceneDelegate?
+  ) -> PostGroupViewControllable {
     let postGroupViewController = self.configureVIPCycle(
       for: PostGroupViewController()
     )
-    self.loadGroupData(for: postGroupViewController, with: payload)
+    self.setPayload(for: postGroupViewController, with: payload, delegate: delegate)
     
     return postGroupViewController
   }
@@ -66,7 +69,12 @@ extension PostGroupSceneBuilder {
   /// - Parameters:
   ///   - viewController: 런타임 의존성을 설정할 ViewController 객체입니다.
   ///   - payload: 런타임에 전달할 의존성입니다.
-  private func loadGroupData(for viewController: PostGroupViewController, with payload: PostGroupScenePayloadable?) {
+  private func setPayload(
+    for viewController: PostGroupViewController,
+    with payload: PostGroupScenePayloadable?,
+    delegate: PostGroupSceneDelegate?
+  ) {
     viewController.router?.dataStore?.payload = payload
+    viewController.router?.dataStore?.delegate = delegate
   }
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -227,7 +227,7 @@ extension PostGroupViewController: PostGroupDisplayLogic {
   }
   
   func displayAfterTouchingDoneButton(viewModel: PostGroup.TouchDoneButton.ViewModel) {
-    self.navigationController?.popViewController(animated: true)
+    self.router?.routeToManageGroupScene()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -18,7 +18,7 @@ import ToDoGardenUIResource
 protocol PostGroupDisplayLogic: AnyObject {
   func displayChangedColor(viewModel: PostGroup.ChangeColor.ViewModel)
   func displayPayload(viewModel: PostGroup.LoadGroupData.ViewModel)
-  func displayTouchedDondButton(viewModel: PostGroup.TouchDoneButton.ViewModel)
+  func displayAfterTouchingDoneButton(viewModel: PostGroup.TouchDoneButton.ViewModel)
 }
 
 final class PostGroupViewController: UIViewController, PostGroupViewControllable {
@@ -226,8 +226,8 @@ extension PostGroupViewController: PostGroupDisplayLogic {
     self.doneBottomButton.isEnabled = viewModel.isDoneBottomButtonEnable
   }
   
-  func displayTouchedDondButton(viewModel: PostGroup.TouchDoneButton.ViewModel) {
-    print("Route to ManageGroupScene")
+  func displayAfterTouchingDoneButton(viewModel: PostGroup.TouchDoneButton.ViewModel) {
+    self.navigationController?.popViewController(animated: true)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupViewController.swift
@@ -154,7 +154,11 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
       ]
     )
     
-    self.colorPickButton.addAction( UIAction { _ in
+    self.colorPickButton.addAction( UIAction { [weak self] _ in
+      guard let self = self else {
+        return
+      }
+      
       postGroupBottomSheet.setupCurrentColor(color: self.postGroupColorPickerRow.getColor())
       self.present(postGroupBottomSheet, animated: true)
     }, for: UIControl.Event.touchUpInside)
@@ -177,13 +181,14 @@ final class PostGroupViewController: UIViewController, PostGroupViewControllable
     
     self.doneBottomButton.addAction(
       UIAction { [weak self] _ in
-        guard let groupName = self?.textInputView.getEditingText(),
-          let groupColor = self?.postGroupColorPickerRow.getColor() else {
+        guard let self = self,
+          let groupName = self.textInputView.getEditingText(),
+          let groupColor = self.postGroupColorPickerRow.getColor() else {
           return
         }
         
         let request = PostGroup.TouchDoneButton.Request(groupName: groupName, groupColor: groupColor)
-        self?.interactor?.touchDoneButton(request: request)
+        self.interactor?.touchDoneButton(request: request)
       },
       for: UIControl.Event.touchUpInside
     )

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupScene/PostGroupWorker.swift
@@ -8,17 +8,17 @@
 import UIKit.UIColor
 
 import PostGroupSceneAPI
+import PostGroupSceneEntity
 
 public struct PostGroupWorker: PostGroupWorkable {
   public init() {}
   
-  public func changeColor(groupColor: UIColor) {
-    // 서버에 hex를 요청 파이어베이스 명세에 따라 로직 변경 가능성 농후
-    // self.hexStringFromColor(color)
-  }
-  
-  public func touchDoneButton(groupID: String, groupName: String, groupColor: UIColor) {
+  public func touchDoneButton(groupID: UUID?, groupName: String, groupColor: UIColor) -> PostGroup.ToDoGroup {
     // 서버에 그룹 변경을 요청
+    // groupID가 nil 경우, 그룹추가하기
+    // groupID가 not nil 경우, 그룹편집하기
+    let group = PostGroup.ToDoGroup(groupID: groupID, groupName: groupName, groupColor: groupColor)
+    return group
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneBuildable.swift
@@ -9,9 +9,9 @@ import UIKit.UIColor
 
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
 public protocol PostGroupScenePayloadable {
-  var groupID: String? { get }
-  var groupName: String? { get }
-  var groupColor: UIColor? { get }
+  var groupID: UUID { get }
+  var groupName: String { get }
+  var groupColor: UIColor { get }
 }
 
 public protocol PostGroupSceneBuildable {

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneBuildable.swift
@@ -7,11 +7,11 @@
 
 import UIKit.UIColor
 
+import PostGroupSceneEntity
+
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
 public protocol PostGroupScenePayloadable {
-  var groupID: UUID { get }
-  var groupName: String { get }
-  var groupColor: UIColor { get }
+  var group: PostGroup.ToDoGroup { get }
 }
 
 public protocol PostGroupSceneBuildable {

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneBuildable.swift
@@ -18,5 +18,5 @@ public protocol PostGroupSceneBuildable {
   ///  VIP Cycle, 런타임 파라미터가 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 파라미터입니다.
   /// - Returns: 런타임 파라미터, VIP Cycle이 설정된 ViewController가 반환되도록 구현합니다.
-  func build(with payload: PostGroupScenePayloadable?) -> PostGroupViewControllable
+  func build(with payload: PostGroupScenePayloadable?, delegate: PostGroupSceneDelegate?) -> PostGroupViewControllable
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupSceneDelegate.swift
@@ -1,0 +1,14 @@
+//
+//  PostGroupSceneDelegate.swift
+//
+//
+//  Created by SONG on 9/12/24.
+//
+
+import Foundation
+import PostGroupSceneEntity
+
+public protocol PostGroupSceneDelegate: AnyObject {
+  func addGroup(group: PostGroup.ToDoGroup)
+  func editGroup(group: PostGroup.ToDoGroup)
+}

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneAPI/PostGroupWorkable.swift
@@ -7,11 +7,12 @@
 
 import UIKit.UIColor
 
+import PostGroupSceneEntity
+
 public protocol PostGroupWorkable {
-  func changeColor(groupColor: UIColor)
   func touchDoneButton(
-    groupID: String,
+    groupID: UUID?,
     groupName: String,
     groupColor: UIColor
-  )
+  ) -> PostGroup.ToDoGroup
 }

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneEntity/PostGroupModels.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneEntity/PostGroupModels.swift
@@ -8,6 +8,17 @@
 import UIKit.UIColor
 
 public enum PostGroup {
+  public struct ToDoGroup: Sendable {
+    public let groupID: UUID?
+    public var groupName: String?
+    public var groupColor: UIColor?
+    
+    public init(groupID: UUID?, groupName: String?, groupColor: UIColor?) {
+      self.groupID = groupID
+      self.groupName = groupName
+      self.groupColor = groupColor
+    }
+  }
   
   // MARK: Use cases
   public enum ChangeColor {
@@ -20,11 +31,9 @@ public enum PostGroup {
     }
     
     public struct Response {
-      public let groupID: String
       public let groupColor: UIColor
       
-      public init(groupID: String, groupColor: UIColor) {
-        self.groupID = groupID
+      public init(groupColor: UIColor) {
         self.groupColor = groupColor
       }
     }
@@ -87,18 +96,10 @@ public enum PostGroup {
     }
     
     public struct Response {
-      public let groupID: String
-      public let groupName: String
-      public let groupColor: UIColor
+      public let group: ToDoGroup
       
-      public init(
-        groupID: String,
-        groupName: String,
-        groupColor: UIColor
-      ) {
-        self.groupID = groupID
-        self.groupName = groupName
-        self.groupColor = groupColor
+      public init(group: ToDoGroup) {
+        self.group = group
       }
     }
     

--- a/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneEntity/PostGroupModels.swift
+++ b/ToDo-Garden/ToDo-Garden/PostGroupScene/Sources/PostGroupSceneEntity/PostGroupModels.swift
@@ -10,10 +10,10 @@ import UIKit.UIColor
 public enum PostGroup {
   public struct ToDoGroup: Sendable {
     public let groupID: UUID?
-    public var groupName: String?
-    public var groupColor: UIColor?
+    public var groupName: String
+    public var groupColor: UIColor
     
-    public init(groupID: UUID?, groupName: String?, groupColor: UIColor?) {
+    public init(groupID: UUID?, groupName: String, groupColor: UIColor) {
       self.groupID = groupID
       self.groupName = groupName
       self.groupColor = groupColor

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/ManageGroupTableViewCellAPI.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIAPI/ManageGroupTableViewCellAPI.swift
@@ -13,7 +13,7 @@ public protocol ManageGroupTableViewCellAPI: UITableViewCell {
   func leaveEditingMode()
   
   func applyModelPrimary(
-    id: String,
+    id: UUID,
     groupName: String,
     progressColor: UIColor,
     progressRate: Float,
@@ -21,7 +21,7 @@ public protocol ManageGroupTableViewCellAPI: UITableViewCell {
   )
   
   func applyModelSecondary(
-    id: String,
+    id: UUID,
     groupName: String,
     progressColor: UIColor,
     progressRate: Float
@@ -29,9 +29,9 @@ public protocol ManageGroupTableViewCellAPI: UITableViewCell {
   
   func update(color: UIColor?, progressRate: Float?, groupName: String?)
 
-  func setupRightButtonAction(handler: @escaping (String, String, UIColor) -> Void)
+  func setupRightButtonAction(handler: @escaping (UUID, String, UIColor) -> Void)
   
-  func setupGroupNameButtonAction(handler: @escaping (String) -> Void)
+  func setupGroupNameButtonAction(handler: @escaping (UUID) -> Void)
   
   func getIdentifier() -> String
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableViewCell.swift
@@ -17,8 +17,8 @@ public final class ManageGroupTableViewCell: UITableViewCell, ManageGroupTableVi
   private var groupNameButton: UIButton?
   private var rightImageButton: UIButton?
   
-  private var rightButtonActionHandler: ((String, String, UIColor) -> Void)?
-  private var groupNameButtonActionHandler: ((String) -> Void)?
+  private var rightButtonActionHandler: ((UUID, String, UIColor) -> Void)?
+  private var groupNameButtonActionHandler: ((UUID) -> Void)?
   
   public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     self.configuration = nil
@@ -65,7 +65,7 @@ public final class ManageGroupTableViewCell: UITableViewCell, ManageGroupTableVi
   }
   
   public func applyModelPrimary(
-    id: String,
+    id: UUID,
     groupName: String,
     progressColor: UIColor,
     progressRate: Float,
@@ -86,7 +86,7 @@ public final class ManageGroupTableViewCell: UITableViewCell, ManageGroupTableVi
   }
   
   public func applyModelSecondary(
-    id: String,
+    id: UUID,
     groupName: String,
     progressColor: UIColor,
     progressRate: Float
@@ -120,13 +120,13 @@ public final class ManageGroupTableViewCell: UITableViewCell, ManageGroupTableVi
     self.startAnimation()
   }
   
-  public func setupRightButtonAction(handler: @escaping (String, String, UIColor) -> Void) {
+  public func setupRightButtonAction(handler: @escaping (UUID, String, UIColor) -> Void) {
     self.rightButtonActionHandler = handler
     self.rightImageButton?.addAction(UIAction { [weak self] _ in
       self?.handleRightButtonAction()
     }, for: UIControl.Event.touchUpInside)
   }
-  public func setupGroupNameButtonAction(handler: @escaping (String) -> Void) {
+  public func setupGroupNameButtonAction(handler: @escaping (UUID) -> Void) {
     self.groupNameButtonActionHandler = handler
     self.groupNameButton?.addAction(UIAction { [weak self] _ in
       self?.handleGroupNameButtonAction()

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManagerGroupListTableViewCellModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManagerGroupListTableViewCellModel.swift
@@ -13,14 +13,14 @@ extension ManageGroupTableViewCell {
   public struct Configuration {
     public enum Style {
       case primary(
-        id: String,
+        id: UUID,
         groupName: String,
         progressColor: UIColor,
         progressRate: Float,
         isEditing: Bool
       )
       case secondary(
-        id: String,
+        id: UUID,
         groupName: String,
         progressColor: UIColor,
         progressRate: Float
@@ -137,13 +137,13 @@ extension ManageGroupTableViewCell {
     }
     
     struct Model {
-      let id: String
+      let id: UUID
       var progressCircle: ProgressCircle
       var groupNameButton: GroupNameButton
       var rightImageButton: RightImageView
       
       init(
-        id: String,
+        id: UUID,
         progressCircle: ProgressCircle,
         groupNameButton: GroupNameButton,
         rightImageButton: RightImageView
@@ -157,7 +157,7 @@ extension ManageGroupTableViewCell {
   }
   
   struct ModelParameters {
-    let id: String
+    let id: UUID
     let groupName: String
     let progressColor: UIColor
     let progressRate: Float


### PR DESCRIPTION
## 💡 관련 이슈
- #486 
- #488 
- #491 

위 세가지 브랜치를 머지한 브랜치 입니다. 

## 🎉 변경 사항
- 그룹 추가 / 편집 작업 이후 manageGroupScene으로 돌아가면서 UI 업데이트가 되는 동작을 구현하였습니다. 
- file_length에 대한 린트 제약을 ManageGroupViewController.swift 파일에서 풀었습니다. (lines: 422)

## 📌 PR Point

### 구현 상세 

- 아래 PR내용을 참고해주세요. 
- #486 
   ( PR : #487  ✅)
- #488 
   ( PR : #489  ✅)
- #491 
   ( PR : #492  ✅)

### 수정할 부분 
- delegate 메서드 호출부 Router로 이동 (#489와 관련된 부분)
- 현재 그룹 추가/ 편집 을 수행하면 아래와 같은 워닝이 표시됩니다. 
![스크린샷 2024-09-25 오후 5 16 39](https://github.com/user-attachments/assets/bb9787d8-05da-4353-8007-4b405160c2a6)

### 현재 PR의 files change가 너무 많은 관계로, 리뷰의 편의성을 위해 현재 PR 머지이후 #501 에서 진행될 예정입니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?