### PR TITLE
EditUserNameDelegate 객체 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneBuilder.swift
@@ -29,6 +29,7 @@ public struct EditUserNameSceneBuilder {
 extension EditUserNameSceneBuilder {
   private struct PreviewScenePayload: EditUserNameScenePayloadable {
     var userName: String = "나야울버린"
+    var delegate: EditUserNameSceneDelegate?
   }
 
   public static let previewScene = Self(

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneBuilder.swift
@@ -29,7 +29,7 @@ public struct EditUserNameSceneBuilder {
 extension EditUserNameSceneBuilder {
   private struct PreviewScenePayload: EditUserNameScenePayloadable {
     var userName: String = "나야울버린"
-    var delegate: EditUserNameSceneDelegate?
+    var delegate: EditUserNameDelegate?
   }
 
   public static let previewScene = Self(

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneBuilder.swift
@@ -80,5 +80,6 @@ extension EditUserNameSceneBuilder {
     with payload: EditUserNameScenePayloadable
   ) {
     viewController.router?.dataStore?.userName = payload.userName
+    viewController.router?.delegate = payload.delegate
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneRouter.swift
@@ -15,12 +15,12 @@ protocol EditUserNameSceneRoutingLogic {
 
 protocol EditUserNameSceneDataPassing {
   var dataStore: EditUserNameSceneDataStore? { get set }
-  var delegate: EditUserNameSceneDelegate? { get set }
+  var delegate: EditUserNameDelegate? { get set }
 }
 
 class EditUserNameSceneRouter: EditUserNameSceneDataPassing {
   weak var viewController: EditUserNameSceneViewController?
-  weak var delegate: EditUserNameSceneDelegate?
+  weak var delegate: EditUserNameDelegate?
   var dataStore: EditUserNameSceneDataStore?
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneRouter.swift
@@ -28,6 +28,10 @@ class EditUserNameSceneRouter: EditUserNameSceneDataPassing {
 
 extension EditUserNameSceneRouter: EditUserNameSceneRoutingLogic {
   func routeToUserInfoScene() {
+    guard let userName = self.dataStore?.userName
+    else { return }
+
+    self.delegate?.userNameDidEdited(userName)
     self.viewController?.navigationController?.popViewController(animated: true)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneRouter.swift
@@ -15,10 +15,12 @@ protocol EditUserNameSceneRoutingLogic {
 
 protocol EditUserNameSceneDataPassing {
   var dataStore: EditUserNameSceneDataStore? { get set }
+  var delegate: EditUserNameSceneDelegate? { get set }
 }
 
 class EditUserNameSceneRouter: EditUserNameSceneDataPassing {
   weak var viewController: EditUserNameSceneViewController?
+  weak var delegate: EditUserNameSceneDelegate?
   var dataStore: EditUserNameSceneDataStore?
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameSceneAPI/EditUserNameDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameSceneAPI/EditUserNameDelegate.swift
@@ -1,5 +1,5 @@
 //
-//  EditUserNameSceneDelegate.swift
+//  EditUserNameDelegate.swift
 //
 //
 //  Created by Wood on 10/22/24.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol EditUserNameSceneDelegate: AnyObject {
+public protocol EditUserNameDelegate: AnyObject {
   /// 닉네임 수정 요청 성공시, Delegate를 채택한 객체에 수정된 닉네임을 전달합니다.
   /// - Parameter userName: 수정된 닉네임 문자열 값입니다.
   func userNameDidEdited(_ userName: String)

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameSceneAPI/EditUserNameSceneDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameSceneAPI/EditUserNameSceneDelegate.swift
@@ -1,0 +1,14 @@
+//
+//  EditUserNameSceneDelegate.swift
+//
+//
+//  Created by Wood on 10/22/24.
+//
+
+import Foundation
+
+public protocol EditUserNameSceneDelegate: AnyObject {
+  /// 닉네임 수정 요청 성공시, Delegate를 채택한 객체에 수정된 닉네임을 전달합니다.
+  /// - Parameter userName: 수정된 닉네임 문자열 값입니다.
+  func userNameDidEdited(_ userName: String)
+}

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameSceneAPI/EditUserNameSceneSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameSceneAPI/EditUserNameSceneSceneBuildable.swift
@@ -10,7 +10,7 @@ import Foundation
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
 public protocol EditUserNameScenePayloadable {
   var userName: String { get }
-  var delegate: EditUserNameSceneDelegate? { get set }
+  var delegate: EditUserNameDelegate? { get set }
 }
 
 public protocol EditUserNameSceneSceneBuildable {

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameSceneAPI/EditUserNameSceneSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameSceneAPI/EditUserNameSceneSceneBuildable.swift
@@ -10,6 +10,7 @@ import Foundation
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
 public protocol EditUserNameScenePayloadable {
   var userName: String { get }
+  var delegate: EditUserNameSceneDelegate? { get set }
 }
 
 public protocol EditUserNameSceneSceneBuildable {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
@@ -80,6 +80,6 @@ extension UserInfoSceneRouter {
 
   struct EditUserNameScenePayload: EditUserNameScenePayloadable {
     let userName: String
-    var delegate: EditUserNameSceneDelegate?
+    var delegate: EditUserNameDelegate?
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
@@ -80,5 +80,6 @@ extension UserInfoSceneRouter {
 
   struct EditUserNameScenePayload: EditUserNameScenePayloadable {
     let userName: String
+    var delegate: EditUserNameSceneDelegate?
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
@@ -46,7 +46,7 @@ extension UserInfoSceneRouter: UserInfoSceneRoutingLogic {
   func routeToEditUserNameScene() {
     guard let userName = self.dataStore?.userName,
       let editUserNameScene = self.editUserNameSceneBuilder?.build(
-      with: EditUserNameScenePayload(userName: userName)
+        with: EditUserNameScenePayload(userName: userName, delegate: self.viewController)
     ) else { return }
 
     self.viewController?.navigationController?.pushViewController(

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -143,9 +143,13 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
 
 // MARK: - Request to interactor
 
-extension UserInfoSceneViewController: EditUserIntroductionDelegate {
+extension UserInfoSceneViewController: EditUserIntroductionDelegate, EditUserNameSceneDelegate {
   func userIntroductionDidEdited(_ introduction: String?) {
     self.interactor?.reloadUserIntroduction(introduction)
+  }
+
+  func userNameDidEdited(_ userName: String) {
+    // TODO: - 변경된 닉네임 전달 Business Logic 호출 예정
   }
 
   func didSelectEditProfileButton() {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -143,7 +143,7 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
 
 // MARK: - Request to interactor
 
-extension UserInfoSceneViewController: EditUserIntroductionDelegate, EditUserNameSceneDelegate {
+extension UserInfoSceneViewController: EditUserIntroductionDelegate, EditUserNameDelegate {
   func userIntroductionDidEdited(_ introduction: String?) {
     self.interactor?.reloadUserIntroduction(introduction)
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #627 

## 🎉 변경 사항
- 닉네임 수정시 변경된 닉네임을 전달하는 EditUserNameDelegate 객체를 추가하였습니다.
- EditUserNameSceneBuilder에서 Delegate를 설정할 수 있도록 수정하였습니다.

## 📌 PR Point
### EditUserIntroductionDelegate
- 수정된 닉네임을 UserInfoScene에 전달하는 객체입니다.
- Payload와 다르게 `이전 화면으로 데이터 전달`이 필요하기에 구현하였습니다.

### 차후 구현 예정
- 이를 채택한 `UserInfoSceneVC`가 Delegate 메서드 호출시, `닉네임 리로드 VIP를 호출`할 예정입니다.
- 해당 작업은 다음 PR에서 진행 예정입니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?