### PR TITLE
UserInfoScene 닉네임 수정화면 Builder 의존성 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
   ],
   dependencies: [
     .package(name: "ToDoGardenUI", path: "../ToDoGardenUI"),
-    .package(name: "EditUserIntroductionScene", path: "EditUserIntroductionScene")
+    .package(name: "EditUserIntroductionScene", path: "EditUserIntroductionScene"),
+    .package(name: "EditUserNameScene", path: "EditUserNameScene")
   ],
   targets: [
     .target(
@@ -40,6 +41,7 @@ let package = Package(
         "UserInfoSceneAPI",
         "UserInfoSceneEntity",
         .product(name: "EditUserIntroductionSceneAPI", package: "EditUserIntroductionScene"),
+        .product(name: "EditUserNameSceneAPI", package: "EditUserNameScene"),
         .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI"),
         .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
         .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI")

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import EditUserIntroductionSceneAPI
+import EditUserNameSceneAPI
 import UserInfoSceneAPI
 
 protocol UserInfoSceneRoutingLogic {
@@ -23,9 +24,14 @@ class UserInfoSceneRouter: UserInfoSceneDataPassing {
   weak var viewController: UserInfoSceneViewController?
   var dataStore: UserInfoSceneDataStore?
   private let editUserIntroductionSceneBuilder: EditUserIntroductionSceneBuildable?
+  private let editUserNameSceneBuilder: EditUserNameSceneSceneBuildable?
 
-  init(editUserIntroductionSceneBuilder: EditUserIntroductionSceneBuildable?) {
+  init(
+    editUserIntroductionSceneBuilder: EditUserIntroductionSceneBuildable?,
+    editUserNameSceneBuilder: EditUserNameSceneSceneBuildable?
+  ) {
     self.editUserIntroductionSceneBuilder = editUserIntroductionSceneBuilder
+    self.editUserNameSceneBuilder = editUserNameSceneBuilder
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
@@ -9,6 +9,7 @@ import PhotosUI
 import UIKit.UIApplication
 
 import EditUserIntroductionSceneAPI
+import EditUserNameSceneAPI
 import UserInfoSceneAPI
 import UserInfoSceneEntity
 
@@ -20,19 +21,22 @@ public struct UserInfoSceneSceneBuilder {
     let userPhotoWorker: UserPhotoWorker
     let userInfoWorker: UserInfoSceneWorkable
     let editUserIntroductionSceneBuilder: EditUserIntroductionSceneBuildable?
+    let editUserNameSceneBuilder: EditUserNameSceneSceneBuildable?
 
     public init(
       photoPicker: PHPickerViewController,
       appServiceWorker: AppServiceWorkable,
       userPhotoWorker: UserPhotoWorker,
       userInfoWorker: UserInfoSceneWorkable,
-      editUserIntroductionSceneBuilder: EditUserIntroductionSceneBuildable?
+      editUserIntroductionSceneBuilder: EditUserIntroductionSceneBuildable?,
+      editUserNameSceneBuilder: EditUserNameSceneSceneBuildable?
     ) {
       self.photoPicker = photoPicker
       self.appServiceWorker = appServiceWorker
       self.userPhotoWorker = userPhotoWorker
       self.userInfoWorker = userInfoWorker
       self.editUserIntroductionSceneBuilder = editUserIntroductionSceneBuilder
+      self.editUserNameSceneBuilder = editUserNameSceneBuilder
     }
   }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
@@ -75,7 +75,8 @@ extension UserInfoSceneSceneBuilder {
     )
     let presenter = UserInfoScenePresenter()
     let router = UserInfoSceneRouter(
-      editUserIntroductionSceneBuilder: self.dependency.editUserIntroductionSceneBuilder
+      editUserIntroductionSceneBuilder: self.dependency.editUserIntroductionSceneBuilder,
+      editUserNameSceneBuilder: self.dependency.editUserNameSceneBuilder
     )
     viewController.interactor = interactor
     viewController.router = router

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -9,6 +9,7 @@ import PhotosUI
 import UIKit
 
 import EditUserIntroductionSceneAPI
+import EditUserNameSceneAPI
 import ToDoGardenUIAPI
 import ToDoGardenUIComponent
 import ToDoGardenUIConstant
@@ -325,7 +326,8 @@ struct SomePayload: UserInfoSceneScenePayloadable {}
       appServiceWorker: AppServiceWorker(),
       userPhotoWorker: UserPhotoWorker(),
       userInfoWorker: UserInfoSceneWorker(),
-      editUserIntroductionSceneBuilder: nil
+      editUserIntroductionSceneBuilder: nil,
+      editUserNameSceneBuilder: nil
     )
   ).build(with: SomePayload())
   return userInfoScene


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #606 

## 🎉 변경 사항
- UserInfoSceneBuilder에 EditUserNameSceneBuilder 의존성을 추가하였습니다.
- UserInfoScene Package.swift 파일에 EditUserNameSceneAPI 패키지 의존성을 추가하였습니다.

## 📌 PR Point
- `유저 정보화면 -> 닉네임 수정 화면`으로 라우팅하기 위해 구현하였습니다.

<img width="500" alt="스크린샷 2024-10-20 16 58 00" src="https://github.com/user-attachments/assets/aa89d5e1-db82-4724-b6ad-f8e52377353c">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?