### PR TITLE
EditUserIntroductionScene Interactor 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
@@ -48,7 +48,7 @@ extension EditUserIntroductionSceneBuilder {
   private func configureVIPCycle(
     for viewController: EditUserIntroductionSceneViewController
   ) -> EditUserIntroductionSceneViewController {
-    let interactor = EditUserIntroductionSceneInteractor(someWorker: self.dependency.someWorker)
+    let interactor = EditUserIntroductionSceneInteractor(editUserIntroductionWorker: self.dependency.someWorker)
     let presenter = EditUserIntroductionScenePresenter()
     let router = EditUserIntroductionSceneRouter()
     viewController.interactor = interactor

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -21,7 +21,7 @@ protocol EditUserIntroductionSceneBusinessLogic {
   func verifyUserIntroduction(_ introduction: String)
   func requestEditUserIntroduction(_ introduction: String)
 
-  func cancelRunningTask()
+  func cancelTask()
 }
 
 final class EditUserIntroductionSceneInteractor: EditUserIntroductionSceneDataStore {
@@ -77,7 +77,7 @@ extension EditUserIntroductionSceneInteractor: EditUserIntroductionSceneBusiness
     }
   }
 
-  func cancelRunningTask() {
+  func cancelTask() {
     self.requestEditUserIntroductionTask?.cancel()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -17,6 +17,7 @@ protocol EditUserIntroductionSceneDataStore {
 
 protocol EditUserIntroductionSceneBusinessLogic {
   func loadUserIntroduction()
+  func verifyUserIntroduction(_ introduction: String)
 }
 
 final class EditUserIntroductionSceneInteractor: EditUserIntroductionSceneDataStore {
@@ -35,5 +36,18 @@ final class EditUserIntroductionSceneInteractor: EditUserIntroductionSceneDataSt
 extension EditUserIntroductionSceneInteractor: EditUserIntroductionSceneBusinessLogic {
   func loadUserIntroduction() {
     self.presenter?.presentUserIntroduction(self.userIntroduction)
+  }
+
+  func verifyUserIntroduction(_ introduction: String) {
+    let isValid = self.checkUserIntroductionValidity(introduction)
+    self.presenter?.presentUserNameVerification(isValid: isValid)
+  }
+}
+
+// MARK: - Private Functions
+
+extension EditUserIntroductionSceneInteractor {
+  private func checkUserIntroductionValidity(_ introduction: String) -> Bool {
+    return introduction.count <= 15
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -20,6 +20,8 @@ protocol EditUserIntroductionSceneBusinessLogic {
   func loadUserIntroduction()
   func verifyUserIntroduction(_ introduction: String)
   func requestEditUserIntroduction(_ introduction: String)
+
+  func cancelRunningTask()
 }
 
 final class EditUserIntroductionSceneInteractor: EditUserIntroductionSceneDataStore {
@@ -55,15 +57,22 @@ extension EditUserIntroductionSceneInteractor: EditUserIntroductionSceneBusiness
       guard let self else { return }
 
       defer { self.requestEditUserIntroductionTask = nil }
+      if Task.isCancelled { return }
 
       do {
         try await self.editUserIntroductionWorker.editUserIntroduction(introduction)
 
+        try Task.checkCancellation()
         self.presenter?.presentEditUserIntroductionResult(nil)
       } catch let error {
+        if error is CancellationError { return }
         self.presenter?.presentEditUserIntroductionResult(error)
       }
     }
+  }
+
+  func cancelRunningTask() {
+    self.requestEditUserIntroductionTask?.cancel()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -50,7 +50,11 @@ extension EditUserIntroductionSceneInteractor: EditUserIntroductionSceneBusiness
 
   func verifyUserIntroduction(_ introduction: String) {
     let isValid = self.checkUserIntroductionValidity(introduction)
-    self.presenter?.presentUserNameVerification(isValid: isValid)
+    if isValid {
+      self.presenter?.presentIntroductionIsValid()
+    } else {
+      self.presenter?.presentIntroductionIsInvalid()
+    }
   }
 
   func requestEditUserIntroduction(_ introduction: String) {

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -53,13 +53,11 @@ extension EditUserIntroductionSceneInteractor: EditUserIntroductionSceneBusiness
     guard self.checkUserIntroductionValidity(introduction)
     else { return }
 
-    self.requestEditUserIntroductionTask = Task { [weak self] in
-      guard let self else { return }
-
+    self.requestEditUserIntroductionTask = Task {
       defer { self.requestEditUserIntroductionTask = nil }
-      if Task.isCancelled { return }
 
       do {
+        try Task.checkCancellation()
         try await self.editUserIntroductionWorker.editUserIntroduction(introduction)
 
         try Task.checkCancellation()

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -16,6 +16,7 @@ protocol EditUserIntroductionSceneDataStore {
 }
 
 protocol EditUserIntroductionSceneBusinessLogic {
+  func loadUserIntroduction()
 }
 
 final class EditUserIntroductionSceneInteractor: EditUserIntroductionSceneDataStore {
@@ -32,4 +33,7 @@ final class EditUserIntroductionSceneInteractor: EditUserIntroductionSceneDataSt
 // MARK: - Request to worker
 
 extension EditUserIntroductionSceneInteractor: EditUserIntroductionSceneBusinessLogic {
+  func loadUserIntroduction() {
+    self.presenter?.presentUserIntroduction(self.userIntroduction)
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -15,7 +15,6 @@ protocol EditUserIntroductionSceneDataStore {
 }
 
 protocol EditUserIntroductionSceneBusinessLogic {
-  func doSomething(request: EditUserIntroductionScene.Something.Request)
 }
 
 class EditUserIntroductionSceneInteractor: EditUserIntroductionSceneDataStore {
@@ -31,10 +30,4 @@ class EditUserIntroductionSceneInteractor: EditUserIntroductionSceneDataStore {
 // MARK: - Request to worker
 
 extension EditUserIntroductionSceneInteractor: EditUserIntroductionSceneBusinessLogic {
-  func doSomething(request: EditUserIntroductionScene.Something.Request) {
-    self.someWorker.doSomeWork()
-
-    let response = EditUserIntroductionScene.Something.Response()
-    self.presenter?.presentSomething(response: response)
-  }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -15,19 +15,23 @@ protocol EditUserIntroductionSceneDataStore {
   var userIntroduction: String? { get }
 }
 
+@MainActor
 protocol EditUserIntroductionSceneBusinessLogic {
   func loadUserIntroduction()
   func verifyUserIntroduction(_ introduction: String)
+  func requestEditUserIntroduction(_ introduction: String)
 }
 
 final class EditUserIntroductionSceneInteractor: EditUserIntroductionSceneDataStore {
   var userIntroduction: String?
 
-  var presenter: EditUserIntroductionScenePresentationLogic?
-  private let someWorker: EditUserIntroductionSceneWorkable
+  private var requestEditUserIntroductionTask: Task<Void, Never>?
 
-  init(someWorker: EditUserIntroductionSceneWorkable) {
-    self.someWorker = someWorker
+  var presenter: EditUserIntroductionScenePresentationLogic?
+  private let editUserIntroductionWorker: EditUserIntroductionSceneWorkable
+
+  init(editUserIntroductionWorker: EditUserIntroductionSceneWorkable) {
+    self.editUserIntroductionWorker = editUserIntroductionWorker
   }
 }
 
@@ -41,6 +45,25 @@ extension EditUserIntroductionSceneInteractor: EditUserIntroductionSceneBusiness
   func verifyUserIntroduction(_ introduction: String) {
     let isValid = self.checkUserIntroductionValidity(introduction)
     self.presenter?.presentUserNameVerification(isValid: isValid)
+  }
+
+  func requestEditUserIntroduction(_ introduction: String) {
+    guard self.checkUserIntroductionValidity(introduction)
+    else { return }
+
+    self.requestEditUserIntroductionTask = Task { [weak self] in
+      guard let self else { return }
+
+      defer { self.requestEditUserIntroductionTask = nil }
+
+      do {
+        try await self.editUserIntroductionWorker.editUserIntroduction(introduction)
+
+        self.presenter?.presentEditUserIntroductionResult(nil)
+      } catch let error {
+        self.presenter?.presentEditUserIntroductionResult(error)
+      }
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -17,7 +17,7 @@ protocol EditUserIntroductionSceneDataStore {
 protocol EditUserIntroductionSceneBusinessLogic {
 }
 
-class EditUserIntroductionSceneInteractor: EditUserIntroductionSceneDataStore {
+final class EditUserIntroductionSceneInteractor: EditUserIntroductionSceneDataStore {
   // var name: String = ""
   var presenter: EditUserIntroductionScenePresentationLogic?
   private let someWorker: EditUserIntroductionSceneWorkable

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -63,10 +63,10 @@ extension EditUserIntroductionSceneInteractor: EditUserIntroductionSceneBusiness
         try await self.editUserIntroductionWorker.editUserIntroduction(introduction)
 
         try Task.checkCancellation()
-        self.presenter?.presentEditUserIntroductionResult(nil)
+        self.presenter?.presentEditUserIntroductionSuccess()
       } catch let error {
         if error is CancellationError { return }
-        self.presenter?.presentEditUserIntroductionResult(error)
+        self.presenter?.presentEditUserIntroductionError(error)
       }
     }
   }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -11,14 +11,16 @@ import EditUserIntroductionSceneAPI
 import EditUserIntroductionSceneEntity
 
 protocol EditUserIntroductionSceneDataStore {
-  // var name: String { get set }
+  /// UserInfoScene에서 Payload로 런타임에 전달받을 한줄 소개에 대한 데이터입니다.
+  var userIntroduction: String? { get }
 }
 
 protocol EditUserIntroductionSceneBusinessLogic {
 }
 
 final class EditUserIntroductionSceneInteractor: EditUserIntroductionSceneDataStore {
-  // var name: String = ""
+  var userIntroduction: String?
+
   var presenter: EditUserIntroductionScenePresentationLogic?
   private let someWorker: EditUserIntroductionSceneWorkable
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -41,7 +41,11 @@ final class EditUserIntroductionSceneInteractor: EditUserIntroductionSceneDataSt
 
 extension EditUserIntroductionSceneInteractor: EditUserIntroductionSceneBusinessLogic {
   func loadUserIntroduction() {
-    self.presenter?.presentUserIntroduction(self.userIntroduction)
+    if let userIntroduction {
+      self.presenter?.presentUserIntroduction(userIntroduction)
+    } else {
+      self.presenter?.presentEmptyUserIntroduction()
+    }
   }
 
   func verifyUserIntroduction(_ introduction: String) {

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -12,6 +12,7 @@ import EditUserIntroductionSceneEntity
 // swiftlint:disable type_name
 protocol EditUserIntroductionScenePresentationLogic {
   func presentUserIntroduction(_ introduction: String?)
+  func presentUserNameVerification(isValid: Bool)
 }
 // swiftlint:enable type_name
 
@@ -23,6 +24,10 @@ class EditUserIntroductionScenePresenter {
 
 extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentationLogic {
   func presentUserIntroduction(_ introduction: String?) {
+    // TODO: - Display 로직 호출
+  }
+
+  func presentUserNameVerification(isValid: Bool) {
     // TODO: - Display 로직 호출
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -10,9 +10,11 @@ import Foundation
 import EditUserIntroductionSceneEntity
 
 // swiftlint:disable type_name
+@MainActor
 protocol EditUserIntroductionScenePresentationLogic {
   func presentUserIntroduction(_ introduction: String?)
   func presentUserNameVerification(isValid: Bool)
+  func presentEditUserIntroductionResult(_ error: Error?)
 }
 // swiftlint:enable type_name
 
@@ -29,5 +31,9 @@ extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentat
 
   func presentUserNameVerification(isValid: Bool) {
     // TODO: - Display 로직 호출
+  }
+
+  func presentEditUserIntroductionResult(_ error: Error?) {
+
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -12,7 +12,8 @@ import EditUserIntroductionSceneEntity
 // swiftlint:disable type_name
 @MainActor
 protocol EditUserIntroductionScenePresentationLogic {
-  func presentUserIntroduction(_ introduction: String?)
+  func presentUserIntroduction(_ introduction: String)
+  func presentEmptyUserIntroduction()
   func presentUserNameVerification(isValid: Bool)
   func presentEditUserIntroductionSuccess()
   func presentEditUserIntroductionError(_ error: Error)
@@ -26,15 +27,19 @@ class EditUserIntroductionScenePresenter {
 // MARK: - Request to ViewController
 
 extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentationLogic {
+  func presentUserIntroduction(_ introduction: String) {
+    // TODO: - Display 로직 호출
+  }
+
+  func presentEmptyUserIntroduction() {
+    // TODO: - Display로직 호출
+  }
+
   func presentEditUserIntroductionSuccess() {
     // TODO: - Display 로직 호출
   }
-  
+
   func presentEditUserIntroductionError(_ error: Error) {
-    // TODO: - Display 로직 호출
-  }
-  
-  func presentUserIntroduction(_ introduction: String?) {
     // TODO: - Display 로직 호출
   }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -14,7 +14,8 @@ import EditUserIntroductionSceneEntity
 protocol EditUserIntroductionScenePresentationLogic {
   func presentUserIntroduction(_ introduction: String?)
   func presentUserNameVerification(isValid: Bool)
-  func presentEditUserIntroductionResult(_ error: Error?)
+  func presentEditUserIntroductionSuccess()
+  func presentEditUserIntroductionError(_ error: Error)
 }
 // swiftlint:enable type_name
 
@@ -25,15 +26,19 @@ class EditUserIntroductionScenePresenter {
 // MARK: - Request to ViewController
 
 extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentationLogic {
+  func presentEditUserIntroductionSuccess() {
+    // TODO: - Display 로직 호출
+  }
+  
+  func presentEditUserIntroductionError(_ error: Error) {
+    // TODO: - Display 로직 호출
+  }
+  
   func presentUserIntroduction(_ introduction: String?) {
     // TODO: - Display 로직 호출
   }
 
   func presentUserNameVerification(isValid: Bool) {
-    // TODO: - Display 로직 호출
-  }
-
-  func presentEditUserIntroductionResult(_ error: Error?) {
     // TODO: - Display 로직 호출
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -14,7 +14,8 @@ import EditUserIntroductionSceneEntity
 protocol EditUserIntroductionScenePresentationLogic {
   func presentUserIntroduction(_ introduction: String)
   func presentEmptyUserIntroduction()
-  func presentUserNameVerification(isValid: Bool)
+  func presentIntroductionIsValid()
+  func presentIntroductionIsInvalid()
   func presentEditUserIntroductionSuccess()
   func presentEditUserIntroductionError(_ error: Error)
 }
@@ -32,7 +33,15 @@ extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentat
   }
 
   func presentEmptyUserIntroduction() {
-    // TODO: - Display로직 호출
+    // TODO: - Display 로직 호출
+  }
+
+  func presentIntroductionIsValid() {
+    // TODO: - Display 로직 호출
+  }
+
+  func presentIntroductionIsInvalid() {
+    // TODO: - Display 로직 호출
   }
 
   func presentEditUserIntroductionSuccess() {
@@ -40,10 +49,6 @@ extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentat
   }
 
   func presentEditUserIntroductionError(_ error: Error) {
-    // TODO: - Display 로직 호출
-  }
-
-  func presentUserNameVerification(isValid: Bool) {
     // TODO: - Display 로직 호출
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -11,7 +11,7 @@ import EditUserIntroductionSceneEntity
 
 // swiftlint:disable type_name
 protocol EditUserIntroductionScenePresentationLogic {
-  func presentSomething(response: EditUserIntroductionScene.Something.Response)
+  func presentUserIntroduction(_ introduction: String?)
 }
 // swiftlint:enable type_name
 
@@ -22,8 +22,7 @@ class EditUserIntroductionScenePresenter {
 // MARK: - Request to ViewController
 
 extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentationLogic {
-  func presentSomething(response: EditUserIntroductionScene.Something.Response) {
-    let viewModel = EditUserIntroductionScene.Something.ViewModel()
-    self.viewController?.displaySomething(viewModel: viewModel)
+  func presentUserIntroduction(_ introduction: String?) {
+    // TODO: - Display 로직 호출
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -34,6 +34,6 @@ extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentat
   }
 
   func presentEditUserIntroductionResult(_ error: Error?) {
-
+    // TODO: - Display 로직 호출
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -50,6 +50,11 @@ class EditUserIntroductionSceneViewController: UIViewController, EditUserIntrodu
     self.setupUI()
     self.doSomething()
   }
+
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    self.interactor?.cancelRunningTask()
+  }
 }
 
 // MARK: - Confirm display logic protocol

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -48,7 +48,6 @@ class EditUserIntroductionSceneViewController: UIViewController, EditUserIntrodu
   override func viewDidLoad() {
     super.viewDidLoad()
     self.setupUI()
-    self.doSomething()
   }
 
   override func viewDidDisappear(_ animated: Bool) {
@@ -68,10 +67,6 @@ extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisp
 // MARK: - Request to interactor
 
 extension EditUserIntroductionSceneViewController {
-  func doSomething() {
-    let request = EditUserIntroductionScene.Something.Request()
-    self.interactor?.doSomething(request: request)
-  }
 }
 
 // MARK: - Set up UI

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -52,7 +52,7 @@ class EditUserIntroductionSceneViewController: UIViewController, EditUserIntrodu
 
   override func viewDidDisappear(_ animated: Bool) {
     super.viewDidDisappear(animated)
-    self.interactor?.cancelRunningTask()
+    self.interactor?.cancelTask()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneWorker.swift
@@ -10,6 +10,7 @@ import Foundation
 import EditUserIntroductionSceneAPI
 
 struct EditUserIntroductionSceneWorker: EditUserIntroductionSceneWorkable {
-  func doSomeWork() {
+  func editUserIntroduction(_ introduction: String) async throws {
+    // TODO: 서버 구현이 완료되면 구현할 예정입니다.
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionSceneWorkable.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 public protocol EditUserIntroductionSceneWorkable {
-  func doSomeWork()
+  func editUserIntroduction(_ introduction: String) async throws
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #562 

## 🎉 변경 사항
- 유저 소개 화면의 유스케이스에 따라 Interactor에 비즈니스 로직을 추가하였습니다.

## 📌 PR Point
- PR을 최대한 쪼개려고 노력했습니다...
- 근데 Worker, Presenter에 빈(깡통) 로직 추가때문에 FileChanged 수가 5개나 되네요.. 양해 부탁드립니다 🥲

### 1. 유저 소개 전달
- Payload로 이전 화면(UserInfoScene)에서 전달받은 소개 데이터를 Presenter에게 전달합니다.
- DataStore에 `userIntroduction 프로퍼티`를 추가하였습니다.

### 2. 소개 유효성 검사
- 유저가 새로 입력한 소개가 `언어 상관없이 15자 이하인지` 유효성 검사를 실시합니다.

### 3. 유저 소개 수정 요청 & Task Cancel
- 유저가 `완료 버튼을 누르면`, Task를 생성하여 Worker를 호출해 서버에 수정 요청을 실행합니다.
- 현재 서버 구현 전이므로, Worker 내부에는 로직을 별도로 구현하지 않았습니다.

- ViewController가 `viewDidDisAppear 호출시, 실행중인 Task를 취소`하도록 구현하였습니다.

``` Swift
extension EditUserIntroductionSceneInteractor: EditUserIntroductionSceneBusinessLogic {
  func requestEditUserIntroduction(_ introduction: String) {
    guard self.checkUserIntroductionValidity(introduction) // 유효성 검사 실시
    else { return }

    self.requestEditUserIntroductionTask = Task { [weak self] in
      guard let self else { return }

      defer { self.requestEditUserIntroductionTask = nil }
      if Task.isCancelled { return } // Task 취소 여부 확인

      do {
        try await self.editUserIntroductionWorker.editUserIntroduction(introduction)

        try Task.checkCancellation() // 서버 요청 로직 이후 Task 취소 확인
        self.presenter?.presentEditUserIntroductionResult(nil)
      } catch let error {
        if error is CancellationError { return } // Task 취소 에러의 경우, early-exit
        self.presenter?.presentEditUserIntroductionResult(error)
      }
    }
  }
```


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?