### PR TITLE
EditUserIntroductionDelegate 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
@@ -78,6 +78,7 @@ extension EditUserIntroductionSceneBuilder {
 #if DEBUG
 extension EditUserIntroductionSceneBuilder {
   private struct PreviewPayload: EditUserIntroductionScenePayloadable {
+    var delegate: EditUserIntroductionDelegate?
     var userIntroduction: String?
   }
 
@@ -86,6 +87,6 @@ extension EditUserIntroductionSceneBuilder {
     dependency: Dependency(
       someWorker: EditUserIntroductionSceneWorker()
     )
-  ).build(with: PreviewPayload(), delegate: nil)
+  ).build(with: PreviewPayload())
 }
 #endif

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
@@ -30,12 +30,15 @@ public struct EditUserIntroductionSceneBuilder {
 extension EditUserIntroductionSceneBuilder: EditUserIntroductionSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
-  /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
+  /// - Parameter delegate: 런타임에 이전 화면으로 데이터를 전달하는 Delegate 객체입니다.
+  /// - Returns: 런타임 의존성, delegate 객체, VIP Cycle이 설정된 ViewController를 반환합니다.
   public func build(
-    with payload: EditUserIntroductionScenePayloadable
+    with payload: EditUserIntroductionScenePayloadable,
+    delegate: EditUserIntroductionDelegate?
   ) -> EditUserIntroductionSceneViewControllable {
     let someViewController = self.configureVIPCycle(for: EditUserIntroductionSceneViewController())
     self.setPayload(for: someViewController, with: payload)
+    self.setDelegate(for: someViewController, with: delegate)
 
     return someViewController
   }
@@ -71,6 +74,14 @@ extension EditUserIntroductionSceneBuilder {
   ) {
     viewController.router?.dataStore?.userIntroduction = payload.userIntroduction
   }
+
+  /// ViewController에 `Delegate`를 설정합니다.
+  private func setDelegate(
+    for viewController: EditUserIntroductionSceneViewController,
+    with delegate: EditUserIntroductionDelegate?
+  ) {
+    viewController.router?.delegate = delegate
+  }
 }
 
 // MARK: - Preview Builder
@@ -86,6 +97,6 @@ extension EditUserIntroductionSceneBuilder {
     dependency: Dependency(
       someWorker: EditUserIntroductionSceneWorker()
     )
-  ).build(with: PreviewPayload())
+  ).build(with: PreviewPayload(), delegate: nil)
 }
 #endif

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
@@ -32,13 +32,9 @@ extension EditUserIntroductionSceneBuilder: EditUserIntroductionSceneBuildable {
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Parameter delegate: 런타임에 이전 화면으로 데이터를 전달하는 Delegate 객체입니다.
   /// - Returns: 런타임 의존성, delegate 객체, VIP Cycle이 설정된 ViewController를 반환합니다.
-  public func build(
-    with payload: EditUserIntroductionScenePayloadable,
-    delegate: EditUserIntroductionDelegate?
-  ) -> EditUserIntroductionSceneViewControllable {
+  public func build(with payload: EditUserIntroductionScenePayloadable) -> EditUserIntroductionSceneViewControllable {
     let someViewController = self.configureVIPCycle(for: EditUserIntroductionSceneViewController())
     self.setPayload(for: someViewController, with: payload)
-    self.setDelegate(for: someViewController, with: delegate)
 
     return someViewController
   }
@@ -73,14 +69,7 @@ extension EditUserIntroductionSceneBuilder {
     with payload: EditUserIntroductionScenePayloadable
   ) {
     viewController.router?.dataStore?.userIntroduction = payload.userIntroduction
-  }
-
-  /// ViewController에 `Delegate`를 설정합니다.
-  private func setDelegate(
-    for viewController: EditUserIntroductionSceneViewController,
-    with delegate: EditUserIntroductionDelegate?
-  ) {
-    viewController.router?.delegate = delegate
+    viewController.router?.delegate = payload.delegate
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -67,6 +67,7 @@ extension EditUserIntroductionSceneInteractor: EditUserIntroductionSceneBusiness
       do {
         try Task.checkCancellation()
         try await self.editUserIntroductionWorker.editUserIntroduction(introduction)
+        self.userIntroduction = introduction
 
         try Task.checkCancellation()
         self.presenter?.presentEditUserIntroductionSuccess()

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneRouter.swift
@@ -16,10 +16,12 @@ protocol EditUserIntroductionSceneRoutingLogic {
 
 protocol EditUserIntroductionSceneDataPassing {
   var dataStore: EditUserIntroductionSceneDataStore? { get set }
+  var delegate: EditUserIntroductionDelegate? { get set }
 }
 
 class EditUserIntroductionSceneRouter: EditUserIntroductionSceneDataPassing {
   weak var viewController: EditUserIntroductionSceneViewController?
+  weak var delegate: EditUserIntroductionDelegate?
   var dataStore: EditUserIntroductionSceneDataStore?
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneRouter.swift
@@ -29,6 +29,7 @@ class EditUserIntroductionSceneRouter: EditUserIntroductionSceneDataPassing {
 
 extension EditUserIntroductionSceneRouter: EditUserIntroductionSceneRoutingLogic {
   func routeToUserInfoScene() {
+    self.delegate?.userIntroductionDidEdited(new: self.dataStore?.userIntroduction)
     self.viewController?.navigationController?.popViewController(animated: true)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionDelegate.swift
@@ -8,5 +8,8 @@
 import Foundation
 
 public protocol EditUserIntroductionDelegate: AnyObject {
+  /// 소개 수정 요청 성공시, Delegate를 채택한 객체에 수정된 소개를 전달합니다.
+  /// - Parameter introduction: 수정된 소개 문자열 값입니다.
+  /// - 유저가 소개를 빈 상태로 설정한 경우, nil을 전달합니다.
   func userIntroductionDidEdited(new introduction: String?)
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionDelegate.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 public protocol EditUserIntroductionDelegate: AnyObject {
-  func userIntroductionDidEdited(new introduction: String)
+  func userIntroductionDidEdited(new introduction: String?)
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  EditUserIntroductionDelegate.swift
+//
+//
+//  Created by Wood on 10/18/24.
+//
+
+import Foundation
+
+public protocol EditUserIntroductionDelegate: AnyObject {
+  func userIntroductionDidEdited(new introduction: String)
+}

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionDelegate.swift
@@ -11,5 +11,5 @@ public protocol EditUserIntroductionDelegate: AnyObject {
   /// 소개 수정 요청 성공시, Delegate를 채택한 객체에 수정된 소개를 전달합니다.
   /// - Parameter introduction: 수정된 소개 문자열 값입니다.
   /// - 유저가 소개를 빈 상태로 설정한 경우, nil을 전달합니다.
-  func userIntroductionDidEdited(new introduction: String?)
+  func userIntroductionDidEdited(_ introduction: String?)
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionSceneBuildable.swift
@@ -10,6 +10,7 @@ import Foundation
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
 public protocol EditUserIntroductionScenePayloadable {
   var userIntroduction: String? { get }
+  var delegate: EditUserIntroductionDelegate? { get }
 }
 
 public protocol EditUserIntroductionSceneBuildable {
@@ -17,8 +18,5 @@ public protocol EditUserIntroductionSceneBuildable {
   /// - Parameter payload: 런타임에 전달받아야 하는 파라미터입니다.
   /// - Parameter delegate: 런타임에 이전 화면으로 데이터를 전달하는 객체입니다.
   /// - Returns: 런타임 파라미터, VIP Cycle이 설정된 ViewController가 반환되도록 구현합니다.
-  func build(
-    with payload: EditUserIntroductionScenePayloadable,
-    delegate: EditUserIntroductionDelegate?
-  ) -> EditUserIntroductionSceneViewControllable
+  func build(with payload: EditUserIntroductionScenePayloadable) -> EditUserIntroductionSceneViewControllable
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneAPI/EditUserIntroductionSceneBuildable.swift
@@ -15,6 +15,10 @@ public protocol EditUserIntroductionScenePayloadable {
 public protocol EditUserIntroductionSceneBuildable {
   ///  VIP Cycle, 런타임 파라미터가 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 파라미터입니다.
+  /// - Parameter delegate: 런타임에 이전 화면으로 데이터를 전달하는 객체입니다.
   /// - Returns: 런타임 파라미터, VIP Cycle이 설정된 ViewController가 반환되도록 구현합니다.
-  func build(with payload: EditUserIntroductionScenePayloadable) -> EditUserIntroductionSceneViewControllable
+  func build(
+    with payload: EditUserIntroductionScenePayloadable,
+    delegate: EditUserIntroductionDelegate?
+  ) -> EditUserIntroductionSceneViewControllable
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
@@ -38,7 +38,10 @@ extension UserInfoSceneRouter: UserInfoSceneRoutingLogic {
 
   func routeToEditUserIntroductionScene() {
     guard let editUserIntroductionScene = self.editUserIntroductionSceneBuilder?.build(
-      with: EditUserIntroductionScenePayload(userIntroduction: self.dataStore?.userIntroduction)
+      with: EditUserIntroductionScenePayload(
+        userIntroduction: self.dataStore?.userIntroduction,
+        delegate: self.viewController
+      )
     ) else { return }
 
     self.viewController?.navigationController?.pushViewController(
@@ -53,5 +56,6 @@ extension UserInfoSceneRouter: UserInfoSceneRoutingLogic {
 extension UserInfoSceneRouter {
   struct EditUserIntroductionScenePayload: EditUserIntroductionScenePayloadable {
     var userIntroduction: String?
+    var delegate: EditUserIntroductionDelegate?
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -125,7 +125,7 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
 // MARK: - Request to interactor
 
 extension UserInfoSceneViewController: EditUserIntroductionDelegate {
-  func userIntroductionDidEdited(new introduction: String?) {
+  func userIntroductionDidEdited(_ introduction: String?) {
     // TODO: 소개 리로드 Business Logic 호출 예정
   }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -8,6 +8,7 @@
 import PhotosUI
 import UIKit
 
+import EditUserIntroductionSceneAPI
 import ToDoGardenUIAPI
 import ToDoGardenUIComponent
 import ToDoGardenUIConstant
@@ -123,7 +124,11 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
 
 // MARK: - Request to interactor
 
-extension UserInfoSceneViewController {
+extension UserInfoSceneViewController: EditUserIntroductionDelegate {
+  func userIntroductionDidEdited(new introduction: String?) {
+    // TODO: 소개 리로드 Business Logic 호출 예정
+  }
+
   func didSelectEditProfileButton() {
     self.interactor?.fetchUserPhotoAccess()
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #599 

## 🎉 변경 사항
- 수정된 소개를 UserInfoScene에 전달하는 Delegate 객체를 추가하였습니다.
- EditUserIntroductionSceneBuilder에서 Delegate를 설정할 수 있도록 수정하였습니다.

## 📌 PR Point

### EditUserIntroductionDelegate
- 수정된 소개 문자열을 UserInfoScene에 전달하는 객체입니다.
- Payload와 다르게 `이전 화면으로 데이터 전달`이 필요하기에 구현하였습니다.

### 차후 구현 예정
- 이를 채택한 `UserInfoSceneVC`가 Delegate 메서드 호출시, `소개 리로드 VIP를 호출`할 예정입니다.
- 해당 작업은 다음 PR에서 진행 예정입니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?