### PR TITLE
UserInfoScene 유저 소개 리로드 Business Logic 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneInteractor.swift
@@ -67,7 +67,7 @@ extension EditUserIntroductionSceneInteractor: EditUserIntroductionSceneBusiness
       do {
         try Task.checkCancellation()
         try await self.editUserIntroductionWorker.editUserIntroduction(introduction)
-        self.userIntroduction = introduction
+        self.userIntroduction = introduction.isEmpty ? nil : introduction
 
         try Task.checkCancellation()
         self.presenter?.presentEditUserIntroductionSuccess()

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneRouter.swift
@@ -29,7 +29,7 @@ class EditUserIntroductionSceneRouter: EditUserIntroductionSceneDataPassing {
 
 extension EditUserIntroductionSceneRouter: EditUserIntroductionSceneRoutingLogic {
   func routeToUserInfoScene() {
-    self.delegate?.userIntroductionDidEdited(new: self.dataStore?.userIntroduction)
+    self.delegate?.userIntroductionDidEdited(self.dataStore?.userIntroduction)
     self.viewController?.navigationController?.popViewController(animated: true)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -14,6 +14,7 @@ protocol UserInfoSceneDataStore {
   var userIntroduction: String? { get set }
 }
 
+@MainActor
 protocol UserInfoSceneBusinessLogic {
   func configureCollectionView()
   func fetchUserPhotoAccess()
@@ -61,7 +62,7 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
       let isPhotoAccessible = await self.userPhotoWorker.requestPhotoAccess()
       let response = UserInfoScene.FetchUserPhotoAccess.Response(isPhotoAccessible: isPhotoAccessible)
 
-      await self.presenter?.presentUserPhotoAccess(response: response)
+      self.presenter?.presentUserPhotoAccess(response: response)
     }
   }
 
@@ -75,13 +76,13 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
             changeResult: Result.success(profileImageToChange)
           )
 
-          await self.presenter?.presentChangedProfileImage(response: response)
+          self.presenter?.presentChangedProfileImage(response: response)
         }
       } catch let error {
         let response = UserInfoScene.ChangeProfileImage.Response(
           changeResult: Result.failure(error)
         )
-        await self.presenter?.presentChangedProfileImage(response: response)
+        self.presenter?.presentChangedProfileImage(response: response)
       }
     }
   }
@@ -101,7 +102,7 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
       }
 
       let response = UserInfoScene.WithdrawMembership.Response(withdrawError: withdrawError)
-      await self.presenter?.presentWithdrawResult(response: response)
+      self.presenter?.presentWithdrawResult(response: response)
     }
   }
 
@@ -116,12 +117,17 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
       }
 
       let response = UserInfoScene.SignOut.Response(signOutError: signOutError)
-      await self.presenter?.presentSignOutResult(response: response)
+      self.presenter?.presentSignOutResult(response: response)
     }
   }
 
   func reloadUserIntroduction(_ introduction: String?) {
     self.userIntroduction = introduction
+    if let introduction {
+      self.presenter?.presentChangedUserIntroduction(introduction)
+    } else {
+      self.presenter?.presentEmptyUserIntroduction()
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -21,6 +21,7 @@ protocol UserInfoSceneBusinessLogic {
   func openSettingApp()
   func withdrawMembership()
   func signOut()
+  func reloadUserIntroduction(_ introduction: String?)
 }
 
 final class UserInfoSceneInteractor: UserInfoSceneDataStore {
@@ -117,6 +118,10 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
       let response = UserInfoScene.SignOut.Response(signOutError: signOutError)
       await self.presenter?.presentSignOutResult(response: response)
     }
+  }
+
+  func reloadUserIntroduction(_ introduction: String?) {
+    self.userIntroduction = introduction
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -11,7 +11,7 @@ import UserInfoSceneEntity
 
 @MainActor
 protocol UserInfoScenePresentationLogic {
-  nonisolated func presentCollectionViewSections()
+  func presentCollectionViewSections()
   func presentUserProfile(response: UserInfoScene.FetchProfile.Response)
   func presentUserPhotoAccess(response: UserInfoScene.FetchUserPhotoAccess.Response)
   func presentChangedProfileImage(response: UserInfoScene.ChangeProfileImage.Response)

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -18,6 +18,7 @@ protocol UserInfoScenePresentationLogic {
   func presentWithdrawResult(response: UserInfoScene.WithdrawMembership.Response)
   func presentSignOutResult(response: UserInfoScene.SignOut.Response)
   func presentChangedUserIntroduction(_ userIntroduction: String)
+  func presentEmptyUserIntroduction()
 }
 
 final class UserInfoScenePresenter {
@@ -65,6 +66,10 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
   }
 
   func presentChangedUserIntroduction(_ userIntroduction: String) {
+    // TODO: - Presenter 로직 구현 예정
+  }
+
+  func presentEmptyUserIntroduction() {
     // TODO: - Presenter 로직 구현 예정
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -17,6 +17,7 @@ protocol UserInfoScenePresentationLogic {
   func presentChangedProfileImage(response: UserInfoScene.ChangeProfileImage.Response)
   func presentWithdrawResult(response: UserInfoScene.WithdrawMembership.Response)
   func presentSignOutResult(response: UserInfoScene.SignOut.Response)
+  func presentChangedUserIntroduction(_ userIntroduction: String)
 }
 
 final class UserInfoScenePresenter {
@@ -61,6 +62,10 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
     let signOutError = response.signOutError
     let viewModel = UserInfoScene.SignOut.ViewModel(signOutError: signOutError)
     self.viewController?.displaySignOutResult(viewModel: viewModel)
+  }
+
+  func presentChangedUserIntroduction(_ userIntroduction: String) {
+    // TODO: - Presenter 로직 구현 예정
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -126,7 +126,7 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
 
 extension UserInfoSceneViewController: EditUserIntroductionDelegate {
   func userIntroductionDidEdited(_ introduction: String?) {
-    // TODO: 소개 리로드 Business Logic 호출 예정
+    self.interactor?.reloadUserIntroduction(introduction)
   }
 
   func didSelectEditProfileButton() {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #604 

## 🎉 변경 사항
- 소개 수정화면에서 수정이 성공했을 때, UserInfoScene의 소개글을 리로드 하는 Business Logic을 추가하였습니다.

## 📌 PR Point
- BusinessLogic 프로토콜에 MainActor 어노테이션을 추가하였습니다.

### 비즈니스 로직
1. 사용자가 수정한 소개글을 리로드합니다. -> `presentChangedUserIntroduction` 호출
2. 사용자가 소개글을 빈 상태로 저장하면, placeholder 텍스트를 보여주어야 합니다. ->`presentEmptyUserIntrouction` 호출

### 동작 GIF
- 아래 GIF에 완성시 동작할 기능을 첨부하였습니다.

<img width="300" src="https://github.com/user-attachments/assets/c7498c49-0338-4bf2-a376-11028bdf6d5f">


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?