### PR TITLE
ToDoCheckBoxButton 크기 변경시 애니메이션 버그 수정

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
@@ -16,14 +16,7 @@ extension Styled.Row {
   }
   
   private func buildButton(stack: UIStackView, isSelecetd: Bool, handler: @escaping (Bool) -> Void) {
-    let button = ToDoCheckBoxButton(
-      checkBoxModel: .init(
-        isToDoDone: isSelecetd,
-        groupColor: UIColor.toDoGardenRed,
-        borderWidth: Constant.Styled.Row.ToDoList.buttonBorderWidth,
-        cornerRadius: Constant.Styled.Row.ToDoList.buttonCornerRadius
-      )
-    )
+    let button = ToDoCheckBoxButton()
     let action = UIAction { [weak self, weak button] _ in
       guard let button else { return }
       self?.configuration.todoListModel

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -76,6 +76,26 @@ extension ToDoCheckBoxButton {
   }
 }
 
+// MARK: Set up UI
+
+extension ToDoCheckBoxButton {
+  private func setup() {
+    self.setupToggle()
+    self.setupLayer()
+    self.setupAnimationLayerUI()
+  }
+
+  private func setupToggle() {
+    self.changesSelectionAsPrimaryAction = true
+  }
+
+  private func setupLayer() {
+    self.layer.masksToBounds = true
+    self.layer.borderWidth = Constant.ToDoCheckBoxButton.Layout.borderWidth
+    self.layer.cornerRadius = Constant.ToDoCheckBoxButton.Layout.cornerRadius
+  }
+}
+
 // MARK: Set up Animation
 
 extension ToDoCheckBoxButton {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import TDUtility
 import ToDoGardenUIAPI
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
@@ -26,48 +27,39 @@ public final class ToDoCheckBoxButton: UIButton, HapticFeedbackable {
   public required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
-}
-
-// MARK: Private Functions
-
-extension ToDoCheckBoxButton {
-  private func setup() {
-    self.setupAction()
-    self.setupToDoCompleteAnimation()
-    self.setupUI()
-  }
-
-  private func completeToDo() {
-    self.isSelected = true
-    self.triggerHapticFeedback(
-      type: HapticFeedbackType.impact(
-        style: UIImpactFeedbackGenerator.FeedbackStyle.heavy
-      )
-    )
-    self.drawCompleteToDoAnimation()
-  }
-
-  private func resetToDo() {
-    self.isSelected = false
-    self.backgroundColor = UIColor.toDoGardenWhite
-  }
-}
-
-// MARK: Set Up Action
-
-extension ToDoCheckBoxButton {
-  private func setupAction() {
-    self.addAction(
-      self.makeButtonAction(),
-      for: UIControl.Event.touchUpInside
-    )
-  }
 
   public override func draw(_ rect: CGRect) {
     super.draw(rect)
     self.setAnimation = {
       self.setupAnimationPath()
     }
+  }
+
+  // TODO: - 런타임에 버튼의 색상을 변경할 수 있어야 함.
+
+  // TODO: - 런타임에 선택 상태 or 선택 해제 상태로 만들 수 있어야 함.
+  public func setSelected() {
+    self.makeVibration()
+  }
+
+  public func setDeSelected() {
+    self.backgroundColor = UIColor.toDoGardenWhite
+  }
+}
+
+// MARK: Set up UI
+
+extension ToDoCheckBoxButton {
+  private func setup() {
+    self.setupAnimationLayerUI()
+  }
+
+  private func makeVibration() {
+    self.triggerHapticFeedback(
+      type: HapticFeedbackType.impact(
+        style: UIImpactFeedbackGenerator.FeedbackStyle.heavy
+      )
+    )
   }
 }
 
@@ -115,13 +107,6 @@ extension ToDoCheckBoxButton {
     let pointY = bezierPath.currentPoint.y - (self.bounds.height * constant.offsetY)
     let endPoint = CGPoint(x: pointX, y: pointY)
     bezierPath.addLine(to: endPoint)
-  }
-}
-
-// MARK: set up UI
-
-extension ToDoCheckBoxButton {
-  private func setupUI() {
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -44,8 +44,9 @@ public final class ToDoCheckBoxButton: UIButton, HapticFeedbackable {
     self.layer.borderColor = color.cgColor
   }
 
-  // TODO: - 런타임에 선택 상태 or 선택 해제 상태로 만들 수 있어야 함.
   public func setSelected() {
+    self.backgroundColor = self.mainColor
+    self.drawCompleteToDoAnimation()
     self.makeVibration()
   }
 
@@ -54,11 +55,16 @@ public final class ToDoCheckBoxButton: UIButton, HapticFeedbackable {
   }
 }
 
-// MARK: Set up UI
+// MARK: - Private Functions
 
 extension ToDoCheckBoxButton {
-  private func setup() {
-    self.setupAnimationLayerUI()
+  private func drawCompleteToDoAnimation() {
+    let animation = CABasicAnimation(keyPath: Constant.ToDoCheckBoxButton.Animation.keyPath)
+    animation.duration = Constant.ToDoCheckBoxButton.Animation.duration
+    animation.fromValue = Constant.ToDoCheckBoxButton.Animation.fromValue
+    animation.toValue = Constant.ToDoCheckBoxButton.Animation.toValue
+    animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+    self.checkmarkDrawingLayer.add(animation, forKey: nil)
   }
 
   private func makeVibration() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -12,11 +12,9 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 public final class ToDoCheckBoxButton: UIButton, HapticFeedbackable {
-  private var checkBoxModel: ToDoCheckBoxButton.CheckBoxModel
   private var checkmarkDrawingLayer: CAShapeLayer
 
-  public init(checkBoxModel: ToDoCheckBoxButton.CheckBoxModel) {
-    self.checkBoxModel = checkBoxModel
+  public init() {
     self.checkmarkDrawingLayer = CAShapeLayer()
     super.init(frame: CGRect.zero)
     self.setup()
@@ -32,23 +30,13 @@ public final class ToDoCheckBoxButton: UIButton, HapticFeedbackable {
 
 extension ToDoCheckBoxButton {
   private func setup() {
-    self.updateState()
     self.setupAction()
     self.setupToDoCompleteAnimation()
     self.setupUI()
   }
 
-  private func updateState() {
-    if self.checkBoxModel.isToDoDone {
-      self.completeToDo()
-    } else {
-      self.resetToDo()
-    }
-  }
-
   private func completeToDo() {
     self.isSelected = true
-    self.backgroundColor = self.checkBoxModel.groupColor
     self.triggerHapticFeedback(
       type: HapticFeedbackType.impact(
         style: UIImpactFeedbackGenerator.FeedbackStyle.heavy
@@ -154,52 +142,13 @@ extension ToDoCheckBoxButton {
 
 extension ToDoCheckBoxButton {
   private func setupUI() {
-    self.setupBorder()
-    self.setupRoundedCorner()
-  }
-
-  private func setupBorder() {
-    self.layer.borderColor = self.checkBoxModel.groupColor.cgColor
-    self.layer.borderWidth = self.checkBoxModel.borderWidth
-  }
-
-  private func setupRoundedCorner() {
-    self.layer.cornerRadius = self.checkBoxModel.cornerRadius
-  }
-}
-
-// MARK: CheckBox Model
-
-extension ToDoCheckBoxButton {
-  public struct CheckBoxModel {
-    var isToDoDone: Bool
-    var groupColor: UIColor
-    var borderWidth: CGFloat
-    var cornerRadius: CGFloat
-
-    public init(
-      isToDoDone: Bool,
-      groupColor: UIColor,
-      borderWidth: CGFloat = Constant.ToDoCheckBoxButton.Layout.borderWidth,
-      cornerRadius: CGFloat = Constant.ToDoCheckBoxButton.Layout.cornerRadius
-    ) {
-      self.isToDoDone = isToDoDone
-      self.groupColor = groupColor
-      self.borderWidth = borderWidth
-      self.cornerRadius = cornerRadius
-    }
   }
 }
 
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-  let button = ToDoCheckBoxButton(
-    checkBoxModel: ToDoCheckBoxButton.CheckBoxModel.init(
-      isToDoDone: true,
-      groupColor: UIColor.toDoGardenBlue
-    )
-  )
+  let button = ToDoCheckBoxButton()
   button.translatesAutoresizingMaskIntoConstraints = false
   button.widthAnchor.constraint(equalToConstant: Constant.ToDoCheckBoxButton.Size.priamry.width).isActive = true
   button.heightAnchor.constraint(equalToConstant: Constant.ToDoCheckBoxButton.Size.priamry.height).isActive = true

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -13,11 +13,13 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 public final class ToDoCheckBoxButton: UIButton, HapticFeedbackable {
+  private var mainColor: UIColor
   private var checkmarkDrawingLayer: CAShapeLayer
 
   @ExecuteOnce private var setAnimation: (() -> Void)?
 
   public init() {
+    self.mainColor = UIColor.toDoGardenGreenDark
     self.checkmarkDrawingLayer = CAShapeLayer()
     super.init(frame: CGRect.zero)
     self.setup()
@@ -35,7 +37,12 @@ public final class ToDoCheckBoxButton: UIButton, HapticFeedbackable {
     }
   }
 
-  // TODO: - 런타임에 버튼의 색상을 변경할 수 있어야 함.
+  /// 체크박스의 메인 색상을 변경하는 함수입니다.
+  /// 메인 색상 변경시, 테두리 색상과 선택되었을 때 배경색이 함께 변경됩니다.
+  public func updateMainColor(_ color: UIColor) {
+    self.mainColor = color
+    self.layer.borderColor = color.cgColor
+  }
 
   // TODO: - 런타임에 선택 상태 or 선택 해제 상태로 만들 수 있어야 함.
   public func setSelected() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -146,10 +146,42 @@ extension ToDoCheckBoxButton {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-  let button = ToDoCheckBoxButton()
-  button.translatesAutoresizingMaskIntoConstraints = false
-  button.widthAnchor.constraint(equalToConstant: Constant.ToDoCheckBoxButton.Size.priamry.width).isActive = true
-  button.heightAnchor.constraint(equalToConstant: Constant.ToDoCheckBoxButton.Size.priamry.height).isActive = true
-  return button
+  var stackView = UIStackView()
+  stackView.axis = .vertical
+  stackView.spacing = 50
+  stackView.alignment = .center
+  stackView.distribution = .fill
+
+  let toDoButton = ToDoCheckBoxButton()
+  toDoButton.updateMainColor(UIColor.toDoGardenRed)
+  toDoButton.addAction(
+    UIAction { _ in
+      if toDoButton.isSelected {
+        toDoButton.setSelected()
+      } else {
+        toDoButton.setDeSelected()
+      }
+    }, for: UIControl.Event.touchUpInside
+  )
+  toDoButton.widthAnchor.constraint(equalToConstant: 18).isActive = true
+  toDoButton.heightAnchor.constraint(equalToConstant: 18).isActive = true
+
+  let agreementButton = ToDoCheckBoxButton()
+  agreementButton.addAction(
+    UIAction { _ in
+      if agreementButton.isSelected {
+        agreementButton.setSelected()
+      } else {
+        agreementButton.setDeSelected()
+      }
+    }, for: UIControl.Event.touchUpInside
+  )
+  agreementButton.layer.cornerRadius = 7
+  agreementButton.widthAnchor.constraint(equalToConstant: 14).isActive = true
+  agreementButton.heightAnchor.constraint(equalToConstant: 14).isActive = true
+  
+  stackView.addArrangedSubview(toDoButton)
+  stackView.addArrangedSubview(agreementButton)
+  return stackView
 }
 #endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -14,6 +14,8 @@ import ToDoGardenUIResource
 public final class ToDoCheckBoxButton: UIButton, HapticFeedbackable {
   private var checkmarkDrawingLayer: CAShapeLayer
 
+  @ExecuteOnce private var setAnimation: (() -> Void)?
+
   public init() {
     self.checkmarkDrawingLayer = CAShapeLayer()
     super.init(frame: CGRect.zero)
@@ -61,14 +63,10 @@ extension ToDoCheckBoxButton {
     )
   }
 
-  private func makeButtonAction() -> UIAction {
-    return UIAction { [weak self] _ in
-      guard let self else { return }
-      if self.isSelected {
-        self.resetToDo()
-      } else {
-        self.completeToDo()
-      }
+  public override func draw(_ rect: CGRect) {
+    super.draw(rect)
+    self.setAnimation = {
+      self.setupAnimationPath()
     }
   }
 }
@@ -76,21 +74,7 @@ extension ToDoCheckBoxButton {
 // MARK: Set up Animation
 
 extension ToDoCheckBoxButton {
-  private func setupToDoCompleteAnimation() {
-    self.setupAnimationUI()
-    self.setupAnimationPath()
-  }
-
-  private func drawCompleteToDoAnimation() {
-    let animation = CABasicAnimation(keyPath: Constant.ToDoCheckBoxButton.Animation.keyPath)
-    animation.duration = Constant.ToDoCheckBoxButton.Animation.duration
-    animation.fromValue = Constant.ToDoCheckBoxButton.Animation.fromValue
-    animation.toValue = Constant.ToDoCheckBoxButton.Animation.toValue
-    animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
-    self.checkmarkDrawingLayer.add(animation, forKey: nil)
-  }
-
-  private func setupAnimationUI() {
+  private func setupAnimationLayerUI() {
     self.checkmarkDrawingLayer.lineWidth = Constant.ToDoCheckBoxButton.Layout.lineWidth
     self.checkmarkDrawingLayer.fillColor = UIColor.clear.cgColor
     self.checkmarkDrawingLayer.strokeColor = UIColor.white.cgColor
@@ -99,6 +83,8 @@ extension ToDoCheckBoxButton {
     self.layer.addSublayer(self.checkmarkDrawingLayer)
   }
 
+  /// 버튼의 크기에 맞게 체크표시 애니메이션의 경로를 설정하는 메서드입니다.
+  /// 버튼의 크기를 얻기 위해 draw 메서드에서 호출됩니다.
   private func setupAnimationPath() {
     let bezierPath = UIBezierPath()
     self.setupStartPoint(to: bezierPath)
@@ -108,32 +94,26 @@ extension ToDoCheckBoxButton {
   }
 
   private func setupStartPoint(to bezierPath: UIBezierPath) {
-    let offsetXToStartPoint = Constant.ToDoCheckBoxButton.Animation.Path.offsetXToStartPoint
-    let offsetYToStartPoint = Constant.ToDoCheckBoxButton.Animation.Path.offsetYToStartPoint
-    let startPoint = CGPoint(
-      x: self.frame.origin.x + offsetXToStartPoint,
-      y: self.frame.origin.x + offsetYToStartPoint
-    )
+    let constant = Constant.ToDoCheckBoxButton.Animation.Path.StartPoint.self
+    let pointX = self.bounds.origin.x + (self.bounds.width * constant.offsetX)
+    let pointY = self.bounds.origin.y + (self.bounds.height * constant.offsetY)
+    let startPoint = CGPoint(x: pointX, y: pointY)
     bezierPath.move(to: startPoint)
   }
 
   private func setupMiddlePoint(to bezierPath: UIBezierPath) {
-    let offsetXToMiddlePoint = Constant.ToDoCheckBoxButton.Animation.Path.offsetXToMiddlePoint
-    let offsetYToMiddlePoint = Constant.ToDoCheckBoxButton.Animation.Path.offsetYToMiddlePoint
-    let middlePoint = CGPoint(
-      x: bezierPath.currentPoint.x + offsetXToMiddlePoint,
-      y: bezierPath.currentPoint.y + offsetYToMiddlePoint
-    )
+    let constant = Constant.ToDoCheckBoxButton.Animation.Path.MiddlePoint.self
+    let pointX = bezierPath.currentPoint.x + (self.bounds.width * constant.offsetX)
+    let pointY = bezierPath.currentPoint.y + (self.bounds.height * constant.offsetY)
+    let middlePoint = CGPoint(x: pointX, y: pointY)
     bezierPath.addLine(to: middlePoint)
   }
 
   private func setupEndPoint(to bezierPath: UIBezierPath) {
-    let offsetXToEndPoint = Constant.ToDoCheckBoxButton.Animation.Path.offsetXToEndPoint
-    let offsetYToEndPoint = Constant.ToDoCheckBoxButton.Animation.Path.offsetYToEndPoint
-    let endPoint = CGPoint(
-      x: bezierPath.currentPoint.x + offsetXToEndPoint,
-      y: bezierPath.currentPoint.y - offsetYToEndPoint
-    )
+    let constant = Constant.ToDoCheckBoxButton.Animation.Path.EndPoint.self
+    let pointX = bezierPath.currentPoint.x + (self.bounds.width * constant.offsetX)
+    let pointY = bezierPath.currentPoint.y - (self.bounds.height * constant.offsetY)
+    let endPoint = CGPoint(x: pointX, y: pointY)
     bezierPath.addLine(to: endPoint)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -146,7 +146,7 @@ extension ToDoCheckBoxButton {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-  var stackView = UIStackView()
+  let stackView = UIStackView()
   stackView.axis = .vertical
   stackView.spacing = 50
   stackView.alignment = .center

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
@@ -37,11 +37,23 @@ extension Constant.ToDoCheckBoxButton.Animation {
 
 extension Constant.ToDoCheckBoxButton.Animation {
   public enum Path {
-    public static let offsetXToStartPoint: CGFloat = 4.0
-    public static let offsetYToStartPoint: CGFloat = 7.5
-    public static let offsetXToMiddlePoint: CGFloat = 3.5
-    public static let offsetYToMiddlePoint: CGFloat = 5.5
-    public static let offsetXToEndPoint: CGFloat = 6.0
-    public static let offsetYToEndPoint: CGFloat = 8.5
+    public enum StartPoint {}
+    public enum MiddlePoint {}
+    public enum EndPoint {}
   }
+}
+
+public extension Constant.ToDoCheckBoxButton.Animation.Path.StartPoint {
+  static let offsetX: CGFloat = 0.29
+  static let offsetY: CGFloat = 0.43
+}
+
+public extension Constant.ToDoCheckBoxButton.Animation.Path.MiddlePoint {
+  static let offsetX: CGFloat = 0.18
+  static let offsetY: CGFloat = 0.29
+}
+
+public extension Constant.ToDoCheckBoxButton.Animation.Path.EndPoint {
+  static let offsetX: CGFloat = 0.25
+  static let offsetY: CGFloat = 0.43
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #527 

## 🎉 변경 사항
- ToDoCheckBoxButton의 애니메이션이 다양한 사이즈에서도 정상적으로 그려지도록 수정하였습니다.
- 코드 복잡도를 증가시키는 Model 객체를 삭제하였습니다.

## 📌 PR Point
### 애니메이션 수정
- 버튼의 크기가 정해진 값(`width: 18, height:18`)이 아닌 경우, 애니메이션이 올바르지 않은 문제를 해결하였습니다.
- 비교 영상을 아래 GIF로 추가하였습니다.

|반영 전|반영 후|
|--|--|
|||
|<img width="300" src="https://github.com/user-attachments/assets/86add747-8093-4cb5-adf0-38e2d83cb714">|<img width="300" src="https://github.com/user-attachments/assets/63b9001b-9959-4d3b-8897-e3d5b5370de0">|

---

### 업데이트 함수 추가
- **상위 객체에서 상태값을 업데이트하도록 수정하였습니다.**
- 기존에는 버튼을 눌렀을 때, 액션으로 즉시 UI를 업데이트하였기에,
https://github.com/ToDo-Garden/ToDo-Garden/pull/344#pullrequestreview-2184818673 에서 Noah가 언급해주신 문제가 발생할 가능성이 높았습니다.

> 뷰에서 직접 상태를 관리하는 대신, 상위 객체에서 이벤트 입력에 따른 상태 변경을 처리하고,
> 하위 뷰에서는 해당 상태를 UI로 표시하는 인터페이스를 상위 객체가 호출할 수 있도록 하면
> 뷰는 단순히 상태를 표시하고 사용자 입력을 처리하는 역할만 할 수 있을 것 같네요

- **결론적으로 버튼 액션을 삭제하고, 선택 상태를 업데이트하는 public 함수를 추가로 구현하였습니다.**

|`setSelected`|`setDeSelected`|
|--|--|
|![2024-10-0316 43 59-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/0665b40f-6224-4789-95b9-5feb484a0a86)|![2024-10-0316 44 09-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/fd4c8f6c-034c-4591-a494-ba08b55f544b)|

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?