### PR TITLE
SettingCollectionViewCell 우측 버튼 액션 설정 기능 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingCollectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingCollectionViewCell.swift
@@ -19,7 +19,7 @@ open class SettingCollectionViewCell: UICollectionViewCell, ReusableIdentifier {
   private var cellPosition: Position
   private let titleLabel: UILabel
   private let descriptionLabel: UILabel
-  private let rightForwardImageView: UIImageView
+  private let rightButton: UIButton
 
   @ExecuteOnce private var isSetupLayerCalled: (() -> Void)?
 
@@ -27,7 +27,7 @@ open class SettingCollectionViewCell: UICollectionViewCell, ReusableIdentifier {
     self.cellPosition = Position.middle
     self.titleLabel = UILabel()
     self.descriptionLabel = UILabel()
-    self.rightForwardImageView = UIImageView()
+    self.rightButton = UIButton()
     super.init(frame: frame)
     self.setup()
   }
@@ -57,7 +57,7 @@ open class SettingCollectionViewCell: UICollectionViewCell, ReusableIdentifier {
   ) {
     self.titleLabel.text = title
     self.titleLabel.font = titleFont
-    self.rightForwardImageView.isHidden = !isShowingModal
+    self.rightButton.isHidden = !isShowingModal
     self.cellPosition = position
   }
 
@@ -92,7 +92,7 @@ extension SettingCollectionViewCell {
   }
 
   private func setupRightForwardImageView() {
-    self.rightForwardImageView.image = UIImage.forwardButtonImage
+    self.rightButton.setImage(UIImage.forwardButtonImage, for: UIControl.State.normal)
     self.setupRightForwardImageViewLayout()
   }
 
@@ -111,18 +111,18 @@ extension SettingCollectionViewCell {
 
 extension SettingCollectionViewCell {
   private func setupRightForwardImageViewLayout() {
-    self.contentView.addSubview(self.rightForwardImageView)
-    self.rightForwardImageView.usingAutolayout()
+    self.contentView.addSubview(self.rightButton)
+    self.rightButton.usingAutolayout()
 
     NSLayoutConstraint.activate(
       [
-        self.rightForwardImageView.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-        self.rightForwardImageView.trailingAnchor.constraint(
+        self.rightButton.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
+        self.rightButton.trailingAnchor.constraint(
           equalTo: self.contentView.trailingAnchor,
           constant: -8
         ),
-        self.rightForwardImageView.widthAnchor.constraint(equalToConstant: 24),
-        self.rightForwardImageView.heightAnchor.constraint(equalToConstant: 24)
+        self.rightButton.widthAnchor.constraint(equalToConstant: 24),
+        self.rightButton.heightAnchor.constraint(equalToConstant: 24)
       ]
     )
   }
@@ -150,7 +150,7 @@ extension SettingCollectionViewCell {
       [
         self.descriptionLabel.leadingAnchor.constraint(greaterThanOrEqualTo: self.titleLabel.trailingAnchor),
         self.descriptionLabel.trailingAnchor.constraint(
-          equalTo: self.rightForwardImageView.leadingAnchor,
+          equalTo: self.rightButton.leadingAnchor,
           constant: -3
         ),
         self.descriptionLabel.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingCollectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SettingCollectionViewCell.swift
@@ -61,6 +61,10 @@ open class SettingCollectionViewCell: UICollectionViewCell, ReusableIdentifier {
     self.cellPosition = position
   }
 
+  public func setupRightButtonAction(_ action: UIAction) {
+    self.rightButton.addAction(action, for: UIControl.Event.touchUpInside)
+  }
+
   public func updateDescription(_ text: String?) {
     self.descriptionLabel.text = text
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #594 
- realted: #590 

## 🎉 변경 사항
- SettingCollectionViewCell의 우측에 있는 화살표를 ImageView > Button으로 수정하였습니다.
- 해당 버튼의 액션을 설정할 수 있는 public 함수를 추가하였습니다.

## 📌 PR Point
### 용도
- 설정 화면에서 Cell 우측 버튼 클릭시 다음 화면으로 이동할 때 사용됩니다!
  - `소개 수정`, `닉네임 수정`

<img width="250" src="https://github.com/user-attachments/assets/8feec474-8489-469f-a395-4d0475c1760f"> 


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?