### PR TITLE
ShareGardenScene preview dependency 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneSceneBuilder.swift
@@ -29,6 +29,13 @@ public struct ShareGardenSceneSceneBuilder {
   }
 }
 
+extension ShareGardenSceneSceneBuilder.Dependency {
+#if DEBUG
+  @MainActor
+  public static let preview = Self(shareGardenSceneWorker: ShareGardenSceneWorkerStub())
+#endif
+}
+
 extension ShareGardenSceneSceneBuilder: ShareGardenSceneSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneSceneBuilder.swift
@@ -31,11 +31,9 @@ public struct ShareGardenSceneSceneBuilder {
 
 extension ShareGardenSceneSceneBuilder: ShareGardenSceneSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
-  /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
-  public func build(with payload: ShareGardenSceneScenePayloadable) -> ShareGardenSceneViewControllable {
+  public func build() -> ShareGardenSceneViewControllable {
     let shareGardenScene = self.configuredVIPCycleShareGardenScene()
-    self.setPayload(for: shareGardenScene, with: payload)
     
     return shareGardenScene
   }
@@ -57,15 +55,5 @@ extension ShareGardenSceneSceneBuilder {
     router.dataStore = interactor
     
     return viewController
-  }
-  
-  /// ViewController에 런타임 파라미터 `payload`를 설정합니다.
-  /// - Parameters:
-  ///   - viewController: 런타임 의존성을 설정할 ViewController 객체입니다.
-  ///   - payload: 런타임에 전달할 의존성입니다.
-  private func setPayload(
-    for viewController: ShareGardenSceneViewController,
-    with payload: ShareGardenSceneScenePayloadable
-  ) {
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -150,7 +150,7 @@ extension ShareGardenSceneViewController {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-  let viewController = ShareGardenSceneSceneBuilder(dependency: .preview).build()
-  return viewController
+  let shareGardenScene = ShareGardenSceneSceneBuilder(dependency: .preview).build()
+  return shareGardenScene
 }
 #endif

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -146,3 +146,11 @@ extension ShareGardenSceneViewController {
     ])
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let viewController = ShareGardenSceneSceneBuilder(dependency: .preview).build()
+  return viewController
+}
+#endif

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneAPI/ShareGardenSceneSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneAPI/ShareGardenSceneSceneBuildable.swift
@@ -15,7 +15,6 @@ public protocol ShareGardenSceneScenePayloadable {
 @MainActor
 public protocol ShareGardenSceneSceneBuildable {
   ///  VIP Cycle, 런타임 파라미터가 설정된 ViewController 인스턴스를 반환하는 함수입니다.
-  /// - Parameter payload: 런타임에 전달받아야 하는 파라미터입니다.
   /// - Returns: 런타임 파라미터, VIP Cycle이 설정된 ViewController가 반환되도록 구현합니다.
-  func build(with payload: ShareGardenSceneScenePayloadable) -> ShareGardenSceneViewControllable
+  func build() -> ShareGardenSceneViewControllable
 }


### PR DESCRIPTION
## 💡 관련 이슈
- related: #299 
## 🎉 변경 사항
- [x] ShareGardenScene preview dependency추가
- [x] viewcontroller preview macro 추가

## 📌 PR Point
- 디버깅 환경에서 preview를 사용할 수 있도록 하기 위해 관련 dependency와 preview macro를 추가하였습니다.
  - preview 에서는 아직 존재하지 않는 의존성(네트워크 요청, 응답 흐름)을 대체한 모방객체를 사용하도록 하였습니다. 
```swift

extension ShareGardenSceneSceneBuilder.Dependency {
#if DEBUG
  @MainActor
  public static let preview = Self(shareGardenSceneWorker: ShareGardenSceneWorkerStub())
#endif
}

let shareGardenScene = ShareGardenSceneSceneBuilder(dependency: .preview).build()
return shareGardenScene

```

|Preview|
|---|
|<img src="https://github.com/user-attachments/assets/001740c6-a92f-4852-99f5-ffdd90bd24d4" width="400"/>|

> 에러로 인한 삭제 실패 시 삭제 이전 상태의 UI로 복구하도록 하였습니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?