### PR TITLE
EditUserIntroductionScene Presenter 로직 구현

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -45,7 +45,7 @@ extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentat
   }
 
   func presentEditUserIntroductionSuccess() {
-    // TODO: - Display 로직 호출
+    self.viewController?.displayEditUserIntroductionSuccess()
   }
 
   func presentEditUserIntroductionError(_ error: Error) {

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -37,7 +37,7 @@ extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentat
   }
 
   func presentIntroductionIsValid() {
-    // TODO: - Display 로직 호출
+    self.viewController?.displayUserIntroductionValid()
   }
 
   func presentIntroductionIsInvalid() {

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -33,7 +33,7 @@ extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentat
   }
 
   func presentEmptyUserIntroduction() {
-    // TODO: - Display 로직 호출
+    self.viewController?.displayEmptyUserIntroduction()
   }
 
   func presentIntroductionIsValid() {

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -49,6 +49,7 @@ extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentat
   }
 
   func presentEditUserIntroductionError(_ error: Error) {
-    // TODO: - Display 로직 호출
+    // TODO: ToDoGardenAlertController에 Model 추가 후 구현 예정입니다. 에러 발생시 알럿에 표시할 문자열을 Display 로직으로 전달합니다.
+//    self.viewController?.displayEditUserIntroductionFailure(error.localizedDescription)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -29,7 +29,7 @@ class EditUserIntroductionScenePresenter {
 
 extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentationLogic {
   func presentUserIntroduction(_ introduction: String) {
-    // TODO: - Display 로직 호출
+    self.viewController?.displayUserIntroduction(introduction)
   }
 
   func presentEmptyUserIntroduction() {

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -21,7 +21,7 @@ protocol EditUserIntroductionScenePresentationLogic {
 }
 // swiftlint:enable type_name
 
-class EditUserIntroductionScenePresenter {
+final class EditUserIntroductionScenePresenter {
   weak var viewController: EditUserIntroductionSceneDisplayLogic?
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -41,7 +41,7 @@ extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentat
   }
 
   func presentIntroductionIsInvalid() {
-    // TODO: - Display 로직 호출
+    self.viewController?.displayUserIntroductionInvalid()
   }
 
   func presentEditUserIntroductionSuccess() {

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -18,6 +18,7 @@ protocol EditUserIntroductionSceneDisplayLogic: AnyObject {
   func displaySomething(viewModel: EditUserIntroductionScene.Something.ViewModel)
   func displayUserIntroduction(_ introduction: String)
   func displayEmptyUserIntroduction()
+  func displayUserIntroductionValid()
 }
 
 final class EditUserIntroductionSceneViewController: UIViewController, EditUserIntroductionSceneViewControllable {
@@ -77,6 +78,10 @@ extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisp
   }
 
   func displayEmptyUserIntroduction() {
+    // TODO: - UI 업데이트 로직
+  }
+
+  func displayUserIntroductionValid() {
     // TODO: - UI 업데이트 로직
   }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -16,6 +16,7 @@ import ToDoGardenUIResource
 
 protocol EditUserIntroductionSceneDisplayLogic: AnyObject {
   func displaySomething(viewModel: EditUserIntroductionScene.Something.ViewModel)
+  func displayUserIntroduction(_ introduction: String)
 }
 
 final class EditUserIntroductionSceneViewController: UIViewController, EditUserIntroductionSceneViewControllable {
@@ -70,6 +71,10 @@ final class EditUserIntroductionSceneViewController: UIViewController, EditUserI
 // MARK: - Confirm display logic protocol
 
 extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisplayLogic {
+  func displayUserIntroduction(_ introduction: String) {
+    // TODO: - UI 업데이트 로직
+  }
+  
   func displaySomething(viewModel: EditUserIntroductionScene.Something.ViewModel) {
     // self.nameTextField.text = viewModel.name
   }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -19,6 +19,7 @@ protocol EditUserIntroductionSceneDisplayLogic: AnyObject {
   func displayUserIntroduction(_ introduction: String)
   func displayEmptyUserIntroduction()
   func displayUserIntroductionValid()
+  func displayUserIntroductionInvalid()
 }
 
 final class EditUserIntroductionSceneViewController: UIViewController, EditUserIntroductionSceneViewControllable {
@@ -82,6 +83,10 @@ extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisp
   }
 
   func displayUserIntroductionValid() {
+    // TODO: - UI 업데이트 로직
+  }
+
+  func displayUserIntroductionInvalid() {
     // TODO: - UI 업데이트 로직
   }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -20,6 +20,7 @@ protocol EditUserIntroductionSceneDisplayLogic: AnyObject {
   func displayEmptyUserIntroduction()
   func displayUserIntroductionValid()
   func displayUserIntroductionInvalid()
+  func displayEditUserIntroductionSuccess()
 }
 
 final class EditUserIntroductionSceneViewController: UIViewController, EditUserIntroductionSceneViewControllable {
@@ -87,6 +88,10 @@ extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisp
   }
 
   func displayUserIntroductionInvalid() {
+    // TODO: - UI 업데이트 로직
+  }
+
+  func displayEditUserIntroductionSuccess() {
     // TODO: - UI 업데이트 로직
   }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -17,6 +17,7 @@ import ToDoGardenUIResource
 protocol EditUserIntroductionSceneDisplayLogic: AnyObject {
   func displaySomething(viewModel: EditUserIntroductionScene.Something.ViewModel)
   func displayUserIntroduction(_ introduction: String)
+  func displayEmptyUserIntroduction()
 }
 
 final class EditUserIntroductionSceneViewController: UIViewController, EditUserIntroductionSceneViewControllable {
@@ -74,7 +75,11 @@ extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisp
   func displayUserIntroduction(_ introduction: String) {
     // TODO: - UI 업데이트 로직
   }
-  
+
+  func displayEmptyUserIntroduction() {
+    // TODO: - UI 업데이트 로직
+  }
+
   func displaySomething(viewModel: EditUserIntroductionScene.Something.ViewModel) {
     // self.nameTextField.text = viewModel.name
   }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -21,6 +21,7 @@ protocol EditUserIntroductionSceneDisplayLogic: AnyObject {
   func displayUserIntroductionValid()
   func displayUserIntroductionInvalid()
   func displayEditUserIntroductionSuccess()
+  func displayEditUserIntroductionFailure(_ errorMessage: String)
 }
 
 final class EditUserIntroductionSceneViewController: UIViewController, EditUserIntroductionSceneViewControllable {
@@ -92,6 +93,10 @@ extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisp
   }
 
   func displayEditUserIntroductionSuccess() {
+    // TODO: - UI 업데이트 로직
+  }
+
+  func displayEditUserIntroductionFailure(_ errorMessage: String) {
     // TODO: - UI 업데이트 로직
   }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #576

## 🎉 변경 사항
- EditUserIntroductionScene Presenter에 유스케이스별로 로직을 추가하였습니다.
- EditUserIntroductionScene ViewController에 빈 메서드들을 추가하였습니다.

## 📌 PR Point
- 유스케이스별 설명이 기술된 [화면 기술서](https://www.notion.so/6ccb1bf2ea9a45d2918b9f6091e93ca5?pvs=4)를 첨부합니다!
- 현재 PR에서는 `UI 업데이트가 안 되지만` 이해를 돕기 위해 GIF를 첨부하였습니다.

### 1. 유저 소개글 전달
- interactor로 부터 전달받은 유저의 기존 소개글을 ViewController에게 전달합니다.
- 소개글이 없는 경우에는 전달하지 않습니다.
- 소개글 존재 여부에 따라 완료 버튼의 활성화 상태가 변경될 예정입니다.

|소개글이 있는 경우|소개글이 없는 경우|
|--|--|
|<img width="250" src="https://github.com/user-attachments/assets/83a8f54e-fbc7-4ad0-a716-1851dbf31083">|<img width="250" src="https://github.com/user-attachments/assets/598b4adb-a9cc-4d9a-bc02-de571e602beb">|


### 2. 입력 소개글 유효성 검사 여부 전달
- 입력한 소개에 대한 유효성 검사 결과에 따라 display 로직을 호출합니다.
- 아래는 유효성 검사 UI 동작을 나타내는 GIF입니다.
- 유효 여부에 따라 완료버튼과 validation Text가 애니메이션으로 보여집니다.

<img width="250" src="https://github.com/user-attachments/assets/44f64919-4cd3-41ed-98ac-e60bb639c5e2">


### 3. 소개 수정 요청 성공 여부 전달
- 소개 수정 요청이 성공 여부에 따라 display 로직을 호출합니다.
- 요청 실패시에는 error 메시지를 전달합니다.
  - 보여줄 error 메시지를 생성하는 작업은 다음 PR에서 진행할 예정입니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?