### PR TITLE
AppleLoginButton 강조효과 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AppleLoginButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AppleLoginButton.swift
@@ -4,17 +4,18 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 public final class AppleLoginButton: UIButton {
-  private var glowLayer: CALayer?
+  private let appleLogo: UIImageView
   
   public override init(frame: CGRect) {
+    self.appleLogo = UIImageView(image: UIImage.appleLogo)
     super.init(frame: frame)
     self.setupButton()
+    self.setupAppleLogo()
   }
   
   @available(*, unavailable)
   required init?(coder: NSCoder) {
-    super.init(coder: coder)
-    fatalError()
+    fatalError("init(coder:) has not been implemented")
   }
   
   public override var intrinsicContentSize: CGSize {
@@ -26,16 +27,17 @@ public final class AppleLoginButton: UIButton {
   
   private func setupButton() {
     self.configureAppearance()
-    self.addAppleLogo()
-    self.setupGlowEffect()
     self.addAction(UIAction { [weak self] _ in
-      self?.buttonTouchDown()
+      self?.highlightOn()
     }, for: UIControl.Event.touchDown)
     self.addAction(UIAction { [weak self] _ in
-      self?.buttonTouchUpInside()
+      self?.highlightOn()
+    }, for: UIControl.Event.touchDragEnter)
+    self.addAction(UIAction { [weak self] _ in
+      self?.highlightOff()
     }, for: UIControl.Event.touchUpInside)
     self.addAction(UIAction { [weak self] _ in
-      self?.buttonTouchDragExit()
+      self?.highlightOff()
     }, for: UIControl.Event.touchDragExit)
   }
   
@@ -60,70 +62,42 @@ public final class AppleLoginButton: UIButton {
     )
   }
   
-  private func addAppleLogo() {
+  private func setupAppleLogo() {
     guard let titleLabel = self.titleLabel else {
       return
     }
     
-    let appleLogo = self.createAppleLogo()
-    self.addSubview(appleLogo)
+    self.appleLogo.contentMode = UIView.ContentMode.scaleAspectFit
+    self.appleLogo.usingAutolayout()
+    self.addSubview(self.appleLogo)
     
     NSLayoutConstraint.activate([
-      appleLogo.trailingAnchor.constraint(
+      self.appleLogo.trailingAnchor.constraint(
         equalTo: titleLabel.leadingAnchor,
         constant: Constant.AppleLoginButton.AppleLogo.trailing
       ),
-      appleLogo.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-      appleLogo.widthAnchor.constraint(
+      self.appleLogo.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+      self.appleLogo.widthAnchor.constraint(
         equalToConstant: Constant.AppleLoginButton.AppleLogo.width
       ),
-      appleLogo.heightAnchor.constraint(
+      self.appleLogo.heightAnchor.constraint(
         equalToConstant: Constant.AppleLoginButton.height
       )
     ])
   }
   
-  private func createAppleLogo() -> UIImageView {
-    let imageView = UIImageView(image: UIImage.appleLogo)
-    imageView.contentMode = UIView.ContentMode.scaleAspectFit
-    imageView.usingAutolayout()
-    return imageView
-  }
-  
-  private func setupGlowEffect() {
-    self.glowLayer = CALayer()
-    self.glowLayer?.backgroundColor = UIColor.white.cgColor
-    self.glowLayer?.opacity = 0
-    self.glowLayer?.cornerRadius = Constant.AppleLoginButton.cornerRadius
-    
-    if let glowLayer = self.glowLayer {
-      self.layer.addSublayer(glowLayer)
+  private func highlightOn() {
+    UIView.animate(withDuration: 0.3) {
+      self.titleLabel?.alpha = 0.5
+      self.appleLogo.alpha = 0.5
     }
   }
   
-  private func buttonTouchDown() {
-    UIView.animate(withDuration: 0.1) {
-      self.glowLayer?.opacity = 0.5
+  private func highlightOff() {
+    UIView.animate(withDuration: 0.3) {
+      self.titleLabel?.alpha = 1.0
+      self.appleLogo.alpha = 1.0
     }
-  }
-  
-  private func buttonTouchUpInside() {
-    self.fadeOutGlowEffect()
-  }
-  
-  private func buttonTouchDragExit() {
-    self.fadeOutGlowEffect()
-  }
-  
-  private func fadeOutGlowEffect() {
-    UIView.animate(withDuration: 0.5, animations: {
-      self.glowLayer?.opacity = 0
-    })
-  }
-  
-  public override func layoutSubviews() {
-    super.layoutSubviews()
-    self.glowLayer?.frame = self.bounds
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AppleLoginButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AppleLoginButton.swift
@@ -4,13 +4,10 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 public final class AppleLoginButton: UIButton {
-  private let appleLogo: UIImageView
-  
   public override init(frame: CGRect) {
-    self.appleLogo = UIImageView(image: UIImage.appleLogo)
     super.init(frame: frame)
-    self.setupButton()
-    self.setupAppleLogo()
+    self.configuration = UIButton.Configuration.plain()
+    self.configureAppearance()
   }
   
   @available(*, unavailable)
@@ -25,29 +22,35 @@ public final class AppleLoginButton: UIButton {
     )
   }
   
-  private func setupButton() {
-    self.configureAppearance()
-    self.addAction(UIAction { [weak self] _ in
-      self?.highlightOn()
-    }, for: UIControl.Event.touchDown)
-    self.addAction(UIAction { [weak self] _ in
-      self?.highlightOn()
-    }, for: UIControl.Event.touchDragEnter)
-    self.addAction(UIAction { [weak self] _ in
-      self?.highlightOff()
-    }, for: UIControl.Event.touchUpInside)
-    self.addAction(UIAction { [weak self] _ in
-      self?.highlightOff()
-    }, for: UIControl.Event.touchDragExit)
+  override public func updateConfiguration() {
+    super.updateConfiguration()
+    if self.isHighlighted {
+      self.highlightOn()
+    } else {
+      self.highlightOff()
+    }
   }
   
   private func configureAppearance() {
-    self.backgroundColor = UIColor.black
-    self.layer.cornerRadius = Constant.AppleLoginButton.cornerRadius
+    let constants = Constant.AppleLoginButton.self
+    
+    self.configuration?.background.backgroundColor = UIColor.toDoGardenBlack
+    self.layer.cornerRadius = constants.cornerRadius
     self.clipsToBounds = true
     
-    let attributedTitle = self.createAttributedButtonTitle(with: Constant.AppleLoginButton.StringLiteral.title)
-    self.setAttributedTitle(attributedTitle, for: UIControl.State.normal)
+    self.configuration?.image = UIImage.appleLogo
+    self.configuration?.attributedTitle = AttributedString(
+      self.createAttributedButtonTitle(
+        with: constants.StringLiteral.title
+      )
+    )
+    self.configuration?.imagePadding = constants.AppleLogo.imagePadding
+    self.configuration?.contentInsets = NSDirectionalEdgeInsets(
+      top: constants.ContentInsets.vertical,
+      leading: constants.ContentInsets.leading,
+      bottom: constants.ContentInsets.vertical,
+      trailing: constants.ContentInsets.trailing
+    )
   }
   
   private func createAttributedButtonTitle(with title: String) -> NSAttributedString {
@@ -62,41 +65,17 @@ public final class AppleLoginButton: UIButton {
     )
   }
   
-  private func setupAppleLogo() {
-    guard let titleLabel = self.titleLabel else {
-      return
-    }
-    
-    self.appleLogo.contentMode = UIView.ContentMode.scaleAspectFit
-    self.appleLogo.usingAutolayout()
-    self.addSubview(self.appleLogo)
-    
-    NSLayoutConstraint.activate([
-      self.appleLogo.trailingAnchor.constraint(
-        equalTo: titleLabel.leadingAnchor,
-        constant: Constant.AppleLoginButton.AppleLogo.trailing
-      ),
-      self.appleLogo.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-      self.appleLogo.widthAnchor.constraint(
-        equalToConstant: Constant.AppleLoginButton.AppleLogo.width
-      ),
-      self.appleLogo.heightAnchor.constraint(
-        equalToConstant: Constant.AppleLoginButton.height
-      )
-    ])
-  }
-  
   private func highlightOn() {
     UIView.animate(withDuration: 0.3) {
       self.titleLabel?.alpha = 0.5
-      self.appleLogo.alpha = 0.5
+      self.imageView?.alpha = 0.5
     }
   }
   
   private func highlightOff() {
     UIView.animate(withDuration: 0.3) {
       self.titleLabel?.alpha = 1.0
-      self.appleLogo.alpha = 1.0
+      self.imageView?.alpha = 1.0
     }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AppleLoginButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AppleLoginButton.swift
@@ -4,6 +4,8 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 public final class AppleLoginButton: UIButton {
+  private var glowLayer: CALayer?
+  
   public override init(frame: CGRect) {
     super.init(frame: frame)
     self.setupButton()
@@ -25,6 +27,16 @@ public final class AppleLoginButton: UIButton {
   private func setupButton() {
     self.configureAppearance()
     self.addAppleLogo()
+    self.setupGlowEffect()
+    self.addAction(UIAction { [weak self] _ in
+      self?.buttonTouchDown()
+    }, for: UIControl.Event.touchDown)
+    self.addAction(UIAction { [weak self] _ in
+      self?.buttonTouchUpInside()
+    }, for: UIControl.Event.touchUpInside)
+    self.addAction(UIAction { [weak self] _ in
+      self?.buttonTouchDragExit()
+    }, for: UIControl.Event.touchDragExit)
   }
   
   private func configureAppearance() {
@@ -61,7 +73,7 @@ public final class AppleLoginButton: UIButton {
         equalTo: titleLabel.leadingAnchor,
         constant: Constant.AppleLoginButton.AppleLogo.trailing
       ),
-      appleLogo.centerYAnchor.constraint(equalTo: centerYAnchor),
+      appleLogo.centerYAnchor.constraint(equalTo: self.centerYAnchor),
       appleLogo.widthAnchor.constraint(
         equalToConstant: Constant.AppleLoginButton.AppleLogo.width
       ),
@@ -76,6 +88,42 @@ public final class AppleLoginButton: UIButton {
     imageView.contentMode = UIView.ContentMode.scaleAspectFit
     imageView.usingAutolayout()
     return imageView
+  }
+  
+  private func setupGlowEffect() {
+    self.glowLayer = CALayer()
+    self.glowLayer?.backgroundColor = UIColor.white.cgColor
+    self.glowLayer?.opacity = 0
+    self.glowLayer?.cornerRadius = Constant.AppleLoginButton.cornerRadius
+    
+    if let glowLayer = self.glowLayer {
+      self.layer.addSublayer(glowLayer)
+    }
+  }
+  
+  private func buttonTouchDown() {
+    UIView.animate(withDuration: 0.1) {
+      self.glowLayer?.opacity = 0.5
+    }
+  }
+  
+  private func buttonTouchUpInside() {
+    self.fadeOutGlowEffect()
+  }
+  
+  private func buttonTouchDragExit() {
+    self.fadeOutGlowEffect()
+  }
+  
+  private func fadeOutGlowEffect() {
+    UIView.animate(withDuration: 0.5, animations: {
+      self.glowLayer?.opacity = 0
+    })
+  }
+  
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    self.glowLayer?.frame = self.bounds
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AppleLoginButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AppleLoginButton.swift
@@ -13,9 +13,14 @@ extension Constant.AppleLoginButton {
   public static let cornerRadius: CGFloat = 10.0
   public static let fontSize: CGFloat = 19.0
   
+  public enum ContentInsets {
+    public static let vertical: CGFloat = 10.0
+    public static let leading: CGFloat = 59.0
+    public static let trailing: CGFloat = 79.0
+  }
+  
   public enum AppleLogo {
-    public static let width: CGFloat = 39.5
-    public static let trailing: CGFloat = -10.0
+    public static let imagePadding: CGFloat = 16.0
   }
   
   public enum StringLiteral {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #519 

## 🎉 변경 사항
- 터치이벤트 감지시에 버튼에 강조효과를 표시합니다.
## 📌 PR Point

- 아무 효과가 없는게 너무 심심해보여서 간단한 강조효과를 추가했습니다. 
- 터치다운 / 터치업인사이드 / 드래그앤엑시트 / 드래그앤엔터 의 경우에 발동합니다. 

![애플로그인버튼](https://github.com/user-attachments/assets/886af688-985b-477a-aaf2-704b029103b8)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?