### PR TITLE
UserInfoScene > EditUserNameScene 라우팅 구현

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
@@ -42,7 +42,7 @@ final class EditUserNameSceneViewController: UIViewController, EditUserNameScene
     self.inputUserNameView = InputTextValidationView(
       inputText: constant.inputText,
       placeholderText: constant.placeholderText,
-      validationText: validationTextConstant.invalidIntroduction
+      validationText: validationTextConstant.invalidNickname
     )
     self.inputUserNameSubject = PassthroughSubject<String, Never>()
     self.cancellables = Set<AnyCancellable>()

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -135,10 +135,19 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
 
 extension UserInfoSceneInteractor: UserInfoLoadable {
   func requestDescription(for userInfo: UserInfoScene.UserInfo) async -> String {
-    let description = await self.userInfoWorker.requestUserProfile(urlString: userInfo.rawValue)
-    if userInfo == .introduction {
-      self.userIntroduction = description
+    let value = await self.userInfoWorker.requestUserProfile(urlString: userInfo.rawValue)
+    self.storeUserInfoData(of: userInfo, value: value)
+    return value
+  }
+
+  private func storeUserInfoData(of userInfo: UserInfoScene.UserInfo, value: String) {
+    switch userInfo {
+    case UserInfoScene.UserInfo.nickName:
+      self.userName = value
+    case UserInfoScene.UserInfo.introduction:
+      self.userIntroduction = value
+    default:
+      break
     }
-    return description
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+makeDiffableDataSource.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/Views/UserInfoSceneViewController+makeDiffableDataSource.swift
@@ -69,6 +69,8 @@ extension UserInfoSceneViewController {
     switch item.userInfo {
     case UserInfoScene.UserInfo.introduction:
       self.router?.routeToEditUserIntroductionScene()
+    case UserInfoScene.UserInfo.nickName:
+      self.router?.routeToEditUserNameScene()
     default:
       break
     }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #625 

## 🎉 변경 사항
- UserInfoScene에서 닉네임 수정화면으로 라우팅하는 기능을 추가하였습니다.

## 📌 PR Point
- UserInfoSceneInteractor에서 서버로부터 Nickname을 받았을 때, 저장하는 기능을 추가하였습니다.
  - 기존에는 저장하지 않아 Payload로 데이터 전달이 불가능했었습니다.

- EditUserNameViewController에서 `ValidationText`가 디자인과 달라 수정하였습니다.

### 동작 GIF
<img width="300" src="https://github.com/user-attachments/assets/66778c20-d3ee-44e7-b3ad-5e894c35d9fb">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?