### PR TITLE
EditUserIntroductionScene ViewController Display 로직 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneRouter.swift
@@ -11,7 +11,7 @@ import EditUserIntroductionSceneAPI
 import EditUserIntroductionSceneEntity
 
 protocol EditUserIntroductionSceneRoutingLogic {
-  func routeToSomewhere()
+  func routeToUserInfoScene()
 }
 
 protocol EditUserIntroductionSceneDataPassing {
@@ -26,7 +26,8 @@ class EditUserIntroductionSceneRouter: EditUserIntroductionSceneDataPassing {
 // MARK: - Routing
 
 extension EditUserIntroductionSceneRouter: EditUserIntroductionSceneRoutingLogic {
-  func routeToSomewhere() {
+  func routeToUserInfoScene() {
+    self.viewController?.navigationController?.popViewController(animated: true)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -87,7 +87,8 @@ extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisp
   }
 
   func displayUserIntroductionValid() {
-    // TODO: - UI 업데이트 로직
+    self.inputUserIntroductionView.hideValidationText()
+    self.doneButton.isEnabled = true
   }
 
   func displayUserIntroductionInvalid() {

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -82,7 +82,8 @@ extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisp
   }
 
   func displayEmptyUserIntroduction() {
-    // TODO: - UI 업데이트 로직
+    self.inputUserIntroductionView.setBeginEditing(with: "")
+    self.doneButton.isEnabled = false
   }
 
   func displayUserIntroductionValid() {

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -92,7 +92,8 @@ extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisp
   }
 
   func displayUserIntroductionInvalid() {
-    // TODO: - UI 업데이트 로직
+    self.inputUserIntroductionView.showValidationText()
+    self.doneButton.isEnabled = false
   }
 
   func displayEditUserIntroductionSuccess() {

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -77,7 +77,8 @@ final class EditUserIntroductionSceneViewController: UIViewController, EditUserI
 
 extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisplayLogic {
   func displayUserIntroduction(_ introduction: String) {
-    // TODO: - UI 업데이트 로직
+    self.inputUserIntroductionView.setBeginEditing(with: introduction)
+    self.doneButton.isEnabled = true
   }
 
   func displayEmptyUserIntroduction() {

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -101,7 +101,7 @@ extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisp
   }
 
   func displayEditUserIntroductionFailure(_ errorMessage: String) {
-    // TODO: - UI 업데이트 로직
+    // TODO: - 알럿을 띄울 예정이며, 알럿 디자인을 추가한 이후에 구현할 예정입니다.
   }
 
   func displaySomething(viewModel: EditUserIntroductionScene.Something.ViewModel) {

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -15,7 +15,6 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 protocol EditUserIntroductionSceneDisplayLogic: AnyObject {
-  func displaySomething(viewModel: EditUserIntroductionScene.Something.ViewModel)
   func displayUserIntroduction(_ introduction: String)
   func displayEmptyUserIntroduction()
   func displayUserIntroductionValid()
@@ -102,10 +101,6 @@ extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisp
 
   func displayEditUserIntroductionFailure(_ errorMessage: String) {
     // TODO: - 알럿을 띄울 예정이며, 알럿 디자인을 추가한 이후에 구현할 예정입니다.
-  }
-
-  func displaySomething(viewModel: EditUserIntroductionScene.Something.ViewModel) {
-    // self.nameTextField.text = viewModel.name
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -97,7 +97,7 @@ extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisp
   }
 
   func displayEditUserIntroductionSuccess() {
-    // TODO: - UI 업데이트 로직
+    self.router?.routeToUserInfoScene()
   }
 
   func displayEditUserIntroductionFailure(_ errorMessage: String) {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #579 

## 🎉 변경 사항
- EditUserIntroductionScene ViewController에 Display 로직을 추가하였습니다.

## 📌 PR Point
- 유스케이스별 설명이 기술된 [화면 기술서](https://www.notion.so/6ccb1bf2ea9a45d2918b9f6091e93ca5?pvs=4)를 첨부합니다!

### 1. 유저 소개글 UI 업데이트
- 유저의 기존 소개글을 보여주고 키보드를 활성화합니다.
- 소개글이 없는 경우에는 완료 버튼을 비활성화합니다.

|소개글이 있는 경우|소개글이 없는 경우|
|--|--|
|<img width="250" src="https://github.com/user-attachments/assets/83a8f54e-fbc7-4ad0-a716-1851dbf31083">|<img width="250" src="https://github.com/user-attachments/assets/598b4adb-a9cc-4d9a-bc02-de571e602beb">|


### 2. 입력 소개글 유효성 검사 여부 전달
- 유저가 입력한 소개가 올바른지 여부에 따라 UI를 업데이트합니다.
- 유효 여부에 따라 `완료버튼의 활성화 상태가 변경`되며, `validation Text가 숨겨지거나 보여`집니다.

<img width="250" src="https://github.com/user-attachments/assets/44f64919-4cd3-41ed-98ac-e60bb639c5e2">


### 3. 소개 수정 요청 성공 여부 전달
- 소개 수정 요청 성공 여부에 따라 UI를 업데이트합니다.
- 요청 성공시에는 이전 화면으로 돌아가도록 Router를 호출합니다.
- 요청 실패시에는 알럿에 에러 메시지를 보여줄 예정이며, 관련 알럿 디자인 추가 후 작업할 예정

<img width="250" src="https://github.com/user-attachments/assets/295970a4-0d46-434a-8deb-f9c088db84f3">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?