### PR TITLE
친구의 가든 목록 요청 테스트 대역 에러 반환 로직 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/TestDouble/ShareGardenSceneWorkerStub.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/TestDouble/ShareGardenSceneWorkerStub.swift
@@ -19,7 +19,11 @@ actor ShareGardenSceneWorkerStub: ShareGardenSceneWorkable {
   
   // MARK: - Friends Garden
   
+  var isThrowErrorForFriendsGardenList: Bool = true
+  
   func requestFriendsGardenList() async throws -> [ShareGardenScene.FriendsGarden] {
+    defer { self.isThrowErrorForFriendsGardenList.toggle() }
+    
     let pomodoroRecords = self.makeRandomPomodoroRecords()
     let nicknames = ["강운", "노아", "우드", "울버린"]
     var friendsGardens = [ShareGardenScene.FriendsGarden]()
@@ -38,6 +42,10 @@ actor ShareGardenSceneWorkerStub: ShareGardenSceneWorkable {
     }
     
     try await Task.sleep(nanoseconds: 2_000_000_000 )
+    
+    if self.isThrowErrorForFriendsGardenList {
+      throw NSError(domain: "", code: 99999)
+    }
     
     return friendsGardens
   }


### PR DESCRIPTION
## 💡 관련 이슈
- related: #588 
## 🎉 변경 사항
- [x] 친구의 가든 목록 요청 테스트 대역 에러 반환 로직 추가
## 📌 PR Point
- 디버그 환경에서 친구의 가든 목록을 요청 하는 테스트 대역에 에러 반환 로직을 추가하였습니다.

## 📝 셀프체크리스트
- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?