### PR TITLE
나의 가든 요청 다시 시도하기 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -134,9 +134,9 @@ extension ShareGardenSceneViewController {
 
 extension ShareGardenSceneViewController {
   private func setupMyGardenViewRetryAction() {
-    self.myGardenView.retryAction = UIAction { _ in
-      self.myGardenView.showContents()
-      self.interactor?.requestMyGarden()
+    self.myGardenView.retryAction = UIAction { [weak self] _ in
+      self?.myGardenView.showContents()
+      self?.interactor?.requestMyGarden()
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -135,8 +135,10 @@ extension ShareGardenSceneViewController {
 extension ShareGardenSceneViewController {
   private func setupMyGardenViewRetryAction() {
     self.myGardenView.retryAction = UIAction { [weak self] _ in
-      self?.myGardenView.showContents()
-      self?.interactor?.requestMyGarden()
+      DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.15) {
+        self?.myGardenView.showContents()
+        self?.interactor?.requestMyGarden()
+      }
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -70,7 +70,7 @@ extension ShareGardenSceneViewController: ShareGardenSceneDisplayLogic {
   }
   
   func displayMyGardenRequestError() {
-    // TODO: - display my garden request error view
+    self.myGardenView.showContentsLoadingFailure()
   }
   
   func displayFriendsGardenList(_ viewModel: ShareGardenScene.RequestFriendsGardenList.ViewModel) {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -105,6 +105,7 @@ extension ShareGardenSceneViewController {
 
 extension ShareGardenSceneViewController {
   private func setup() {
+    self.setupActions()
     self.setupViewAppearance()
     self.addSubviews()
     self.setupLayoutConstraints()
@@ -122,6 +123,21 @@ extension ShareGardenSceneViewController {
   private func setupLayoutConstraints() {
     self.setupMyGardenViewLayoutConstraints()
     self.setupFriendsGardenViewLayoutConstraints()
+  }
+  
+  private func setupActions() {
+    self.setupMyGardenViewRetryAction()
+  }
+}
+
+// MARK: - Setup ui action
+
+extension ShareGardenSceneViewController {
+  private func setupMyGardenViewRetryAction() {
+    self.myGardenView.retryAction = UIAction { _ in
+      self.myGardenView.showContents()
+      self.interactor?.requestMyGarden()
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -63,6 +63,12 @@ extension ShareGardenSceneViewController {
     
     @ExecuteOnce private var setupLayoutIfNeeded: (() -> Void)?
     
+    var retryAction: UIAction? {
+      didSet {
+        self.retryRequestView.retryAction = self.retryAction
+      }
+    }
+    
     init() {
       self.contentView = UIVStackView(
         alignment: UIStackView.Alignment.center,

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -18,6 +18,8 @@ extension ShareGardenSceneViewController {
     
     // MARK: - UI Properties
     
+    private let contentView: UIStackView
+    
     private let sectionHeaderView: SectionHeaderView = {
       let shareButton = UIButton()
       shareButton.setImage(UIImage.shareIconImage, for: UIControl.State.normal)
@@ -61,6 +63,14 @@ extension ShareGardenSceneViewController {
     @ExecuteOnce private var setupLayoutIfNeeded: (() -> Void)?
     
     init() {
+      self.contentView = UIVStackView(
+        alignment: UIStackView.Alignment.center,
+        spacing: 14,
+        arrangedSubviews: [
+          self.profileInfoView,
+          self.gardenView
+        ]
+      )
       super.init(frame: CGRect.zero)
       self.setup()
     }
@@ -107,8 +117,7 @@ extension ShareGardenSceneViewController.MyGardenView {
   
   private func addSubviews() {
     self.addArrangedSubview(self.sectionHeaderView)
-    self.addArrangedSubview(self.profileInfoView)
-    self.addArrangedSubview(self.gardenView)
+    self.addArrangedSubview(self.contentView)
   }
   
   private func updateProfileInfoView(with nickname: String, _ description: String) {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -18,6 +18,7 @@ extension ShareGardenSceneViewController {
     
     // MARK: - UI Properties
     
+    private let retryRequestView: RetryRequestView = RetryRequestView()
     private let contentView: UIStackView
     
     private let sectionHeaderView: SectionHeaderView = {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -112,6 +112,14 @@ extension ShareGardenSceneViewController {
       self.retryRequestView.view.isHidden = false
       self.stopShimmeringAnimation()
     }
+    
+    func showContents() {
+      self.addArrangedSubview(self.contentView)
+      self.removeArrangedSubview(self.retryRequestView.view)
+      self.contentView.isHidden = false
+      self.retryRequestView.view.isHidden = true
+      self.startShimmeringAnimation()
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -198,3 +198,11 @@ extension ShareGardenSceneViewController.MyGardenView {
     ])
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let view = ShareGardenSceneViewController.MyGardenView()
+  return view
+}
+#endif

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -104,6 +104,14 @@ extension ShareGardenSceneViewController {
       self.layoutIfNeeded()
       self.profileInfoView.startShimmering()
     }
+    
+    func showContentsLoadingFailure() {
+      self.removeArrangedSubview(self.contentView)
+      self.addArrangedSubview(self.retryRequestView.view)
+      self.contentView.isHidden = true
+      self.retryRequestView.view.isHidden = false
+      self.stopShimmeringAnimation()
+    }
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- related: #588 
## 🎉 변경 사항
- [x] 다시 시도하기 뷰 추가
- [x] 다시 시도하기 action 추가
- [x] 나의가든 요청 실패 시 다시 시도하기 뷰 표시

## 📌 PR Point
- 나의가든 요청 실패 시 다시 시도하기 뷰를 표시하도록 하였습니다.
- 버튼의 눌림 표시를 사용자에게 보여주기 위해 0.15초의 delay를 주었습니다.

|Demo|
|---|
|<img src="https://github.com/user-attachments/assets/cb4430f3-3c9b-460a-935e-5a7fe82f029e" width="200" />|



## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?