### PR TITLE
친구의 가든 목록 요청 VIP Cycle 연결

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneInteractor.swift
@@ -92,11 +92,10 @@ extension ShareGardenSceneInteractor {
       guard let stream = self?.friendsGardenDataStore.stream
       else { return }
       defer { self?.tasks[TaskKey.observeFriendsGardenStoreStream] = nil }
-
+      
       for await friendsGardens in stream {
-        // stream에서 받은 값을 기반으로 뷰 업데이트
-        // let response = ShareGardenScene.RequestFriendsGardenList.Response(friendsGardenList: friendsGardens)
-        // await self?.presenter?.presentFriendsGardens(response: response)
+        let response = ShareGardenScene.RequestFriendsGardenList.Response(friendsGardenList: friendsGardens)
+        self?.presenter?.presentFriendsGardens(response: response)
       }
     }
   }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneInteractor.swift
@@ -50,6 +50,8 @@ extension ShareGardenSceneInteractor: ShareGardenSceneBusinessLogic {
         // TODO: - worker에 FriendsGardenList 비동기 요청
         // let friendsGardenList = try await self.shareGardenSceneWorker.requestFriendsGardenList()
         if Task.isCancelled { return }
+        
+        self.presenter?.stopShimmeringFriendsGardenList()
         // TODO: - friends Garden data store 업데이트
         // self.friendsGardenStore.update(to: friendsGardenList)
       } catch {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenScenePresenter.swift
@@ -12,6 +12,7 @@ import ShareGardenSceneEntity
 @MainActor
 protocol ShareGardenScenePresentationLogic {
   func presentFriendsGardens(response: ShareGardenScene.RequestFriendsGardenList.Response)
+  func stopShimmeringFriendsGardenList()
 }
 
 final class ShareGardenScenePresenter {
@@ -27,5 +28,9 @@ extension ShareGardenScenePresenter: ShareGardenScenePresentationLogic {
     self.viewController?.displayFriendsGardenList(
       ShareGardenScene.RequestFriendsGardenList.ViewModel(identifiers: identifiers)
     )
+  }
+  
+  func stopShimmeringFriendsGardenList() {
+    self.viewController?.stopShimmeringFriendsGardenList()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenScenePresenter.swift
@@ -11,6 +11,7 @@ import ShareGardenSceneEntity
 
 @MainActor
 protocol ShareGardenScenePresentationLogic {
+  func presentFriendsGardens(response: ShareGardenScene.RequestFriendsGardenList.Response)
 }
 
 final class ShareGardenScenePresenter {
@@ -20,4 +21,11 @@ final class ShareGardenScenePresenter {
 // MARK: - Request to ViewController
 
 extension ShareGardenScenePresenter: ShareGardenScenePresentationLogic {
+  func presentFriendsGardens(response: ShareGardenScene.RequestFriendsGardenList.Response) {
+    let identifiers = response.friendsGardenList.map(\.id)
+    
+    self.viewController?.displayFriendsGardenList(
+      ShareGardenScene.RequestFriendsGardenList.ViewModel(identifiers: identifiers)
+    )
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -13,6 +13,7 @@ import ShareGardenSceneEntity
 @MainActor
 protocol ShareGardenSceneDisplayLogic: AnyObject {
   func displayFriendsGardenList(_ viewModel: ShareGardenScene.RequestFriendsGardenList.ViewModel)
+  func stopShimmeringFriendsGardenList()
 }
 
 final class ShareGardenSceneViewController: UIViewController, ShareGardenSceneViewControllable {
@@ -54,6 +55,10 @@ final class ShareGardenSceneViewController: UIViewController, ShareGardenSceneVi
 
 extension ShareGardenSceneViewController: ShareGardenSceneDisplayLogic {
   func displayFriendsGardenList(_ viewModel: ShareGardenScene.RequestFriendsGardenList.ViewModel) {
+    // TODO: - view update
+  }
+  
+  func stopShimmeringFriendsGardenList() {
     // TODO: - view update
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -12,6 +12,7 @@ import ShareGardenSceneEntity
 
 @MainActor
 protocol ShareGardenSceneDisplayLogic: AnyObject {
+  func displayFriendsGardenList(_ viewModel: ShareGardenScene.RequestFriendsGardenList.ViewModel)
 }
 
 final class ShareGardenSceneViewController: UIViewController, ShareGardenSceneViewControllable {
@@ -52,6 +53,9 @@ final class ShareGardenSceneViewController: UIViewController, ShareGardenSceneVi
 // MARK: - Conform to display logic protocol
 
 extension ShareGardenSceneViewController: ShareGardenSceneDisplayLogic {
+  func displayFriendsGardenList(_ viewModel: ShareGardenScene.RequestFriendsGardenList.ViewModel) {
+    // TODO: - view update
+  }
 }
 
 // MARK: - Request to interactor

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -52,8 +52,19 @@ final class ShareGardenSceneViewController: UIViewController, ShareGardenSceneVi
     super.viewDidLoad()
     self.setup()
   }
+ 
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    self.cleanUpViewResources()
+  }
   
-  // MARK: - View lifecycle
+  deinit {
+    // TODO: - Swift6.x `isolated deinit` 구현에 따라 바뀔 예정입니다.
+    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0371-isolated-synchronous-deinit.md
+    Task { @MainActor [weak self] in
+      self?.cleanUpViewResources()
+    }
+  }
 }
 
 // MARK: - Conform to display logic protocol
@@ -74,6 +85,10 @@ extension ShareGardenSceneViewController {
   private func updateViewContents() {
     self.friendsGardenView.startShimmeringAnimation()
     self.interactor?.requestFriendsGardenList()
+  }
+  
+  private func cleanUpViewResources() {
+    self.interactor?.cancelEntireTask()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -43,6 +43,11 @@ final class ShareGardenSceneViewController: UIViewController, ShareGardenSceneVi
  
   // MARK: - View life cycle
 
+  override func viewIsAppearing(_ animated: Bool) {
+    super.viewIsAppearing(animated)
+    self.updateViewContents()
+  }
+  
   override func viewDidLoad() {
     super.viewDidLoad()
     self.setup()
@@ -66,6 +71,9 @@ extension ShareGardenSceneViewController: ShareGardenSceneDisplayLogic {
 // MARK: - Request to interactor
 
 extension ShareGardenSceneViewController {
+  private func updateViewContents() {
+    self.interactor?.requestFriendsGardenList()
+  }
 }
 
 // MARK: - Setup

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -72,6 +72,7 @@ extension ShareGardenSceneViewController: ShareGardenSceneDisplayLogic {
 
 extension ShareGardenSceneViewController {
   private func updateViewContents() {
+    self.friendsGardenView.startShimmeringAnimation()
     self.interactor?.requestFriendsGardenList()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneEntity/ShareGardenSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneEntity/ShareGardenSceneModels.swift
@@ -10,8 +10,6 @@ import Foundation
 import ToDoGardenUIComponent
 
 public enum ShareGardenScene {
-  // MARK: Use cases
-  
   public struct FriendsGarden: Identifiable, Sendable {
     public let id: UUID
     public let nickname: String
@@ -28,6 +26,26 @@ public enum ShareGardenScene {
       self.nickname = nickname
       self.focusStreakDays = focusStreakDays
       self.pomodoroRecords = pomodoroRecords
+    }
+  }
+  
+  // MARK: Use cases
+  
+  public enum RequestFriendsGardenList {
+    public struct Response: Sendable {
+      public let friendsGardenList: [FriendsGarden]
+      
+      public init(friendsGardenList: [FriendsGarden]) {
+        self.friendsGardenList = friendsGardenList
+      }
+    }
+    
+    public struct ViewModel: Sendable {
+      public let identifiers: [UUID]
+      
+      public init(identifiers: [UUID]) {
+        self.identifiers = identifiers
+      }
     }
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- related: #299
- related: #300 

## 🎉 변경 사항
- [x] 친구의 가든 목록 요청 VIP Cycle 연결

## 📌 PR Point
- 친구의 가든 목록을 요청하는 VIP Cycle을 연결하였습니다.
- async stream에 suspend 된 작업이 재개될 때 반환받은 최신의 friendsGardenList값을 토대로 뷰에 업데이트 하는 흐름을 연결하였습니다.
- view lifecycle에 따라 친구의 가든 목록을 요청하는 함수를 추가하였습니다.

- deinit의 경우 현재 mainactor isolation이 적용되지 않아 동시성 관련 경고를 제거하기 위한 조치를 하였습니다.
 - deinit 작업 특성상 중단되지 않아 task를 handling할 필요가 없을 것 같아 따로 변수에 할당하지 않았습니다.

isolated deinit은 현재 논의중인 상태이며, 해당 내용 구현에 따라 현재의 deinit도 바뀔 예정이며, 관련 주석을 추가하였습니다.

proposal link: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0371-isolated-synchronous-deinit.md
```swift
deinit {
  // TODO: - Swift6.x `isolated deinit` 구현에 따라 바뀔 예정입니다.
  // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0371-isolated-synchronous-deinit.md
  Task { @MainActor [weak self] in
    self?.cleanUpViewResources()
  }
}
```

## 📝 셀프체크리스트
- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?