### PR TITLE
로그인 <-> 사인업 라우팅 구현사항 signup scene에 반영

### DIFF
--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -55,6 +55,7 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
   }
   
   private func setupNavigationBar() {
+    self.navigationController?.navigationBar.isHidden = false
     let backButton = UIBarButtonItem(
       image: UIImage.backwardButtonImage,
       primaryAction: UIAction { [weak self] _ in

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpSceneAPI/SignUpSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpSceneAPI/SignUpSceneBuildable.swift
@@ -9,7 +9,9 @@ import Foundation
 
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
 public protocol SignUpScenePayloadable {
-  // var name: String { get }
+  var userIdentifier: String { get }
+  var userEmailAddress: String? { get }
+  var agreeOptionalCondition: Bool { get }
 }
 
 public protocol SignUpSceneBuildable {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #631 

## 🎉 변경 사항
- 로그인 <-> 사인업 라우팅 구현사항 signup scene에 반영

## 📌 PR Point
- 로그인씬에서는 NavigationBar를 숨깁니다. 
- 사인업씬에서는 NavigationBar를 표시합니다. 
- Payloadable 프로토콜의 명세를 작성합니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?