### PR TITLE
MyGardenView 뷰 계층 구조 수정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -133,6 +133,7 @@ extension ShareGardenSceneViewController.MyGardenView {
   
   private func setupStackView() {
     self.spacing = 14
+    self.setCustomSpacing(0, after: self.contentView)
     self.distribution = UIStackView.Distribution.fill
     self.axis = NSLayoutConstraint.Axis.vertical
     self.alignment = UIStackView.Alignment.center

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -141,6 +141,20 @@ extension ShareGardenSceneViewController.MyGardenView {
   private func addSubviews() {
     self.addArrangedSubview(self.sectionHeaderView)
     self.addArrangedSubview(self.contentView)
+    self.addSpacerAtLast()
+  }
+  
+  private func addSpacerAtLast() {
+    let spacer = UIView()
+    spacer.setContentHuggingPriority(
+      UILayoutPriority.defaultLow,
+      for: NSLayoutConstraint.Axis.vertical
+    )
+    spacer.setContentCompressionResistancePriority(
+      UILayoutPriority.defaultLow,
+      for: NSLayoutConstraint.Axis.vertical
+    )
+    self.addArrangedSubview(spacer)
   }
   
   private func updateProfileInfoView(with nickname: String, _ description: String) {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -107,14 +107,14 @@ extension ShareGardenSceneViewController {
     
     func showContentsLoadingFailure() {
       self.removeArrangedSubview(self.contentView)
-      self.addArrangedSubview(self.retryRequestView.view)
+      self.insertArrangedSubview(self.retryRequestView.view, at: 1)
       self.contentView.isHidden = true
       self.retryRequestView.view.isHidden = false
       self.stopShimmeringAnimation()
     }
     
     func showContents() {
-      self.addArrangedSubview(self.contentView)
+      self.insertArrangedSubview(self.contentView, at: 1)
       self.removeArrangedSubview(self.retryRequestView.view)
       self.contentView.isHidden = false
       self.retryRequestView.view.isHidden = true


### PR DESCRIPTION
## 💡 관련 이슈
- related: #588 
## 🎉 변경 사항
- [x] content view 하단 spacer 추가

## 📌 PR Point
- stackview 하단의 빈공간을 채우기 위해 spacer역할을 할 고유크기 우선순위를 낮춘 view를 추가하였습니다.

|Spacer|
|---|
|<img width="400" alt="Screenshot 2024-10-21 at 12 04 50 AM" src="https://github.com/user-attachments/assets/70e2120c-3805-412e-9f2d-aa14263f8d03">|


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?