### PR TITLE
FriendsGardenListView UI 업데이트 기능 구현

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -75,7 +75,7 @@ extension ShareGardenSceneViewController: ShareGardenSceneDisplayLogic {
   }
   
   func stopShimmeringFriendsGardenList() {
-    // TODO: - view update
+    self.friendsGardenView.stopShimmeringAnimation()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -71,7 +71,7 @@ final class ShareGardenSceneViewController: UIViewController, ShareGardenSceneVi
 
 extension ShareGardenSceneViewController: ShareGardenSceneDisplayLogic {
   func displayFriendsGardenList(_ viewModel: ShareGardenScene.RequestFriendsGardenList.ViewModel) {
-    // TODO: - view update
+    self.friendsGardenView.displayFriendsGardenList(viewModel.identifiers)
   }
   
   func stopShimmeringFriendsGardenList() {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -97,17 +97,8 @@ extension ShareGardenSceneViewController.FriendsGardenView {
       self.friendsGardenListDataSource.apply(Snapshot())
     }
     
-    func append(_ identifiers: [ShareGardenScene.FriendsGarden.ID]) {
-      var snapshot = self.friendsGardenListDataSource.snapshot()
-      if snapshot.sectionIdentifiers.contains(Section.main) == false {
-        snapshot.appendSections([Section.main])
-      }
-      
-      let firendsGardens: [ShareGardenScene.FriendsGarden] = identifiers.compactMap {
-        return self.friendsGardenStore?.fetch(by: $0)
-      }
-      let sectionSnapshot = self.makeSectionSnapshot(for: firendsGardens)
-      
+    func displayFriendsGardenList(_ identifiers: [ShareGardenScene.FriendsGarden.ID]) {
+      let sectionSnapshot = self.makeSectionSnapshot(using: identifiers)
       self.friendsGardenListDataSource.apply(sectionSnapshot, to: Section.main)
     }
   }
@@ -115,19 +106,21 @@ extension ShareGardenSceneViewController.FriendsGardenView {
 
 extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView {
   private func makeSectionSnapshot(
-    for friendsGardens: [ShareGardenScene.FriendsGarden]
+    using identifiers: [ShareGardenScene.FriendsGarden.ID]
   ) -> NSDiffableDataSourceSectionSnapshot<Item> {
     var sectionSnapshot = NSDiffableDataSourceSectionSnapshot<Item>()
     
+    let friendsGardens: [ShareGardenScene.FriendsGarden] = identifiers.compactMap { identifier in
+      return self.friendsGardenStore?.fetch(by: identifier)
+    }
+    
     let friendsGardenItems: [Item] = friendsGardens.map { friendsGarden in
-      let item = Item.friendsGarden(
+      return Item.friendsGarden(
         ShareGardenSceneViewController.FriendsGardenContentConfiguration(
           id: friendsGarden.id,
           pomodoroRecords: friendsGarden.pomodoroRecords
         )
       )
-      
-      return item
     }
     
     let combined = zip(friendsGardens, friendsGardenItems)

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -192,15 +192,20 @@ extension ShareGardenSceneViewController.FriendsGardenView.FriendsGardenListView
     guard let indexPath = indexPath,
       let cell = self.friendListView.cellForItem(at: indexPath)?.contentView as? ShareGardenSceneViewController
       .FriendsGardenProfileInfoView,
-      cell.isExpanded == false
+      cell.isExpanded == false,
+      let item = self.friendsGardenListDataSource.itemIdentifier(for: indexPath),
+      case let Item.friendsProfile(configuration) = item
     else {
       return nil
     }
+    
+    let identifier = configuration.id
         
     let deleteAction = UIContextualAction(
       style: UIContextualAction.Style.destructive,
       title: nil
     ) { _, _, _ in
+      self.friendsGardenStore?.delete(by: identifier)
     }
     deleteAction.accessibilityLabel = "Delete"
     deleteAction.image = UIImage(systemName: "trash")

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -76,6 +76,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     func startShimmeringAnimation(numberOfCells: Int) {
       self.isUserInteractionEnabled = false
       var snapshot = self.friendsGardenListDataSource.snapshot()
+      snapshot.deleteAllItems()
       
       if snapshot.sectionIdentifiers.contains(Section.main) == false {
         snapshot.appendSections([Section.main])

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -71,7 +71,7 @@ extension ShareGardenSceneViewController {
     }
     
     func displayFriendsGardenList(_ identifiers: [UUID]) {
-      
+      self.friendsGardenListView.displayFriendsGardenList(identifiers)
     }
     
     func startShimmeringAnimation() {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -70,8 +70,8 @@ extension ShareGardenSceneViewController {
       }
     }
     
-    func append(_ identifiers: [ShareGardenScene.FriendsGarden.ID]) {
-      self.friendsGardenListView.append(identifiers)
+    func displayFriendsGardenList(_ identifiers: [UUID]) {
+      
     }
     
     func startShimmeringAnimation() {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsProfileContentConfiguration.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsProfileContentConfiguration.swift
@@ -72,17 +72,14 @@ extension ShareGardenSceneViewController {
     
     // MARK: - UI Properties
     
-    /// 링크의 issue가 close되면, 구현이 바뀌게 될 예정입니다.
-    ///
-    /// [이슈 링크](https://github.com/ToDo-Garden/ToDo-Garden/issues/439)
     private let profileInfoView: Styled.Row = {
       let profileInfoViewConfiguration = Styled.Row.Configuration.self
       let profileInfoView = Styled.Row(
         configuration: profileInfoViewConfiguration.profile(
           profileInfoViewConfiguration.ProfileModel(
             style: profileInfoViewConfiguration.ProfileModel.Style.shareRow,
-            title: "이인우",
-            description: "연속 19일 집중!"
+            title: "",
+            description: ""
           )
         )
       )
@@ -137,6 +134,7 @@ extension ShareGardenSceneViewController.FriendsGardenProfileInfoView {
     
     self.isExpanded = state.isExpanded
     self.isEditing = state.isEditing
+    self.updateProfileInfoView(using: configuration.friendsGarden)
   }
   
   private func setup() {
@@ -152,6 +150,17 @@ extension ShareGardenSceneViewController.FriendsGardenProfileInfoView {
   
   private func addSubviews() {
     self.addSubview(self.profileInfoView)
+  }
+  
+  private func updateProfileInfoView(using friendsGarden: ShareGardenScene.FriendsGarden) {
+    let configuration = Styled.Row.Configuration.self
+    self.profileInfoView.configuration = configuration.profile(
+      configuration.ProfileModel.init(
+        style: configuration.ProfileModel.Style.shareRow,
+        title: friendsGarden.nickname,
+        description: "연속 \(friendsGarden.focusStreakDays)일 집중"
+      )
+    )
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- related: #299 #300 #298 
## 🎉 변경 사항
- [x] FriendsGardenListView UI 업데이트 기능 구현

## 📌 PR Point
- VIP요청 흐름에 따라 갱신되는 데이터를 UI에 반영하는 기능을 구현하였습니다.
- 별도의 계산을 하지 않고 `interactor`의 `asyncStream`을 통해 수신 받은 값을 기반으로 매번 최신 요소를 넣어주어 이전 snapshot과 diff연산이 자연스럽게 이루어지도록 하여 코드의 복잡도를 낮추었습니다.
```swift
func displayFriendsGardenList(_ identifiers: [ShareGardenScene.FriendsGarden.ID]) {
  let sectionSnapshot = self.makeSectionSnapshot(using: identifiers)
  self.friendsGardenListDataSource.apply(sectionSnapshot, to: Section.main)
}
```
## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?