### PR TITLE
로그인 <-> 사인업 라우팅 구현 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/LoginScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
   ],
   dependencies: [
     .package(name: "ToDoGardenUI", path: "../ToDoGardenUI"),
-    .package(path: "../TDUtility")
+    .package(path: "../TDUtility"),
+    .package(name: "SignUpScene", path: "./SignUpScene")
   ],
   targets: [
     .target(
@@ -41,7 +42,8 @@ let package = Package(
         "LoginSceneAPI",
         "LoginSceneEntity",
         .product(name: "TDUtility", package: "TDUtility"),
-        .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI")
+        .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI"),
+        .product(name: "SignUpSceneAPI", package: "SignUpScene")
       ]
     ),
     .testTarget(

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginRouter.swift
@@ -10,7 +10,11 @@ import Foundation
 import LoginSceneAPI
 
 protocol LoginRoutingLogic {
-  func routeToSomewhere()
+  func routeToSignUpScene(
+    userIdentifier: String,
+    userEmailAddress: String?,
+    agreeOptionalCondition: Bool
+  )
 }
 
 protocol LoginDataPassing {
@@ -30,9 +34,11 @@ class LoginRouter: LoginDataPassing {
 // MARK: - Routing
 
 extension LoginRouter: LoginRoutingLogic {
-  func routeToSomewhere() {
-    // let destinationViewController = self.nextSceneBuilder.build(with: NextScenePayload())
-    // self.viewController?.present(destinationViewController, animated: true)
+  func routeToSignUpScene(
+    userIdentifier: String,
+    userEmailAddress: String?,
+    agreeOptionalCondition: Bool
+  ) {
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginRouter.swift
@@ -1,6 +1,6 @@
 //
 //  LoginRouter.swift
-//  
+//
 //
 //  Created by SONG on 10/2/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
@@ -8,6 +8,7 @@
 import Foundation
 
 import LoginSceneAPI
+import SignUpSceneAPI
 
 protocol LoginRoutingLogic {
   func routeToSignUpScene(
@@ -24,10 +25,10 @@ protocol LoginDataPassing {
 class LoginRouter: LoginDataPassing {
   weak var viewController: LoginViewController?
   var dataStore: LoginDataStore?
-  private let nextSceneBuilder: NextSceneBuildable
+  private let signUpSceneBuilder: SignUpSceneBuildable
   
-  init(nextSceneBuilder: NextSceneBuildable) {
-    self.nextSceneBuilder = nextSceneBuilder
+  init(signUpSceneBuilder: SignUpSceneBuildable) {
+    self.signUpSceneBuilder = signUpSceneBuilder
   }
 }
 
@@ -39,13 +40,24 @@ extension LoginRouter: LoginRoutingLogic {
     userEmailAddress: String?,
     agreeOptionalCondition: Bool
   ) {
+    let destinationViewController = self.signUpSceneBuilder.build(
+      with: SignUpScenePayload(
+        userIdentifier: userIdentifier,
+        userEmailAddress: userEmailAddress,
+        agreeOptionalCondition: agreeOptionalCondition
+      )
+    )
+    self.viewController?.navigationController?.navigationBar.isHidden = false
+    self.viewController?.navigationController?.pushViewController(destinationViewController, animated: true)
   }
 }
 
 // MARK: - Declare Payload for scene
-
+// MARK: - 변경 가능성 있음
 extension LoginRouter {
-  struct NextScenePayload: NextScenePayloadable {
-    // var name: String
+  struct SignUpScenePayload: SignUpScenePayloadable {
+    var userIdentifier: String
+    var userEmailAddress: String?
+    var agreeOptionalCondition: Bool
   }
 }

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginSceneBuilder.swift
@@ -8,16 +8,17 @@
 import Foundation
 
 import LoginSceneAPI
+import SignUpSceneAPI
 
 public struct LoginSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
-    let someWorker: LoginWorkable
-    let nextSceneBuilder: NextSceneBuildable
+    let loginWorker: LoginWorkable
+    let signUpSceneBuilder: SignUpSceneBuildable
     
-    public init(someWorker: LoginWorkable, nextSceneBuilder: NextSceneBuildable) {
-      self.someWorker = someWorker
-      self.nextSceneBuilder = nextSceneBuilder
+    public init(loginWorker: LoginWorkable, signUpSceneBuilder: SignUpSceneBuildable) {
+      self.loginWorker = loginWorker
+      self.signUpSceneBuilder = signUpSceneBuilder
     }
   }
   
@@ -32,7 +33,7 @@ extension LoginSceneBuilder: LoginSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
-  public func build(with payload: LoginScenePayloadable) -> LoginViewControllable {
+  public func build(with payload: LoginScenePayloadable?) -> LoginViewControllable {
     let someViewController = self.configureVIPCycle(for: LoginViewController())
     self.setPayload(for: someViewController, with: payload)
     
@@ -45,9 +46,9 @@ extension LoginSceneBuilder {
   /// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
   private func configureVIPCycle(for viewController: LoginViewController) -> LoginViewController {
-    let interactor = LoginInteractor(someWorker: self.dependency.someWorker)
+    let interactor = LoginInteractor(someWorker: self.dependency.loginWorker)
     let presenter = LoginPresenter()
-    let router = LoginRouter(nextSceneBuilder: self.dependency.nextSceneBuilder)
+    let router = LoginRouter(signUpSceneBuilder: self.dependency.signUpSceneBuilder)
     viewController.interactor = interactor
     viewController.router = router
     interactor.presenter = presenter
@@ -62,7 +63,7 @@ extension LoginSceneBuilder {
   /// - Parameters:
   ///   - viewController: 런타임 의존성을 설정할 ViewController 객체입니다.
   ///   - payload: 런타임에 전달할 의존성입니다.
-  private func setPayload(for viewController: LoginViewController, with payload: LoginScenePayloadable) {
+  private func setPayload(for viewController: LoginViewController, with payload: LoginScenePayloadable?) {
     // viewController.router?.dataStore?.name = payload.name
   }
 }

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginSceneBuilder.swift
@@ -33,7 +33,7 @@ extension LoginSceneBuilder: LoginSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
-  public func build(with payload: LoginScenePayloadable?) -> LoginViewControllable {
+  public func build(with payload: LoginScenePayloadable) -> LoginViewControllable {
     let someViewController = self.configureVIPCycle(for: LoginViewController())
     self.setPayload(for: someViewController, with: payload)
     

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginViewController.swift
@@ -55,6 +55,11 @@ final class LoginViewController: UIViewController, LoginViewControllable {
     self.setUI()
     self.doSomething()
   }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    self.navigationController?.navigationBar.isHidden = true
+  }
 }
 
 extension LoginViewController {

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginViewController.swift
@@ -28,6 +28,11 @@ final class LoginViewController: UIViewController, LoginViewControllable {
   private let dimmingView: UIView
   private let termAgreementView: TermsAgreementView
   
+  // MARK: - 임시 저장용 개인정보 / 인증정보 등 이후 PR에서 프로퍼티 제거 및 보안강화 처리 예정
+  private var userIdentifier: String = ""
+  private var userEmailAddress: String?
+  private var agreeOptionalCondition: Bool = false
+  
   // MARK: - Object lifecycle
   
   init() {
@@ -205,11 +210,16 @@ extension LoginViewController: TermsAgreementViewDelegate {
   ) {
     self.hideTermAgreementView()
     // TODO: 이벤트, 광고성 정보 안내 (선택)에 동의했을 때 / 안했을 때 동작 분기
-    
-    let nextVC = UIViewController()
-    nextVC.view.backgroundColor = UIColor.white
-    
-    self.navigationController?.pushViewController(nextVC, animated: true)
+    if isEventAndPromotionalInformationAgreed {
+      self.agreeOptionalCondition = true
+    } else {
+      self.agreeOptionalCondition = false
+    }
+    self.router?.routeToSignUpScene(
+      userIdentifier: self.userIdentifier,
+      userEmailAddress: self.userEmailAddress,
+      agreeOptionalCondition: self.agreeOptionalCondition
+    )
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginWorker.swift
@@ -9,7 +9,10 @@ import Foundation
 
 import LoginSceneAPI
 
-struct LoginWorker: LoginWorkable {
-  func doSomeWork() {
+public struct LoginWorker: LoginWorkable {
+  
+  public init() { }
+  public func doSomeWork() {
+    // TODO: 이후 신규회원 / 기존회원 판단 로직이 들어갈 예정
   }
 }

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginSceneAPI/LoginSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginSceneAPI/LoginSceneBuildable.swift
@@ -16,5 +16,5 @@ public protocol LoginSceneBuildable {
   ///  VIP Cycle, 런타임 파라미터가 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 파라미터입니다.
   /// - Returns: 런타임 파라미터, VIP Cycle이 설정된 ViewController가 반환되도록 구현합니다.
-  func build(with payload: LoginScenePayloadable) -> LoginViewControllable
+  func build(with payload: LoginScenePayloadable?) -> LoginViewControllable
 }

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginSceneAPI/LoginSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginSceneAPI/LoginSceneBuildable.swift
@@ -16,5 +16,5 @@ public protocol LoginSceneBuildable {
   ///  VIP Cycle, 런타임 파라미터가 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 파라미터입니다.
   /// - Returns: 런타임 파라미터, VIP Cycle이 설정된 ViewController가 반환되도록 구현합니다.
-  func build(with payload: LoginScenePayloadable?) -> LoginViewControllable
+  func build(with payload: LoginScenePayloadable) -> LoginViewControllable
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #624 
## 🎉 변경 사항
- 로그인씬에서 사인업씬으로 넘어갑니다. 

## 📌 PR Point
- 로그인씬 <-> 사인업씬 
   - 페이로드 전달 
   - 라우터로 화면 이동
- 내비게이션바 표시 / 미표시 

### 실행 화면 

![Simulator Screen Recording - iPhone 15 - 2024-10-22 at 14 56 36](https://github.com/user-attachments/assets/6d678a0d-4ec0-4fc5-8a96-ce675cccfcf7)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?