### PR TITLE
Signup Input View 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AnimatedMultiLinesTitleView.swift
@@ -10,7 +10,7 @@ import UIKit
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
-public final class AnimatedMultiLinesTitleView: UIStackView {
+final class AnimatedMultiLinesTitleView: UIStackView {
   private let mainTitleLabelFirst: UILabel
   private let mainTitleLabelSecond: UILabel
   private let subTitleLabel: UILabel
@@ -22,7 +22,7 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
   private var isAnimating: Bool
   private var animationTask: Task<Void, Never>?
   
-  public init(
+  init(
     firstLineText: String,
     secondLineText: String,
     thirdLineText: String
@@ -44,8 +44,7 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
     fatalError()
   }
   
-  @MainActor
-  public func startAnimation() {
+  func startAnimation() {
     guard !self.isAnimating else { return }
     
     self.isAnimating = true
@@ -74,8 +73,7 @@ public final class AnimatedMultiLinesTitleView: UIStackView {
     }
   }
   
-  @MainActor
-  public func cancelTask() {
+  func cancelTask() {
     if self.isAnimating {
       self.completeAnimationImmediately()
     }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
@@ -43,9 +43,12 @@ public class SignUpInputView: UIView {
   }
   
   public override var intrinsicContentSize: CGSize {
+    let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+    let screenWidth = windowScene?.screen.bounds.width ?? CGFloat.zero
+    let screenHeight = windowScene?.screen.bounds.height ?? CGFloat.zero
     return CGSize(
-      width: UIScreen.main.bounds.width,
-      height: UIScreen.main.bounds.height * Constant.SignUpInputView.heightMultiplier
+      width: screenWidth,
+      height: screenHeight * Constant.SignUpInputView.heightMultiplier
     )
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
@@ -100,6 +100,7 @@ extension SignUpInputView {
   }
 }
 
+#if DEBUG
 @available(iOS 17.0, *)
 #Preview {
   let view = SignUpInputView(
@@ -121,3 +122,4 @@ extension SignUpInputView {
   }
   return view
 }
+#endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
@@ -33,6 +33,7 @@ public class SignUpInputView: UIView {
       validationText: validationText
     )
     super.init(frame: CGRect.zero)
+    self.setupUI()
     self.backgroundColor = UIColor.white
   }
   
@@ -46,5 +47,40 @@ public class SignUpInputView: UIView {
       width: UIScreen.main.bounds.width,
       height: UIScreen.main.bounds.height * Constant.SignUpInputView.heightMultiplier
     )
+  }
+extension SignUpInputView {
+  private func setupUI() {
+    self.setupTextInputView()
+    self.setupTitleView()
+  }
+  
+  private func setupTextInputView() {
+    let constants = Constant.SignUpInputView.TextInputView.self
+    self.addSubview(self.textInputView)
+    self.textInputView.usingAutolayout()
+    NSLayoutConstraint.activate([
+      self.textInputView.topAnchor.constraint(
+        equalTo: self.topAnchor,
+        constant: constants.topMargin
+      ),
+      self.textInputView.leadingAnchor.constraint(
+        equalTo: self.leadingAnchor,
+        constant: self.intrinsicContentSize.width * constants.leadingMultiplier
+      ),
+      self.textInputView.trailingAnchor.constraint(
+        equalTo: self.trailingAnchor,
+        constant: self.intrinsicContentSize.width * constants.trailingMultiplier
+      )
+    ])
+  }
+  
+  private func setupTitleView() {
+    self.addSubview(self.titleView)
+    self.titleView.usingAutolayout()
+    NSLayoutConstraint.activate([
+      self.titleView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.titleView.leadingAnchor.constraint(equalTo: self.textInputView.leadingAnchor),
+      self.titleView.trailingAnchor.constraint(lessThanOrEqualTo: self.textInputView.trailingAnchor)
+    ])
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
@@ -1,0 +1,12 @@
+//
+//  SignUpInputView.swift
+//
+//
+//  Created by SONG on 10/10/24.
+//
+
+import UIKit
+
+class SignUpInputView: UIView {
+  
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
@@ -96,3 +96,25 @@ extension SignUpInputView {
     ])
   }
 }
+
+@available(iOS 17.0, *)
+#Preview {
+  let view = SignUpInputView(
+    firstTitle: "환영해요!",
+    secondTitle: "아이디를 정해볼까요?",
+    thirdTitle: "아이디로 친구의 가든을 찾을 수 있어요.",
+    textFieldTitle: "아이디",
+    placeholderText: "아이디를 입력해주세요.",
+    validationText: "아이디는 5~12자 내외 띄어쓰기 없이\n영문, 숫자만 사용 가능합니다"
+  )
+  
+  view.startTitleAnimation()
+  DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+    view.textInputView.showValidationText()
+  }
+  
+  DispatchQueue.main.asyncAfter(deadline: .now() + 6) {
+    view.textInputView.hideValidationText()
+  }
+  return view
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import ToDoGardenUIConstant
 
-public class SignUpInputView: UIView {
+public final class SignUpInputView: UIView {
   private let titleView: AnimatedMultiLinesTitleView
   
   public let textInputView: InputTextValidationView

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
@@ -7,6 +7,44 @@
 
 import UIKit
 
-class SignUpInputView: UIView {
+import ToDoGardenUIConstant
+
+public class SignUpInputView: UIView {
+  private let titleView: AnimatedMultiLinesTitleView
   
+  public let textInputView: InputTextValidationView
+  
+  public init(
+    firstTitle: String,
+    secondTitle: String,
+    thirdTitle: String,
+    textFieldTitle: String,
+    placeholderText: String,
+    validationText: String
+  ) {
+    self.titleView = AnimatedMultiLinesTitleView(
+      firstLineText: firstTitle,
+      secondLineText: secondTitle,
+      thirdLineText: thirdTitle
+    )
+    self.textInputView = InputTextValidationView(
+      inputText: textFieldTitle,
+      placeholderText: placeholderText,
+      validationText: validationText
+    )
+    super.init(frame: CGRect.zero)
+    self.backgroundColor = UIColor.white
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  public override var intrinsicContentSize: CGSize {
+    return CGSize(
+      width: UIScreen.main.bounds.width,
+      height: UIScreen.main.bounds.height * Constant.SignUpInputView.heightMultiplier
+    )
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SignUpInputView.swift
@@ -48,6 +48,18 @@ public class SignUpInputView: UIView {
       height: UIScreen.main.bounds.height * Constant.SignUpInputView.heightMultiplier
     )
   }
+  
+  @MainActor
+  public func startTitleAnimation() {
+    self.titleView.startAnimation()
+  }
+  
+  @MainActor
+  public func cancelTitleAnimation() {
+    self.titleView.cancelTask()
+  }
+}
+
 extension SignUpInputView {
   private func setupUI() {
     self.setupTextInputView()

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SignUpInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SignUpInputView.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by SONG on 10/10/24.
+//
+
+import Foundation

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SignUpInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SignUpInputView.swift
@@ -1,8 +1,18 @@
 //
-//  File.swift
-//  
+//  Constant+SignUpInputView.swift
+//
 //
 //  Created by SONG on 10/10/24.
 //
 
 import Foundation
+
+extension Constant.SignUpInputView {
+  public static let heightMultiplier: CGFloat = 0.2
+  
+  public enum TextInputView {
+    public static let topMargin: CGFloat = 75
+    public static let leadingMultiplier: CGFloat = 0.1
+    public static let trailingMultiplier: CGFloat = -0.13
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -40,4 +40,5 @@ public enum Constant {
   public enum TermsAgreementView { }
   public enum TermsAgreementViewRow { }
   public enum InputTextValidationView {}
+  public enum SignUpInputView { }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #568 

## 🎉 변경 사항
- Signup Input View를 추가합니다. 

## 📌 PR Point
<img width="254" alt="스크린샷 2024-10-10 오후 5 08 02" src="https://github.com/user-attachments/assets/36c8e2d8-bd6b-4c25-acf1-f26b97a0a068">

- ↑ SignUp Scene 을 3개로 분할해서 만드려고 계획했을 당시에는 , 위 이미지의 두 녀석을 각각의 뷰로 쓰려고 했습니다. 
그런데 3개를 통합한 SignUpScene에서 그래버리면 , SignUpVC 에서 최소 6개의 뷰 객체를 들고있게 되고, 그것들을 분간하기가 불편할 것이고, 레이아웃 설정 코드도 상당한 양이 될 것 같아서, 두 녀석을 하나로 합쳐버린 새로운 뷰 객체를 만들어보았습니다. 

- 이니셜라이저에서 각각의 텍스트를 설정할 수 있게 구성하였습니다. 
- 레이아웃은 디바이스 크기에 따라 피그마 가이드 비율에 맞게 길이가 조절됩니다. 
- 서브뷰로 포함된 AnimatedMultiLinesTitleView 의 startAnimation() / cancelAnimation() 메서드에 표기되어있던 MainActor 키워드는 제거되었고, SignUpInputView으로 옮겨왔습니다. 

```swift
  @MainActor
  public func startTitleAnimation() {
    self.titleView.startAnimation()
  }
  
  @MainActor
  public func cancelTitleAnimation() {
    self.titleView.cancelTask()
  }
```

- ↑ VC에서 startTitleAnimation() 를 호출할 때, MainActor 키워드를 확인 할 수 있습니다.

### 실행화면 
![signupInputView](https://github.com/user-attachments/assets/0c72c8b0-4b80-4bbc-9a27-9e0979c9890d)


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?