### PR TITLE
프로젝트 컴파일 경고 삭제

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
@@ -67,7 +67,7 @@ extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {
         try Task.checkCancellation()
         await self.presenter?.presentEditUserNameResult(nil)
       } catch let error {
-        if let cancellationError = error as? CancellationError { return }
+        if error is CancellationError { return }
         await self.presenter?.presentEditUserNameResult(error)
       }
     }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -233,7 +233,7 @@ extension TextInputView {
     inputText: constant.UserName.inputText,
     placeholderText: constant.UserName.placeholderText
   )
-  stackView.addArrangedSubview(toDoNameView)
+  stackView.addArrangedSubview(groupNameView)
 
   let groupNameInputView = TextInputView(
     inputText: constant.GroupName.inputText,


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #557 

## 🎉 변경 사항
- 프로젝트에 발생하는 컴파일 경고들을 삭제하였습니다.

## 📌 PR Point
변경사항은 크게 2 가지입니다.

1. EditUserNameSceneInteractor: task 취소 확인 로직에서 `미사용 변수 컴파일 경고를 삭제`하였습니다.
2. TextInputView Preview: 오타로 인해 발생하던 `미사용 변수 컴파일 경고를 삭제`하였습니다.

<img width="527" alt="스크린샷 2024-10-08 15 45 02" src="https://github.com/user-attachments/assets/9d1f124b-92b8-4503-9489-54e0ebf68cb4">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?