### PR TITLE
UserInfoScene 소개 수정화면 Builder 의존성 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Package.swift
@@ -21,7 +21,8 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(name: "ToDoGardenUI", path: "../ToDoGardenUI")
+    .package(name: "ToDoGardenUI", path: "../ToDoGardenUI"),
+    .package(name: "EditUserIntroductionScene", path: "EditUserIntroductionScene")
   ],
   targets: [
     .target(
@@ -38,6 +39,7 @@ let package = Package(
       dependencies: [
         "UserInfoSceneAPI",
         "UserInfoSceneEntity",
+        .product(name: "EditUserIntroductionSceneAPI", package: "EditUserIntroductionScene"),
         .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI"),
         .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
         .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI")

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -23,21 +23,7 @@ protocol UserInfoSceneBusinessLogic {
   func signOut()
 }
 
-actor UserInfoDataManager {
-  private var userInfoData: [UserInfoScene.UserInfo: String]
-
-  init() {
-    self.userInfoData = [:]
-  }
-
-  func updateUserInfoData(for userInfo: UserInfoScene.UserInfo, with value: String) {
-    self.userInfoData[userInfo] = value
-  }
-}
-
 final class UserInfoSceneInteractor: UserInfoSceneDataStore {
-  private var userInfoDataManager: UserInfoDataManager
-
   private var requestPhotoAccessTask: Task<Void, Error>?
   private var requestUserPhotoTask: Task<Void, Error>?
   private var requestWithdrawTask: Task<Void, Error>?
@@ -54,7 +40,6 @@ final class UserInfoSceneInteractor: UserInfoSceneDataStore {
     appServiceWorker: AppServiceWorkable,
     userPhotoWorker: UserPhotoWorker
   ) {
-    self.userInfoDataManager = UserInfoDataManager()
     self.userInfoWorker = userInfoWorker
     self.appServiceWorker = appServiceWorker
     self.userPhotoWorker = userPhotoWorker
@@ -136,7 +121,6 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
 extension UserInfoSceneInteractor: UserInfoLoadable {
   func requestDescription(for userInfo: UserInfoScene.UserInfo) async -> String {
     let description = await self.userInfoWorker.requestUserProfile(urlString: userInfo.rawValue)
-    await self.userInfoDataManager.updateUserInfoData(for: userInfo, with: description)
     return description
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -11,7 +11,7 @@ import UserInfoSceneAPI
 import UserInfoSceneEntity
 
 protocol UserInfoSceneDataStore {
-  // var name: String { get set }
+  var userIntroduction: String? { get set }
 }
 
 protocol UserInfoSceneBusinessLogic {
@@ -24,6 +24,8 @@ protocol UserInfoSceneBusinessLogic {
 }
 
 final class UserInfoSceneInteractor: UserInfoSceneDataStore {
+  var userIntroduction: String?
+
   private var requestPhotoAccessTask: Task<Void, Error>?
   private var requestUserPhotoTask: Task<Void, Error>?
   private var requestWithdrawTask: Task<Void, Error>?
@@ -121,6 +123,9 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
 extension UserInfoSceneInteractor: UserInfoLoadable {
   func requestDescription(for userInfo: UserInfoScene.UserInfo) async -> String {
     let description = await self.userInfoWorker.requestUserProfile(urlString: userInfo.rawValue)
+    if userInfo == .introduction {
+      self.userIntroduction = description
+    }
     return description
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+import EditUserIntroductionSceneAPI
 import UserInfoSceneAPI
 
 protocol UserInfoSceneRoutingLogic {
@@ -20,10 +21,10 @@ protocol UserInfoSceneDataPassing {
 class UserInfoSceneRouter: UserInfoSceneDataPassing {
   weak var viewController: UserInfoSceneViewController?
   var dataStore: UserInfoSceneDataStore?
-  private let nextSceneBuilder: NextSceneBuildable?
+  private let editUserIntroductionSceneBuilder: EditUserIntroductionSceneBuildable?
 
-  init(nextSceneBuilder: NextSceneBuildable?) {
-    self.nextSceneBuilder = nextSceneBuilder
+  init(editUserIntroductionSceneBuilder: EditUserIntroductionSceneBuildable?) {
+    self.editUserIntroductionSceneBuilder = editUserIntroductionSceneBuilder
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
@@ -39,7 +39,4 @@ extension UserInfoSceneRouter: UserInfoSceneRoutingLogic {
 // MARK: - Declare Payload for scene
 
 extension UserInfoSceneRouter {
-  struct NextScenePayload: NextScenePayloadable {
-    // var name: String
-  }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
@@ -8,6 +8,7 @@
 import PhotosUI
 import UIKit.UIApplication
 
+import EditUserIntroductionSceneAPI
 import UserInfoSceneAPI
 import UserInfoSceneEntity
 
@@ -18,20 +19,20 @@ public struct UserInfoSceneSceneBuilder {
     let appServiceWorker: AppServiceWorkable
     let userPhotoWorker: UserPhotoWorker
     let userInfoWorker: UserInfoSceneWorkable
-    let nextSceneBuilder: NextSceneBuildable?
+    let editUserIntroductionSceneBuilder: EditUserIntroductionSceneBuildable?
 
     public init(
       photoPicker: PHPickerViewController,
       appServiceWorker: AppServiceWorkable,
       userPhotoWorker: UserPhotoWorker,
       userInfoWorker: UserInfoSceneWorkable,
-      nextSceneBuilder: NextSceneBuildable?
+      editUserIntroductionSceneBuilder: EditUserIntroductionSceneBuildable?
     ) {
       self.photoPicker = photoPicker
       self.appServiceWorker = appServiceWorker
       self.userPhotoWorker = userPhotoWorker
       self.userInfoWorker = userInfoWorker
-      self.nextSceneBuilder = nextSceneBuilder
+      self.editUserIntroductionSceneBuilder = editUserIntroductionSceneBuilder
     }
   }
 
@@ -69,7 +70,9 @@ extension UserInfoSceneSceneBuilder {
       userPhotoWorker: self.dependency.userPhotoWorker
     )
     let presenter = UserInfoScenePresenter()
-    let router = UserInfoSceneRouter(nextSceneBuilder: self.dependency.nextSceneBuilder)
+    let router = UserInfoSceneRouter(
+      editUserIntroductionSceneBuilder: self.dependency.editUserIntroductionSceneBuilder
+    )
     viewController.interactor = interactor
     viewController.router = router
     interactor.presenter = presenter

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -320,7 +320,7 @@ struct SomePayload: UserInfoSceneScenePayloadable {}
       appServiceWorker: AppServiceWorker(),
       userPhotoWorker: UserPhotoWorker(),
       userInfoWorker: UserInfoSceneWorker(),
-      nextSceneBuilder: nil
+      editUserIntroductionSceneBuilder: nil
     )
   ).build(with: SomePayload())
   return userInfoScene


### PR DESCRIPTION
## 💡 관련 이슈
- related: #590
- closed: #591

## 🎉 변경 사항
- UserInfoScene에서 소개 수정화면으로 라우팅하기 위해 EditUserIntroductionSceneBuilder 의존성을 추가하였습니다.

## 📌 PR Point
- #482 에서 리뷰를 통해 UserInfoScene VIP 흐름을 잘 알고계신 울버린께 요청합니다!
- `userIntroduction`: 소개 수정화면으로 라우팅시 Payload로 전달 유저 소개글 데이터입니다.

### UserInfoDataManager 삭제
- 기존에는 비동기 작업에서 모든 유저 정보를 저장하기 위해 `UserInfoDataManager` 액터를 사용했었습니다.
- 모든 데이터를 유지할 필요가 없기에, 해당 액터를 삭제하였습니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?