### PR TITLE
MyGardenView 다시 시도하기 메서드 명 통일

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -70,7 +70,7 @@ extension ShareGardenSceneViewController: ShareGardenSceneDisplayLogic {
   }
   
   func displayMyGardenRequestError() {
-    self.myGardenView.showContentsLoadingFailure()
+    self.myGardenView.showRetryRequestView()
   }
   
   func displayFriendsGardenList(_ viewModel: ShareGardenScene.RequestFriendsGardenList.ViewModel) {

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -137,7 +137,7 @@ extension ShareGardenSceneViewController {
   private func setupMyGardenViewRetryAction() {
     self.myGardenView.retryAction = UIAction { [weak self] _ in
       DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.15) {
-        self?.myGardenView.showContents()
+        self?.myGardenView.showMyGardenView()
         self?.interactor?.requestMyGarden()
       }
     }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -114,7 +114,7 @@ extension ShareGardenSceneViewController {
       self.profileInfoView.startShimmering()
     }
     
-    func showContentsLoadingFailure() {
+    func showRetryRequestView() {
       self.removeArrangedSubview(self.contentView)
       self.insertArrangedSubview(self.retryRequestView.view, at: 1)
       self.contentView.isHidden = true

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -122,7 +122,7 @@ extension ShareGardenSceneViewController {
       self.stopShimmeringAnimation()
     }
     
-    func showContents() {
+    func showMyGardenView() {
       self.insertArrangedSubview(self.contentView, at: 1)
       self.removeArrangedSubview(self.retryRequestView.view)
       self.contentView.isHidden = false


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #621 
## 🎉 변경 사항

- [x] 메서드 명 수정
- [x] 호출 부 메서드 명 수정

## 📌 PR Point
- FriendsGardenView와의 일관성을 지키기 위해 MyGardenView의 다시 시도하기와 관련된 메서드 명을 통일하였습니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?