### PR TITLE
나의 가든 요청에 따른 MyGaredenView UI 업데이트

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -72,7 +72,7 @@ final class ShareGardenSceneViewController: UIViewController, ShareGardenSceneVi
 
 extension ShareGardenSceneViewController: ShareGardenSceneDisplayLogic {
   func displayMyGarden(_ viewModel: ShareGardenSceneEntity.ShareGardenScene.RequestMyGarden.ViewModel) {
-    // TODO: - view update
+    self.myGardenView.update(viewModel: viewModel)
   }
   
   func displayFriendsGardenList(_ viewModel: ShareGardenScene.RequestFriendsGardenList.ViewModel) {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -89,6 +89,7 @@ extension ShareGardenSceneViewController: ShareGardenSceneDisplayLogic {
 extension ShareGardenSceneViewController {
   private func updateViewContents() {
     self.friendsGardenView.startShimmeringAnimation()
+    self.myGardenView.startShimmeringAnimation()
     self.interactor?.requestMyGarden()
     self.interactor?.requestFriendsGardenList()
   }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -83,10 +83,6 @@ extension ShareGardenSceneViewController {
       self.layoutIfNeeded()
       self.profileInfoView.startShimmering()
     }
-    
-    func stopShimmeringAnimation() {
-      self.profileInfoView.stopShimmering()
-    }
   }
 }
 
@@ -109,6 +105,10 @@ extension ShareGardenSceneViewController.MyGardenView {
     self.addArrangedSubview(self.sectionHeaderView)
     self.addArrangedSubview(self.profileInfoView)
     self.addArrangedSubview(self.gardenView)
+  }
+  
+  private func stopShimmeringAnimation() {
+    self.profileInfoView.stopShimmering()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -11,6 +11,8 @@ import TDUtility
 import ToDoGardenUIComponent
 import ToDoGardenUIResource
 
+import ShareGardenSceneEntity
+
 extension ShareGardenSceneViewController {
   final class MyGardenView: UIStackView {
     
@@ -75,8 +77,10 @@ extension ShareGardenSceneViewController {
       }
     }
     
-    func configure(with pomodoroRecordCollection: PomodoroRecordCollection) {
-      self.gardenView.configure(with: pomodoroRecordCollection)
+    func update(viewModel: ShareGardenScene.RequestMyGarden.ViewModel) {
+      self.updateGardenView(with: viewModel.pomodoroRecords)
+      self.updateProfileInfoView(with: viewModel.nickname, viewModel.description)
+      self.stopShimmeringAnimation()
     }
     
     func startShimmeringAnimation() {
@@ -105,6 +109,20 @@ extension ShareGardenSceneViewController.MyGardenView {
     self.addArrangedSubview(self.sectionHeaderView)
     self.addArrangedSubview(self.profileInfoView)
     self.addArrangedSubview(self.gardenView)
+  }
+  
+  private func updateProfileInfoView(with nickname: String, _ description: String) {
+    self.profileInfoView.configuration = Styled.Row.Configuration.profile(
+      Styled.Row.Configuration.ProfileModel(
+        style: Styled.Row.Configuration.ProfileModel.Style.shareProfile,
+        title: nickname,
+        description: description
+      )
+    )
+  }
+  
+  private func updateGardenView(with pomodoroRecordCollection: PomodoroRecordCollection) {
+    self.gardenView.configure(with: pomodoroRecordCollection)
   }
   
   private func stopShimmeringAnimation() {


### PR DESCRIPTION
## 💡 관련 이슈
- related: #299 
## 🎉 변경 사항
- [x] MyGardenView Shimmering 애니메이션 시작 요청 코드추가
- [x] MyGardenView profile 정보 업데이트
- [x] MyGardenView garden 정보 업데이트

## 📌 PR Point
나의 가든 요청에 따른 MyGardenView UI 업데이트를 구현하였습니다.

|iPhone SE|
|---|
|<img src="https://github.com/user-attachments/assets/66af8b15-85c4-4ada-a00b-c333a47b0681" width="300"/>|



## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?