### PR TITLE
친구의 가든 다시 시도하기 뷰 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -98,5 +98,6 @@ extension ShareGardenSceneViewController.Constant.Layout {
     static let searchGardenButtonHorizontalInsetRatio: CGFloat = 19.0 / 375.0
     static let numberOfPlaceholderCells: Int = 3
     static let retryRequestViewTopSpacingRatio: CGFloat = 72 / 812
+    static let friendsGardenListViewMinimumHeight: CGFloat = 278
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -97,5 +97,6 @@ extension ShareGardenSceneViewController.Constant.Layout {
     static let searchGardenButtonHeight: CGFloat = 24.0
     static let searchGardenButtonHorizontalInsetRatio: CGFloat = 19.0 / 375.0
     static let numberOfPlaceholderCells: Int = 3
+    static let retryRequestViewTopSpacingRatio: CGFloat = 72 / 812
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import TDUtility
 
+import ToDoGardenUIComponent
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
@@ -18,6 +19,8 @@ extension ShareGardenSceneViewController {
   final class FriendsGardenView: UIStackView {
     
     // MARK: - UI Properties
+    
+    private let retryRequestView: RetryRequestView = RetryRequestView()
     
     private let sectionHeaderView: SectionHeaderView = {
       let editButton = UIButton()

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -177,10 +177,12 @@ extension ShareGardenSceneViewController.FriendsGardenView {
   
   private func setupFriendsGadenListViewLayoutConstraints() {
     self.friendsGardenListView.usingAutolayout()
+    let height = Self.layoutConstant.friendsGardenListViewMinimumHeight
     
     NSLayoutConstraint.activate([
       self.friendsGardenListView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-      self.friendsGardenListView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+      self.friendsGardenListView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.friendsGardenListView.heightAnchor.constraint(greaterThanOrEqualToConstant: height)
     ])
   }
   

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -123,7 +123,7 @@ extension ShareGardenSceneViewController {
       self.spacer.isHidden = true
       self.retryRequestView.view.isHidden = true
       self.friendsGardenListView.isHidden = false
-      self.setCustomrSpacingForFriendsGardenListView()
+      self.setCustomSpacingForFriendsGardenListView()
       self.startShimmeringAnimation()
     }
   }
@@ -227,7 +227,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     )
   }
   
-  private func setCustomrSpacingForFriendsGardenListView() {
+  private func setCustomSpacingForFriendsGardenListView() {
     self.setCustomSpacing(
       Self.layoutConstant.stackViewSpacing,
       after: self.searchGardenButton

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -197,4 +197,11 @@ extension ShareGardenSceneViewController.FriendsGardenView {
       after: self.searchGardenButton
     )
   }
+  
+  private func setCustomrSpacingForFriendsGardenListView() {
+    self.setCustomSpacing(
+      Self.layoutConstant.stackViewSpacing,
+      after: self.searchGardenButton
+    )
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -99,6 +99,16 @@ extension ShareGardenSceneViewController {
     func stopShimmeringAnimation() {
       self.friendsGardenListView.stopShimmeringAnimation()
     }
+    
+    func showRetryRequestView() {
+      self.removeArrangedSubview(self.friendsGardenListView)
+      self.insertArrangedSubview(self.retryRequestView.view, at: 2)
+      self.addArrangedSubview(self.spacer)
+      self.friendsGardenListView.isHidden = true
+      self.retryRequestView.view.isHidden = false
+      self.spacer.isHidden = false
+      self.setCustomSpacingForRetryRequestView()
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -69,6 +69,12 @@ extension ShareGardenSceneViewController {
     private static let layoutConstant = ShareGardenSceneViewController.Constant.Layout.FriendsGardenView.self
     @ExecuteOnce private var setupLayoutIfNeeded: (() -> Void)?
     
+    var retryAction: UIAction? {
+      didSet {
+        self.retryRequestView.retryAction = self.retryAction
+      }
+    }
+    
     init(friendsGardenStore: FriendsGardenStore) {
       self.friendsGardenListView = FriendsGardenListView(friendsGardenStore: friendsGardenStore)
       super.init(frame: CGRect.zero)

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -50,6 +50,20 @@ extension ShareGardenSceneViewController {
     }()
     
     private let friendsGardenListView: FriendsGardenListView
+    private let spacer: UIView = {
+      let spacer = UIView()
+      spacer.translatesAutoresizingMaskIntoConstraints = false
+      spacer.setContentHuggingPriority(
+        UILayoutPriority.defaultLow,
+        for: NSLayoutConstraint.Axis.vertical
+      )
+      spacer.setContentCompressionResistancePriority(
+        UILayoutPriority.defaultLow,
+        for: NSLayoutConstraint.Axis.vertical
+      )
+      
+      return spacer
+    }()
     
     // MARK: - Properties
     private static let layoutConstant = ShareGardenSceneViewController.Constant.Layout.FriendsGardenView.self

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -95,7 +95,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     self.setupStackView()
     self.setupEditButton()
     self.addSubviews()
-    self.setCustomSpacing()
+    self.setCustomSpacingForSearchGardenButton()
   }
   
   private func setupStackView() {
@@ -170,7 +170,7 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     ])
   }
   
-  private func setCustomSpacing() {
+  private func setCustomSpacingForSearchGardenButton() {
     let searchGardenButtonTopInset = Self.layoutConstant.searchGardenButtonTopInset
     self.setCustomSpacing(searchGardenButtonTopInset, after: self.sectionHeaderView)
   }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -188,4 +188,13 @@ extension ShareGardenSceneViewController.FriendsGardenView {
     let searchGardenButtonTopInset = Self.layoutConstant.searchGardenButtonTopInset
     self.setCustomSpacing(searchGardenButtonTopInset, after: self.sectionHeaderView)
   }
+  
+  private func setCustomSpacingForRetryRequestView() {
+    let spacingRatio: CGFloat = Self.layoutConstant.retryRequestViewTopSpacingRatio
+    
+    self.setCustomSpacing(
+      self.bounds.height * spacingRatio,
+      after: self.searchGardenButton
+    )
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsGardenView.swift
@@ -109,6 +109,17 @@ extension ShareGardenSceneViewController {
       self.spacer.isHidden = false
       self.setCustomSpacingForRetryRequestView()
     }
+    
+    func showFriendsGardenListView() {
+      self.removeArrangedSubview(self.retryRequestView.view)
+      self.removeArrangedSubview(self.spacer)
+      self.addArrangedSubview(self.friendsGardenListView)
+      self.spacer.isHidden = true
+      self.retryRequestView.view.isHidden = true
+      self.friendsGardenListView.isHidden = false
+      self.setCustomrSpacingForFriendsGardenListView()
+      self.startShimmeringAnimation()
+    }
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- related: #588 
## 🎉 변경 사항
- [x] 다시 시도하기 뷰 추가

## 📌 PR Point
친구의 가든 뷰에 다시 시도하기 뷰를 추가하였습니다.

|친구의 가든|
|---|
|<img width="368" alt="Screenshot 2024-10-21 at 12 40 47 AM" src="https://github.com/user-attachments/assets/b3f3809d-8474-4bde-ac1d-29660ccd7bd4">|

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?