### PR TITLE
SignUpScene 문자 유효성검사 구현 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpInteractor.swift
@@ -15,26 +15,31 @@ protocol SignUpDataStore {
 }
 
 protocol SignUpBusinessLogic {
-  func doSomething(request: SignUp.Something.Request)
+  func checkStringValidation(request: SignUp.CheckStringValidation.Request)
 }
 
 class SignUpInteractor: SignUpDataStore {
   // var name: String = ""
   var presenter: SignUpPresentationLogic?
-  private let someWorker: SignUpWorkable
+  private let signUpWorker: SignUpWorkable
   
+  // TODO: 파라미터 명 바꾸기
   init(someWorker: SignUpWorkable) {
-    self.someWorker = someWorker
+    self.signUpWorker = someWorker
   }
 }
 
 // MARK: - Request to worker
 
 extension SignUpInteractor: SignUpBusinessLogic {
-  func doSomething(request: SignUp.Something.Request) {
-    self.someWorker.doSomeWork()
+  func checkStringValidation(request: SignUp.CheckStringValidation.Request) {
+    let state = self.signUpWorker.checkStringValidation(text: request.text, currentPageIndex: request.currentPageIndex)
     
-    let response = SignUp.Something.Response()
-    self.presenter?.presentSomething(response: response)
+    let response = SignUp.CheckStringValidation.Response(
+      validationState: state,
+      currentPageIndex: request.currentPageIndex
+    )
+    
+    self.presenter?.presentValidation(response: response)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpInteractor.swift
@@ -40,6 +40,17 @@ extension SignUpInteractor: SignUpBusinessLogic {
       currentPageIndex: request.currentPageIndex
     )
     
-    self.presenter?.presentValidation(response: response)
+    switch state {
+    case SignUp.ValidationState.valid:
+      self.presenter?.presentValid(response: response)
+    case SignUp.ValidationState.invalid:
+      self.presenter?.presentInvalid(response: response)
+    case SignUp.ValidationState.empty:
+      if request.currentPageIndex == 1 {
+        self.presenter?.presentValid(response: response)
+      } else {
+        self.presenter?.presentInvalid(response: response)
+      }
+    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpPresenter.swift
@@ -10,7 +10,8 @@ import Foundation
 import SignUpSceneEntity
 
 protocol SignUpPresentationLogic {
-  func presentValidation(response: SignUp.CheckStringValidation.Response)
+  func presentValid(response: SignUp.CheckStringValidation.Response)
+  func presentInvalid(response: SignUp.CheckStringValidation.Response)
 }
 
 class SignUpPresenter {
@@ -20,9 +21,17 @@ class SignUpPresenter {
 // MARK: - Request to ViewController
 
 extension SignUpPresenter: SignUpPresentationLogic {
-  func presentValidation(response: SignUp.CheckStringValidation.Response) {
-    let viewModel = self.makeViewModel(response: response)
-    self.viewController?.displayValidation(viewModel: viewModel)
+  func presentValid(response: SignUp.CheckStringValidation.Response) {
+    let viewModel = SignUp.CheckStringValidation.ViewModel(warningText: "", currentPageIndex: response.currentPageIndex)
+    self.viewController?.displayValid(viewModel: viewModel)
+  }
+  
+  func presentInvalid(response: SignUp.CheckStringValidation.Response) {
+    let viewModel = SignUp.CheckStringValidation.ViewModel(
+      warningText: self.makeWarningText(currentPageIndex: response.currentPageIndex),
+      currentPageIndex: response.currentPageIndex
+    )
+    self.viewController?.displayInvalid(viewModel: viewModel)
   }
   
   private func makeViewModel(
@@ -30,10 +39,6 @@ extension SignUpPresenter: SignUpPresentationLogic {
   ) -> SignUp.CheckStringValidation.ViewModel {
     let viewModel = SignUp.CheckStringValidation.ViewModel(
       warningText: self.makeWarningText(currentPageIndex: response.currentPageIndex),
-      isValid: self.isValid(
-        currentPageIndex: response.currentPageIndex,
-        validationState: response.validationState
-      ),
       currentPageIndex: response.currentPageIndex
     )
     return viewModel
@@ -49,24 +54,6 @@ extension SignUpPresenter: SignUpPresentationLogic {
       return Constant.ScrollView.SignUpInputView.StringLiteral.nicknameWarning
     default:
       return ""
-    }
-  }
-  
-  private func isValid(currentPageIndex: Int, validationState: SignUp.ValidationState) -> Bool {
-    if currentPageIndex == 1 {
-      switch validationState {
-      case SignUp.ValidationState.invalid:
-        return false
-      default:
-        return true
-      }
-    } else {
-      switch validationState {
-      case SignUp.ValidationState.valid:
-        return true
-      default:
-        return false
-      }
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpPresenter.swift
@@ -10,7 +10,7 @@ import Foundation
 import SignUpSceneEntity
 
 protocol SignUpPresentationLogic {
-  func presentSomething(response: SignUp.Something.Response)
+  func presentValidation(response: SignUp.CheckStringValidation.Response)
 }
 
 class SignUpPresenter {
@@ -20,8 +20,53 @@ class SignUpPresenter {
 // MARK: - Request to ViewController
 
 extension SignUpPresenter: SignUpPresentationLogic {
-  func presentSomething(response: SignUp.Something.Response) {
-    let viewModel = SignUp.Something.ViewModel()
-    self.viewController?.displaySomething(viewModel: viewModel)
+  func presentValidation(response: SignUp.CheckStringValidation.Response) {
+    let viewModel = self.makeViewModel(response: response)
+    self.viewController?.presentValidation(viewModel: viewModel)
+  }
+  
+  private func makeViewModel(
+    response: SignUp.CheckStringValidation.Response
+  ) -> SignUp.CheckStringValidation.ViewModel {
+    let viewModel = SignUp.CheckStringValidation.ViewModel(
+      warningText: self.makeWarningText(currentPageIndex: response.currentPageIndex),
+      isValid: self.isValid(
+        currentPageIndex: response.currentPageIndex,
+        validationState: response.validationState
+      ),
+      currentPageIndex: response.currentPageIndex
+    )
+    return viewModel
+  }
+  
+  private func makeWarningText(currentPageIndex: Int) -> String {
+    switch currentPageIndex {
+    case 0:
+      return Constant.ScrollView.SignUpInputView.StringLiteral.conditionsForIDGenerationWarning
+    case 1:
+      return Constant.ScrollView.SignUpInputView.StringLiteral.introductionWarning
+    case 2:
+      return Constant.ScrollView.SignUpInputView.StringLiteral.nicknameWarning
+    default:
+      return ""
+    }
+  }
+  
+  private func isValid(currentPageIndex: Int, validationState: SignUp.ValidationState) -> Bool {
+    if currentPageIndex == 1 {
+      switch validationState {
+      case SignUp.ValidationState.invalid:
+        return false
+      default:
+        return true
+      }
+    } else {
+      switch validationState {
+      case SignUp.ValidationState.valid:
+        return true
+      default:
+        return false
+      }
+    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpPresenter.swift
@@ -22,7 +22,7 @@ class SignUpPresenter {
 extension SignUpPresenter: SignUpPresentationLogic {
   func presentValidation(response: SignUp.CheckStringValidation.Response) {
     let viewModel = self.makeViewModel(response: response)
-    self.viewController?.presentValidation(viewModel: viewModel)
+    self.viewController?.displayValidation(viewModel: viewModel)
   }
   
   private func makeViewModel(

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -92,6 +92,7 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
   
   private func setupBottomButton() {
     self.view.addSubview(self.bottomButton)
+    self.bottomButton.isEnabled = false
     self.bottomButton.usingAutolayout()
     self.bottomButton.addAction(UIAction { [weak self] _ in
       self?.signUpScrollView.goToNextPage()

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -12,7 +12,7 @@ import SignUpSceneEntity
 import ToDoGardenUIComponent
 
 protocol SignUpDisplayLogic: AnyObject {
-  func displaySomething(viewModel: SignUp.Something.ViewModel)
+  func presentValidation(viewModel: SignUp.CheckStringValidation.ViewModel)
 }
 
 final class SignUpViewController: UIViewController, SignUpViewControllable {
@@ -46,7 +46,6 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    self.doSomething()
   }
   
   // MARK: - Setups
@@ -73,6 +72,12 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
   
   private func setupSignUpScrollView() {
     self.signUpScrollView.changeButtonDelegate = self
+    self.signUpScrollView.delegate = self
+    let inputViews = self.signUpScrollView.inputViews
+    for inputView in inputViews {
+      inputView.textInputView.delegate = self
+    }
+    
     self.view.addSubview(self.signUpScrollView)
     self.signUpScrollView.usingAutolayout()
     NSLayoutConstraint.activate(
@@ -180,13 +185,25 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
     self.bottomButton.isHidden = false
     self.bottomButton.alpha = 1
   }
+  
+  private func changeButtonState(isEnabled: Bool) {
+    self.bottomButton.isEnabled = isEnabled
+  }
 }
 
 // MARK: - Confirm display logic protocol
 
 extension SignUpViewController: SignUpDisplayLogic {
-  func displaySomething(viewModel: SignUp.Something.ViewModel) {
-    // self.nameTextField.text = viewModel.name
+  func presentValidation(viewModel: SignUp.CheckStringValidation.ViewModel) {
+    let textInputView = self.signUpScrollView.inputViews[viewModel.currentPageIndex].textInputView
+    textInputView.changeValidationText(viewModel.warningText)
+
+    if viewModel.isValid {
+      textInputView.hideValidationText()
+    } else {
+      textInputView.showValidationText()
+    }
+    self.changeButtonState(isEnabled: viewModel.isValid)
   }
 }
 
@@ -203,10 +220,6 @@ extension SignUpViewController {
 }
 
 extension SignUpViewController: ChangeButtonDelegate {
-  func changeButtonState(isEnabled: Bool) {
-    self.bottomButton.isEnabled = isEnabled
-  }
-  
   func changeButtonTitle(pageIndex: Int) {
     let editingText = self.signUpScrollView.getEditingText()
     let isEditingTextEmpty: Bool = editingText?.isEmpty ?? true

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -72,7 +72,7 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
   }
   
   private func setupSignUpScrollView() {
-    self.signUpScrollView.changeButtonTitleDelegate = self
+    self.signUpScrollView.changeButtonDelegate = self
     self.view.addSubview(self.signUpScrollView)
     self.signUpScrollView.usingAutolayout()
     NSLayoutConstraint.activate(
@@ -198,7 +198,7 @@ extension SignUpViewController {
   }
 }
 
-extension SignUpViewController: ChangeButtonTitleDelegate {
+extension SignUpViewController: ChangeButtonDelegate {
   func changeButtonTitle(pageIndex: Int) {
     let editingText = self.signUpScrollView.getEditingText()
     let isEditingTextEmpty: Bool = editingText?.isEmpty ?? true

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -193,9 +193,12 @@ extension SignUpViewController: SignUpDisplayLogic {
 // MARK: - Request to interactor
 
 extension SignUpViewController {
-  func doSomething() {
-    let request = SignUp.Something.Request()
-    self.interactor?.doSomething(request: request)
+  func checkStringValidation(text: String?) {
+    let request = SignUp.CheckStringValidation.Request(
+      text: text,
+      currentPageIndex: self.signUpScrollView.currentPageIndex
+    )
+    self.interactor?.checkStringValidation(request: request)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -42,12 +42,6 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
     fatalError("init(coder:) has not been implemented")
   }
   
-  // MARK: - View lifecycle
-  
-  override func viewDidLoad() {
-    super.viewDidLoad()
-  }
-  
   // MARK: - Setups
   
   private func setup() {

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -12,7 +12,8 @@ import SignUpSceneEntity
 import ToDoGardenUIComponent
 
 protocol SignUpDisplayLogic: AnyObject {
-  func displayValidation(viewModel: SignUp.CheckStringValidation.ViewModel)
+  func displayValid(viewModel: SignUp.CheckStringValidation.ViewModel)
+  func displayInvalid(viewModel: SignUp.CheckStringValidation.ViewModel)
 }
 
 final class SignUpViewController: UIViewController, SignUpViewControllable {
@@ -188,16 +189,21 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
 // MARK: - Confirm display logic protocol
 
 extension SignUpViewController: SignUpDisplayLogic {
-  func displayValidation(viewModel: SignUp.CheckStringValidation.ViewModel) {
+  func displayValid(viewModel: SignUp.CheckStringValidation.ViewModel) {
+    guard self.signUpScrollView.currentPageIndex == viewModel.currentPageIndex else { return }
+    
+    self.changeButtonState(isEnabled: true)
+    let textInputView = self.signUpScrollView.inputViews[viewModel.currentPageIndex].textInputView
+    textInputView.hideValidationText()
+  }
+  
+  func displayInvalid(viewModel: SignUp.CheckStringValidation.ViewModel) {
+    guard self.signUpScrollView.currentPageIndex == viewModel.currentPageIndex else { return }
+    
+    self.changeButtonState(isEnabled: false)
     let textInputView = self.signUpScrollView.inputViews[viewModel.currentPageIndex].textInputView
     textInputView.changeValidationText(viewModel.warningText)
-
-    if viewModel.isValid {
-      textInputView.hideValidationText()
-    } else {
-      textInputView.showValidationText()
-    }
-    self.changeButtonState(isEnabled: viewModel.isValid)
+    textInputView.showValidationText()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -200,6 +200,10 @@ extension SignUpViewController {
 }
 
 extension SignUpViewController: ChangeButtonDelegate {
+  func changeButtonState(isEnabled: Bool) {
+    self.bottomButton.isEnabled = isEnabled
+  }
+  
   func changeButtonTitle(pageIndex: Int) {
     let editingText = self.signUpScrollView.getEditingText()
     let isEditingTextEmpty: Bool = editingText?.isEmpty ?? true

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -231,6 +231,19 @@ extension SignUpViewController: ChangeButtonDelegate {
   }
 }
 
+extension SignUpViewController: InputTextValidationViewDelegate {
+  public func inputTextDidChanged(_ text: String?) {
+    self.checkStringValidation(text: text)
+    self.changeButtonTitle(pageIndex: self.signUpScrollView.currentPageIndex)
+  }
+}
+
+extension SignUpViewController: UIScrollViewDelegate {
+  public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    self.checkStringValidation(text: self.signUpScrollView.getEditingText())
+  }
+}
+
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -12,7 +12,7 @@ import SignUpSceneEntity
 import ToDoGardenUIComponent
 
 protocol SignUpDisplayLogic: AnyObject {
-  func presentValidation(viewModel: SignUp.CheckStringValidation.ViewModel)
+  func displayValidation(viewModel: SignUp.CheckStringValidation.ViewModel)
 }
 
 final class SignUpViewController: UIViewController, SignUpViewControllable {
@@ -188,7 +188,7 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
 // MARK: - Confirm display logic protocol
 
 extension SignUpViewController: SignUpDisplayLogic {
-  func presentValidation(viewModel: SignUp.CheckStringValidation.ViewModel) {
+  func displayValidation(viewModel: SignUp.CheckStringValidation.ViewModel) {
     let textInputView = self.signUpScrollView.inputViews[viewModel.currentPageIndex].textInputView
     textInputView.changeValidationText(viewModel.warningText)
 

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpWorker.swift
@@ -15,7 +15,7 @@ public struct SignUpWorker: SignUpWorkable {
   public init() {}
   
   public func checkStringValidation(text: String?, currentPageIndex: Int) -> SignUp.ValidationState {
-    guard let text = text else {
+    guard let text else {
       return SignUp.ValidationState.empty
     }
     switch currentPageIndex {

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpWorker.swift
@@ -1,6 +1,6 @@
 //
 //  SignUpWorker.swift
-//  
+//
 //
 //  Created by SONG on 10/7/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
@@ -8,8 +8,37 @@
 import Foundation
 
 import SignUpSceneAPI
+import SignUpSceneEntity
+import TDUtility
 
-struct SignUpWorker: SignUpWorkable {
-  func doSomeWork() {
+public struct SignUpWorker: SignUpWorkable {
+  public init() {}
+  
+  public func checkStringValidation(text: String?, currentPageIndex: Int) -> SignUp.ValidationState {
+    guard let text = text else {
+      return SignUp.ValidationState.empty
+    }
+    switch currentPageIndex {
+    case 0:
+      if StringValidationChecker.isValidID(text) {
+        return SignUp.ValidationState.valid
+      } else {
+        return SignUp.ValidationState.invalid
+      }
+    case 1:
+      if StringValidationChecker.isValidIntroduction(text) {
+        return SignUp.ValidationState.valid
+      } else {
+        return SignUp.ValidationState.invalid
+      }
+    case 2:
+      if StringValidationChecker.isValidNickName(text) {
+        return SignUp.ValidationState.valid
+      } else {
+        return SignUp.ValidationState.invalid
+      }
+    default:
+      return SignUp.ValidationState.empty
+    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpSceneConstants.swift
@@ -34,6 +34,8 @@ enum Constant {
         
         static let conditionsForIDGenerationWarning: String = "아이디는 5~12자 내외 띄어쓰기 없이\n영문, 숫자만 사용 가능합니다"
         static let inUseIDAlreadyWarning: String = "이미 사용중인 아이디 입니다"
+        static let introductionWarning: String = "한줄소개는 최대 15글자까지 사용 가능합니다"
+        static let nicknameWarning: String = "닉네임은 5~12자 내외\n띄어쓰기, 특수기호 없이 사용 가능합니다"
       }
     }
   }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
@@ -12,7 +12,6 @@ import ToDoGardenUIComponent
 
 protocol ChangeButtonDelegate: AnyObject {
   func changeButtonTitle(pageIndex: Int)
-  func changeButtonState(isEnabled: Bool)
 }
 
 final class SignUpScrollView: UIScrollView {
@@ -87,10 +86,6 @@ final class SignUpScrollView: UIScrollView {
         validationText: ""
       )
     ]
-    
-    for inputView in self.inputViews {
-      inputView.textInputView.delegate = self
-    }
   }
   // swiftlint:enable function_body_length
 
@@ -180,78 +175,23 @@ final class SignUpScrollView: UIScrollView {
     self.inputViews[self.currentPageIndex].cancelTitleAnimation()
   }
   
-  // swiftlint:disable function_body_length
   private func didChangePage() {
     let animation: (() -> Void)? = {
       self.inputViews[self.currentPageIndex].startTitleAnimation()
     }
     
     switch self.currentPageIndex {
-    case 0: self.firstPageAnimation = animation
-      self.changeButtonDelegate?.changeButtonState(
-        isEnabled: StringValidationChecker.isValidID(
-          self.inputViews[0].textInputView.getEditingText() ?? ""
-        )
-      )
-    case 1: self.secondPageAnimation = animation
-      self.changeButtonDelegate?.changeButtonState(
-        isEnabled: StringValidationChecker.isValidIntroduction(
-          self.inputViews[1].textInputView.getEditingText() ?? ""
-        )
-      )
-    case 2: self.thirdPageAnimation = animation
-      self.changeButtonDelegate?.changeButtonState(
-        isEnabled: StringValidationChecker.isValidNickName(
-          self.inputViews[2].textInputView.getEditingText() ?? ""
-        )
-      )
-    default: break
+    case 0:
+      self.firstPageAnimation = animation
+    case 1: 
+      self.secondPageAnimation = animation
+    case 2: 
+      self.thirdPageAnimation = animation
+    default: 
+      break
     }
     
     self.changeButtonDelegate?.changeButtonTitle(pageIndex: self.currentPageIndex)
     self.inputViews[self.currentPageIndex].textInputView.setBecomeFirstRespoder()
-  }
-}
-// swiftlint:enable function_body_length
-
-extension SignUpScrollView: InputTextValidationViewDelegate {
-  func inputTextDidChanged(_ text: String?) {
-    self.changeButtonDelegate?.changeButtonTitle(pageIndex: self.currentPageIndex)
-    self.checkStringValidation(text: text)
-  }
-  
-  private func checkStringValidation(text: String?) {
-    guard let text = text else { return }
-    
-    let validationMethods: [(validationMethod: (String) -> Bool, warningText: String)] = [
-      (
-        StringValidationChecker.isValidID,
-        Constant.ScrollView.SignUpInputView.StringLiteral.conditionsForIDGenerationWarning
-      ),
-      (
-        StringValidationChecker.isValidIntroduction,
-        Constant.ScrollView.SignUpInputView.StringLiteral.introductionWarning
-      ),
-      (
-        StringValidationChecker.isValidNickName,
-        Constant.ScrollView.SignUpInputView.StringLiteral.nicknameWarning
-      )
-    ]
-    
-    if self.currentPageIndex < validationMethods.count {
-      let (validationMethod, warningText) = validationMethods[self.currentPageIndex]
-      self.validateInput(text: text, validationMethod: validationMethod, warningText: warningText)
-    }
-  }
-  
-  private func validateInput(text: String, validationMethod: (String) -> Bool, warningText: String) {
-    self.inputViews[self.currentPageIndex].textInputView.changeValidationText(warningText)
-    if !validationMethod(text) {
-      self.inputViews[self.currentPageIndex].textInputView.showValidationText()
-      self.changeButtonDelegate?.changeButtonState(isEnabled: false)
-    } else {
-      self.inputViews[self.currentPageIndex].textInputView.hideValidationText()
-      self.changeButtonDelegate?.changeButtonState(isEnabled: true)
-    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
@@ -10,8 +10,9 @@ import UIKit
 import TDUtility
 import ToDoGardenUIComponent
 
-protocol ChangeButtonTitleDelegate: AnyObject {
+protocol ChangeButtonDelegate: AnyObject {
   func changeButtonTitle(pageIndex: Int)
+  func changeButtonState(isEnabled: Bool)
 }
 
 final class SignUpScrollView: UIScrollView {
@@ -33,7 +34,7 @@ final class SignUpScrollView: UIScrollView {
   @ExecuteOnce private var secondPageAnimation: (() -> Void)?
   @ExecuteOnce private var thirdPageAnimation: (() -> Void)?
   
-  weak var changeButtonTitleDelegate: ChangeButtonTitleDelegate?
+  weak var changeButtonDelegate: ChangeButtonDelegate?
   
   override init(frame: CGRect) {
     self.currentPageIndex = Int.zero
@@ -189,13 +190,13 @@ final class SignUpScrollView: UIScrollView {
     default: break
     }
     
-    self.changeButtonTitleDelegate?.changeButtonTitle(pageIndex: self.currentPageIndex)
+    self.changeButtonDelegate?.changeButtonTitle(pageIndex: self.currentPageIndex)
     self.inputViews[self.currentPageIndex].textInputView.setBecomeFirstRespoder()
   }
 }
 
 extension SignUpScrollView: InputTextValidationViewDelegate {
   func inputTextDidChanged(_ text: String?) {
-    self.changeButtonTitleDelegate?.changeButtonTitle(pageIndex: self.currentPageIndex)
+    self.changeButtonDelegate?.changeButtonTitle(pageIndex: self.currentPageIndex)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
@@ -88,10 +88,12 @@ final class SignUpScrollView: UIScrollView {
       )
     ]
     
-    self.inputViews[1].textInputView.delegate = self
+    for inputView in self.inputViews {
+      inputView.textInputView.delegate = self
+    }
   }
   // swiftlint:enable function_body_length
-  
+
   private func setupScrollView() {
     self.isPagingEnabled = true
     self.showsHorizontalScrollIndicator = false
@@ -178,6 +180,7 @@ final class SignUpScrollView: UIScrollView {
     self.inputViews[self.currentPageIndex].cancelTitleAnimation()
   }
   
+  // swiftlint:disable function_body_length
   private func didChangePage() {
     let animation: (() -> Void)? = {
       self.inputViews[self.currentPageIndex].startTitleAnimation()
@@ -185,8 +188,23 @@ final class SignUpScrollView: UIScrollView {
     
     switch self.currentPageIndex {
     case 0: self.firstPageAnimation = animation
+      self.changeButtonDelegate?.changeButtonState(
+        isEnabled: StringValidationChecker.isValidID(
+          self.inputViews[0].textInputView.getEditingText() ?? ""
+        )
+      )
     case 1: self.secondPageAnimation = animation
+      self.changeButtonDelegate?.changeButtonState(
+        isEnabled: StringValidationChecker.isValidIntroduction(
+          self.inputViews[1].textInputView.getEditingText() ?? ""
+        )
+      )
     case 2: self.thirdPageAnimation = animation
+      self.changeButtonDelegate?.changeButtonState(
+        isEnabled: StringValidationChecker.isValidNickName(
+          self.inputViews[2].textInputView.getEditingText() ?? ""
+        )
+      )
     default: break
     }
     
@@ -194,9 +212,46 @@ final class SignUpScrollView: UIScrollView {
     self.inputViews[self.currentPageIndex].textInputView.setBecomeFirstRespoder()
   }
 }
+// swiftlint:enable function_body_length
 
 extension SignUpScrollView: InputTextValidationViewDelegate {
   func inputTextDidChanged(_ text: String?) {
     self.changeButtonDelegate?.changeButtonTitle(pageIndex: self.currentPageIndex)
+    self.checkStringValidation(text: text)
+  }
+  
+  private func checkStringValidation(text: String?) {
+    guard let text = text else { return }
+    
+    let validationMethods: [(validationMethod: (String) -> Bool, warningText: String)] = [
+      (
+        StringValidationChecker.isValidID,
+        Constant.ScrollView.SignUpInputView.StringLiteral.conditionsForIDGenerationWarning
+      ),
+      (
+        StringValidationChecker.isValidIntroduction,
+        Constant.ScrollView.SignUpInputView.StringLiteral.introductionWarning
+      ),
+      (
+        StringValidationChecker.isValidNickName,
+        Constant.ScrollView.SignUpInputView.StringLiteral.nicknameWarning
+      )
+    ]
+    
+    if self.currentPageIndex < validationMethods.count {
+      let (validationMethod, warningText) = validationMethods[self.currentPageIndex]
+      self.validateInput(text: text, validationMethod: validationMethod, warningText: warningText)
+    }
+  }
+  
+  private func validateInput(text: String, validationMethod: (String) -> Bool, warningText: String) {
+    self.inputViews[self.currentPageIndex].textInputView.changeValidationText(warningText)
+    if !validationMethod(text) {
+      self.inputViews[self.currentPageIndex].textInputView.showValidationText()
+      self.changeButtonDelegate?.changeButtonState(isEnabled: false)
+    } else {
+      self.inputViews[self.currentPageIndex].textInputView.hideValidationText()
+      self.changeButtonDelegate?.changeButtonState(isEnabled: true)
+    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
@@ -26,7 +26,7 @@ final class SignUpScrollView: UIScrollView {
     return windowScene?.screen.bounds.width ?? CGFloat.zero
   }
   
-  private var inputViews: [SignUpInputView]
+  var inputViews: [SignUpInputView]
   private let contentView: UIView
   
   @ExecuteOnce private var firstPageAnimation: (() -> Void)?

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpSceneAPI/SignUpWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpSceneAPI/SignUpWorkable.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+import SignUpSceneEntity
+
 public protocol SignUpWorkable {
-  func doSomeWork()
+  func checkStringValidation(text: String?, currentPageIndex: Int) -> SignUp.ValidationState
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpSceneEntity/SignUpModels.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpSceneEntity/SignUpModels.swift
@@ -11,15 +11,47 @@ public enum SignUp {
   
   // MARK: Use cases
   
-  public enum Something {
+  public enum CheckStringValidation {
     public struct Request {
-      public init() { }
+      public let text: String?
+      public let currentPageIndex: Int
+      
+      public init(text: String?, currentPageIndex: Int) {
+        self.text = text
+        self.currentPageIndex = currentPageIndex
+      }
     }
     public struct Response {
-      public init() { }
+      public let validationState: ValidationState
+      public let currentPageIndex: Int
+      
+      public init(validationState: ValidationState, currentPageIndex: Int) {
+        self.validationState = validationState
+        self.currentPageIndex = currentPageIndex
+      }
     }
     public struct ViewModel {
-      public init() { }
+      public let warningText: String
+      public let isValid: Bool
+      public let currentPageIndex: Int
+      
+      public init(
+        warningText: String,
+        isValid: Bool,
+        currentPageIndex: Int
+      ) {
+        self.warningText = warningText
+        self.isValid = isValid
+        self.currentPageIndex = currentPageIndex
+      }
     }
+  }
+}
+
+extension SignUp {
+  public enum ValidationState {
+    case valid
+    case invalid
+    case empty
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpSceneEntity/SignUpModels.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpSceneEntity/SignUpModels.swift
@@ -32,16 +32,13 @@ public enum SignUp {
     }
     public struct ViewModel {
       public let warningText: String
-      public let isValid: Bool
       public let currentPageIndex: Int
       
       public init(
         warningText: String,
-        isValid: Bool,
         currentPageIndex: Int
       ) {
         self.warningText = warningText
-        self.isValid = isValid
         self.currentPageIndex = currentPageIndex
       }
     }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #581 

## 🎉 변경 사항
- SignUpScene 문자 유효성검사 구현 
## 📌 PR Point

<img width="899" alt="스크린샷 2024-10-18 오후 8 27 20" src="https://github.com/user-attachments/assets/b18c147e-43a7-429a-9857-d2e7336e2d78">
__________

### 텍스트필드가 수정될 때마다 검사를 하는 이유 
<img width="365" alt="스크린샷 2024-10-18 오후 8 31 05" src="https://github.com/user-attachments/assets/02cf6be2-27ad-489c-b33f-a21b606b5fbe">

- 아무래도 텍스트필드가 수정될 때마다 검사를 하게 되면, 그만큼 여러번의 사이클을 돌게 됩니다. 그럼에도 불구하고 이러한 방식을 채택한 것은 특수문자, 공백 등과 같은 캐릭터가 포함되었는지 확인해야 하기 때문입니다. 
글자 수 제한만 있었다면, 카운트가 5,12일때만 검사를 하는 방식을 채택하려했지만 특수문자와 공백이 입력 되었을때 즉각적으로 경고문을 보여줘야 하기 때문에 텍스트필드가 수정될 때마다 검사를 하도록 하였습니다. 

_____________
### 페이지 변경 시 검사를 하는 이유 
<img width="293" alt="스크린샷 2024-10-18 오후 8 35 19" src="https://github.com/user-attachments/assets/bcbbd057-5506-405a-8d36-54fe54431c09">
<img width="293" alt="스크린샷 2024-10-18 오후 8 36 36" src="https://github.com/user-attachments/assets/bd050547-22c6-406d-8606-d66829812174">

- 스크롤뷰 위의 페이지들은 버튼의 상태를 마치 독립적으로 각각 가진 듯 동작해야합니다. 유효성검사의 결과에 따라 버튼의 비활/활성화가 결정되고, 페이지 마다 그 버튼상태는 서로 영향을 받지 않으며, 버튼 타이틀이 페이지마다 다른 경우도 있습니다. 하지만, 버튼은 하나죠. 2페이지에서 버튼이 활성화되어있고, 3페이지는 비활성화 되어있다면, 
2 -> 3 으로 이동할때 버튼을 비활성화로 바꿔주어야 합니다. 
이와같이 페이지 마다 갖고있는 상태를 페이지가 변경되었을때 마다 맞춰주어야 하는 작업이 필요했습니다. 
_____________

### 실행화면 
![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-10-18 at 20 41 37](https://github.com/user-attachments/assets/ad5a4fb0-ca6e-4361-97ec-d90b1a88258a)

* 현재 VIPW 를 제외한 다른 녀석들은 손을 대지 않은 상태입니다. 시뮬레이터로 직접 확인하시려면 다소 번거로우실듯.. 
* 레이아웃 이슈 x 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?