### PR TITLE
친구의 가든 목록 요청 다시 시도하기 UI표시

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -86,6 +86,10 @@ extension ShareGardenSceneViewController.Constant.Layout {
     )
   }
   
+  enum MyGardenView {
+    static let contentHeight: CGFloat = 270
+  }
+  
   enum FriendsGardenView {
     static let editButtonWidth: CGFloat = 35.0
     static let editButtonHeight: CGFloat = 35.0

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -37,7 +37,6 @@ extension ShareGardenSceneViewController.Constant.StringLiteral {
 
 extension ShareGardenSceneViewController.Constant.Layout {
   static let myGardenViewTopInsetRatio: CGFloat = 19 / 812
-  static let friendsGardenViewTopInsetRatio: CGFloat = 26 / 812
   
   enum SectionHeaderView {
     static let spacingRatio: CGFloat = 100 / 323

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -78,7 +78,7 @@ extension ShareGardenSceneViewController: ShareGardenSceneDisplayLogic {
   }
   
   func displayFriendsGardenListRequestError() {
-    // TODO: - display friends garden request error view
+    self.friendsGardenView.showRetryRequestView()
   }
   
   func stopShimmeringFriendsGardenList() {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -160,13 +160,10 @@ extension ShareGardenSceneViewController {
   }
   
   private func setupFriendsGardenViewLayoutConstraints() {
-    let topInsetRatio = Constant.Layout.friendsGardenViewTopInsetRatio
-    let topInset: CGFloat = self.view.bounds.height * topInsetRatio
-    
     self.friendsGardenView.usingAutolayout()
     
     NSLayoutConstraint.activate([
-      self.friendsGardenView.topAnchor.constraint(equalTo: self.myGardenView.bottomAnchor, constant: topInset),
+      self.friendsGardenView.topAnchor.constraint(equalTo: self.myGardenView.bottomAnchor),
       self.friendsGardenView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
       self.friendsGardenView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
       self.friendsGardenView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -127,6 +127,7 @@ extension ShareGardenSceneViewController {
   
   private func setupActions() {
     self.setupMyGardenViewRetryAction()
+    self.setupFriendsGardenViewRetryAction()
   }
 }
 
@@ -139,6 +140,13 @@ extension ShareGardenSceneViewController {
         self?.myGardenView.showContents()
         self?.interactor?.requestMyGarden()
       }
+    }
+  }
+  
+  private func setupFriendsGardenViewRetryAction() {
+    self.friendsGardenView.retryAction = UIAction { [weak self] _ in
+      self?.friendsGardenView.showFriendsGardenListView()
+      self?.interactor?.requestFriendsGardenList()
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -63,6 +63,11 @@ extension ShareGardenSceneViewController {
     
     @ExecuteOnce private var setupLayoutIfNeeded: (() -> Void)?
     
+    override var intrinsicContentSize: CGSize {
+      let contentHeight = Constant.Layout.MyGardenView.contentHeight
+      return CGSize(width: super.intrinsicContentSize.width, height: contentHeight)
+    }
+    
     var retryAction: UIAction? {
       didSet {
         self.retryRequestView.retryAction = self.retryAction


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #588 
## 🎉 변경 사항
- [x] 레이아웃 상수 수정
- [x] 다시 시도하기 UI표시

## 📌 PR Point
친구의 가든 목록 실패 시 요청 다시 시도하기 UI를 표시하는 작업을 진행하였습니다.
작동 영상은 아래의 Demo에서 확인하실 수 있습니다.

|Demo|
|---|
|<img src="https://github.com/user-attachments/assets/0fad4ca1-0289-41ac-8536-50eced3882ed" width="250" />|



## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?