### PR TITLE
ShareGardenSceneWorker Stub 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Package.swift
@@ -42,6 +42,7 @@ let package = Package(
     .target(
       name: "ShareGardenSceneAPI",
       dependencies: [
+        "ShareGardenSceneEntity",
         Target.Dependency.product(
           name: "ToDoGardenUIAPI",
           package: "ToDoGardenUI"

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneWorker.swift
@@ -8,6 +8,15 @@
 import Foundation
 
 import ShareGardenSceneAPI
+import ShareGardenSceneEntity
 
+// TODO: - ShareGardenSceneWorker 빈 구현 대체
 struct ShareGardenSceneWorker: ShareGardenSceneWorkable {
+  func requestFriendsGardenList() async throws -> [ShareGardenScene.FriendsGarden] {
+    return []
+  }
+  
+  func delete(by id: ShareGardenScene.FriendsGarden.ID) async throws {
+    return
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/TestDouble/ShareGardenSceneWorkerStub.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/TestDouble/ShareGardenSceneWorkerStub.swift
@@ -58,6 +58,18 @@ final class ShareGardenSceneWorkerStub: ShareGardenSceneWorkable {
 
     return friendsGardens
   }
+  
+  var isThrowErrorForDelete: Bool = false
+
+  func delete(by id: ShareGardenScene.FriendsGarden.ID) async throws {
+    defer { self.isThrowErrorForDelete.toggle() }
+
+    try await Task.sleep(nanoseconds: 1_000_000_000 )
+
+    if self.isThrowErrorForDelete {
+      throw NSError(domain: "", code: 99999)
+    }
+  }
 }
 #endif
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/TestDouble/ShareGardenSceneWorkerStub.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/TestDouble/ShareGardenSceneWorkerStub.swift
@@ -1,0 +1,64 @@
+// swiftlint:disable all
+//
+//  ShareGardenSceneWorkerStub.swift
+//  ShareGardenScene
+//
+//  Created by Noah on 10/1/24.
+//
+
+#if DEBUG
+import Foundation
+
+import ToDoGardenUIComponent
+
+import ShareGardenSceneAPI
+import ShareGardenSceneEntity
+
+
+final class ShareGardenSceneWorkerStub: ShareGardenSceneWorkable {
+  func requestFriendsGardenList() async throws -> [ShareGardenScene.FriendsGarden] {
+    var pomodoroRecords = [PomodoroRecord]()
+
+    let calendar = Calendar.current
+
+    let startDateComponents = DateComponents(year: 2024, month: 6, day: 14)
+    let date = calendar.date(from: startDateComponents)!
+
+    for i in 0..<140 {
+      let currentDate = calendar.date(byAdding: .day, value: i, to: date)!
+      let pomodoroCount = Int.random(in: 0...10) // Random pomodoro count between 0 and 10
+      let formattedDate = calendar.date(
+        from: DateComponents(
+          year: calendar.component(.year, from: currentDate),
+          month: calendar.component(.month, from: currentDate),
+          day: calendar.component(.day, from: currentDate)
+        )
+      )!
+      let pomodoroRecord = PomodoroRecord(date: formattedDate, pomodoroCount: pomodoroCount)
+      pomodoroRecords.append(pomodoroRecord)
+    }
+
+    let nicknames = ["강운", "노아", "우드", "울버린"]
+    var friendsGardens = [ShareGardenScene.FriendsGarden]()
+
+    for _ in 0..<25 {
+      let randomNickname = nicknames.randomElement()!
+      let randomFocusStreakDays = Int.random(in: 1...30)
+      let randomPomodoroRecords = PomodoroRecordCollection(pomodoroRecords: pomodoroRecords.shuffled())
+
+      let friendsGarden = ShareGardenScene.FriendsGarden(
+        nickname: randomNickname,
+        focusStreakDays: randomFocusStreakDays,
+        pomodoroRecords: randomPomodoroRecords
+      )
+      friendsGardens.append(friendsGarden)
+    }
+
+    try await Task.sleep(nanoseconds: 2_000_000_000 )
+
+    return friendsGardens
+  }
+}
+#endif
+
+// swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneAPI/ShareGardenSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneAPI/ShareGardenSceneWorkable.swift
@@ -7,5 +7,8 @@
 
 import Foundation
 
+import ShareGardenSceneEntity
+
 public protocol ShareGardenSceneWorkable {
+  func requestFriendsGardenList() async throws -> [ShareGardenScene.FriendsGarden]
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneAPI/ShareGardenSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneAPI/ShareGardenSceneWorkable.swift
@@ -11,4 +11,5 @@ import ShareGardenSceneEntity
 
 public protocol ShareGardenSceneWorkable {
   func requestFriendsGardenList() async throws -> [ShareGardenScene.FriendsGarden]
+  func delete(by id: ShareGardenScene.FriendsGarden.ID) async throws
 }


### PR DESCRIPTION
## 💡 관련 이슈
- related: #299 
## 🎉 변경 사항
- [x] ShareGardenSceneWorker Stub 추가
## 📌 PR Point
- 디버깅 환경에서 ShareGardenSceneWorkable 의존성을 대체하기 위해 Stub을 ShareGardenSceneWorker Stub을 추가하였습니다.

- 현재 친구의 가든 삭제 관련 에러 처리는 되어있으나, 요청 관련 에러처리는 되어있지않아(에러를 알리는 뷰 표시 예정)친구의 가든 삭제 요청만 교대로 에러가 발생하도록 하였습니다.
```swift
var isThrowErrorForDelete: Bool = false

func delete(by id: ShareGardenScene.FriendsGarden.ID) async throws {
  defer { self.isThrowErrorForDelete.toggle() }

  try await Task.sleep(nanoseconds: 1_000_000_000 )

  if self.isThrowErrorForDelete {
    throw NSError(domain: "", code: 99999)
  }
}
```

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?