### PR TITLE
ShareGardenScene 완전한 동시성 검사 모드 활성화

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Package.swift
@@ -2,6 +2,10 @@
 
 import PackageDescription
 
+let swiftSettings: [SwiftSetting] = [
+  SwiftSetting.enableExperimentalFeature("StrictConcurrency")
+]
+
 let package = Package(
   name: "ShareGardenScene",
   platforms: [
@@ -65,3 +69,11 @@ let package = Package(
     )
   ]
 )
+
+for target in package.targets {
+  var swiftSettings = target.swiftSettings ?? []
+  swiftSettings.append(
+    SwiftSetting.enableExperimentalFeature("StrictConcurrency")
+  )
+  target.swiftSettings = swiftSettings
+}

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneSceneBuilder.swift
@@ -9,6 +9,7 @@ import Foundation
 
 import ShareGardenSceneAPI
 
+@MainActor
 public struct ShareGardenSceneSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsProfileContentConfiguration.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsProfileContentConfiguration.swift
@@ -5,7 +5,7 @@
 //  Created by Noah on 9/12/24.
 //
 
-import UIKit
+@preconcurrency import UIKit
 
 import ToDoGardenUIComponent
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsProfileContentConfiguration.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsProfileContentConfiguration.swift
@@ -24,7 +24,7 @@ extension ShareGardenSceneViewController {
       self.friendsGarden = friendsGarden
     }
     
-    var state: UICellConfigurationState?
+    private(set) var state: UICellConfigurationState?
     
     func updated(for state: UIConfigurationState) -> FriendsProfileContentConfiguration {
       var mutableCopyOfSelf = self

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneAPI/ShareGardenSceneSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneAPI/ShareGardenSceneSceneBuildable.swift
@@ -12,6 +12,7 @@ public protocol ShareGardenSceneScenePayloadable {
   // var name: String { get }
 }
 
+@MainActor
 public protocol ShareGardenSceneSceneBuildable {
   ///  VIP Cycle, 런타임 파라미터가 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 파라미터입니다.


### PR DESCRIPTION
## 💡 관련 이슈
- related: #299 
## 🎉 변경 사항
- [x] 모든 타겟 complete concurrency checking 활성화
- [x] 동시성 검사에 따른 경고 메시지 해결 

## 📌 PR Point
```swift

let swiftSettings: [SwiftSetting] = [
  SwiftSetting.enableExperimentalFeature("StrictConcurrency")
]

let package = Package(
  name: "ShareGardenScene",
  platforms: [
// ....
    )
  ]
)

for target in package.targets {
  var swiftSettings = target.swiftSettings ?? []
  swiftSettings.append(
    SwiftSetting.enableExperimentalFeature("StrictConcurrency")
  )
  target.swiftSettings = swiftSettings
}
```
- ShareGardenScene 패키지 내의 모든 타겟에 대해 complete concurrency checking을 적용하였습니다.


```swift
@preconcurrency import UIKit
/// import ...
/// import ...

struct FriendsProfileContentConfiguration: UIContentConfiguration, Identifiable {
    let id: UUID
    let friendsGarden: ShareGardenScene.FriendsGarden
    
    init(
      id: UUID,
      friendsGarden: ShareGardenScene.FriendsGarden
    ) {
      self.id = id
      self.friendsGarden = friendsGarden
    }
    
    private(set) var state: UICellConfigurationState?
    
    func updated(for state: UIConfigurationState) -> FriendsProfileContentConfiguration {
      var mutableCopyOfSelf = self
      
      mutableCopyOfSelf.state = state as? UICellConfigurationState
      
      return mutableCopyOfSelf
    }
    
    func makeContentView() -> UIView & UIContentView {
      return FriendsGardenProfileInfoView(configuration: self)
    }
  }
}

```

value semantics를 사용하는 구조체의 경우 모든 멤버가 Sendable해야 암시적 Sendable이 적용되어야 하지만,
UIKit의`UICellConfigurationState`의 경우 Sendable하지 않습니다.

UIKit의 경우 제가 수정할수 없는 모듈이기에 해당 타입의 암시적 Sendable을 채택할 수 있도록 하기 위해 preconcurrency 속성을 추가해 import해주었습니다.

또한 최소한의 안전장치로 외부에서의 mutation을 방지하기 위해 private(set)을 설정해주었습니다.


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?