### PR TITLE
SignUp VC의 UI세팅 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -35,6 +35,7 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
     )
     super.init(nibName: nil, bundle: nil)
     self.view.backgroundColor = UIColor.white
+    self.setupNavigationBar()
   }
   
   @available(*, unavailable)
@@ -47,6 +48,27 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.doSomething()
+  }
+  
+  // MARK: - Setups
+  
+  private func setupNavigationBar() {
+    let backButton = UIBarButtonItem(
+      image: UIImage.backwardButtonImage,
+      style: UIBarButtonItem.Style.plain,
+      target: self,
+      action: #selector(self.backButtonTapped)
+    )
+    backButton.tintColor = UIColor.toDoGardenGreenDark
+    self.navigationItem.setLeftBarButton(backButton, animated: true)
+  }
+  
+  @objc private func backButtonTapped() {
+    if self.signUpScrollView.currentPageIndex == Int.zero {
+      self.exitSignUpFlow()
+    } else {
+      self.signUpScrollView.goToPreviousPage()
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -37,6 +37,7 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
     self.view.backgroundColor = UIColor.white
     self.setupNavigationBar()
     self.setupSignUpScrollView()
+    self.setupBottomButton()
   }
   
   @available(*, unavailable)
@@ -80,6 +81,29 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
         )
       ]
     )
+  }
+  
+  private func setupBottomButton() {
+    self.view.addSubview(self.bottomButton)
+    self.bottomButton.usingAutolayout()
+    self.bottomButton.addAction(UIAction { [weak self] _ in
+      self?.signUpScrollView.goToNextPage()
+    }, for: UIControl.Event.touchUpInside)
+    
+    NSLayoutConstraint.activate(
+      [
+        self.bottomButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+        self.bottomButton.centerYAnchor.constraint(
+          equalTo: self.view.centerYAnchor,
+          constant: Constant.BottomButton.centerYOffset
+        )
+      ]
+    )
+  }
+  
+  private func exitSignUpFlow() {
+    // TODO: Router
+    self.navigationController?.popViewController(animated: true)
   }
   
   @objc private func backButtonTapped() {

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -38,6 +38,7 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
     self.setupNavigationBar()
     self.setupSignUpScrollView()
     self.setupBottomButton()
+    self.setupTapRecognizer()
   }
   
   @available(*, unavailable)
@@ -101,6 +102,11 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
     )
   }
   
+  private func setupTapRecognizer() {
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.handleTap))
+    self.view.addGestureRecognizer(tapGesture)
+  }
+  
   private func exitSignUpFlow() {
     // TODO: Router
     self.navigationController?.popViewController(animated: true)
@@ -112,6 +118,10 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
     } else {
       self.signUpScrollView.goToPreviousPage()
     }
+  }
+  
+  @objc private func handleTap() {
+    self.signUpScrollView.cancelAnimation()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -141,3 +141,12 @@ extension SignUpViewController {
     self.interactor?.doSomething(request: request)
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let viewController = SignUpViewController()
+  let navi = UINavigationController(rootViewController: viewController)
+  return navi
+}
+#endif

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -36,6 +36,7 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
     super.init(nibName: nil, bundle: nil)
     self.view.backgroundColor = UIColor.white
     self.setupNavigationBar()
+    self.setupSignUpScrollView()
   }
   
   @available(*, unavailable)
@@ -61,6 +62,24 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
     )
     backButton.tintColor = UIColor.toDoGardenGreenDark
     self.navigationItem.setLeftBarButton(backButton, animated: true)
+  }
+  
+  private func setupSignUpScrollView() {
+    self.view.addSubview(self.signUpScrollView)
+    self.signUpScrollView.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        self.signUpScrollView.topAnchor.constraint(
+          equalTo: self.view.safeAreaLayoutGuide.topAnchor,
+          constant: Constant.ScrollView.topMargin
+        ),
+        self.signUpScrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+        self.signUpScrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+        self.signUpScrollView.heightAnchor.constraint(
+          equalToConstant: self.view.bounds.height * Constant.ScrollView.heightMultiplier
+        )
+      ]
+    )
   }
   
   @objc private func backButtonTapped() {

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -9,22 +9,32 @@ import UIKit
 
 import SignUpSceneAPI
 import SignUpSceneEntity
+import ToDoGardenUIComponent
 
 protocol SignUpDisplayLogic: AnyObject {
   func displaySomething(viewModel: SignUp.Something.ViewModel)
 }
 
-class SignUpViewController: UIViewController, SignUpViewControllable {
+final class SignUpViewController: UIViewController, SignUpViewControllable {
   
   // MARK: - VIP Properties
   
   var interactor: SignUpBusinessLogic?
   var router: (SignUpRoutingLogic & SignUpDataPassing)?
   
+  private let signUpScrollView: SignUpScrollView
+  private let bottomButton: ToDoGardenBoxButton
+  
   // MARK: - Object lifecycle
   
   init() {
+    self.signUpScrollView = SignUpScrollView()
+    self.bottomButton = ToDoGardenBoxButton(
+      title: Constant.BottomButton.StringLiteral.done,
+      buttonType: ToDoGardenBoxButton.Configuration.rectangleButton
+    )
     super.init(nibName: nil, bundle: nil)
+    self.view.backgroundColor = UIColor.white
   }
   
   @available(*, unavailable)

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpSceneConstants.swift
@@ -1,8 +1,49 @@
 //
-//  File.swift
-//  
+//  SignUpSceneConstants.swift
+//
 //
 //  Created by SONG on 10/11/24.
 //
 
 import Foundation
+
+enum Constant {
+  enum ScrollView {
+    static let topMargin: CGFloat = 40.0
+    static let heightMultiplier: CGFloat = 0.25
+    
+    enum SignUpInputView {
+      enum StringLiteral {
+        static let idFirstTitle: String = "환영해요!"
+        static let idSecondTitle: String = "아이디를 정해볼까요?"
+        static let idThirdTitle: String = "아이디로 친구의 가든을 찾을 수 있어요"
+        static let idTextFieldTitle: String = "아이디"
+        static let idPlaceholderText: String = "아이디를 입력해주세요"
+        
+        static let introductionFirstTitle: String = "멋진 아이디에요!"
+        static let introductionSecondTitle: String = "당신을 한 줄로 소개해주세요!"
+        static let introductionThirdTitle: String = "소개는 언제든지 변경할 수 있어요"
+        static let introductionTextFieldTitle: String = "소개"
+        static let introductionPlaceholderText: String = "당신을 소개해주세요."
+        
+        static let nicknameFirstTitle: String = "마지막으로,"
+        static let nicknameSecondTitle: String = "당신의 이름을 알려주세요!"
+        static let nicknameThirdTitle: String = "별명도 사용 가능해요"
+        static let nicknameTextFieldTitle: String = "이름"
+        static let nicknamePlaceholderText: String = "이름을 입력해주세요."
+        
+        static let conditionsForIDGenerationWarning: String = "아이디는 5~12자 내외 띄어쓰기 없이\n영문, 숫자만 사용 가능합니다"
+        static let inUseIDAlreadyWarning: String = "이미 사용중인 아이디 입니다"
+      }
+    }
+  }
+  
+  enum BottomButton {
+    static let centerYOffset: CGFloat = 100.0
+    
+    enum StringLiteral {
+      static let done: String = "완료"
+      static let doItLater: String = "나중에 할래요."
+    }
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpSceneConstants.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by SONG on 10/11/24.
+//
+
+import Foundation

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
@@ -70,4 +70,48 @@ final class SignUpScrollView: UIScrollView {
     ]
   }
   // swiftlint:enable function_body_length
+  
+  private func setupScrollView() {
+    self.isPagingEnabled = true
+    self.showsHorizontalScrollIndicator = false
+    self.isScrollEnabled = false
+  
+    self.addSubview(self.contentView)
+    self.contentView.usingAutolayout()
+    
+    self.setupContentViewConstraints()
+    self.setupInputViewConstraints()
+    
+    self.contentView.widthAnchor.constraint(
+      equalTo: self.widthAnchor,
+      multiplier: CGFloat(self.inputViews.count)
+    ).isActive = true
+  }
+  
+  private func setupContentViewConstraints() {
+    NSLayoutConstraint.activate([
+      self.contentView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.contentView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.contentView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.contentView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+      self.contentView.heightAnchor.constraint(equalTo: self.heightAnchor)
+    ])
+  }
+  
+  private func setupInputViewConstraints() {
+    for (index, inputView) in self.inputViews.enumerated() {
+      self.contentView.addSubview(inputView)
+      inputView.usingAutolayout()
+      
+      NSLayoutConstraint.activate([
+        inputView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
+        inputView.leadingAnchor.constraint(
+          equalTo: self.contentView.leadingAnchor,
+          constant: CGFloat(index) * self.screenWidth
+        ),
+        inputView.widthAnchor.constraint(equalTo: self.widthAnchor),
+        inputView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor)
+      ])
+    }
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
@@ -16,11 +16,19 @@ final class SignUpScrollView: UIScrollView {
       self.didChangePage()
     }
   }
+  
+  private var screenWidth: CGFloat {
+    let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+    return windowScene?.screen.bounds.width ?? CGFloat.zero
+  }
+  
   private var inputViews: [SignUpInputView]
+  private let contentView: UIView
   
   override init(frame: CGRect) {
     self.currentPageIndex = Int.zero
     self.inputViews = []
+    self.contentView = UIView()
     super.init(frame: frame)
   }
   

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
@@ -25,6 +25,10 @@ final class SignUpScrollView: UIScrollView {
   private var inputViews: [SignUpInputView]
   private let contentView: UIView
   
+  @ExecuteOnce private var firstPageAnimation: (() -> Void)?
+  @ExecuteOnce private var secondPageAnimation: (() -> Void)?
+  @ExecuteOnce private var thirdPageAnimation: (() -> Void)?
+  
   override init(frame: CGRect) {
     self.currentPageIndex = Int.zero
     self.inputViews = []
@@ -32,6 +36,7 @@ final class SignUpScrollView: UIScrollView {
     super.init(frame: frame)
     self.setupInputViews()
     self.setupScrollView()
+    self.didChangePage()
   }
   
   @available(*, unavailable)
@@ -143,6 +148,24 @@ final class SignUpScrollView: UIScrollView {
         animated: true
       )
       self.currentPageIndex = previousPageIndex
+    }
+  }
+  
+  // MARK: Animation Controls
+  func cancelAnimation() {
+    self.inputViews[self.currentPageIndex].cancelTitleAnimation()
+  }
+  
+  private func didChangePage() {
+    let animation: (() -> Void)? = {
+      self.inputViews[self.currentPageIndex].startTitleAnimation()
+    }
+    
+    switch self.currentPageIndex {
+    case 0: self.firstPageAnimation = animation
+    case 1: self.secondPageAnimation = animation
+    case 2: self.thirdPageAnimation = animation
+    default: break
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
@@ -1,0 +1,4 @@
+import UIKit
+
+import TDUtility
+import ToDoGardenUIComponent

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
@@ -1,4 +1,31 @@
+//
+//  SignUpScrollView.swift
+//
+//
+//  Created by SONG on 10/7/24.
+//  Copyright (c) 2024 ToDoGarden. All rights reserved.
+
 import UIKit
 
 import TDUtility
 import ToDoGardenUIComponent
+
+final class SignUpScrollView: UIScrollView {
+  private(set) var currentPageIndex: Int {
+    didSet {
+      self.didChangePage()
+    }
+  }
+  private var inputViews: [SignUpInputView]
+  
+  override init(frame: CGRect) {
+    self.currentPageIndex = Int.zero
+    self.inputViews = []
+    super.init(frame: frame)
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
@@ -31,6 +31,7 @@ final class SignUpScrollView: UIScrollView {
     self.contentView = UIView()
     super.init(frame: frame)
     self.setupInputViews()
+    self.setupScrollView()
   }
   
   @available(*, unavailable)
@@ -38,6 +39,7 @@ final class SignUpScrollView: UIScrollView {
     fatalError("init(coder:) has not been implemented")
   }
   
+  // MARK: Setups
   // swiftlint:disable function_body_length
   private func setupInputViews() {
     let constants = Constant.ScrollView.SignUpInputView.StringLiteral.self

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
@@ -30,10 +30,44 @@ final class SignUpScrollView: UIScrollView {
     self.inputViews = []
     self.contentView = UIView()
     super.init(frame: frame)
+    self.setupInputViews()
   }
   
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+  
+  // swiftlint:disable function_body_length
+  private func setupInputViews() {
+    let constants = Constant.ScrollView.SignUpInputView.StringLiteral.self
+    
+    self.inputViews = [
+      SignUpInputView(
+        firstTitle: constants.idFirstTitle,
+        secondTitle: constants.idSecondTitle,
+        thirdTitle: constants.idThirdTitle,
+        textFieldTitle: constants.idTextFieldTitle,
+        placeholderText: constants.idPlaceholderText,
+        validationText: constants.conditionsForIDGenerationWarning
+      ),
+      SignUpInputView(
+        firstTitle: constants.introductionFirstTitle,
+        secondTitle: constants.introductionSecondTitle,
+        thirdTitle: constants.introductionThirdTitle,
+        textFieldTitle: constants.introductionTextFieldTitle,
+        placeholderText: constants.introductionPlaceholderText,
+        validationText: ""
+      ),
+      SignUpInputView(
+        firstTitle: constants.nicknameFirstTitle,
+        secondTitle: constants.nicknameSecondTitle,
+        thirdTitle: constants.nicknameThirdTitle,
+        textFieldTitle: constants.nicknameTextFieldTitle,
+        placeholderText: constants.nicknamePlaceholderText,
+        validationText: ""
+      )
+    ]
+  }
+  // swiftlint:enable function_body_length
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
@@ -116,4 +116,33 @@ final class SignUpScrollView: UIScrollView {
       ])
     }
   }
+  
+  // MARK: Page Controls
+  func goToNextPage() {
+    let nextPageIndex = self.currentPageIndex + 1
+    if nextPageIndex < self.inputViews.count {
+      self.setContentOffset(
+        CGPoint(
+          x: self.screenWidth * CGFloat(nextPageIndex),
+          y: CGFloat.zero
+        ),
+        animated: true
+      )
+      self.currentPageIndex = nextPageIndex
+    }
+  }
+  
+  func goToPreviousPage() {
+    let previousPageIndex = self.currentPageIndex - 1
+    if previousPageIndex >= Int.zero {
+      self.setContentOffset(
+        CGPoint(
+          x: self.screenWidth * CGFloat(previousPageIndex),
+          y: CGFloat.zero
+        ),
+        animated: true
+      )
+      self.currentPageIndex = previousPageIndex
+    }
+  }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #567 
## 🎉 변경 사항
- SignUp VC위에 필요한 뷰를 배치합니다. 

## 📌 PR Point
![스크린샷 2024-10-11 오후 4 39 07](https://github.com/user-attachments/assets/562cd860-d8ec-449b-9bf7-2621977d2d89)

### 구현 설명
![스크린샷 2024-10-11 오후 4 47 46](https://github.com/user-attachments/assets/c898b2da-ba0e-4382-be84-be82d839585d)

### 페이지가 최초로 등장했을 때만 애니메이션이 실행되고, 입력사항이 페이지를 넘어가도 유지됩니다. 
![사인업씬애니메이션](https://github.com/user-attachments/assets/790556f8-f68d-4fbf-856f-b0a861072014)

ExecuteOnce를 사용하였습니다. 
```swift
  @ExecuteOnce private var firstPageAnimation: (() -> Void)?
  @ExecuteOnce private var secondPageAnimation: (() -> Void)?
  @ExecuteOnce private var thirdPageAnimation: (() -> Void)?
```

### 애니메이션 도중 터치이벤트를 감지하면, 애니메이션이 중단되고 모든 제목이 즉시 표시됩니다. 
![사인업씬 애니메이션 취소](https://github.com/user-attachments/assets/2b06a965-548b-4da6-9e5d-a74fb9c98a0b)

- 레이아웃 이슈 X
- TODO : 프리뷰에서는 NavigationBar가 투명하게 보이지만, 시뮬레이터에서는 투명하게 보이지 않습니다. 해당 작업은 빌더를 건들때 할 예정입니다. 
- TODO: bottomButton에 대한 구현은 미완성입니다. 키보드와 함께 엮어서 다른 PR에서 구현 예정입니다. 


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?