### PR TITLE
LoginScene VC 뷰 배치 

### DIFF
--- a/ToDo-Garden/ToDo-Garden.xcodeproj/project.pbxproj
+++ b/ToDo-Garden/ToDo-Garden.xcodeproj/project.pbxproj
@@ -30,6 +30,9 @@
 		E40EB3F32C3BBD64004D5329 /* PostGroupScene in Frameworks */ = {isa = PBXBuildFile; productRef = E40EB3F22C3BBD64004D5329 /* PostGroupScene */; };
 		E40EB3F52C3BBD88004D5329 /* PostGroupSceneAPI in Frameworks */ = {isa = PBXBuildFile; productRef = E40EB3F42C3BBD88004D5329 /* PostGroupSceneAPI */; };
 		E40EB3F72C3BBD88004D5329 /* PostGroupSceneEntity in Frameworks */ = {isa = PBXBuildFile; productRef = E40EB3F62C3BBD88004D5329 /* PostGroupSceneEntity */; };
+		E48680232CAE902600C6D535 /* LoginScene in Frameworks */ = {isa = PBXBuildFile; productRef = E48680222CAE902600C6D535 /* LoginScene */; };
+		E48680252CAE902600C6D535 /* LoginSceneAPI in Frameworks */ = {isa = PBXBuildFile; productRef = E48680242CAE902600C6D535 /* LoginSceneAPI */; };
+		E48680272CAE902600C6D535 /* LoginSceneEntity in Frameworks */ = {isa = PBXBuildFile; productRef = E48680262CAE902600C6D535 /* LoginSceneEntity */; };
 		E4DEA1742C2BED0700E3CE3C /* ManageGroupScene in Frameworks */ = {isa = PBXBuildFile; productRef = E4DEA1732C2BED0700E3CE3C /* ManageGroupScene */; };
 		E4DEA1762C2BED0700E3CE3C /* ManageGroupSceneAPI in Frameworks */ = {isa = PBXBuildFile; productRef = E4DEA1752C2BED0700E3CE3C /* ManageGroupSceneAPI */; };
 		E4DEA1782C2BED0700E3CE3C /* ManageGroupSceneEntity in Frameworks */ = {isa = PBXBuildFile; productRef = E4DEA1772C2BED0700E3CE3C /* ManageGroupSceneEntity */; };
@@ -80,6 +83,7 @@
 				E40EB3F72C3BBD88004D5329 /* PostGroupSceneEntity in Frameworks */,
 				E4DEA1782C2BED0700E3CE3C /* ManageGroupSceneEntity in Frameworks */,
 				4FEB41422C3686DB00E3682A /* ShareGardenScene in Frameworks */,
+				E48680272CAE902600C6D535 /* LoginSceneEntity in Frameworks */,
 				4FC8C1512B8C575A00BA223E /* ToDoGardenUIAPI in Frameworks */,
 				638F7F592C7F4E0900338FA3 /* UserInfoSceneEntity in Frameworks */,
 				634BD17A2CA1755B00396CAB /* EditUserNameSceneAPI in Frameworks */,
@@ -91,10 +95,12 @@
 				4F3D03862B8EF89800C495E5 /* ToDoGardenUIResource in Frameworks */,
 				E4DEA1742C2BED0700E3CE3C /* ManageGroupScene in Frameworks */,
 				4F3D03842B8EF89800C495E5 /* ToDoGardenUIComponent in Frameworks */,
+				E48680252CAE902600C6D535 /* LoginSceneAPI in Frameworks */,
 				E40EB3F52C3BBD88004D5329 /* PostGroupSceneAPI in Frameworks */,
 				E40EB3F32C3BBD64004D5329 /* PostGroupScene in Frameworks */,
 				4F577A2D2C2BE05F0006F44F /* TDUtility in Frameworks */,
 				63C1A0F32C2FD74100B6D6DE /* EditToDoSceneEntity in Frameworks */,
+				E48680232CAE902600C6D535 /* LoginScene in Frameworks */,
 				63C1A0EF2C2FD74100B6D6DE /* EditToDoScene in Frameworks */,
 				E4F7D3B22B996B1F00324294 /* ToDoGardenUIConstant in Frameworks */,
 			);
@@ -232,6 +238,9 @@
 				634BD1772CA1755B00396CAB /* EditUserNameScene */,
 				634BD1792CA1755B00396CAB /* EditUserNameSceneAPI */,
 				634BD17B2CA1755B00396CAB /* EditUserNameSceneEntity */,
+				E48680222CAE902600C6D535 /* LoginScene */,
+				E48680242CAE902600C6D535 /* LoginSceneAPI */,
+				E48680262CAE902600C6D535 /* LoginSceneEntity */,
 			);
 			productName = "ToDo-Garden";
 			productReference = 4F0DF1282B4EABCE00097B7D /* ToDo-Garden.app */;
@@ -664,6 +673,18 @@
 		E40EB3F62C3BBD88004D5329 /* PostGroupSceneEntity */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = PostGroupSceneEntity;
+		};
+		E48680222CAE902600C6D535 /* LoginScene */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LoginScene;
+		};
+		E48680242CAE902600C6D535 /* LoginSceneAPI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LoginSceneAPI;
+		};
+		E48680262CAE902600C6D535 /* LoginSceneEntity */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LoginSceneEntity;
 		};
 		E4DEA1732C2BED0700E3CE3C /* ManageGroupScene */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/AppleLoginBottomSheetViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/AppleLoginBottomSheetViewController.swift
@@ -1,0 +1,27 @@
+//
+//  AppleLoginBottomSheetViewController.swift
+//
+//
+//  Created by SONG on 10/3/24.
+//
+
+import UIKit
+
+final class AppleLoginBottomSheetViewController: UIViewController {
+  weak var delegate: AppleLoginBottomSheetDelegate?
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.view.backgroundColor = UIColor.white
+  }
+  
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    self.delegate?.bottomSheetWillDisappear()
+  }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    self.delegate?.bottomSheetWillAppear()
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginSceneConstant.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginSceneConstant.swift
@@ -1,0 +1,23 @@
+//
+//  LoginSceneConstant.swift
+//
+//
+//  Created by SONG on 10/3/24.
+//
+
+import Foundation
+
+enum Constant {
+  enum AppleLoginButton {
+    static let centerYMultiplier: CGFloat = -0.14
+  }
+  
+  enum AppleLoginBottomSheet {
+    static let heightMultiplier: CGFloat = 0.59
+  }
+  
+  enum DimmingView {
+    static let animateDuration: CGFloat = 0.3
+    static let alpha: CGFloat = 0.25
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import LoginSceneAPI
 import LoginSceneEntity
+import ToDoGardenUIComponent
 
 protocol LoginDisplayLogic: AnyObject {
   func displaySomething(viewModel: Login.Something.ViewModel)
@@ -21,9 +22,14 @@ class LoginViewController: UIViewController, LoginViewControllable {
   var interactor: LoginBusinessLogic?
   var router: (LoginRoutingLogic & LoginDataPassing)?
   
+  private let appleLoginButton: AppleLoginButton
+  private let dimmingView: UIView
+  
   // MARK: - Object lifecycle
   
   init() {
+    self.appleLoginButton = AppleLoginButton()
+    self.dimmingView = UIView()
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -36,7 +42,69 @@ class LoginViewController: UIViewController, LoginViewControllable {
   
   override func viewDidLoad() {
     super.viewDidLoad()
+    self.setUI()
     self.doSomething()
+  }
+}
+
+extension LoginViewController {
+  private func setUI() {
+    self.setBackgroundImage()
+    self.setAppleLoginButton()
+    self.setupDimmingView()
+  }
+  
+  private func setBackgroundImage() {
+    let backgroundImageView = UIImageView(image: UIImage.loginBackground)
+    backgroundImageView.contentMode = UIView.ContentMode.scaleAspectFill
+    backgroundImageView.frame = self.view.bounds
+    self.view.addSubview(backgroundImageView)
+    self.view.sendSubviewToBack(backgroundImageView)
+  }
+  
+  private func setAppleLoginButton() {
+    self.view.addSubview(self.appleLoginButton)
+    self.appleLoginButton.usingAutolayout()
+    NSLayoutConstraint.activate([
+      self.appleLoginButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+      self.appleLoginButton.centerYAnchor.constraint(
+        equalTo: self.view.bottomAnchor,
+        constant: self.view.bounds.height * Constant.AppleLoginButton.centerYMultiplier
+      )
+    ])
+    self.appleLoginButton.addAction(UIAction { [weak self] _ in
+      self?.appleLoginButtonTapped()
+    }, for: UIControl.Event.touchUpInside)
+  }
+  
+  private func setupDimmingView() {
+    self.dimmingView.backgroundColor = UIColor.black.withAlphaComponent(Constant.DimmingView.alpha)
+    self.dimmingView.alpha = 0
+    self.view.addSubview(self.dimmingView)
+    self.dimmingView.frame = self.view.bounds
+  }
+  
+  private func appleLoginButtonTapped() {
+    let bottomSheetVC = AppleLoginBottomSheetViewController()
+    bottomSheetVC.delegate = self
+    bottomSheetVC.modalPresentationStyle = UIModalPresentationStyle.pageSheet
+    
+    if let sheet = bottomSheetVC.sheetPresentationController {
+      if #available(iOS 16.0, *) {
+        sheet.detents = [UISheetPresentationController.Detent.custom { _ in
+          return self.view.bounds.height * Constant.AppleLoginBottomSheet.heightMultiplier
+        }]
+      } else {
+        sheet.detents = [UISheetPresentationController.Detent.medium()]
+      }
+      sheet.prefersGrabberVisible = true
+    }
+    
+    self.present(bottomSheetVC, animated: true, completion: nil)
+  }
+  
+  private func setGuestLoginButon() {
+    
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginViewController.swift
@@ -15,7 +15,12 @@ protocol LoginDisplayLogic: AnyObject {
   func displaySomething(viewModel: Login.Something.ViewModel)
 }
 
-class LoginViewController: UIViewController, LoginViewControllable {
+protocol AppleLoginBottomSheetDelegate: AnyObject {
+  func bottomSheetWillDisappear()
+  func bottomSheetWillAppear()
+}
+
+final class LoginViewController: UIViewController, LoginViewControllable {
   
   // MARK: - VIP Properties
   
@@ -122,5 +127,22 @@ extension LoginViewController {
   func doSomething() {
     let request = Login.Something.Request()
     self.interactor?.doSomething(request: request)
+  }
+}
+
+extension LoginViewController: AppleLoginBottomSheetDelegate {
+  func bottomSheetWillDisappear() {
+    UIView.animate(withDuration: Constant.DimmingView.animateDuration) {
+      self.dimmingView.alpha = 0
+    } completion: { _ in
+      self.dimmingView.isHidden = true
+    }
+  }
+  
+  func bottomSheetWillAppear() {
+    self.dimmingView.isHidden = false
+    UIView.animate(withDuration: Constant.DimmingView.animateDuration) {
+      self.dimmingView.alpha = 1
+    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginViewController.swift
@@ -146,3 +146,11 @@ extension LoginViewController: AppleLoginBottomSheetDelegate {
     }
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let view = LoginViewController()
+  return view
+}
+#endif


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #530 

## 🎉 변경 사항

- 배경화면 적용 
- 애플로그인 버튼 배치 
- 바텀시트 및 디밍뷰 배치 

## 📌 PR Point

### ↓아래 화면에 표시되는 뷰를 배치하였습니다. 
![로그인씬  뷰 배치](https://github.com/user-attachments/assets/01de10f0-014a-42b9-a5a5-64e14b3ad54c)

* 다음 PR에서 AppleLoginBottomSheetViewController.swift는 제거될 예정입니다. 
* 바텀시트를 직접 띄우는 방식이 아닌, Apple에서 제공하는 AuthService 패키지를 이용하여 구현하는 방식으로  변경됩니다. 
* 현재 PR에서는 버튼에 대한 동작만 AppleLoginBottomSheetViewController를 통해 확인해주시길 바랍니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?