### PR TITLE
ShareGardenScene VIP 단위 테스트 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
@@ -35,6 +35,52 @@ final class ShareGardenSceneTests {
   }
 }
 
+// swiftlint:disable function_body_length
+extension ShareGardenSceneTests {
+  @Test(arguments: [true, false])
+  func myGardenRequest(isSuccessful: Bool) async {
+    // Given
+    await self.shareGardenSceneWorkerMock.setIsSuccessful(isSuccessful)
+    let pomodoroRecords = [PomodoroRecord(date: Date(), pomodoroCount: 0)]
+    let expectedMyGarden = ShareGardenScene.MyGarden(
+      nickname: UUID().uuidString,
+      description: UUID().uuidString,
+      pomodoroRecords: PomodoroRecordCollection(pomodoroRecords: pomodoroRecords)
+    )
+    await self.shareGardenSceneWorkerMock.setMyGarden(expectedMyGarden)
+    
+    // When
+    self.loadView()
+    
+    // Then
+    await withTaskGroup(of: Void.self) { group in
+      group.addTask {
+        for await viewModel in self.sut.myGardenStream {
+          guard isSuccessful else { fatalError("성공 시나리오에 대한 테스트입니다.") }
+          #expect(viewModel.nickname == expectedMyGarden.nickname)
+          #expect(viewModel.description == expectedMyGarden.description)
+          #expect(viewModel.pomodoroRecords == expectedMyGarden.pomodoroRecords)
+          #expect(isSuccessful)
+          return
+        }
+      }
+      
+      group.addTask {
+        for await _ in self.sut.myGardenRequestErrorStream {
+          guard isSuccessful == false else { fatalError("실패 시나리오에 대한 테스트입니다.") }
+          
+          #expect(isSuccessful == false)
+          return
+        }
+      }
+      
+      await group.next()
+      group.cancelAll()
+    }
+  }
+}
+// swiftlint:enable function_body_length
+
 extension ShareGardenSceneTests {
   private func configureUnitTestVIPCycle() {
     self.shareGardenScene.interactor = self.interactor

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
@@ -38,7 +38,7 @@ final class ShareGardenSceneTests {
 // swiftlint:disable function_body_length
 extension ShareGardenSceneTests {
   @Test(arguments: [true, false])
-  func myGardenRequest(isSuccessful: Bool) async {
+  private func myGardenRequest(isSuccessful: Bool) async {
     // Given
     await self.shareGardenSceneWorkerMock.setIsSuccessful(isSuccessful)
     let pomodoroRecords = [PomodoroRecord(date: Date(), pomodoroCount: 0)]
@@ -80,7 +80,7 @@ extension ShareGardenSceneTests {
   }
   
   @Test(arguments: [true, false])
-  func friendsGardenListRequest(isSuccessful: Bool) async {
+  private func friendsGardenListRequest(isSuccessful: Bool) async {
     // Given
     await self.shareGardenSceneWorkerMock.setIsSuccessful(isSuccessful)
     let pomodoroRecords = [PomodoroRecord(date: Date(), pomodoroCount: 0)]

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
@@ -42,4 +42,8 @@ extension ShareGardenSceneTests {
     self.presenter.viewController = self.sut
     self.sut.viewController = self.shareGardenScene
   }
+  
+  private func loadView() {
+    self.window.addSubview(self.shareGardenScene.view)
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  ShareGardenSceneTests.swift
 //  ShareGardenScene
 //
 //  Created by Noah on 10/8/24.

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
@@ -145,6 +145,87 @@ extension ShareGardenSceneTests {
       group.cancelAll()
     }
   }
+  
+  @Test(arguments: [true, false])
+  private func deleteFriendsGarden(isSuccessful: Bool) async {
+    // Given
+    let pomodoroRecords = [PomodoroRecord(date: Date(), pomodoroCount: 0)]
+    let sourceFriendsGardenList = [
+      ShareGardenScene.FriendsGarden(
+        nickname: UUID().uuidString,
+        focusStreakDays: Int.random(
+          in: 0..<100
+        ),
+        pomodoroRecords: PomodoroRecordCollection(
+          pomodoroRecords: pomodoroRecords
+        )
+      ),
+      ShareGardenScene.FriendsGarden(
+        nickname: UUID().uuidString,
+        focusStreakDays: Int.random(
+          in: 0..<100
+        ),
+        pomodoroRecords: PomodoroRecordCollection(
+          pomodoroRecords: pomodoroRecords
+        )
+      ),
+      ShareGardenScene
+        .FriendsGarden(
+          nickname: UUID().uuidString,
+          focusStreakDays: Int.random(
+            in: 0..<100
+          ),
+          pomodoroRecords: PomodoroRecordCollection(
+            pomodoroRecords: pomodoroRecords
+          )
+        )
+    ]
+    await self.shareGardenSceneWorkerMock.setFriendsGardenList(sourceFriendsGardenList)
+    await self.shareGardenSceneWorkerMock.setIsSuccessful(true)
+    let deleteTargetFriendsGarden = sourceFriendsGardenList[0]
+    let expectedDeleteResult: [UUID] = sourceFriendsGardenList
+      .filter { $0.id != deleteTargetFriendsGarden.id }
+      .map { $0.id }
+    
+    self.loadView()
+    
+    /// 삭제 요청이 진행되었는지 여부를 나타내는 변수입니다.
+    var isDeleteExecuted = false
+    /// 롤백 요청이 진행되었는지 여부를 나타내는 변수입니다.
+    var isRollbackExecuted = false
+    
+    for await viewModel in self.sut.friendsGardenListStream {
+      if isDeleteExecuted == false {
+        await self.shareGardenSceneWorkerMock.setIsSuccessful(isSuccessful)
+        // When
+        self.interactor.delete(by: deleteTargetFriendsGarden.id)
+        isDeleteExecuted = true
+        continue
+      }
+      
+      if isDeleteExecuted {
+        // Then
+        if isSuccessful {
+          // 삭제에 성공했을 경우, 삭제 기대값과 같아야합니다.
+          #expect(viewModel.identifiers == expectedDeleteResult)
+          self.sut.friendsGardenListStreamContinuation.finish()
+        }
+        
+        if isSuccessful == false {
+          if isRollbackExecuted == false {
+            // 먼저 사용자에게 삭제가 반영된 친구 목록 리스트를 표시합니다.
+            #expect(viewModel.identifiers == expectedDeleteResult)
+            isRollbackExecuted = true
+            continue
+          }
+          
+          // 삭제에 실패했을 경우, 삭제 이전의 친구 목록 리스트를 표시합니다.
+          #expect(viewModel.identifiers == sourceFriendsGardenList.map { $0.id })
+          self.sut.friendsGardenListStreamContinuation.finish()
+        }
+      }
+    }
+  }
 }
 // swiftlint:enable function_body_length
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
@@ -31,5 +31,15 @@ final class ShareGardenSceneTests {
     self.shareGardenScene = ShareGardenSceneViewController(friendsGardenStore: self.interactor)
     self.presenter = ShareGardenScenePresenter()
     self.sut = ShareGardenSceneViewControllerStub()
+    self.configureUnitTestVIPCycle()
+  }
+}
+
+extension ShareGardenSceneTests {
+  private func configureUnitTestVIPCycle() {
+    self.shareGardenScene.interactor = self.interactor
+    self.interactor.presenter = self.presenter
+    self.presenter.viewController = self.sut
+    self.sut.viewController = self.shareGardenScene
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
@@ -5,4 +5,31 @@
 //  Created by Noah on 10/8/24.
 //
 
-import Foundation
+import Testing
+import UIKit
+
+import ToDoGardenUIComponent
+
+@testable import ShareGardenScene
+import ShareGardenSceneAPI
+import ShareGardenSceneEntity
+
+@MainActor
+final class ShareGardenSceneTests {
+  private let window: UIWindow
+  private let shareGardenScene: ShareGardenSceneViewController
+  private let shareGardenSceneWorkerMock: ShareGardenSceneWorkerMock
+  private let interactor: ShareGardenSceneInteractor
+  private let presenter: ShareGardenScenePresenter
+  
+  private let sut: ShareGardenSceneViewControllerStub
+  
+  init() {
+    self.window = UIWindow()
+    self.shareGardenSceneWorkerMock = ShareGardenSceneWorkerMock()
+    self.interactor = ShareGardenSceneInteractor(shareGardenSceneWorker: self.shareGardenSceneWorkerMock)
+    self.shareGardenScene = ShareGardenSceneViewController(friendsGardenStore: self.interactor)
+    self.presenter = ShareGardenScenePresenter()
+    self.sut = ShareGardenSceneViewControllerStub()
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/ShareGardenSceneTests.swift
@@ -78,6 +78,73 @@ extension ShareGardenSceneTests {
       group.cancelAll()
     }
   }
+  
+  @Test(arguments: [true, false])
+  func friendsGardenListRequest(isSuccessful: Bool) async {
+    // Given
+    await self.shareGardenSceneWorkerMock.setIsSuccessful(isSuccessful)
+    let pomodoroRecords = [PomodoroRecord(date: Date(), pomodoroCount: 0)]
+    let expectedFriendsGardenList = [
+      ShareGardenScene.FriendsGarden(
+        nickname: UUID().uuidString,
+        focusStreakDays: Int.random(
+          in: 0..<100
+        ),
+        pomodoroRecords: PomodoroRecordCollection(
+          pomodoroRecords: pomodoroRecords
+        )
+      ),
+      ShareGardenScene.FriendsGarden(
+        nickname: UUID().uuidString,
+        focusStreakDays: Int.random(
+          in: 0..<100
+        ),
+        pomodoroRecords: PomodoroRecordCollection(
+          pomodoroRecords: pomodoroRecords
+        )
+      ),
+      ShareGardenScene.FriendsGarden(
+        nickname: UUID().uuidString,
+        focusStreakDays: Int.random(in: 0..<100),
+        pomodoroRecords: PomodoroRecordCollection(pomodoroRecords: pomodoroRecords)
+      )
+    ]
+    await self.shareGardenSceneWorkerMock.setFriendsGardenList(expectedFriendsGardenList)
+    
+    // When
+    self.loadView()
+    
+    // Then
+    await withTaskGroup(of: Void.self) { group in
+      group.addTask {
+        var isShimmeringStopped = false
+        for await _ in self.sut.shimmeringStopStream {
+          isShimmeringStopped = true
+          self.sut.shimmeringStopStreamContinuation.finish()
+        }
+        
+        for await viewModel in self.sut.friendsGardenListStream {
+          guard isSuccessful else { fatalError("성공 시나리오에 대한 테스트 입니다.") }
+          
+          #expect(isShimmeringStopped)
+          #expect(viewModel.identifiers == expectedFriendsGardenList.map { $0.id })
+          #expect(isSuccessful)
+          return
+        }
+      }
+      
+      group.addTask {
+        for await _ in self.sut.friendsGardenListRequestErrorStream {
+          guard isSuccessful == false else { fatalError("실패 시나리오에 대한 테스트 입니다.") }
+          #expect(isSuccessful == false)
+          return
+        }
+      }
+      
+      await group.next()
+      group.cancelAll()
+    }
+  }
 }
 // swiftlint:enable function_body_length
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneViewControllerStub.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Tests/ShareGardenSceneTests/TestDouble/ShareGardenSceneViewControllerStub.swift
@@ -11,7 +11,11 @@ import Foundation
 @testable import ShareGardenScene
 import ShareGardenSceneEntity
 
+@MainActor
 final class ShareGardenSceneViewControllerStub {
+  
+  weak var viewController: ShareGardenSceneDisplayLogic?
+  
   // MARK: - My Garden 관련 스트림
   let (myGardenStream, myGardenStreamContinuation) = AsyncStream.makeStream(
     of: ShareGardenScene.RequestMyGarden.ViewModel.self,
@@ -44,22 +48,27 @@ final class ShareGardenSceneViewControllerStub {
 extension ShareGardenSceneViewControllerStub: ShareGardenSceneDisplayLogic {
   func displayMyGarden(_ viewModel: ShareGardenScene.RequestMyGarden.ViewModel) {
     self.myGardenStreamContinuation.yield(viewModel)
+    self.viewController?.displayMyGarden(viewModel)
   }
   
   func displayMyGardenRequestError() {
     self.myGardenRequestErrorStreamContinuation.yield()
+    self.viewController?.displayMyGardenRequestError()
   }
   
   func displayFriendsGardenList(_ viewModel: ShareGardenScene.RequestFriendsGardenList.ViewModel) {
     self.friendsGardenListStreamContinuation.yield(viewModel)
+    self.viewController?.displayFriendsGardenList(viewModel)
   }
   
   func displayFriendsGardenListRequestError() {
     self.friendsGardenListRequestErrorStreamContinuation.yield()
+    self.viewController?.displayFriendsGardenListRequestError()
   }
   
   func stopShimmeringFriendsGardenList() {
     self.shimmeringStopStreamContinuation.yield()
+    self.viewController?.stopShimmeringFriendsGardenList()
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #299 
## 🎉 변경 사항
- [x] ShareGardenScene VIP 단위 테스트 추가
## 📌 PR Point

## 🧪 무엇을 테스트 해야하는가?
먼저 ShareGardenScene에 대한 테스트를 작성하기 위해 어떤 부분을 테스트 해야하는지 고민했습니다.

[Clean-Swift](https://clean-swift.com/)에서는 Scene에 대한 단위 테스트를 작성할 때 크게 3가지의 테스트 `[ViewController => Interactor]` 테스트, `[Interactor => Presenter]` 테스트, `[Presenter => ViewController]` 테스트를 통해 Spy객체(모의 객체)의 특정 메서드가 호출되었는지 여부를 검사하는 것을 통해 구현을 검증하도록 [가이드](https://github.com/Clean-Swift/CleanStore/blob/e13b868bda3ad1a5987aadbff249b557c1e82d27/CleanStoreTests/Scenes/CreateOrder/CreateOrderInteractorTests.swift)합니다.

제가 생각하는 기존 단위 테스트의 문제점은 테스트 내부에서 인터페이스를 어떻게 사용하는지 하나하나를 다 검증하기 때문에 구현 내용 혹은 인터페이스가 바뀌게 될 경우 테스트가 쉽게 깨질 수 있다는 점입니다.

또한 Scene에 대한 단위 테스트를 작성하기 위해 최소 3개의 Spy객체(모의 객체)를 생성해야한다는 점 또한 테스트를 작성하는데 부담이 되는 지점이라 생각하였습니다.

이러한 문제점 때문에 무엇을 테스트 해야하는지에 대한 고민이 있었습니다.
따라서 모의 객체의 특정 메소드를 호출했는지를 검증하는 것보다, 실제 **실행 후 최종 상태에 대해 검증**해야겠다는 생각을 하기 시작했습니다.

|Black box test |
|---|
|<img width="442" alt="Screenshot 2024-10-14 at 5 24 15 PM" src="https://github.com/user-attachments/assets/eacdfc03-9787-4a49-973e-f99683e6569c">|
> 이미지 출처: https://sos-cer.github.io/testing/version/6.0.0/bbt

마치 블랙 박스 테스트처럼 내부 구현보다는 외부에서 보이는 결과를 중심으로 테스트하는 방향으로 말이죠. 이렇게 하면 인터페이스 변경에 따른 테스트 유지보수 비용을 줄이고, 테스트가 더 견고하게 유지될 수 있을 것이라 기대했습니다.

그렇다면, VIP Cycle에 대한 output은 무엇일까요?
|VIP Cycle|
|---|
|<img src="https://github.com/user-attachments/assets/bf548655-4caf-475f-849c-9cfd504ffc99" width="500"/>|

제가 생각한 VIP Cycle에 대한 output은 display logic이라고 판단하였습니다.
view에서 시작된 데이터가 가공, 요청을 거쳐 view에 다시 표시되기 때문입니다.
VIP Cycle이 올바르게 표시되는지 검증하기 위해서는 display logic을 검증하면 되겠다고 판단하였습니다.
|Display logic stub|
|---|
|<img src="https://github.com/user-attachments/assets/4f0a30bd-8360-4ec0-89d2-5484231a39b2" width="500"/>|


따라서 presenter의 display logic을 stubbing하여 VIP Cycle의 결과를 검증하도록 하였습니다.
- #561 
> display logic stubbing PullRequest

이를 통해 VIP Cycle의 내부구현 검증을 피하고, 실제 실행 후 최종 상태에 대해 검증함으로써 테스트가 쉽게 깨지지 않도록 하였습니다.

|VIP test coverage|
|---|
|<img width="1838" alt="Screenshot 2024-10-14 at 4 24 51 PM" src="https://github.com/user-attachments/assets/7c8e8cfd-747e-4f93-877c-a641b7e41190">|

VIP Cycle 테스트의 결과로 핵심 객체인 ViewController, Interactor, Presenter의 커버리지는 평균 `94.8%`를 가질 수 있게되었으며,

|ShareGardenScene test coverage|
|---|
|<img width="1838" alt="Screenshot 2024-10-14 at 4 24 58 PM" src="https://github.com/user-attachments/assets/b5e443c5-9974-44fa-9aee-fe67ffdac90d">

`ShareGardenScene`기준 평균 `84.9%`의 테스트 커버리지를 가지게 되었습니다.🎉

또한 사용자가 입력하고 보게되는 최종 상태에 대한 검증을 하게 됨으로써 백로그에 작성한 시나리오에 대한 테스트를 한 눈에 확인할 수 있게 되었습니다.

검증한 시나리오는 아래와 같습니다.

1. 나의 가든 요청 cycle
2. 친구의 가든 목록 요청 cycle
3. 친구의 가든 삭제 cycle

parameterized test를 사용하기 위해 `Swift Testing`을 사용하였습니다.
이를 통해 성공, 실패 시나리오에 대한 테스트를 진행하였습니다.

> VIP Cycle과 별개로 별도의 로직 테스트가 필요한 부분은 따로 테스트를 작성할 예정입니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?