### PR TITLE
다시 시도하기 뷰 UI 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
@@ -1,0 +1,14 @@
+//
+//  RetryRequestView.swift
+//  ShareGardenScene
+//
+//  Created by Noah on 10/15/24.
+//
+
+import UIKit
+
+import ToDoGardenUIComponent
+
+@MainActor
+final class RetryRequestView {
+}

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
@@ -12,3 +12,58 @@ import ToDoGardenUIComponent
 @MainActor
 final class RetryRequestView {
 }
+
+extension RetryRequestView {
+  private final class RetryButton: UIButton {
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+      self.configureAppearance()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configureAppearance() {
+      let title = "다시 시도하기"
+      let configuration = UIButton.Configuration.plain()
+      self.configuration = configuration
+      
+      self.configurationUpdateHandler = { button in
+        guard var updatedConfiguration = button.configuration
+        else { return }
+        let isHighlighted = button.isHighlighted
+        let highlightedColor = UIColor.toDoGardenGreenDark.withAlphaComponent(0.5)
+        let normalColor = UIColor.toDoGardenGreenDark
+        let titleColor: UIColor = isHighlighted ? highlightedColor : normalColor
+        if let attributedTitle = self.createAttributedButtonTitle(title: title, with: titleColor) {
+          updatedConfiguration.attributedTitle = AttributedString(attributedTitle)
+        }
+        
+        self.setConfiguration(updatedConfiguration)
+      }
+    }
+    
+    private func createAttributedButtonTitle(title: String, with color: UIColor) -> NSAttributedString? {
+      let attributedTitle = title.applyTextAttributes(
+        attributes: [
+          NSAttributedString.Key.font: UIFont.pretendardBodyBold,
+          NSAttributedString.Key.foregroundColor: color
+        ]
+      )
+      return NSMutableAttributedString(attributedString: attributedTitle)
+        .addUnderline(with: UIColor.toDoGardenGreenDark, from: 0, to: title.count)
+    }
+    
+    private func setConfiguration(_ configuration: UIButton.Configuration, duration: Double = 0.3) {
+      UIView.transition(
+        with: self,
+        duration: duration,
+        options: .transitionCrossDissolve
+      ) {
+        self.configuration? = configuration
+      }
+    }
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
@@ -103,7 +103,7 @@ extension RetryRequestView {
       UIView.transition(
         with: self,
         duration: duration,
-        options: .transitionCrossDissolve
+        options: UIView.AnimationOptions.transitionCrossDissolve
       ) {
         self.configuration? = configuration
       }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
@@ -25,7 +25,7 @@ final class RetryRequestView {
     let titleLabel = UILabel()
     titleLabel.numberOfLines = 2
     titleLabel.textAlignment = NSTextAlignment.center
-    titleLabel.text = "앗 로딩을 하지 못했어요.\n 다시 시도해주세요."
+    titleLabel.text = Constant.StringLiteral.title
     titleLabel.font = UIFont.pretendardHeadBold
     titleLabel.textColor = UIColor.toDoGardenGreenDark
     
@@ -65,7 +65,7 @@ extension RetryRequestView {
     }
     
     private func configureAppearance() {
-      let title = "다시 시도하기"
+      let title = Constant.StringLiteral.Button.title
       let configuration = UIButton.Configuration.plain()
       self.configuration = configuration
       
@@ -105,6 +105,19 @@ extension RetryRequestView {
       }
     }
   }
+}
+
+extension RetryRequestView {
+  enum Constant {
+    enum StringLiteral { }
+  }
+}
+
+extension RetryRequestView.Constant.StringLiteral {
+  enum Button {
+    static let title = "다시 시도하기"
+  }
+  static let title = "앗 로딩을 하지 못했어요.\n 다시 시도해주세요."
 }
 
 #if DEBUG

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
@@ -11,6 +11,45 @@ import ToDoGardenUIComponent
 
 @MainActor
 final class RetryRequestView {
+  private let logoImageView: UIImageView = {
+    let logoImageView = UIImageView(image: UIImage.leafSymbolImage)
+    logoImageView.contentMode = UIView.ContentMode.scaleAspectFit
+    logoImageView.usingAutolayout()
+    logoImageView.widthAnchor.constraint(equalToConstant: 48).isActive = true
+    logoImageView.heightAnchor.constraint(equalToConstant: 60).isActive = true
+    
+    return logoImageView
+  }()
+  
+  private let titleLabel: UILabel = {
+    let titleLabel = UILabel()
+    titleLabel.numberOfLines = 2
+    titleLabel.textAlignment = NSTextAlignment.center
+    titleLabel.text = "앗 로딩을 하지 못했어요.\n 다시 시도해주세요."
+    titleLabel.font = UIFont.pretendardHeadBold
+    titleLabel.textColor = UIColor.toDoGardenGreenDark
+    
+    return titleLabel
+  }()
+  
+  private let retryButton = RetryButton()
+  
+  var retryAction: UIAction? {
+    didSet {
+      guard let retryAction
+      else { return }
+      
+      self.retryButton.addAction(retryAction, for: UIControl.Event.touchUpInside)
+    }
+  }
+  
+  lazy var view: UIView = {
+    return UIVStackView(
+      alignment: UIStackView.Alignment.center,
+      spacing: 14,
+      arrangedSubviews: [self.logoImageView, self.titleLabel, self.retryButton]
+    )
+  }()
 }
 
 extension RetryRequestView {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
@@ -92,7 +92,7 @@ extension RetryRequestView {
         ]
       )
       return NSMutableAttributedString(attributedString: attributedTitle)
-        .addUnderline(with: UIColor.toDoGardenGreenDark, from: 0, to: title.count)
+        .addUnderline(with: color, from: 0, to: title.count)
     }
     
     private func setConfiguration(_ configuration: UIButton.Configuration, duration: Double = 0.3) {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
@@ -15,15 +15,19 @@ final class RetryRequestView {
     let logoImageView = UIImageView(image: UIImage.leafSymbolImage)
     logoImageView.contentMode = UIView.ContentMode.scaleAspectFit
     logoImageView.usingAutolayout()
-    logoImageView.widthAnchor.constraint(equalToConstant: 48).isActive = true
-    logoImageView.heightAnchor.constraint(equalToConstant: 60).isActive = true
+    logoImageView.widthAnchor.constraint(
+      equalToConstant: Constant.Layout.LogoImageView.size.width
+    ).isActive = true
+    logoImageView.heightAnchor.constraint(
+      equalToConstant: Constant.Layout.LogoImageView.size.height
+    ).isActive = true
     
     return logoImageView
   }()
   
   private let titleLabel: UILabel = {
     let titleLabel = UILabel()
-    titleLabel.numberOfLines = 2
+    titleLabel.numberOfLines = Constant.Layout.TitleLabel.numberOfLines
     titleLabel.textAlignment = NSTextAlignment.center
     titleLabel.text = Constant.StringLiteral.title
     titleLabel.font = UIFont.pretendardHeadBold
@@ -46,7 +50,7 @@ final class RetryRequestView {
   lazy var view: UIView = {
     return UIVStackView(
       alignment: UIStackView.Alignment.center,
-      spacing: 14,
+      spacing: Constant.Layout.spacing,
       arrangedSubviews: [self.logoImageView, self.titleLabel, self.retryButton]
     )
   }()
@@ -110,6 +114,7 @@ extension RetryRequestView {
 extension RetryRequestView {
   enum Constant {
     enum StringLiteral { }
+    enum Layout { }
   }
 }
 
@@ -118,6 +123,18 @@ extension RetryRequestView.Constant.StringLiteral {
     static let title = "다시 시도하기"
   }
   static let title = "앗 로딩을 하지 못했어요.\n 다시 시도해주세요."
+}
+
+extension RetryRequestView.Constant.Layout {
+  enum LogoImageView {
+    static let size: CGSize = CGSize(width: 100, height: 100)
+  }
+  
+  enum TitleLabel {
+    static let numberOfLines: Int = 2
+  }
+  
+  static let spacing: CGFloat = 14
 }
 
 #if DEBUG

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
@@ -122,7 +122,7 @@ extension RetryRequestView.Constant.StringLiteral {
   enum Button {
     static let title = "다시 시도하기"
   }
-  static let title = "앗 로딩을 하지 못했어요.\n 다시 시도해주세요."
+  static let title = "앗, 로딩을 하지 못했어요.\n 다시 시도해주세요."
 }
 
 extension RetryRequestView.Constant.Layout {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/RetryRequestView.swift
@@ -106,3 +106,11 @@ extension RetryRequestView {
     }
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let retryRequestView = RetryRequestView()
+  return retryRequestView.view
+}
+#endif


### PR DESCRIPTION
## 💡 관련 이슈
- related: #588 

## 🎉 변경 사항
- [x] 다시 시도하기 버튼 추가
- [x] 다시 시도하기 뷰 추가

## 📌 PR Point
- 다시 시도하기 UI를 추가하였습니다.

현재는 다시 시도하기 UI가 공유하기 화면에만 존재하여 해당 패키지에 구현해놓았습니다.
다른 화면에서도 해당 UI를 사용하게 된다면, 해당 객체를 다른 패키지로 이관하도록 하겠습니다:)

|Demo|
|---|
|<img src="https://github.com/user-attachments/assets/a9fd87ff-52d5-4f8b-99bf-161bf0a2d3db" width="250" />|


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?