### PR TITLE
UserInfoScene > EditUserIntroductionScene 화면 Routing 로직 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
@@ -77,7 +77,9 @@ extension EditUserIntroductionSceneBuilder {
 
 #if DEBUG
 extension EditUserIntroductionSceneBuilder {
-  private struct PreviewPayload: EditUserIntroductionScenePayloadable {}
+  private struct PreviewPayload: EditUserIntroductionScenePayloadable {
+    var userIntroduction: String?
+  }
 
   /// Preview에서 VIP 동작을 확인하기 위한 Builder입니다.
   static let previewScene = Self(

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
@@ -69,7 +69,7 @@ extension EditUserIntroductionSceneBuilder {
     for viewController: EditUserIntroductionSceneViewController,
     with payload: EditUserIntroductionScenePayloadable
   ) {
-    // viewController.router?.dataStore?.name = payload.name
+    viewController.router?.dataStore?.userIntroduction = payload.userIntroduction
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -12,7 +12,7 @@ import EditUserIntroductionSceneEntity
 
 protocol EditUserIntroductionSceneDataStore {
   /// UserInfoScene에서 Payload로 런타임에 전달받을 한줄 소개에 대한 데이터입니다.
-  var userIntroduction: String? { get }
+  var userIntroduction: String? { get set }
 }
 
 @MainActor

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneRouter.swift
@@ -15,7 +15,7 @@ protocol EditUserIntroductionSceneRoutingLogic {
 }
 
 protocol EditUserIntroductionSceneDataPassing {
-  var dataStore: EditUserIntroductionSceneDataStore? { get }
+  var dataStore: EditUserIntroductionSceneDataStore? { get set }
 }
 
 class EditUserIntroductionSceneRouter: EditUserIntroductionSceneDataPassing {

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionSceneBuildable.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
 public protocol EditUserIntroductionScenePayloadable {
-  // var name: String { get }
+  var userIntroduction: String? { get }
 }
 
 public protocol EditUserIntroductionSceneBuildable {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
@@ -12,6 +12,7 @@ import UserInfoSceneAPI
 
 protocol UserInfoSceneRoutingLogic {
   func routeToLoginScene()
+  func routeToEditUserIntroductionScene()
 }
 
 protocol UserInfoSceneDataPassing {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
@@ -35,9 +35,23 @@ extension UserInfoSceneRouter: UserInfoSceneRoutingLogic {
   func routeToLoginScene() {
     // TODO: LoginSceneBuilder가 구현되면 해당 화면으로 라우팅할 예정입니다.
   }
+
+  func routeToEditUserIntroductionScene() {
+    guard let editUserIntroductionScene = self.editUserIntroductionSceneBuilder?.build(
+      with: EditUserIntroductionScenePayload(userIntroduction: self.dataStore?.userIntroduction)
+    ) else { return }
+
+    self.viewController?.navigationController?.pushViewController(
+      editUserIntroductionScene,
+      animated: true
+    )
+  }
 }
 
 // MARK: - Declare Payload for scene
 
 extension UserInfoSceneRouter {
+  struct EditUserIntroductionScenePayload: EditUserIntroductionScenePayloadable {
+    var userIntroduction: String?
+  }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #596 
- related: #590 

## 🎉 변경 사항
- UserInfoScene > EditUserIntroductionScene으로 Routing하는 로직을 추가하였습니다.

## 📌 PR Point
- 유저 정보화면에서 소개 Cell의 `Right Button` 클릭시 소개 수정 화면으로 이동합니다.
- `소개` 문자열을 `Payload로 전달`합니다.

<img width="250" src="https://github.com/user-attachments/assets/f665dac6-de77-498e-87a7-bc37af55d2a3">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?