### PR TITLE
테스트 대역 값이 없는 경우 에러를 throw 하도록 수정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneWorkerMock.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneWorkerMock.swift
@@ -36,13 +36,21 @@ extension ShareGardenSceneWorkerMock: ShareGardenSceneWorkable {
   func requestMyGarden() async throws -> ShareGardenScene.MyGarden {
     try self.checkIsSuccessfulTask()
     
-    return self.myGarden!
+    if let myGarden {
+      return myGarden
+    }
+    
+    throw NSError()
   }
   
   func requestFriendsGardenList() async throws -> [ShareGardenScene.FriendsGarden] {
     try self.checkIsSuccessfulTask()
     
-    return self.friendsGardenList!
+    if let friendsGardenList {
+      return friendsGardenList
+    }
+    
+    throw NSError()
   }
   
   func delete(by id: ShareGardenSceneEntity.ShareGardenScene.FriendsGarden.ID) async throws {


### PR DESCRIPTION
## 💡 관련 이슈
- related: #299 
## 🎉 변경 사항
- [x] 값이 없는 경우 에러를 throw 하도록 수정

## 📌 PR Point
- 테스트 대역 사용 시 강제 언래핑이 아닌, 값이 없는 경우 에러를 throw하도록 하여 테스트가 실행될 수 있도록 하였습니다.
- 검증하려는 단위에서는 값이 있는 것을 보장하고 사용할 예정이기에 검증하려고 하는 단위가 아닌 경우의 크래시를 방지하기 위해 에러를 throw 하는 코드를 추가하였습니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?