### PR TITLE
편집모드 설정 시 열린 셀이 모두 닫히도록 수정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenListView.swift
@@ -15,6 +15,9 @@ extension ShareGardenSceneViewController.FriendsGardenView {
       get {
         return self.friendListView.isEditing
       } set {
+        if newValue {
+          self.collapseAll()
+        }
         self.friendListView.isEditing = newValue
       }
     }


### PR DESCRIPTION
## 💡 관련 이슈
- #298 
## 🎉 변경 사항
- [x] 편집 모드 설정 시 열린 셀이 모두 닫히도록 수정

## 📌 PR Point

아래의 영상과 같이 편집 모드 설정 시 열려있는 셀이 모두 닫히도록 수정하였습니다.
| 편집 모드 설정 | 
|---|
|<img src="https://github.com/user-attachments/assets/104ec3f3-0e2c-4b10-a996-d7b7349f1bc6" width="300" />|

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?