### PR TITLE
implement multiline title view

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
@@ -10,7 +10,7 @@ import UIKit
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
-final class AnimatedMultiLinesTitleView: UIStackView {
+public final class AnimatedMultiLinesTitleView: UIStackView {
   private let mainTitleLabelFirst: UILabel
   private let mainTitleLabelSecond: UILabel
   private let subTitleLabel: UILabel
@@ -19,7 +19,7 @@ final class AnimatedMultiLinesTitleView: UIStackView {
   private let secondLineText: String
   private let thirdLineText: String
   
-  init(
+  public init(
     firstLineText: String,
     secondLineText: String,
     thirdLineText: String

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
@@ -1,0 +1,40 @@
+//
+//  DynamicInfoInputView.swift
+//
+//
+//  Created by SONG on 10/6/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+import ToDoGardenUIResource
+
+final class AnimatedMultiLinesTitleView: UIStackView {
+  private let mainTitleLabelFirst: UILabel
+  private let mainTitleLabelSecond: UILabel
+  private let subTitleLabel: UILabel
+  
+  private let firstLineText: String
+  private let secondLineText: String
+  private let thirdLineText: String
+  
+  init(
+    firstLineText: String,
+    secondLineText: String,
+    thirdLineText: String
+  ) {
+    self.mainTitleLabelFirst = UILabel()
+    self.mainTitleLabelSecond = UILabel()
+    self.subTitleLabel = UILabel()
+    self.firstLineText = firstLineText
+    self.secondLineText = secondLineText
+    self.thirdLineText = thirdLineText
+    super.init(frame: CGRect.zero)
+  }
+  
+  @available(*, unavailable)
+  required init(coder: NSCoder) {
+    fatalError()
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
@@ -39,6 +39,27 @@ final class AnimatedMultiLinesTitleView: UIStackView {
   required init(coder: NSCoder) {
     fatalError()
   }
+  
+  public func startAnimation() {
+    Task {
+      await withTaskGroup(of: Void.self) { group in
+        group.addTask { await self.animateText(for: self.mainTitleLabelFirst, with: self.firstLineText) }
+        group.addTask { await self.animateText(for: self.mainTitleLabelSecond, with: self.secondLineText) }
+        group.addTask { await self.animateText(for: self.subTitleLabel, with: self.thirdLineText) }
+      }
+    }
+  }
+  
+  private func animateText(for label: UILabel, with text: String) async {
+    for character in text {
+      await MainActor.run {
+        label.text?.append(character)
+      }
+      try? await Task.sleep(nanoseconds: 100_000_000)
+    }
+  }
+}
+
 extension AnimatedMultiLinesTitleView {
   private func setupStackView() {
     self.axis = NSLayoutConstraint.Axis.vertical

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
@@ -19,7 +19,7 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
   private let secondLineText: String
   private let thirdLineText: String
   
-  private var isAnimating = false
+  private var isAnimating: Bool
   private var animationTask: Task<Void, Never>?
   
   public init(
@@ -33,6 +33,7 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
     self.firstLineText = firstLineText
     self.secondLineText = secondLineText
     self.thirdLineText = thirdLineText
+    self.isAnimating = false
     super.init(frame: CGRect.zero)
     self.setupStackView()
     self.setupTitles()
@@ -44,9 +45,9 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
   }
   
   public func startAnimation() {
-    guard !isAnimating else { return }
-    self.isAnimating = true
+    guard !self.isAnimating else { return }
     
+    self.isAnimating = true
     self.animationTask = Task { @MainActor in
       await withTaskGroup(of: Void.self) { group in
         group.addTask { await self.animateText(for: self.mainTitleLabelFirst, with: self.firstLineText) }
@@ -59,7 +60,8 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
   
   private func animateText(for label: UILabel, with text: String) async {
     for character in text {
-      guard isAnimating else { return }
+      guard self.isAnimating else { return }
+      
       await MainActor.run {
         label.text?.append(character)
       }
@@ -84,6 +86,7 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
     }
   }
 }
+
 extension AnimatedMultiLinesTitleView {
   private func setupStackView() {
     self.axis = NSLayoutConstraint.Axis.vertical

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
@@ -63,7 +63,11 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
     for character in text {
       label.text?.append(character)
       do {
+        guard !Task.isCancelled else { return }
+        
         try await Task.sleep(nanoseconds: 100_000_000)
+        
+        guard !Task.isCancelled else { return }
       } catch {
         guard !Task.isCancelled else { return }
       }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
@@ -61,10 +61,12 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
   
   private func animateText(for label: UILabel, with text: String) async {
     for character in text {
-      guard self.isAnimating else { return }
-      
       label.text?.append(character)
-      try? await Task.sleep(nanoseconds: 100_000_000)
+      do {
+        try await Task.sleep(nanoseconds: 100_000_000)
+      } catch {
+        guard !Task.isCancelled else { return }
+      }
     }
   }
   
@@ -95,7 +97,7 @@ extension AnimatedMultiLinesTitleView {
     self.addArrangedSubview(self.mainTitleLabelSecond)
     self.addArrangedSubview(self.subTitleLabel)
   }
-
+  
   private func setupTitles() {
     self.setupMainTitle(text: self.firstLineText, at: self.mainTitleLabelFirst)
     self.setupMainTitle(text: self.secondLineText, at: self.mainTitleLabelSecond)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
@@ -96,4 +96,28 @@ extension AnimatedMultiLinesTitleView {
   }
 }
 
+@available(iOS 17.0, *)
+#Preview {
+  let backplaneView = UIView()
+  backplaneView.backgroundColor = .white
+  backplaneView.usingAutolayout()
+  
+  let view = AnimatedMultiLinesTitleView(
+    firstLineText: "환영한다.",
+    secondLineText: "안녕하세요.안녕하세요.안녕??",
+    thirdLineText: "안녕. 내이름은 홍길동"
+  )
+  
+  view.usingAutolayout()
+  backplaneView.addSubview(view)
+  
+  NSLayoutConstraint.activate([
+    backplaneView.widthAnchor.constraint(equalToConstant: 300),
+    backplaneView.heightAnchor.constraint(equalToConstant: 200),
+    view.leadingAnchor.constraint(equalTo: backplaneView.leadingAnchor, constant: 16),
+    view.topAnchor.constraint(equalTo: backplaneView.topAnchor, constant: 16)
+  ])
+  
+  view.startAnimation()
+  return backplaneView
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
@@ -63,13 +63,13 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
     for character in text {
       label.text?.append(character)
       do {
-        guard !Task.isCancelled else { return }
+        try Task.checkCancellation()
         
         try await Task.sleep(nanoseconds: 100_000_000)
         
-        guard !Task.isCancelled else { return }
+        try Task.checkCancellation()
       } catch {
-        guard !Task.isCancelled else { return }
+        return
       }
     }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
@@ -44,11 +44,12 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
     fatalError()
   }
   
+  @MainActor
   public func startAnimation() {
     guard !self.isAnimating else { return }
     
     self.isAnimating = true
-    self.animationTask = Task { @MainActor in
+    self.animationTask = Task {
       await withTaskGroup(of: Void.self) { group in
         group.addTask { await self.animateText(for: self.mainTitleLabelFirst, with: self.firstLineText) }
         group.addTask { await self.animateText(for: self.mainTitleLabelSecond, with: self.secondLineText) }
@@ -62,13 +63,12 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
     for character in text {
       guard self.isAnimating else { return }
       
-      await MainActor.run {
-        label.text?.append(character)
-      }
+      label.text?.append(character)
       try? await Task.sleep(nanoseconds: 100_000_000)
     }
   }
   
+  @MainActor
   public func cancelTask() {
     if self.isAnimating {
       self.completeAnimationImmediately()
@@ -79,11 +79,9 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
     self.animationTask?.cancel()
     self.isAnimating = false
     
-    Task { @MainActor in
-      self.mainTitleLabelFirst.text = self.firstLineText
-      self.mainTitleLabelSecond.text = self.secondLineText
-      self.subTitleLabel.text = self.thirdLineText
-    }
+    self.mainTitleLabelFirst.text = self.firstLineText
+    self.mainTitleLabelSecond.text = self.secondLineText
+    self.subTitleLabel.text = self.thirdLineText
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
@@ -1,5 +1,5 @@
 //
-//  DynamicInfoInputView.swift
+//  AnimatedMultiLinesTitleView.swift
 //
 //
 //  Created by SONG on 10/6/24.
@@ -31,10 +31,48 @@ final class AnimatedMultiLinesTitleView: UIStackView {
     self.secondLineText = secondLineText
     self.thirdLineText = thirdLineText
     super.init(frame: CGRect.zero)
+    self.setupStackView()
+    self.setupTitles()
   }
   
   @available(*, unavailable)
   required init(coder: NSCoder) {
     fatalError()
   }
+extension AnimatedMultiLinesTitleView {
+  private func setupStackView() {
+    self.axis = NSLayoutConstraint.Axis.vertical
+    self.spacing = 4.0
+    self.alignment = UIStackView.Alignment.leading
+    
+    self.addArrangedSubview(self.mainTitleLabelFirst)
+    self.addArrangedSubview(self.mainTitleLabelSecond)
+    self.addArrangedSubview(self.subTitleLabel)
+  }
+
+  private func setupTitles() {
+    self.setupMainTitle(text: self.firstLineText, at: self.mainTitleLabelFirst)
+    self.setupMainTitle(text: self.secondLineText, at: self.mainTitleLabelSecond)
+    self.setupSubTitle(text: self.thirdLineText)
+  }
+  
+  private func setupMainTitle(text: String, at mainTitleLabel: UILabel) {
+    mainTitleLabel.numberOfLines = 1
+    mainTitleLabel.attributedText = text.applyTextAttributes(attributes: [
+      NSAttributedString.Key.font: UIFont.pretendardHeadBold,
+      NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+    ])
+    mainTitleLabel.text = ""
+  }
+  
+  private func setupSubTitle(text: String) {
+    self.subTitleLabel.numberOfLines = 1
+    self.subTitleLabel.attributedText = text.applyTextAttributes(attributes: [
+      NSAttributedString.Key.font: UIFont.pretendardDetailRegular12,
+      NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+    ])
+    self.subTitleLabel.text = ""
+  }
+}
+
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
@@ -19,6 +19,9 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
   private let secondLineText: String
   private let thirdLineText: String
   
+  private var isAnimating = false
+  private var animationTask: Task<Void, Never>?
+  
   public init(
     firstLineText: String,
     secondLineText: String,
@@ -41,25 +44,46 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
   }
   
   public func startAnimation() {
-    Task {
+    guard !isAnimating else { return }
+    self.isAnimating = true
+    
+    self.animationTask = Task { @MainActor in
       await withTaskGroup(of: Void.self) { group in
         group.addTask { await self.animateText(for: self.mainTitleLabelFirst, with: self.firstLineText) }
         group.addTask { await self.animateText(for: self.mainTitleLabelSecond, with: self.secondLineText) }
         group.addTask { await self.animateText(for: self.subTitleLabel, with: self.thirdLineText) }
       }
+      self.isAnimating = false
     }
   }
   
   private func animateText(for label: UILabel, with text: String) async {
     for character in text {
+      guard isAnimating else { return }
       await MainActor.run {
         label.text?.append(character)
       }
       try? await Task.sleep(nanoseconds: 100_000_000)
     }
   }
+  
+  public func cancelTask() {
+    if self.isAnimating {
+      self.completeAnimationImmediately()
+    }
+  }
+  
+  private func completeAnimationImmediately() {
+    self.animationTask?.cancel()
+    self.isAnimating = false
+    
+    Task { @MainActor in
+      self.mainTitleLabelFirst.text = self.firstLineText
+      self.mainTitleLabelSecond.text = self.secondLineText
+      self.subTitleLabel.text = self.thirdLineText
+    }
+  }
 }
-
 extension AnimatedMultiLinesTitleView {
   private func setupStackView() {
     self.axis = NSLayoutConstraint.Axis.vertical


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #541 
## 🎉 변경 사항
- 멀티라인 타이틀 뷰를 구현합니다. 
## 📌 PR Point

- 아래는 회원가입 흐름에 포함되는 inputID , nickname , description Scene입니다. 
- 보시다시피, text만 다를뿐, 똑같은 UI를 표시하고 있습니다. 
(+ 텍스트필드는 이미 구현이 되어있음)
<img width="445" alt="스크린샷 2024-10-07 오후 4 49 53" src="https://github.com/user-attachments/assets/d3d91625-e7f5-4337-a9f9-7f6abfe8ee82">

- 세 씬에서 사용될 타이틀 표시 UI를 컴포넌트화 시켜 재사용성을 확보하였습니다. 
- 그냥은 심심해서 각각의 line의 text가 타이핑되는 듯한 애니메이션을 넣어보았습니다. 

![타이핑애니메이션](https://github.com/user-attachments/assets/260f349c-b3c2-43a0-8026-f55695e6fd1b)

- Task를 사용한, 비동기 컨텍스트를 생성하여 UI 블로킹 없이 애니메이션을 실행합니다.
- withTaskGroup를 이용하여 여러 애니메이션 태스크를 동시에 병렬적으로 실행하기 위해 사용해보았습니다.
- 그룹에 추가된 태스크들은 각 라인의 타이핑 애니메이션 작업을 수행합니다.
mainTitleLabelFirst에 firstLineText 애니메이션
mainTitleLabelSecond에 secondLineText 애니메이션
subTitleLabel에 thirdLineText 애니메이션

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?