### PR TITLE
TermsAgreementViewRow 체크박스 버튼 교체

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TermsAgreementViewRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TermsAgreementViewRow.swift
@@ -18,7 +18,14 @@ final class TermsAgreementViewRow: UIView {
   
   var isSelected: Bool {
     get { return self.checkButton.isSelected }
-    set { self.checkButton.isSelected = newValue }
+    set {
+      if newValue {
+        self.checkButton.setSelected()
+      } else {
+        self.checkButton.setDeSelected()
+      }
+      self.checkButton.isSelected = newValue
+    }
   }
   
   var chevronAction: (() -> Void)?
@@ -60,6 +67,14 @@ final class TermsAgreementViewRow: UIView {
   private func setupCheckButtonRoundedCorner() {
     let length = Constant.TermsAgreementViewRow.CheckButton.Layout.length
     self.checkButton.layer.cornerRadius = length / 2.0
+    self.checkButton.updateMainColor(UIColor.toDoGardenGreenDark)
+    self.checkButton.changesSelectionAsPrimaryAction = true
+    self.checkButton.addAction(
+      UIAction { [weak self] _ in
+        self?.checkButtonTapped()
+      },
+      for: UIControl.Event.touchUpInside
+    )
   }
 
   private func setupTextLabel() {
@@ -138,6 +153,7 @@ final class TermsAgreementViewRow: UIView {
   
   // MARK: - Actions
   private func checkButtonTapped() {
+    self.checkButton.isSelected.toggle()
     self.isSelected.toggle()
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TermsAgreementViewRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TermsAgreementViewRow.swift
@@ -12,7 +12,7 @@ import ToDoGardenUIResource
 
 final class TermsAgreementViewRow: UIView {
   // MARK: - Properties
-  let checkButton: UIButton
+  let checkButton: ToDoCheckBoxButton
   private let textLabel: UILabel
   private let chevronButton: UIButton
   
@@ -29,7 +29,7 @@ final class TermsAgreementViewRow: UIView {
   
   // MARK: - Initialization
   init(title: String, font: UIFont, chevronIsHidden: Bool) {
-    self.checkButton = UIButton(type: UIButton.ButtonType.custom)
+    self.checkButton = ToDoCheckBoxButton()
     self.textLabel = UILabel()
     self.chevronButton = UIButton(type: UIButton.ButtonType.system)
     
@@ -53,12 +53,7 @@ final class TermsAgreementViewRow: UIView {
   }
   
   private func setupCheckButton() {
-    self.checkButton.setImage(UIImage.circledCheckMarkEmpty, for: UIControl.State.normal)
-    self.checkButton.setImage(UIImage.circledCheckMarkFill, for: UIControl.State.selected)
-    self.checkButton.tintColor = UIColor.toDoGardenGreenDark
-    self.checkButton.addAction(UIAction(handler: { [weak self] _ in
-      self?.checkButtonTapped()
-    }), for: UIControl.Event.touchUpInside)
+    self.checkButton.updateMainColor(UIColor.toDoGardenGreenDark)
   }
   
   private func setupTextLabel() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TermsAgreementViewRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TermsAgreementViewRow.swift
@@ -54,8 +54,14 @@ final class TermsAgreementViewRow: UIView {
   
   private func setupCheckButton() {
     self.checkButton.updateMainColor(UIColor.toDoGardenGreenDark)
+    self.setupCheckButtonRoundedCorner()
   }
-  
+
+  private func setupCheckButtonRoundedCorner() {
+    let length = Constant.TermsAgreementViewRow.CheckButton.Layout.length
+    self.checkButton.layer.cornerRadius = length / 2.0
+  }
+
   private func setupTextLabel() {
     self.textLabel.textColor = UIColor.toDoGardenGreenDark
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+TermsAgreementViewRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+TermsAgreementViewRow.swift
@@ -35,6 +35,6 @@ extension Constant.TermsAgreementViewRow.ChevronButton {
 
 extension Constant.TermsAgreementViewRow.CheckButton {
   public enum Layout {
-    public static let length: CGFloat = 24.0
+    public static let length: CGFloat = 14.0
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+TermsAgreementViewRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+TermsAgreementViewRow.swift
@@ -10,7 +10,7 @@ import Foundation
 extension Constant.TermsAgreementViewRow {
   public enum Layout {
     public static let size: CGSize = CGSize(width: 220.0, height: 30.0)
-    public static let commonMargin: CGFloat = 4.0
+    public static let commonMargin: CGFloat = 7.0
   }
   
   public enum TextLabel { }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #534 
- related: #499

## 🎉 변경 사항
- TermsAgreementView에 있는 CheckButton을 ToDoCheckBoxButton으로 교체하였습니다.

## 📌 PR Point
체크표시를 애니메이션으로 그려줌으로써, 더 직관적이고 부드러운 UI를 보여주고자 교체하였습니다.
- 이전에 https://github.com/ToDo-Garden/ToDo-Garden/pull/499#discussion_r1780384130 에서 언급했던 제안을 반영하였습니다.

### 동작 GIF
<img width="250" src="https://github.com/user-attachments/assets/db10b110-12bb-4b05-baa4-17acf1c19050">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?