### PR TITLE
EditUserIntroduction PreviewScene 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
@@ -72,3 +72,18 @@ extension EditUserIntroductionSceneBuilder {
     // viewController.router?.dataStore?.name = payload.name
   }
 }
+
+// MARK: - Preview Builder
+
+#if DEBUG
+extension EditUserIntroductionSceneBuilder {
+  private struct PreviewPayload: EditUserIntroductionScenePayloadable {}
+
+  /// Preview에서 VIP 동작을 확인하기 위한 Builder입니다.
+  static let previewScene = Self(
+    dependency: Dependency(
+      someWorker: EditUserIntroductionSceneWorker()
+    )
+  ).build(with: PreviewPayload())
+}
+#endif

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
@@ -14,11 +14,9 @@ public struct EditUserIntroductionSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
     let someWorker: EditUserIntroductionSceneWorkable
-    let nextSceneBuilder: NextSceneBuildable
 
-    public init(someWorker: EditUserIntroductionSceneWorkable, nextSceneBuilder: NextSceneBuildable) {
+    public init(someWorker: EditUserIntroductionSceneWorkable) {
       self.someWorker = someWorker
-      self.nextSceneBuilder = nextSceneBuilder
     }
   }
 
@@ -52,7 +50,7 @@ extension EditUserIntroductionSceneBuilder {
   ) -> EditUserIntroductionSceneViewController {
     let interactor = EditUserIntroductionSceneInteractor(someWorker: self.dependency.someWorker)
     let presenter = EditUserIntroductionScenePresenter()
-    let router = EditUserIntroductionSceneRouter(nextSceneBuilder: self.dependency.nextSceneBuilder)
+    let router = EditUserIntroductionSceneRouter()
     viewController.interactor = interactor
     viewController.router = router
     interactor.presenter = presenter

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
@@ -10,7 +10,7 @@ import Foundation
 import EditUserIntroductionSceneAPI
 import EditUserIntroductionSceneEntity
 
-public struct EditUserIntroductionSceneSceneBuilder {
+public struct EditUserIntroductionSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
     let someWorker: EditUserIntroductionSceneWorkable
@@ -29,7 +29,7 @@ public struct EditUserIntroductionSceneSceneBuilder {
   }
 }
 
-extension EditUserIntroductionSceneSceneBuilder: EditUserIntroductionSceneBuildable {
+extension EditUserIntroductionSceneBuilder: EditUserIntroductionSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
@@ -43,7 +43,7 @@ extension EditUserIntroductionSceneSceneBuilder: EditUserIntroductionSceneBuilda
   }
 }
 
-extension EditUserIntroductionSceneSceneBuilder {
+extension EditUserIntroductionSceneBuilder {
   /// VIP Cycle을 설정합니다.
   /// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneRouter.swift
@@ -21,20 +21,12 @@ protocol EditUserIntroductionSceneDataPassing {
 class EditUserIntroductionSceneRouter: EditUserIntroductionSceneDataPassing {
   weak var viewController: EditUserIntroductionSceneViewController?
   var dataStore: EditUserIntroductionSceneDataStore?
-  private let nextSceneBuilder: NextSceneBuildable
-  
-  init(nextSceneBuilder: NextSceneBuildable) {
-    self.nextSceneBuilder = nextSceneBuilder
-  }
 }
 
 // MARK: - Routing
 
 extension EditUserIntroductionSceneRouter: EditUserIntroductionSceneRoutingLogic {
   func routeToSomewhere() {
-    let destinationViewController = self.nextSceneBuilder.build(with: NextScenePayload())
-    
-    self.viewController?.present(destinationViewController, animated: true)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -124,6 +124,6 @@ extension EditUserIntroductionSceneViewController {
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
-  return UINavigationController(rootViewController: EditUserIntroductionSceneViewController())
+  return UINavigationController(rootViewController: EditUserIntroductionSceneBuilder.previewScene)
 }
 #endif


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #563 

## 🎉 변경 사항
- Preview에서 VIP 동작을 확인할 수 있도록 Builder에 `previewScene` 타입 프로퍼티를 추가하였습니다.
- Payload 네이밍 네이밍을 수정하였습니다.
  - `EditUserIntroductionSceneScenePayload` > `EditUserIntroductionScenePayload`
- 소개 수정화면에서 다음 화면이 없기에, nextSceneBuilder를 삭제하였습니다.

## 📌 PR Point
- 아직 VIP가 구현되어 있지 않지만, `개발 과정의 간편함`과 리뷰과정에 `리뷰어가 VIP 동작을 확인`할 수 있게 하고자 추가하였습니다.

### Preview GIF
<img width="250" src="https://github.com/user-attachments/assets/f45a7575-1acb-4195-9b0a-a37d0dfbe5da">


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?