### PR TITLE
GardenView 고유 콘텐츠 크기에 따른 레이아웃 상수 설정

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/GardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GardenView/GardenView.swift
@@ -77,31 +77,29 @@ extension GardenView {
     self.setupPomodoroRecordsCollectionViewLayoutConstraints()
   }
   
-  // TODO: - Intrinsic content size를 기준으로 수정
-  
   private func setupPomodoroRecordsCollectionViewLayoutConstraints() {
     self.pomodoroRecordCollectionView.usingAutolayout()
-    let topMarginFraction: CGFloat = Constant.GardenView.Layout.PomodoroRecordCollectionView.topMarginFraction
-    let horizontalMarginFraction: CGFloat =
-    Constant.GardenView.Layout.PomodoroRecordCollectionView.horizontalMarginFraction
-    let bottomMarginFraction: CGFloat = Constant.GardenView.Layout.PomodoroRecordCollectionView.bottomMarginFraction
+    let topMargin: CGFloat = Constant.GardenView.Layout.PomodoroRecordCollectionView.topMargin
+    let horizontalMargin: CGFloat =
+    Constant.GardenView.Layout.PomodoroRecordCollectionView.horizontalMargin
+    let bottomMargin: CGFloat = Constant.GardenView.Layout.PomodoroRecordCollectionView.bottomMargin
     
     NSLayoutConstraint.activate([
       self.pomodoroRecordCollectionView.topAnchor.constraint(
         equalTo: self.topAnchor,
-        constant: self.bounds.height * topMarginFraction
+        constant: topMargin
       ),
       self.pomodoroRecordCollectionView.leadingAnchor.constraint(
         equalTo: self.leadingAnchor,
-        constant: self.bounds.width * horizontalMarginFraction
+        constant: horizontalMargin
       ),
       self.pomodoroRecordCollectionView.trailingAnchor.constraint(
         equalTo: self.trailingAnchor,
-        constant: -(self.bounds.width * horizontalMarginFraction)
+        constant: -(horizontalMargin)
       ),
       self.pomodoroRecordCollectionView.bottomAnchor.constraint(
         equalTo: self.bottomAnchor,
-        constant: -(self.bounds.height * bottomMarginFraction)
+        constant: -(bottomMargin)
       )
     ])
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+GardenView.swift
@@ -20,7 +20,7 @@ extension Constant.GardenView.Layout {
 }
 
 extension Constant.GardenView.Layout.PomodoroRecordCollectionView {
-  public static let topMarginFraction: CGFloat = 18.21 / 119.0
-  public static let horizontalMarginFraction: CGFloat = 19.0 / 332.0
-  public static let bottomMarginFraction: CGFloat = 9.48 / 119.0
+  public static let topMargin: CGFloat = 18.21
+  public static let horizontalMargin: CGFloat = 19.0
+  public static let bottomMargin: CGFloat = 9.48
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #609 
## 🎉 변경 사항
- [x] 고유 콘텐츠 크기에 따른 레이아웃 상수 설정
## 📌 PR Point
GardenView가 고유 콘텐츠 크기(intrinsic content size)를 가짐에 따라 비율이 아닌, 레이아웃 관련 값들이 상수 값을 가지도록 수정하였습니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?