### PR TITLE
친구의 가든 편집 버튼 액션 설정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -90,6 +90,7 @@ extension ShareGardenSceneViewController {
 extension ShareGardenSceneViewController.FriendsGardenView {
   private func setup() {
     self.setupStackView()
+    self.setupEditButton()
     self.addSubviews()
     self.setCustomSpacing()
   }
@@ -99,6 +100,13 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     self.distribution = UIStackView.Distribution.fill
     self.axis = NSLayoutConstraint.Axis.vertical
     self.alignment = UIStackView.Alignment.center
+  }
+  
+  private func setupEditButton() {
+    let editButtonDidTap = UIAction { [weak self] _ in
+      self?.friendsGardenListView.isEditing.toggle()
+    }
+    self.sectionHeaderView.setupRightActionButton(action: editButtonDidTap)
   }
   
   private func addSubviews() {


### PR DESCRIPTION
## 💡 관련 이슈
- related: #298 
## 🎉 변경 사항
- [x] 친구의 가든 편집 버튼 액션을 설정하였습니다.

## 📌 PR Point

|친구의 가든 편집 버튼|
|---|
|<img src="https://github.com/user-attachments/assets/a06a9e7a-1af0-4e8b-910d-5089fdd04d04" width="350" />|



## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?