### PR TITLE
InputTextValidationView 수정

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/InputTextValidationView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/InputTextValidationView.swift
@@ -35,6 +35,10 @@ public final class InputTextValidationView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
 
+  public func setBeginEditing(with text: String) {
+    self.textInputView.setBeginEditing(with: text)
+  }
+
   public func showValidationText() {
     self.moveValidationTextLabel(isShowing: true)
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/InputTextValidationView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/InputTextValidationView.swift
@@ -39,6 +39,10 @@ public final class InputTextValidationView: UIView {
     self.textInputView.setBeginEditing(with: text)
   }
 
+  public func getEditingText() -> String? {
+    return textInputView.getEditingText()
+  }
+
   public func showValidationText() {
     self.moveValidationTextLabel(isShowing: true)
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #516 

## 🎉 변경 사항
- #504 에서 구현했던 InputTextValidationView에 일부 기능을 추가하였습니다.

## 📌 PR Point
- 추가한 기능은 다음과 같습니다.

1. `setBeginEditing`: 텍스트를 입력창에 설정하고, 입력모드로 변경하는 메서드입니다. 
    - `이미 입력된 텍스트가 존재할 때` 사용됩니다. (닉네임 수정 화면에서 이미 닉네임이 존재할 때)

2. `getEditingText`: 입력된 텍스트를 반환하는 메서드입니다.
    - `입력된 텍스트로 서버에 요청이 필요할 때` 사용됩니다. (닉네임 수정, 등등)

``` Swift
let inputTextValidationView = InputTextValidationView(
  inputText: "닉네임",
  validationText: Constant.InputTextValidationView.StringLiteral.ValidationText.invalidNickname
)

inputTextValidationView.setBeginEditing(text: "우드") // 기존 텍스트 설정 & 입력모드 진입

let text = inputTextValidationView.getEditingText() // 현재 입력된 텍스트 반환
```

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?