### PR TITLE
UserInfoScene 수정된 소개 UI 업데이트 로직 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -66,7 +66,7 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
   }
 
   func presentChangedUserIntroduction(_ userIntroduction: String) {
-    // TODO: - Presenter 로직 구현 예정
+    self.viewController?.displayChangedUserIntroduction(userIntroduction)
   }
 
   func presentEmptyUserIntroduction() {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -70,7 +70,7 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
   }
 
   func presentEmptyUserIntroduction() {
-    // TODO: - Presenter 로직 구현 예정
+    self.viewController?.displayEmptyUserIntroduction(Self.userIntroductionPlaceholderText)
   }
 }
 
@@ -96,4 +96,6 @@ extension UserInfoScenePresenter {
 
     return [profileSection, accountSection]
   }
+
+  static let userIntroductionPlaceholderText = "소개글을 입력해주세요"
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -70,7 +70,8 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
   }
 
   func presentEmptyUserIntroduction() {
-    self.viewController?.displayEmptyUserIntroduction(Self.userIntroductionPlaceholderText)
+    let placeholderText = UserInfoSceneTheme.StringLiteral.UserInfoCollectionView.userIntroductionPlaceholderText
+    self.viewController?.displayEmptyUserIntroduction(placeholderText)
   }
 }
 
@@ -96,6 +97,4 @@ extension UserInfoScenePresenter {
 
     return [profileSection, accountSection]
   }
-
-  static let userIntroductionPlaceholderText = "소개글을 입력해주세요"
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneTheme.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneTheme.swift
@@ -25,6 +25,7 @@ extension UserInfoSceneTheme.StringLiteral {
 
   enum UserInfoCollectionView {
     static let introductionNotExisted = "소개글을 입력해주세요"
+    static let userIntroductionPlaceholderText = "소개글을 입력해주세요"
 
     enum Section {
       static let profileSetting = "프로필 설정"

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -25,6 +25,7 @@ protocol UserInfoSceneDisplayLogic: AnyObject {
   func displayWithdrawResult(viewModel: UserInfoScene.WithdrawMembership.ViewModel)
   func displaySignOutResult(viewModel: UserInfoScene.SignOut.ViewModel)
   func displayChangedUserIntroduction(_ introduction: String)
+  func displayEmptyUserIntroduction(_ placeholderText: String)
 }
 
 final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewControllable {
@@ -125,6 +126,10 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
 
   func displayChangedUserIntroduction(_ introduction: String) {
     self.updateUserIntroduction(introduction)
+  }
+
+  func displayEmptyUserIntroduction(_ placeholderText: String) {
+    
   }
 
   private func updateUserIntroduction(_ introduction: String) {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -129,7 +129,7 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
   }
 
   func displayEmptyUserIntroduction(_ placeholderText: String) {
-    
+    self.updateUserIntroduction(placeholderText)
   }
 
   private func updateUserIntroduction(_ introduction: String) {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -24,6 +24,7 @@ protocol UserInfoSceneDisplayLogic: AnyObject {
   func displayChangedProfileImage(viewModel: UserInfoScene.ChangeProfileImage.ViewModel)
   func displayWithdrawResult(viewModel: UserInfoScene.WithdrawMembership.ViewModel)
   func displaySignOutResult(viewModel: UserInfoScene.SignOut.ViewModel)
+  func displayChangedUserIntroduction(_ userIntroduction: String)
 }
 
 final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewControllable {
@@ -120,6 +121,10 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
     if viewModel.signOutError == nil {
       self.router?.routeToLoginScene()
     }
+  }
+
+  func displayChangedUserIntroduction(_ userIntroduction: String) {
+    
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -24,7 +24,7 @@ protocol UserInfoSceneDisplayLogic: AnyObject {
   func displayChangedProfileImage(viewModel: UserInfoScene.ChangeProfileImage.ViewModel)
   func displayWithdrawResult(viewModel: UserInfoScene.WithdrawMembership.ViewModel)
   func displaySignOutResult(viewModel: UserInfoScene.SignOut.ViewModel)
-  func displayChangedUserIntroduction(_ userIntroduction: String)
+  func displayChangedUserIntroduction(_ introduction: String)
 }
 
 final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewControllable {
@@ -123,8 +123,16 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
     }
   }
 
-  func displayChangedUserIntroduction(_ userIntroduction: String) {
-    
+  func displayChangedUserIntroduction(_ introduction: String) {
+    self.updateUserIntroduction(introduction)
+  }
+
+  private func updateUserIntroduction(_ introduction: String) {
+    guard let userIntroductionCell = self.userInfoCollectionView.cellForItem(
+      at: IndexPath(row: 1, section: 0)
+    ) as? UserInfoCollectionViewCell else { return }
+
+    userIntroductionCell.updateDescription(introduction)
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #619 

## 🎉 변경 사항
- UserInfoScene에 수정된 소개로 UI 업데이트하는 로직을 추가하였습니다.

## 📌 PR Point
- 사용자가 수정한 소개로 업데이트하는 로직을 추가하였습니다.
- 만약 사용자가 소개글을 삭제한 경우, placeholder 텍스트를 보여줍니다.

|수정된 소개 UI 업데이트|Placeholder Text UI 업데이트|
|--|--|
|<img width="300" src="https://github.com/user-attachments/assets/77546ce1-2cbf-4db3-8967-0f18b4672f27">|<img width="300" src="https://github.com/user-attachments/assets/dfd30de7-a3f5-48cf-9f8d-a447461458c2">|


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?