### PR TITLE
가이드씬에서 활용될 그룹관리 화면 준비 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupMockData.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupMockData.swift
@@ -10,9 +10,9 @@ import Foundation
 import ManageGroupSceneEntity
 import ToDoGardenUIResource
 
-struct ManageGroupMockData {
+public struct ManageGroupMockData {
   
-  static let guideSceneData: [ManageGroup.ToDoGroup] = [
+  public static let guideSceneData: [ManageGroup.ToDoGroup] = [
     ManageGroup.ToDoGroup(groupName: "영어 독해", progressColor: .toDoGardenYellow, progressRate: 0.5),
     ManageGroup.ToDoGroup(groupName: "역사와 문화 이해", progressColor: .toDoGardenRed, progressRate: 0.5),
     ManageGroup.ToDoGroup(groupName: "디자인 창작", progressColor: .toDoGardenOlive, progressRate: 0.5)

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneConstants.swift
@@ -17,7 +17,10 @@ enum Constant {
   }
   
   enum Layout {
-    
+    enum BarButton {
+      static let width: CGFloat = 30.0
+      static let height: CGFloat = 20.0
+    }
     enum Cell {
       static let height: CGFloat = 45.0
     }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneConstants.swift
@@ -20,7 +20,6 @@ enum Constant {
     
     enum Cell {
       static let height: CGFloat = 45.0
-      static let cornerRadius: CGFloat = 18.0
     }
     enum FooterView {
       static let height: CGFloat = 50.0

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneConstants.swift
@@ -20,7 +20,7 @@ enum Constant {
     
     enum Cell {
       static let height: CGFloat = 45.0
-      static let cornerRadius: CGFloat = 15.0
+      static let cornerRadius: CGFloat = 18.0
     }
     enum FooterView {
       static let height: CGFloat = 50.0

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupTableViewDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupTableViewDelegate.swift
@@ -10,10 +10,10 @@ import UIKit
 import ManageGroupSceneEntity
 import ToDoGardenUIComponent
 
-final class ManageGroupTableViewDelegate: NSObject {
+public final class ManageGroupTableViewDelegate: NSObject {
   
   // MARK: - Properties
-  var displayedGroups: [ManageGroup.ToDoGroup]
+  public var displayedGroups: [ManageGroup.ToDoGroup]
   var displayedGroupsBeforeEditing: [ManageGroup.ToDoGroup]
   private let footerView: UIView
   
@@ -55,19 +55,19 @@ final class ManageGroupTableViewDelegate: NSObject {
 
 // MARK: - UITableViewDataSource
 extension ManageGroupTableViewDelegate: UITableViewDataSource {
-  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+  public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     return self.displayedGroups.count
   }
   
-  func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+  public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
     return Constant.Layout.Cell.height
   }
   
-  func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+  public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
     return Constant.Layout.FooterView.height
   }
   
-  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+  public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     guard let cell = tableView.dequeueReusableCell(
       withIdentifier: ManageGroupTableViewCell.identifier,
       for: indexPath
@@ -99,7 +99,7 @@ extension ManageGroupTableViewDelegate: UITableViewDataSource {
 
 // MARK: - UITableViewDelegate
 extension ManageGroupTableViewDelegate: UITableViewDelegate {
-  func tableView(
+  public func tableView(
     _ tableView: UITableView,
     commit editingStyle: UITableViewCell.EditingStyle,
     forRowAt indexPath: IndexPath
@@ -114,30 +114,30 @@ extension ManageGroupTableViewDelegate: UITableViewDelegate {
     }
   }
   
-  func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+  public func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
     return tableView.isEditing
   }
   
-  func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+  public func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
     return self.footerView
   }
 }
 
 // MARK: - UITableViewDragDelegate
 extension ManageGroupTableViewDelegate: UITableViewDragDelegate {
-  func tableView(_ tableView: UITableView, dragSessionWillBegin session: UIDragSession) {
+  public func tableView(_ tableView: UITableView, dragSessionWillBegin session: UIDragSession) {
     self.isReordering = true
   }
   
-  func tableView(_ tableView: UITableView, dragSessionDidEnd session: UIDragSession) {
+  public func tableView(_ tableView: UITableView, dragSessionDidEnd session: UIDragSession) {
     self.isReordering = false
   }
   
-  func tableView(_ tableView: UITableView, dragSessionAllowsMoveOperation session: UIDragSession) -> Bool {
+  public func tableView(_ tableView: UITableView, dragSessionAllowsMoveOperation session: UIDragSession) -> Bool {
     return tableView.isEditing
   }
   
-  func tableView(
+  public func tableView(
     _ tableView: UITableView,
     itemsForBeginning session: UIDragSession,
     at indexPath: IndexPath
@@ -150,7 +150,7 @@ extension ManageGroupTableViewDelegate: UITableViewDragDelegate {
 
 // MARK: - UITableViewDropDelegate
 extension ManageGroupTableViewDelegate: UITableViewDropDelegate {
-  func tableView(_ tableView: UITableView, performDropWith coordinator: UITableViewDropCoordinator) {
+  public func tableView(_ tableView: UITableView, performDropWith coordinator: UITableViewDropCoordinator) {
     guard let destinationIndexPath = coordinator.destinationIndexPath else { return }
     
     if coordinator.proposal.operation == UIDropOperation.move {
@@ -162,7 +162,7 @@ extension ManageGroupTableViewDelegate: UITableViewDropDelegate {
     }
   }
   
-  func tableView(
+  public func tableView(
     _ tableView: UITableView,
     dropSessionDidUpdate session: UIDropSession,
     withDestinationIndexPath destinationIndexPath: IndexPath?

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -36,6 +36,7 @@ open class ManageGroupViewController: UIViewController, ManageGroupViewControlla
   
   private let groupListTableViewCell: ManageGroupTableViewCell
   private var editModeLeftBarButton: UIBarButtonItem
+  private var rightBarButtonCustomView: UIButton
   // MARK: - Object lifecycle
   
   public init() {
@@ -44,10 +45,12 @@ open class ManageGroupViewController: UIViewController, ManageGroupViewControlla
       style: UITableViewCell.CellStyle.default,
       reuseIdentifier: ManageGroupTableViewCell.identifier
     )
-    self.rightBarButton = UIBarButtonItem()
+    self.rightBarButtonCustomView = UIButton(type: .system)
+    self.rightBarButton = UIBarButtonItem(customView: self.rightBarButtonCustomView)
     self.editModeLeftBarButton = UIBarButtonItem()
     self.manageGroupTableViewDelegate = nil
     self.footerView = UIView()
+    self.displayedGroups = []
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -101,14 +104,7 @@ open class ManageGroupViewController: UIViewController, ManageGroupViewControlla
 extension ManageGroupViewController {
   public func setupNavigationBar() {
     self.navigationItem.title = Constant.StringLiteral.navigationbarTitle
-    self.rightBarButton = UIBarButtonItem(
-      title: Constant.StringLiteral.rightBarButtonTitleEdit,
-      style: UIBarButtonItem.Style.plain,
-      target: self,
-      action: #selector(self.setEditingMode)
-    )
-    self.rightBarButton.tintColor = UIColor.toDoGardenOrange
-    self.navigationItem.setRightBarButton(self.rightBarButton, animated: true)
+    self.setupRightBarButton()
     self.editModeLeftBarButton = UIBarButtonItem(
       title: Constant.StringLiteral.leftBarButtonTitleSave,
       style: UIBarButtonItem.Style.plain,
@@ -119,14 +115,32 @@ extension ManageGroupViewController {
     self.navigationItem.setLeftBarButton(nil, animated: true)
   }
   
+  private func setupRightBarButton() {
+    self.rightBarButtonCustomView.setTitle(Constant.StringLiteral.rightBarButtonTitleEdit, for: .normal)
+    self.rightBarButtonCustomView.setTitleColor(UIColor.toDoGardenOrange, for: .normal)
+    self.rightBarButtonCustomView.addTarget(self, action: #selector(self.setEditingMode), for: .touchUpInside)
+    
+    self.rightBarButtonCustomView.usingAutolayout()
+    
+    NSLayoutConstraint.activate(
+      [
+        self.rightBarButtonCustomView.widthAnchor.constraint(equalToConstant: 30.0),
+        self.rightBarButtonCustomView.heightAnchor.constraint(equalToConstant: 20.0)
+      ]
+    )
+    self.rightBarButton = UIBarButtonItem(customView: self.rightBarButtonCustomView)
+
+    self.navigationItem.setRightBarButton(self.rightBarButton, animated: true)
+  }
+  
   @objc public func setEditingMode() {
-    self.rightBarButton.isEnabled = false
+    self.rightBarButtonCustomView.isEnabled = false
     let isEditingMode = self.groupListTableView.isEditing
     self.updateBarButtonItems(isEditingMode: isEditingMode)
     if isEditingMode {
       self.cancelEditing()
     }
-    self.rightBarButton.isEnabled = true
+    self.rightBarButtonCustomView.isEnabled = true
   }
   
   @objc private func saveAndOutEditingMode() {
@@ -135,17 +149,18 @@ extension ManageGroupViewController {
     if isEditingMode {
       self.saveGroupList()
     }
-    self.rightBarButton.isEnabled = true
+    self.rightBarButtonCustomView.isEnabled = true
   }
   
   private func updateBarButtonItems(isEditingMode: Bool) {
     self.groupListTableView.setEditingMode(!isEditingMode, animated: true)
     if isEditingMode {
-      self.rightBarButton.title = Constant.StringLiteral.rightBarButtonTitleEdit
+      self.rightBarButtonCustomView.setTitle(Constant.StringLiteral.rightBarButtonTitleEdit, for: .normal)
       self.navigationItem.setLeftBarButton(nil, animated: true)
     } else {
       self.navigationItem.setLeftBarButton(self.editModeLeftBarButton, animated: true)
-      self.rightBarButton.title = Constant.StringLiteral.rightBarButtonTitleCancel
+      self.rightBarButtonCustomView.setTitle(Constant.StringLiteral.rightBarButtonTitleCancel, for: .normal)
+      
       self.manageGroupTableViewDelegate?.displayedGroupsBeforeEditing =
       self.manageGroupTableViewDelegate?.displayedGroups ?? []
     }
@@ -174,7 +189,7 @@ extension ManageGroupViewController {
     self.setupTableViewNoBounce()
     self.setupTableViewLayout()
     self.manageGroupTableViewDelegate?.setOnReorderingStateChange { [weak self] isReordering in
-      self?.rightBarButton.isEnabled = !isReordering
+      self?.rightBarButtonCustomView.isEnabled = !isReordering
     }
   }
   
@@ -321,7 +336,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     newGroups: [ManageGroup.ToDoGroup]
   ) {
     let changes = calculateTableViewChanges(oldGroups: oldGroups, newGroups: newGroups)
-    self.rightBarButton.isEnabled = false
+    self.rightBarButtonCustomView.isEnabled = false
     Task { @MainActor in
       self.groupListTableView.performBatchUpdates({
         self.groupListTableView.deleteRows(at: changes.deletions, with: UITableView.RowAnimation.fade)
@@ -331,7 +346,7 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
         }
       }, completion: { _ in
         self.groupListTableView.reloadRows(at: changes.updates, with: UITableView.RowAnimation.fade)
-        self.rightBarButton.isEnabled = true
+        self.rightBarButtonCustomView.isEnabled = true
       })
     }
   }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -152,12 +152,21 @@ extension ManageGroupViewController {
     }
   }
   
-  func setupTableView() {
+  func setupTableView(isForGuide: Bool = false) {
+    self.groupListTableView.backgroundColor = .clear
     self.footerView = self.buildAddGroupFooterButton()
-    self.manageGroupTableViewDelegate = ManageGroupTableViewDelegate(
-      displayedGroups: [],
-      footerView: self.footerView
-    )
+    if !isForGuide {
+      self.manageGroupTableViewDelegate = ManageGroupTableViewDelegate(
+        displayedGroups: self.displayedGroups,
+        footerView: self.footerView
+      )
+    } else {
+      self.manageGroupTableViewDelegate = ManageGroupTableViewDelegate(
+        displayedGroups: self.displayedGroups,
+        footerView: UIView()
+      )
+    }
+    
     self.groupListTableView.delegate = self.manageGroupTableViewDelegate
     self.groupListTableView.dataSource = self.manageGroupTableViewDelegate
     self.groupListTableView.dragDelegate = self.manageGroupTableViewDelegate

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -22,24 +22,23 @@ protocol ManageGroupDisplayLogic: AnyObject {
   func displayEditedGroup(viewModel: ManageGroup.EditGroup.ViewModel)
 }
 
-public class ManageGroupViewController: UIViewController, ManageGroupViewControllable {
+open class ManageGroupViewController: UIViewController, ManageGroupViewControllable {
   // MARK: - VIP Properties
   
   var interactor: ManageGroupBusinessLogic?
   var router: (ManageGroupRoutingLogic & ManageGroupDataPassing)?
-  
+  public let groupListTableView: ManageGroupTableView
+  public var manageGroupTableViewDelegate: ManageGroupTableViewDelegate?
   public var rightBarButton: UIBarButtonItem
   public var footerView: UIView
   
   var displayedGroups: [ManageGroup.ToDoGroup]
-  var manageGroupTableViewDelegate: ManageGroupTableViewDelegate?
-  public let groupListTableView: ManageGroupTableView
   
   private let groupListTableViewCell: ManageGroupTableViewCell
   private var editModeLeftBarButton: UIBarButtonItem
   // MARK: - Object lifecycle
   
-  init() {
+  public init() {
     self.groupListTableView = ManageGroupTableView()
     self.groupListTableViewCell = ManageGroupTableViewCell(
       style: UITableViewCell.CellStyle.default,
@@ -53,13 +52,13 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
   }
   
   @available(*, unavailable)
-  required init?(coder: NSCoder) {
+  required public init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
   
   // MARK: - View lifecycle
   
-  public override func viewDidLoad() {
+  open override func viewDidLoad() {
     super.viewDidLoad()
     self.view.backgroundColor = UIColor.white
     self.setupTableView()
@@ -100,7 +99,7 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
 
 // MARK: - Setup
 extension ManageGroupViewController {
-  func setupNavigationBar() {
+  public func setupNavigationBar() {
     self.navigationItem.title = Constant.StringLiteral.navigationbarTitle
     self.rightBarButton = UIBarButtonItem(
       title: Constant.StringLiteral.rightBarButtonTitleEdit,
@@ -152,7 +151,7 @@ extension ManageGroupViewController {
     }
   }
   
-  func setupTableView(isForGuide: Bool = false) {
+  public func setupTableView(isForGuide: Bool = false) {
     self.groupListTableView.backgroundColor = .clear
     self.footerView = self.buildAddGroupFooterButton()
     if !isForGuide {

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -124,8 +124,8 @@ extension ManageGroupViewController {
     
     NSLayoutConstraint.activate(
       [
-        self.rightBarButtonCustomView.widthAnchor.constraint(equalToConstant: 30.0),
-        self.rightBarButtonCustomView.heightAnchor.constraint(equalToConstant: 20.0)
+        self.rightBarButtonCustomView.widthAnchor.constraint(equalToConstant: Constant.Layout.BarButton.width),
+        self.rightBarButtonCustomView.heightAnchor.constraint(equalToConstant: Constant.Layout.BarButton.height)
       ]
     )
     self.rightBarButton = UIBarButtonItem(customView: self.rightBarButtonCustomView)

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -27,10 +27,14 @@ public class ManageGroupViewController: UIViewController, ManageGroupViewControl
   
   var interactor: ManageGroupBusinessLogic?
   var router: (ManageGroupRoutingLogic & ManageGroupDataPassing)?
-  var manageGroupTableViewDelegate: ManageGroupTableViewDelegate?
-  let groupListTableView: ManageGroupTableView
+  
   public var rightBarButton: UIBarButtonItem
   public var footerView: UIView
+  
+  var displayedGroups: [ManageGroup.ToDoGroup]
+  var manageGroupTableViewDelegate: ManageGroupTableViewDelegate?
+  public let groupListTableView: ManageGroupTableView
+  
   private let groupListTableViewCell: ManageGroupTableViewCell
   private var editModeLeftBarButton: UIBarButtonItem
   // MARK: - Object lifecycle
@@ -116,7 +120,8 @@ extension ManageGroupViewController {
     self.navigationItem.setLeftBarButton(nil, animated: true)
   }
   
-  @objc private func setEditingMode() {
+  @objc public func setEditingMode() {
+    self.rightBarButton.isEnabled = false
     let isEditingMode = self.groupListTableView.isEditing
     self.updateBarButtonItems(isEditingMode: isEditingMode)
     if isEditingMode {

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -45,7 +45,7 @@ open class ManageGroupViewController: UIViewController, ManageGroupViewControlla
       style: UITableViewCell.CellStyle.default,
       reuseIdentifier: ManageGroupTableViewCell.identifier
     )
-    self.rightBarButtonCustomView = UIButton(type: .system)
+    self.rightBarButtonCustomView = UIButton(type: UIButton.ButtonType.system)
     self.rightBarButton = UIBarButtonItem(customView: self.rightBarButtonCustomView)
     self.editModeLeftBarButton = UIBarButtonItem()
     self.manageGroupTableViewDelegate = nil
@@ -116,9 +116,13 @@ extension ManageGroupViewController {
   }
   
   private func setupRightBarButton() {
-    self.rightBarButtonCustomView.setTitle(Constant.StringLiteral.rightBarButtonTitleEdit, for: .normal)
-    self.rightBarButtonCustomView.setTitleColor(UIColor.toDoGardenOrange, for: .normal)
-    self.rightBarButtonCustomView.addTarget(self, action: #selector(self.setEditingMode), for: .touchUpInside)
+    self.rightBarButtonCustomView.setTitle(Constant.StringLiteral.rightBarButtonTitleEdit, for: UIButton.State.normal)
+    self.rightBarButtonCustomView.setTitleColor(UIColor.toDoGardenOrange, for: UIButton.State.normal)
+    self.rightBarButtonCustomView.addTarget(
+      self,
+      action: #selector(self.setEditingMode),
+      for: UIControl.Event.touchUpInside
+    )
     
     self.rightBarButtonCustomView.usingAutolayout()
     
@@ -155,11 +159,14 @@ extension ManageGroupViewController {
   private func updateBarButtonItems(isEditingMode: Bool) {
     self.groupListTableView.setEditingMode(!isEditingMode, animated: true)
     if isEditingMode {
-      self.rightBarButtonCustomView.setTitle(Constant.StringLiteral.rightBarButtonTitleEdit, for: .normal)
+      self.rightBarButtonCustomView.setTitle(Constant.StringLiteral.rightBarButtonTitleEdit, for: UIButton.State.normal)
       self.navigationItem.setLeftBarButton(nil, animated: true)
     } else {
       self.navigationItem.setLeftBarButton(self.editModeLeftBarButton, animated: true)
-      self.rightBarButtonCustomView.setTitle(Constant.StringLiteral.rightBarButtonTitleCancel, for: .normal)
+      self.rightBarButtonCustomView.setTitle(
+        Constant.StringLiteral.rightBarButtonTitleCancel,
+        for: UIButton.State.normal
+      )
       
       self.manageGroupTableViewDelegate?.displayedGroupsBeforeEditing =
       self.manageGroupTableViewDelegate?.displayedGroups ?? []

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
@@ -11,12 +11,6 @@ import ToDoGardenUIComponent
 
 public final class ManageGroupViewControllerForGuide: ManageGroupViewController {
   
-  public lazy var groupCells: [UITableViewCell] = {
-    self.groupListTableView.layoutIfNeeded()
-    let cells = self.groupListTableView.visibleCells
-    return cells
-  }()
-  
   public override init() {
     super.init()
   }
@@ -31,7 +25,7 @@ public final class ManageGroupViewControllerForGuide: ManageGroupViewController 
   override func fetchGroupList() {
     let fetchedData = ManageGroupMockData.guideSceneData
     self.manageGroupTableViewDelegate?.displayedGroups = fetchedData
-    self.groupListTableView.reloadData()
+  }
   }
 }
 
@@ -39,13 +33,11 @@ public final class ManageGroupViewControllerForGuide: ManageGroupViewController 
 @available(iOS 17.0, *)
 #Preview {
   let viewController = ManageGroupViewControllerForGuide()
-  viewController.loadViewIfNeeded()
-  viewController.footerView.backgroundColor = .red
-  viewController.groupCells.forEach { cell in
-    cell.backgroundColor = .green
-  }
   
-  let naviController = UINavigationController(rootViewController: viewController)
-  return naviController
+  // 실험용 dimmedView 추가
+  let dimmedView = UIView(frame: viewController.view.bounds)
+  dimmedView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+  viewController.view.addSubview(dimmedView)
+  
 }
 #endif

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
@@ -47,16 +47,3 @@ public final class ManageGroupViewControllerForGuide: ManageGroupViewController 
     )
   }
 }
-
-#if DEBUG
-@available(iOS 17.0, *)
-#Preview {
-  let viewController = ManageGroupViewControllerForGuide()
-  
-  // 실험용 dimmedView 추가
-  let dimmedView = UIView(frame: viewController.view.bounds)
-  dimmedView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
-  viewController.view.addSubview(dimmedView)
-  
-}
-#endif

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
@@ -31,8 +31,6 @@ public final class ManageGroupViewControllerForGuide: ManageGroupViewController 
   }
   
   private func setFooterViewForGuide() {
-    self.footerView.layer.cornerRadius = Constant.Layout.Cell.cornerRadius
-    self.footerView.layer.masksToBounds = true
     self.footerView.usingAutolayout()
     self.view.addSubview(self.footerView)
     

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewControllerForGuide.swift
@@ -8,24 +8,45 @@
 import UIKit
 
 import ToDoGardenUIComponent
+import ToDoGardenUIConstant
 
 public final class ManageGroupViewControllerForGuide: ManageGroupViewController {
   
   public override init() {
     super.init()
   }
-
+  
   public override func viewDidLoad() {
     self.view.backgroundColor = UIColor.white
-    self.setupTableView()
+    self.setupTableView(isForGuide: true)
     self.setupNavigationBar()
     self.fetchGroupList()
+    self.setFooterViewForGuide()
+    self.view.isUserInteractionEnabled = false
   }
   
   override func fetchGroupList() {
     let fetchedData = ManageGroupMockData.guideSceneData
     self.manageGroupTableViewDelegate?.displayedGroups = fetchedData
   }
+  
+  private func setFooterViewForGuide() {
+    self.footerView.layer.cornerRadius = Constant.Layout.Cell.cornerRadius
+    self.footerView.layer.masksToBounds = true
+    self.footerView.usingAutolayout()
+    self.view.addSubview(self.footerView)
+    
+    NSLayoutConstraint.activate(
+      [
+        self.footerView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+        self.footerView.topAnchor.constraint(
+          equalTo: self.groupListTableView.topAnchor,
+          constant: Constant.Layout.Cell.height * 3
+        ),
+        self.footerView.leadingAnchor.constraint(equalTo: self.groupListTableView.leadingAnchor),
+        self.footerView.heightAnchor.constraint(equalToConstant: Constant.Layout.FooterView.height)
+      ]
+    )
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #443 

## 🎉 변경 사항
- 가이드씬에서 활용될 그룹관리VC를 준비합니다. 

## 📌 PR Point
-> ManageGroupViewControllerForGuide는 기존의 ManageGroupViewController에서 I,P를 떼어낸 GuideScene만을 위한 객체입니다.  인터랙터를 거치지 않고, 3개의 그룹셀과, 하나의 푸터셀을 가진 테이블뷰를 표시합니다. 
-> ManageGroupViewControllerForGuide는 일부 수정되어 다음PR에서 CommonViews로 옮겨갈 예정입니다. 

- setTableView() 메서드에 플래그 역할을 하는 파라미터를 추가하였습니다. 
   - 해당 플래그에 의해서 가이드씬에서 사용할 TableView임이 확인되면, footerView는 TableView에 속하지 않고 footerView자리에 독립적으로 표시됩니다. (투명영역의 frame을 얻을때 TableView와 FooterView를 분리하기 위함)
- ManageGroupViewControllerForGuide이 CommonViews로 옮겨졌을때, 정상적으로 동작할 수 있게 접근제어자를 재설정합니다. 
(public / open) 
- UIBarButtonItem의 CGRect값을 얻기가 까다로워서 UIBarButtonItem.customView를 이용하기 위해 rightBarButtonCustomView를 customView에 할당하여 사용합니다. 
- 이제 코너값을 View에 설정하지 않아도, TransparentRegion에서 코너값을 가진 구멍을 만들 수 있으므로 cornerRadius constant를 제거하였습니다. 


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?