### PR TITLE
EditUserNameScene VIP 사이클 구현

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
@@ -23,6 +23,8 @@ protocol EditUserNameSceneBusinessLogic {
 final class EditUserNameSceneInteractor: EditUserNameSceneDataStore {
   var userName: String?
 
+  private var editUserNameTask: Task<Void, Never>?
+
   var presenter: EditUserNameScenePresentationLogic?
   private let editUserNameWorker: EditUserNameSceneWorkable
 
@@ -44,6 +46,22 @@ extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {
   }
 
   func requestEditUserName(_ userName: String) {
+    guard self.isValidNickname(userName)
+    else { return }
+
+    self.editUserNameTask = Task { [weak self] in
+      guard let self else { return }
+
+      defer { self.editUserNameTask = nil }
+      if Task.isCancelled { return }
+
+      do {
+        try await self.editUserNameWorker.requestEditUserName(userName)
+        await self.presenter?.presentEditUserNameResult(nil)
+      } catch let error {
+        await self.presenter?.presentEditUserNameResult(error)
+      }
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
@@ -15,7 +15,6 @@ protocol EditUserNameSceneDataStore {
 }
 
 protocol EditUserNameSceneBusinessLogic {
-  func doSomething(request: EditUserNameScene.Something.Request)
 }
 
 class EditUserNameSceneInteractor: EditUserNameSceneDataStore {
@@ -30,11 +29,4 @@ class EditUserNameSceneInteractor: EditUserNameSceneDataStore {
 
 // MARK: - Request to worker
 
-extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {
-  func doSomething(request: EditUserNameScene.Something.Request) {
-    self.editUserNameWorker.doSomeWork()
-    
-    let response = EditUserNameScene.Something.Response()
-    self.presenter?.presentSomething(response: response)
-  }
-}
+extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {}

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
@@ -15,9 +15,10 @@ protocol EditUserNameSceneDataStore {
 }
 
 protocol EditUserNameSceneBusinessLogic {
+  func setUserName()
 }
 
-class EditUserNameSceneInteractor: EditUserNameSceneDataStore {
+final class EditUserNameSceneInteractor: EditUserNameSceneDataStore {
   var userName: String?
 
   var presenter: EditUserNameScenePresentationLogic?
@@ -31,4 +32,7 @@ class EditUserNameSceneInteractor: EditUserNameSceneDataStore {
 // MARK: - Request to worker
 
 extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {
+  func setUserName() {
+    self.presenter?.presentUserName(self.userName)
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
@@ -61,6 +61,8 @@ extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {
 
       do {
         try await self.editUserNameWorker.requestEditUserName(userName)
+
+        try Task.checkCancellation()
         await self.presenter?.presentEditUserNameResult(nil)
       } catch let error {
         if error as? CancellationError != nil { return }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
@@ -65,7 +65,7 @@ extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {
         try Task.checkCancellation()
         await self.presenter?.presentEditUserNameResult(nil)
       } catch let error {
-        if error as? CancellationError != nil { return }
+        if let cancellationError = error as? CancellationError { return }
         await self.presenter?.presentEditUserNameResult(error)
       }
     }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
@@ -38,6 +38,15 @@ extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {
   }
 
   func verifyUserName(_ userName: String) {
-    print(userName)
+    let isValid = self.isValidNickname(userName)
+    self.presenter?.presentUserNameVerification(isValid: isValid)
+  }
+}
+
+extension EditUserNameSceneInteractor {
+  private func isValidNickname(_ nickName: String) -> Bool {
+    let regexPattern = "^[\\p{L}\\p{N}]{5,12}$"
+    let result = nickName.range(of: regexPattern, options: String.CompareOptions.regularExpression)
+    return result != nil
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
@@ -31,6 +31,10 @@ final class EditUserNameSceneInteractor: EditUserNameSceneDataStore {
   init(editUserNameWorker: EditUserNameSceneWorkable) {
     self.editUserNameWorker = editUserNameWorker
   }
+
+  deinit {
+    self.editUserNameTask?.cancel()
+  }
 }
 
 // MARK: - Request to worker

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
@@ -63,6 +63,7 @@ extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {
         try await self.editUserNameWorker.requestEditUserName(userName)
         await self.presenter?.presentEditUserNameResult(nil)
       } catch let error {
+        if error as? CancellationError != nil { return }
         await self.presenter?.presentEditUserNameResult(error)
       }
     }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
@@ -16,6 +16,7 @@ protocol EditUserNameSceneDataStore {
 
 protocol EditUserNameSceneBusinessLogic {
   func setUserName()
+  func verifyUserName(_ userName: String)
 }
 
 final class EditUserNameSceneInteractor: EditUserNameSceneDataStore {
@@ -34,5 +35,9 @@ final class EditUserNameSceneInteractor: EditUserNameSceneDataStore {
 extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {
   func setUserName() {
     self.presenter?.presentUserName(self.userName)
+  }
+
+  func verifyUserName(_ userName: String) {
+    print(userName)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
@@ -17,6 +17,7 @@ protocol EditUserNameSceneDataStore {
 protocol EditUserNameSceneBusinessLogic {
   func setUserName()
   func verifyUserName(_ userName: String)
+  func requestEditUserName(_ userName: String)
 }
 
 final class EditUserNameSceneInteractor: EditUserNameSceneDataStore {
@@ -40,6 +41,9 @@ extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {
   func verifyUserName(_ userName: String) {
     let isValid = self.isValidNickname(userName)
     self.presenter?.presentUserNameVerification(isValid: isValid)
+  }
+
+  func requestEditUserName(_ userName: String) {
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
@@ -1,6 +1,6 @@
 //
 //  EditUserNameSceneInteractor.swift
-//  
+//
 //
 //  Created by Wood on 9/23/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
@@ -11,14 +11,15 @@ import EditUserNameSceneAPI
 import EditUserNameSceneEntity
 
 protocol EditUserNameSceneDataStore {
-  // var name: String { get set }
+  var userName: String? { get }
 }
 
 protocol EditUserNameSceneBusinessLogic {
 }
 
 class EditUserNameSceneInteractor: EditUserNameSceneDataStore {
-  // var name: String = ""
+  var userName: String?
+
   var presenter: EditUserNameScenePresentationLogic?
   private let editUserNameWorker: EditUserNameSceneWorkable
 
@@ -29,4 +30,5 @@ class EditUserNameSceneInteractor: EditUserNameSceneDataStore {
 
 // MARK: - Request to worker
 
-extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {}
+extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {
+}

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
@@ -18,6 +18,8 @@ protocol EditUserNameSceneBusinessLogic {
   func setUserName()
   func verifyUserName(_ userName: String)
   func requestEditUserName(_ userName: String)
+
+  func cancelAllTasks()
 }
 
 final class EditUserNameSceneInteractor: EditUserNameSceneDataStore {
@@ -33,7 +35,7 @@ final class EditUserNameSceneInteractor: EditUserNameSceneDataStore {
   }
 
   deinit {
-    self.editUserNameTask?.cancel()
+    self.cancelAllTasks()
   }
 }
 
@@ -69,6 +71,12 @@ extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {
         await self.presenter?.presentEditUserNameResult(error)
       }
     }
+  }
+}
+
+extension EditUserNameSceneInteractor {
+  func cancelAllTasks() {
+    self.editUserNameTask?.cancel()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
@@ -30,6 +30,10 @@ extension EditUserNameScenePresenter: EditUserNameScenePresentationLogic {
   }
 
   func presentUserNameVerification(isValid: Bool) {
-    
+    if isValid {
+      self.viewController?.displayUserNameValid()
+    } else {
+      self.viewController?.displayUserNameInvalid()
+    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
@@ -10,7 +10,6 @@ import Foundation
 import EditUserNameSceneEntity
 
 protocol EditUserNameScenePresentationLogic {
-  func presentSomething(response: EditUserNameScene.Something.Response)
 }
 
 class EditUserNameScenePresenter {
@@ -20,8 +19,4 @@ class EditUserNameScenePresenter {
 // MARK: - Request to ViewController
 
 extension EditUserNameScenePresenter: EditUserNameScenePresentationLogic {
-  func presentSomething(response: EditUserNameScene.Something.Response) {
-    let viewModel = EditUserNameScene.Something.ViewModel()
-    self.viewController?.displaySomething(viewModel: viewModel)
-  }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
@@ -12,6 +12,7 @@ import EditUserNameSceneEntity
 protocol EditUserNameScenePresentationLogic {
   func presentUserName(_ userName: String?)
   func presentUserNameVerification(isValid: Bool)
+  @MainActor func presentEditUserNameResult(_ error: Error?)
 }
 
 class EditUserNameScenePresenter {
@@ -21,6 +22,9 @@ class EditUserNameScenePresenter {
 // MARK: - Request to ViewController
 
 extension EditUserNameScenePresenter: EditUserNameScenePresentationLogic {
+  func presentEditUserNameResult(_ error: Error?) {
+  }
+  
   func presentUserName(_ userName: String?) {
     if let userName {
       self.viewController?.displayUserName(userName)

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
@@ -11,6 +11,7 @@ import EditUserNameSceneEntity
 
 protocol EditUserNameScenePresentationLogic {
   func presentUserName(_ userName: String?)
+  func presentUserNameVerification(isValid: Bool)
 }
 
 class EditUserNameScenePresenter {
@@ -26,5 +27,9 @@ extension EditUserNameScenePresenter: EditUserNameScenePresentationLogic {
     } else {
       self.viewController?.displayEmptyUserName()
     }
+  }
+
+  func presentUserNameVerification(isValid: Bool) {
+    
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
@@ -10,6 +10,7 @@ import Foundation
 import EditUserNameSceneEntity
 
 protocol EditUserNameScenePresentationLogic {
+  func presentUserName(_ userName: String?)
 }
 
 class EditUserNameScenePresenter {
@@ -19,4 +20,5 @@ class EditUserNameScenePresenter {
 // MARK: - Request to ViewController
 
 extension EditUserNameScenePresenter: EditUserNameScenePresentationLogic {
+  func presentUserName(_ userName: String?) {}
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
@@ -20,5 +20,11 @@ class EditUserNameScenePresenter {
 // MARK: - Request to ViewController
 
 extension EditUserNameScenePresenter: EditUserNameScenePresentationLogic {
-  func presentUserName(_ userName: String?) {}
+  func presentUserName(_ userName: String?) {
+    if let userName {
+      self.viewController?.displayUserName(userName)
+    } else {
+      self.viewController?.displayEmptyUserName()
+    }
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
@@ -23,6 +23,9 @@ class EditUserNameScenePresenter {
 
 extension EditUserNameScenePresenter: EditUserNameScenePresentationLogic {
   func presentEditUserNameResult(_ error: Error?) {
+    if error != nil {
+      self.viewController?.displayEditUserNameSuccess()
+    }
   }
   
   func presentUserName(_ userName: String?) {

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
@@ -15,7 +15,7 @@ protocol EditUserNameScenePresentationLogic {
   @MainActor func presentEditUserNameResult(_ error: Error?)
 }
 
-class EditUserNameScenePresenter {
+final class EditUserNameScenePresenter {
   weak var viewController: EditUserNameSceneDisplayLogic?
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneRouter.swift
@@ -10,6 +10,7 @@ import Foundation
 import EditUserNameSceneAPI
 
 protocol EditUserNameSceneRoutingLogic {
+  func routeToUserInfoScene()
 }
 
 protocol EditUserNameSceneDataPassing {
@@ -24,6 +25,9 @@ class EditUserNameSceneRouter: EditUserNameSceneDataPassing {
 // MARK: - Routing
 
 extension EditUserNameSceneRouter: EditUserNameSceneRoutingLogic {
+  func routeToUserInfoScene() {
+    self.viewController?.navigationController?.popViewController(animated: true)
+  }
 }
 
 // MARK: - Declare Payload for scene

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneRouter.swift
@@ -10,7 +10,6 @@ import Foundation
 import EditUserNameSceneAPI
 
 protocol EditUserNameSceneRoutingLogic {
-  func routeToSomewhere()
 }
 
 protocol EditUserNameSceneDataPassing {
@@ -25,8 +24,6 @@ class EditUserNameSceneRouter: EditUserNameSceneDataPassing {
 // MARK: - Routing
 
 extension EditUserNameSceneRouter: EditUserNameSceneRoutingLogic {
-  func routeToSomewhere() {
-  }
 }
 
 // MARK: - Declare Payload for scene

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
@@ -59,11 +59,13 @@ final class EditUserNameSceneViewController: UIViewController, EditUserNameScene
 
 extension EditUserNameSceneViewController: EditUserNameSceneDisplayLogic {
   func displayUserName(_ userName: String) {
-    
+    self.inputUserNameView.setBeginEditing(with: userName)
+    self.editUserNameButton.isEnabled = true
   }
   
   func displayEmptyUserName() {
-
+    self.inputUserNameView.setBeginEditing(with: "")
+    self.editUserNameButton.isEnabled = false
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
@@ -100,6 +100,16 @@ extension EditUserNameSceneViewController {
       }
       .store(in: &self.cancellables)
   }
+
+  private func setupEditUserNameButtonAction() {
+    self.editUserNameButton.primaryAction = UIAction { [weak self] _ in
+      guard let self else { return }
+
+      if let userName = self.inputUserNameView.getEditingText() {
+        self.interactor?.requestEditUserName(userName)
+      }
+    }
+  }
 }
 
 // MARK: - Subview Delegate Functions
@@ -128,6 +138,7 @@ extension EditUserNameSceneViewController {
   }
 
   private func setupEditUserNameButton() {
+    self.setupEditUserNameButtonAction()
     let horizontalOffset = Constant.Layout.EditUserNameButton.titleHorizontalOffset
     self.editUserNameButton.setTitlePositionAdjustment(
       UIOffset(horizontal: -horizontalOffset, vertical: 0),

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
@@ -14,7 +14,6 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 protocol EditUserNameSceneDisplayLogic: AnyObject {
-  func displaySomething(viewModel: EditUserNameScene.Something.ViewModel)
 }
 
 final class EditUserNameSceneViewController: UIViewController, EditUserNameSceneViewControllable {
@@ -46,25 +45,17 @@ final class EditUserNameSceneViewController: UIViewController, EditUserNameScene
   override func viewDidLoad() {
     super.viewDidLoad()
     self.setupUI()
-    self.doSomething()
   }
 }
 
 // MARK: - Confirm display logic protocol
 
 extension EditUserNameSceneViewController: EditUserNameSceneDisplayLogic {
-  func displaySomething(viewModel: EditUserNameScene.Something.ViewModel) {
-    // self.nameTextField.text = viewModel.name
-  }
 }
 
 // MARK: - Request to interactor
 
 extension EditUserNameSceneViewController {
-  func doSomething() {
-    let request = EditUserNameScene.Something.Request()
-    self.interactor?.doSomething(request: request)
-  }
 }
 
 // MARK: - Set up UI

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
@@ -14,6 +14,8 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 protocol EditUserNameSceneDisplayLogic: AnyObject {
+  func displayUserName(_ userName: String)
+  func displayEmptyUserName()
 }
 
 final class EditUserNameSceneViewController: UIViewController, EditUserNameSceneViewControllable {
@@ -56,6 +58,13 @@ final class EditUserNameSceneViewController: UIViewController, EditUserNameScene
 // MARK: - Confirm display logic protocol
 
 extension EditUserNameSceneViewController: EditUserNameSceneDisplayLogic {
+  func displayUserName(_ userName: String) {
+    
+  }
+  
+  func displayEmptyUserName() {
+
+  }
 }
 
 // MARK: - Request to interactor

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
@@ -18,6 +18,8 @@ import ToDoGardenUIResource
 protocol EditUserNameSceneDisplayLogic: AnyObject {
   func displayUserName(_ userName: String)
   func displayEmptyUserName()
+  func displayUserNameValid()
+  func displayUserNameInvalid()
 }
 
 final class EditUserNameSceneViewController: UIViewController, EditUserNameSceneViewControllable {
@@ -73,6 +75,16 @@ extension EditUserNameSceneViewController: EditUserNameSceneDisplayLogic {
   func displayEmptyUserName() {
     self.inputUserNameView.setBeginEditing(with: "")
     self.editUserNameButton.isEnabled = false
+  }
+
+  func displayUserNameInvalid() {
+    self.inputUserNameView.showValidationText()
+    self.editUserNameButton.isEnabled = false
+  }
+
+  func displayUserNameValid() {
+    self.inputUserNameView.hideValidationText()
+    self.editUserNameButton.isEnabled = true
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
@@ -5,10 +5,12 @@
 //  Created by Wood on 9/23/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
+import Combine
 import UIKit
 
 import EditUserNameSceneAPI
 import EditUserNameSceneEntity
+import ToDoGardenUIAPI
 import ToDoGardenUIComponent
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
@@ -22,6 +24,9 @@ final class EditUserNameSceneViewController: UIViewController, EditUserNameScene
   private let editUserNameButton: UIBarButtonItem
   private let inputUserNameView: InputTextValidationView
 
+  private var inputUserNameSubject: PassthroughSubject<String, Never>
+  private var cancellables: Set<AnyCancellable>
+
   var interactor: EditUserNameSceneBusinessLogic?
   var router: (EditUserNameSceneRoutingLogic & EditUserNameSceneDataPassing)?
 
@@ -34,6 +39,8 @@ final class EditUserNameSceneViewController: UIViewController, EditUserNameScene
       inputText: constant.TextInputView.StringLiteral.Model.userNickname,
       validationText: constant.InputTextValidationView.StringLiteral.ValidationText.invalidNickname
     )
+    self.inputUserNameSubject = PassthroughSubject<String, Never>()
+    self.cancellables = Set<AnyCancellable>()
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -72,6 +79,25 @@ extension EditUserNameSceneViewController: EditUserNameSceneDisplayLogic {
 // MARK: - Request to interactor
 
 extension EditUserNameSceneViewController {
+  private func bindInputTextChanged() {
+    self.inputUserNameView.delegate = self
+    self.inputUserNameSubject
+      .debounce(for: .seconds(0.7), scheduler: RunLoop.main)
+      .sink { [weak self] inputUserName in
+        self?.interactor?.verifyUserName(inputUserName)
+      }
+      .store(in: &self.cancellables)
+  }
+}
+
+// MARK: - Subview Delegate Functions
+
+extension EditUserNameSceneViewController: InputTextValidationViewDelegate {
+  func inputTextDidChanged(_ text: String?) {
+    if let inputUserName = self.inputUserNameView.getEditingText() {
+      self.inputUserNameSubject.send(inputUserName)
+    }
+  }
 }
 
 // MARK: - Set up UI
@@ -80,6 +106,7 @@ extension EditUserNameSceneViewController {
   private func setupUI() {
     self.setupMainView()
     self.setupEditUserNameButton()
+    self.bindInputTextChanged()
     self.setupInputNameViewLayout()
   }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
@@ -20,6 +20,7 @@ protocol EditUserNameSceneDisplayLogic: AnyObject {
   func displayEmptyUserName()
   func displayUserNameValid()
   func displayUserNameInvalid()
+  func displayEditUserNameSuccess()
 }
 
 final class EditUserNameSceneViewController: UIViewController, EditUserNameSceneViewControllable {
@@ -85,6 +86,10 @@ extension EditUserNameSceneViewController: EditUserNameSceneDisplayLogic {
   func displayUserNameValid() {
     self.inputUserNameView.hideValidationText()
     self.editUserNameButton.isEnabled = true
+  }
+
+  func displayEditUserNameSuccess() {
+    self.router?.routeToUserInfoScene()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
@@ -46,6 +46,11 @@ final class EditUserNameSceneViewController: UIViewController, EditUserNameScene
     super.viewDidLoad()
     self.setupUI()
   }
+
+  override func viewIsAppearing(_ animated: Bool) {
+    super.viewIsAppearing(animated)
+    self.interactor?.setUserName()
+  }
 }
 
 // MARK: - Confirm display logic protocol

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
@@ -94,7 +94,7 @@ extension EditUserNameSceneViewController {
   private func bindInputTextChanged() {
     self.inputUserNameView.delegate = self
     self.inputUserNameSubject
-      .debounce(for: .seconds(0.7), scheduler: RunLoop.main)
+      .debounce(for: .seconds(0.5), scheduler: RunLoop.main)
       .sink { [weak self] inputUserName in
         self?.interactor?.verifyUserName(inputUserName)
       }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
@@ -63,6 +63,15 @@ final class EditUserNameSceneViewController: UIViewController, EditUserNameScene
     super.viewIsAppearing(animated)
     self.interactor?.setUserName()
   }
+
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    self.interactor?.cancelAllTasks()
+  }
+
+  deinit {
+    self.interactor?.cancelAllTasks()
+  }
 }
 
 // MARK: - Confirm display logic protocol

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
@@ -1,6 +1,6 @@
 //
 //  EditUserNameSceneViewController.swift
-//  
+//
 //
 //  Created by Wood on 9/23/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
@@ -22,9 +22,9 @@ final class EditUserNameSceneViewController: UIViewController, EditUserNameScene
 
   var interactor: EditUserNameSceneBusinessLogic?
   var router: (EditUserNameSceneRoutingLogic & EditUserNameSceneDataPassing)?
-  
+
   // MARK: - Object lifecycle
-  
+
   init() {
     self.editUserNameButton = UIBarButtonItem()
     let constant = ToDoGardenUIConstant.Constant.self
@@ -34,14 +34,14 @@ final class EditUserNameSceneViewController: UIViewController, EditUserNameScene
     )
     super.init(nibName: nil, bundle: nil)
   }
-  
+
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
-  
+
   // MARK: - View lifecycle
-  
+
   override func viewDidLoad() {
     super.viewDidLoad()
     self.setupUI()

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneWorker.swift
@@ -10,6 +10,4 @@ import Foundation
 import EditUserNameSceneAPI
 
 struct EditUserNameSceneWorker: EditUserNameSceneWorkable {
-  func doSomeWork() {
-  }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneWorker.swift
@@ -10,4 +10,7 @@ import Foundation
 import EditUserNameSceneAPI
 
 struct EditUserNameSceneWorker: EditUserNameSceneWorkable {
+  func requestEditUserName(_ userName: String) async throws {
+    
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneWorker.swift
@@ -10,6 +10,7 @@ import Foundation
 import EditUserNameSceneAPI
 
 struct EditUserNameSceneWorker: EditUserNameSceneWorkable {
+  // TODO: 서버에 닉네임 수정 요청을 하는 메서드로, 서버가 완성되면 구현할 예정입니다.
   func requestEditUserName(_ userName: String) async throws {
     
   }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneWorker.swift
@@ -11,7 +11,5 @@ import EditUserNameSceneAPI
 
 struct EditUserNameSceneWorker: EditUserNameSceneWorkable {
   // TODO: 서버에 닉네임 수정 요청을 하는 메서드로, 서버가 완성되면 구현할 예정입니다.
-  func requestEditUserName(_ userName: String) async throws {
-    try Task.checkCancellation()
-  }
+  func requestEditUserName(_ userName: String) async throws {}
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneWorker.swift
@@ -12,6 +12,6 @@ import EditUserNameSceneAPI
 struct EditUserNameSceneWorker: EditUserNameSceneWorkable {
   // TODO: 서버에 닉네임 수정 요청을 하는 메서드로, 서버가 완성되면 구현할 예정입니다.
   func requestEditUserName(_ userName: String) async throws {
-    
+    try Task.checkCancellation()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameSceneAPI/EditUserNameSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameSceneAPI/EditUserNameSceneWorkable.swift
@@ -8,4 +8,5 @@
 import Foundation
 
 public protocol EditUserNameSceneWorkable {
+  func requestEditUserName(_ userName: String) async throws
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameSceneAPI/EditUserNameSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameSceneAPI/EditUserNameSceneWorkable.swift
@@ -8,5 +8,4 @@
 import Foundation
 
 public protocol EditUserNameSceneWorkable {
-  func doSomeWork()
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #509

## 🎉 변경 사항
- 닉네임 수정 화면에 유스케이스에 맞는 VIP 사이클을 구현하였습니다.
- [관련 기술서](https://www.notion.so/6e420303e66e43e68479f6be136554cf?pvs=4)

## 📌 PR Point
### 1. 닉네임 출력 VIP
- UserInfoScene에서 닉네임을 `Payload로 런타임에 전달`받을 예정입니다.
- 해당 구현사항은 다음 PR에서 진행할 예정입니다.

<img width="500" alt="스크린샷 2024-10-02 17 44 22" src="https://github.com/user-attachments/assets/2f8fc644-2fc8-418d-9d6a-5c87939d8f3a">

### 2. 입력 닉네임 유효성 검사 VIP
- 사용자가 입력한 닉네임이 올바른지 유효성 검사를 합니다.
  - `Debounce`를 이용하여 비즈니스 로직 호출에 간격을 주었습니다.
- 입력조건 불일치시, 조건을 `애니메이션`으로 보여주고 `완료버튼을 비활성화`합니다.

<img width="250" src="https://github.com/user-attachments/assets/8f640a4b-149a-4f54-aa1b-795d7002dabb">

### 3. 닉네임 수정 요청 VIP
- 닉네임 수정 요청에 `성공하면 이전화면으로 이동`하도록 구현하였습니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?