### PR TITLE
ShareGardenScene 테스트 대역 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneViewControllerStub.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneViewControllerStub.swift
@@ -1,0 +1,14 @@
+//
+//  ShareGardenSceneViewControllerStub.swift
+//  ShareGardenScene
+//
+//  Created by Noah on 10/8/24.
+//
+
+import Foundation
+
+@testable import ShareGardenScene
+import ShareGardenSceneEntity
+
+final class ShareGardenSceneViewControllerStub {
+}

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneViewControllerStub.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneViewControllerStub.swift
@@ -11,4 +11,31 @@ import Foundation
 import ShareGardenSceneEntity
 
 final class ShareGardenSceneViewControllerStub {
+  // MARK: - My Garden 관련 스트림
+  let (myGardenStream, myGardenStreamContinuation) = AsyncStream.makeStream(
+    of: ShareGardenScene.RequestMyGarden.ViewModel.self,
+    bufferingPolicy: AsyncStream.Continuation.BufferingPolicy.bufferingNewest(1)
+  )
+  
+  let (myGardenRequestErrorStream, myGardenRequestErrorStreamContinuation) = AsyncStream.makeStream(
+    of: Void.self,
+    bufferingPolicy: AsyncStream.Continuation.BufferingPolicy.bufferingNewest(1)
+  )
+  
+  // MARK: - Friends Garden 관련 스트림
+  let (friendsGardenListStream, friendsGardenListStreamContinuation) = AsyncStream.makeStream(
+    of: ShareGardenScene.RequestFriendsGardenList.ViewModel.self,
+    bufferingPolicy: AsyncStream.Continuation.BufferingPolicy.bufferingNewest(1)
+  )
+  
+  let (friendsGardenListRequestErrorStream, friendsGardenListRequestErrorStreamContinuation) = AsyncStream.makeStream(
+    of: Void.self,
+    bufferingPolicy: AsyncStream.Continuation.BufferingPolicy.bufferingNewest(1)
+  )
+  
+  // MARK: - Shimmering 관련 스트림
+  let (shimmeringStopStream, shimmeringStopStreamContinuation) = AsyncStream.makeStream(
+    of: Void.self,
+    bufferingPolicy: AsyncStream.Continuation.BufferingPolicy.bufferingNewest(1)
+  )
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneViewControllerStub.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneViewControllerStub.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable all
 //
 //  ShareGardenSceneViewControllerStub.swift
 //  ShareGardenScene
@@ -61,3 +62,5 @@ extension ShareGardenSceneViewControllerStub: ShareGardenSceneDisplayLogic {
     self.shimmeringStopStreamContinuation.yield()
   }
 }
+
+// swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneViewControllerStub.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneViewControllerStub.swift
@@ -39,3 +39,25 @@ final class ShareGardenSceneViewControllerStub {
     bufferingPolicy: AsyncStream.Continuation.BufferingPolicy.bufferingNewest(1)
   )
 }
+
+extension ShareGardenSceneViewControllerStub: ShareGardenSceneDisplayLogic {
+  func displayMyGarden(_ viewModel: ShareGardenScene.RequestMyGarden.ViewModel) {
+    self.myGardenStreamContinuation.yield(viewModel)
+  }
+  
+  func displayMyGardenRequestError() {
+    self.myGardenRequestErrorStreamContinuation.yield()
+  }
+  
+  func displayFriendsGardenList(_ viewModel: ShareGardenScene.RequestFriendsGardenList.ViewModel) {
+    self.friendsGardenListStreamContinuation.yield(viewModel)
+  }
+  
+  func displayFriendsGardenListRequestError() {
+    self.friendsGardenListRequestErrorStreamContinuation.yield()
+  }
+  
+  func stopShimmeringFriendsGardenList() {
+    self.shimmeringStopStreamContinuation.yield()
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneWorkerMock.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneWorkerMock.swift
@@ -15,6 +15,14 @@ import ShareGardenSceneAPI
 import ShareGardenSceneEntity
 
 actor ShareGardenSceneWorkerMock {
+  private var isSuccessful: Bool = false
+
+extension ShareGardenSceneWorkerMock {
+  private func checkIsSuccessfulTask() throws {
+    if self.isSuccessful == false {
+      throw NSError(domain: "", code: 999)
+    }
+  }
 }
 
 // swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneWorkerMock.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneWorkerMock.swift
@@ -1,0 +1,20 @@
+// swiftlint:disable all
+//
+//  ShareGardenSceneWorkerMock.swift
+//  ShareGardenScene
+//
+//  Created by Noah on 10/8/24.
+//
+
+import Foundation
+
+import ToDoGardenUIComponent
+
+import ShareGardenScene
+import ShareGardenSceneAPI
+import ShareGardenSceneEntity
+
+actor ShareGardenSceneWorkerMock {
+}
+
+// swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneWorkerMock.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneWorkerMock.swift
@@ -16,6 +16,11 @@ import ShareGardenSceneEntity
 
 actor ShareGardenSceneWorkerMock {
   private var isSuccessful: Bool = false
+  private var myGarden: ShareGardenScene.MyGarden?
+  
+  func setMyGarden(_ myGarden: ShareGardenScene.MyGarden) {
+    self.myGarden = myGarden
+  }
 
 extension ShareGardenSceneWorkerMock {
   private func checkIsSuccessfulTask() throws {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneWorkerMock.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneWorkerMock.swift
@@ -17,9 +17,14 @@ import ShareGardenSceneEntity
 actor ShareGardenSceneWorkerMock {
   private var isSuccessful: Bool = false
   private var myGarden: ShareGardenScene.MyGarden?
+  private var friendsGardenList: [ShareGardenScene.FriendsGarden]?
   
   func setMyGarden(_ myGarden: ShareGardenScene.MyGarden) {
     self.myGarden = myGarden
+  }
+  
+  func setFriendsGardenList(_ friendsGardenList: [ShareGardenScene.FriendsGarden]) {
+    self.friendsGardenList = friendsGardenList
   }
 
 extension ShareGardenSceneWorkerMock {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneWorkerMock.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneWorkerMock.swift
@@ -26,6 +26,11 @@ actor ShareGardenSceneWorkerMock {
   func setFriendsGardenList(_ friendsGardenList: [ShareGardenScene.FriendsGarden]) {
     self.friendsGardenList = friendsGardenList
   }
+  
+  func setIsSuccessful(_ isSuccessful: Bool) {
+    self.isSuccessful = isSuccessful
+  }
+}
 
 extension ShareGardenSceneWorkerMock {
   private func checkIsSuccessfulTask() throws {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneWorkerMock.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneWorkerMock.swift
@@ -32,6 +32,24 @@ actor ShareGardenSceneWorkerMock {
   }
 }
 
+extension ShareGardenSceneWorkerMock: ShareGardenSceneWorkable {
+  func requestMyGarden() async throws -> ShareGardenScene.MyGarden {
+    try self.checkIsSuccessfulTask()
+    
+    return self.myGarden!
+  }
+  
+  func requestFriendsGardenList() async throws -> [ShareGardenScene.FriendsGarden] {
+    try self.checkIsSuccessfulTask()
+    
+    return self.friendsGardenList!
+  }
+  
+  func delete(by id: ShareGardenSceneEntity.ShareGardenScene.FriendsGarden.ID) async throws {
+    try self.checkIsSuccessfulTask()
+  }
+}
+
 extension ShareGardenSceneWorkerMock {
   private func checkIsSuccessfulTask() throws {
     if self.isSuccessful == false {


### PR DESCRIPTION
## 💡 관련 이슈
- related: #299 
## 🎉 변경 사항
- [x] ShareGardenSceneViewControllerStub 파일 추가
- [x] ShareGardenSceneWorkerMock 파일 추가

## 📌 PR Point
- ShareGardenScene 단위 테스트에 필요한 테스트 대역을 추가하였습니다.

|단위 테스트|
|---|
|<img src="https://github.com/user-attachments/assets/1352029c-2f60-4e75-9608-c35356d45c8c" width="500" />|

의 기준에 따라 명령에 해당하는 ShareGardenSceneWorkable 테스트 대역에는 Mock이라는 suffix를

조회에 해당하는 ShareGardenSceneDisplayLogic 테스트 대역에는 Stub이라는 suffix를 붙여주었습니다.
(Stub에 해당하는 ShareGardenSceneDisplayLogic의 테스트 대역으로 VIP Cycle의 결과를 검증할 예정입니다.)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?