### PR TITLE
keychain crud 구현 + loginVC에 적용 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/KeychainManager.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/KeychainManager.swift
@@ -1,8 +1,71 @@
 //
-//  File.swift
-//  
+//  KeychainManager.swift
+//
 //
 //  Created by SONG on 10/23/24.
 //
 
 import Foundation
+import Security
+
+final class KeychainManager {
+  static let shared = KeychainManager()
+  
+  private init() {}
+  
+  private enum KeychainKey {
+    static let userIdentifier = "user_identifier"
+    static let userEmail = "user_email"
+    static let identifyToken = "identity_token"
+    // MARK: - 필요한 키값을 직접 추가하세요
+  }
+  
+  func save(_ data: Data, forKey key: String) throws {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: key,
+      kSecValueData as String: data,
+      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked
+    ]
+    
+    SecItemDelete(query as CFDictionary)
+    
+    let status = SecItemAdd(query as CFDictionary, nil)
+    guard status == errSecSuccess else {
+      throw KeychainError.unhandledError(status: status)
+    }
+  }
+  
+  func load(forKey key: String) throws -> Data? {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: key,
+      kSecReturnData as String: kCFBooleanTrue as Any, // 강제 언래핑 제거를 위한 "as Any"
+      kSecMatchLimit as String: kSecMatchLimitOne
+    ]
+    
+    var result: AnyObject?
+    let status = SecItemCopyMatching(query as CFDictionary, &result)
+    
+    switch status {
+    case errSecSuccess:
+      return result as? Data
+    case errSecItemNotFound:
+      throw KeychainError.nonExistentKey
+    default:
+      throw KeychainError.unhandledError(status: status)
+    }
+  }
+  
+  func delete(forKey key: String) throws {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: key
+    ]
+    
+    let status = SecItemDelete(query as CFDictionary)
+    guard status == errSecSuccess || status == errSecItemNotFound else {
+      throw KeychainError.unhandledError(status: status)
+    }
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/KeychainManager.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/KeychainManager.swift
@@ -129,6 +129,6 @@ extension KeychainManager {
 
 enum KeychainError: Error {
   case nonExistentKey
-  case alreadyExistentKey // 새로운 에러 추가
+  case alreadyExistentKey
   case unhandledError(status: OSStatus)
 }

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/KeychainManager.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/KeychainManager.swift
@@ -69,3 +69,8 @@ final class KeychainManager {
     }
   }
 }
+
+enum KeychainError: Error {
+  case nonExistentKey
+  case unhandledError(status: OSStatus)
+}

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/KeychainManager.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/KeychainManager.swift
@@ -20,7 +20,7 @@ final class KeychainManager {
     // MARK: - 필요한 키값을 직접 추가하세요
   }
   
-  func save(_ data: Data, forKey key: String) throws {
+  func create(_ data: Data, forKey key: String) throws {
     let query: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrAccount as String: key,
@@ -28,9 +28,29 @@ final class KeychainManager {
       kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked
     ]
     
-    SecItemDelete(query as CFDictionary)
-    
     let status = SecItemAdd(query as CFDictionary, nil)
+    if status == errSecSuccess {
+      return
+    } else if status == errSecDuplicateItem {
+      // MARK: - 이미 존재하는 Key에 대해 create를 시도할 경우 실패함. 그럴땐 업데이트 시도
+      try update(data, forKey: key)
+    } else {
+      // MARK: - 업데이트 마저 실패하면 Error throwing
+      throw KeychainError.unhandledError(status: status)
+    }
+  }
+  
+  func update(_ data: Data, forKey key: String) throws {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: key
+    ]
+    
+    let attributesToUpdate: [String: Any] = [
+      kSecValueData as String: data
+    ]
+    
+    let status = SecItemUpdate(query as CFDictionary, attributesToUpdate as CFDictionary)
     guard status == errSecSuccess else {
       throw KeychainError.unhandledError(status: status)
     }
@@ -74,13 +94,13 @@ final class KeychainManager {
 
 extension KeychainManager {
   func saveLoginData(identifier: String, identifyToken: Data, email: String?) throws {
-    try save(Data(identifier.utf8), forKey: KeychainKey.userIdentifier)
-    try save(identifyToken, forKey: KeychainKey.identifyToken)
+    try create(Data(identifier.utf8), forKey: KeychainKey.userIdentifier)
+    try create(identifyToken, forKey: KeychainKey.identifyToken)
     
     if let email = email {
-      try save(Data(email.utf8), forKey: KeychainKey.userEmail)
+      try create(Data(email.utf8), forKey: KeychainKey.userEmail)
     } else {
-      try save(Data(), forKey: KeychainKey.userEmail)
+      try create(Data(), forKey: KeychainKey.userEmail)
     }
   }
   

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/KeychainManager.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/KeychainManager.swift
@@ -32,10 +32,8 @@ final class KeychainManager {
     if status == errSecSuccess {
       return
     } else if status == errSecDuplicateItem {
-      // MARK: - 이미 존재하는 Key에 대해 create를 시도할 경우 실패함. 그럴땐 업데이트 시도
-      try update(data, forKey: key)
+      throw KeychainError.alreadyExistentKey
     } else {
-      // MARK: - 업데이트 마저 실패하면 Error throwing
       throw KeychainError.unhandledError(status: status)
     }
   }
@@ -94,40 +92,43 @@ final class KeychainManager {
 
 extension KeychainManager {
   func saveLoginData(identifier: String, identifyToken: Data, email: String?) throws {
-    try create(Data(identifier.utf8), forKey: KeychainKey.userIdentifier)
-    try create(identifyToken, forKey: KeychainKey.identifyToken)
+    try self.clearLoginData()
+    
+    try self.create(Data(identifier.utf8), forKey: KeychainKey.userIdentifier)
+    try self.create(identifyToken, forKey: KeychainKey.identifyToken)
     
     if let email = email {
-      try create(Data(email.utf8), forKey: KeychainKey.userEmail)
+      try self.create(Data(email.utf8), forKey: KeychainKey.userEmail)
     } else {
-      try create(Data(), forKey: KeychainKey.userEmail)
+      try self.create(Data(), forKey: KeychainKey.userEmail)
     }
   }
   
   // swiftlint:disable large_tuple
   func getLoginData() throws -> (identifier: String, identifyToken: String, email: String?)? {
-    guard let identifierData = try load(forKey: KeychainKey.userIdentifier),
+    guard let identifierData = try self.load(forKey: KeychainKey.userIdentifier),
       let identifier = String(data: identifierData, encoding: String.Encoding.utf8),
-      let tokenData = try load(forKey: KeychainKey.identifyToken),
+      let tokenData = try self.load(forKey: KeychainKey.identifyToken),
       let identifyToken = String(data: tokenData, encoding: String.Encoding.utf8)
     else {
       return nil
     }
     
-    let emailData = try load(forKey: KeychainKey.userEmail)
+    let emailData = try self.load(forKey: KeychainKey.userEmail)
     let email = emailData.flatMap { String(data: $0, encoding: String.Encoding.utf8) }
     return (identifier, identifyToken, email)
   }
   // swiftlint:enable large_tuple
   
   func clearLoginData() throws {
-    try delete(forKey: KeychainKey.userIdentifier)
-    try delete(forKey: KeychainKey.userEmail)
-    try delete(forKey: KeychainKey.identifyToken)
+    try self.delete(forKey: KeychainKey.userIdentifier)
+    try self.delete(forKey: KeychainKey.userEmail)
+    try self.delete(forKey: KeychainKey.identifyToken)
   }
 }
 
 enum KeychainError: Error {
   case nonExistentKey
+  case alreadyExistentKey // 새로운 에러 추가
   case unhandledError(status: OSStatus)
 }

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/KeychainManager.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/KeychainManager.swift
@@ -70,6 +70,43 @@ final class KeychainManager {
   }
 }
 
+// MARK: - Login 관련
+
+extension KeychainManager {
+  func saveLoginData(identifier: String, identifyToken: Data, email: String?) throws {
+    try save(Data(identifier.utf8), forKey: KeychainKey.userIdentifier)
+    try save(identifyToken, forKey: KeychainKey.identifyToken)
+    
+    if let email = email {
+      try save(Data(email.utf8), forKey: KeychainKey.userEmail)
+    } else {
+      try save(Data(), forKey: KeychainKey.userEmail)
+    }
+  }
+  
+  // swiftlint:disable large_tuple
+  func getLoginData() throws -> (identifier: String, identifyToken: String, email: String?)? {
+    guard let identifierData = try load(forKey: KeychainKey.userIdentifier),
+      let identifier = String(data: identifierData, encoding: String.Encoding.utf8),
+      let tokenData = try load(forKey: KeychainKey.identifyToken),
+      let identifyToken = String(data: tokenData, encoding: String.Encoding.utf8)
+    else {
+      return nil
+    }
+    
+    let emailData = try load(forKey: KeychainKey.userEmail)
+    let email = emailData.flatMap { String(data: $0, encoding: String.Encoding.utf8) }
+    return (identifier, identifyToken, email)
+  }
+  // swiftlint:enable large_tuple
+  
+  func clearLoginData() throws {
+    try delete(forKey: KeychainKey.userIdentifier)
+    try delete(forKey: KeychainKey.userEmail)
+    try delete(forKey: KeychainKey.identifyToken)
+  }
+}
+
 enum KeychainError: Error {
   case nonExistentKey
   case unhandledError(status: OSStatus)

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/KeychainManager.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/KeychainManager.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by SONG on 10/23/24.
+//
+
+import Foundation

--- a/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/LoginScene/Sources/LoginScene/LoginViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
 import AuthenticationServices
+import OSLog
 import UIKit
 
 import LoginSceneAPI
@@ -28,11 +29,7 @@ final class LoginViewController: UIViewController, LoginViewControllable {
   private let dimmingView: UIView
   private let termAgreementView: TermsAgreementView
   
-  // MARK: - 임시 저장용 개인정보 / 인증정보 등 이후 PR에서 프로퍼티 제거 및 보안강화 처리 예정
-  private var userIdentifier: String = ""
-  private var userEmailAddress: String?
-  private var agreeOptionalCondition: Bool = false
-  
+  private let loger = Logger()
   // MARK: - Object lifecycle
   
   init() {
@@ -168,24 +165,28 @@ extension LoginViewController: ASAuthorizationControllerPresentationContextProvi
   }
 }
 
-// TODO: 린트관련 주석 지우기
-// swiftlint:disable empty_enum_arguments
 extension LoginViewController: AppleLoginManagerDelegate {
   func appleLoginDidComplete(with result: Result<ASAuthorizationAppleIDCredential, Error>) {
     switch result {
-    case .success(_):
-      //      let userIdentifier = appleIDCredential.user
-      //      let fullName = appleIDCredential.fullName
-      //      let email = appleIDCredential.email
-      // TODO: 신규회원인지 기존회원인지 체크
-      self.showTermAgreementView()
+    case .success(let credential):
+      do {
+        try KeychainManager.shared.saveLoginData(
+          identifier: credential.user,
+          identifyToken: credential.identityToken ?? Data(),
+          email: credential.email
+        )
+        
+        // TODO: 신규회원인지 기존회원인지 판별
+        self.showTermAgreementView()
+      } catch {
+        self.loger.log("Keychain에 저장 실패: \(error)")
+      }
       
-    case .failure(_): break
-      // TODO: 에러처리
+    case .failure(let error):
+      self.loger.log("Apple Login 실패: \(error)")
     }
   }
 }
-// swiftlint:enable empty_enum_arguments
 
 extension LoginViewController: TermsAgreementViewDelegate {
   public func termsAgreementView(
@@ -214,17 +215,18 @@ extension LoginViewController: TermsAgreementViewDelegate {
     didTapDoneButton isEventAndPromotionalInformationAgreed: Bool
   ) {
     self.hideTermAgreementView()
-    // TODO: 이벤트, 광고성 정보 안내 (선택)에 동의했을 때 / 안했을 때 동작 분기
-    if isEventAndPromotionalInformationAgreed {
-      self.agreeOptionalCondition = true
-    } else {
-      self.agreeOptionalCondition = false
+    do {
+      if let loginData = try KeychainManager.shared.getLoginData() {
+        self.router?.routeToSignUpScene(
+          userIdentifier: loginData.identifier,
+          userEmailAddress: loginData.email,
+          agreeOptionalCondition: isEventAndPromotionalInformationAgreed
+        )
+        // try KeychainManager.shared.clearLoginData()
+      }
+    } catch {
+      self.loger.log("Keychain에 저장된 데이터 뽑아오기 실패: \(error)")
     }
-    self.router?.routeToSignUpScene(
-      userIdentifier: self.userIdentifier,
-      userEmailAddress: self.userEmailAddress,
-      agreeOptionalCondition: self.agreeOptionalCondition
-    )
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #630 

## 🎉 변경 사항
- KeyChainManager를 만들었습니다. 

## 📌 PR Point
### 현재는 loginScene에 포함되어 있지만, 다른 패키지로 이관될 파일입니다 ! 

### 구현 상세 
1) 싱글톤으로 만들었습니다. 
2) 키체인에 저장될 키-값 쌍을 관리할 수 있는 CRUD 메서드를 구현하였습니다. 
3) 로그인씬에 활용될 메서드를 구현해놓았습니다. 활용예시로 참고하시면 되겠습니다. 

### 예상 작동 흐름 
앱에서:
   - Apple 서버와 직접 통신하여 인증 수행
   - ASAuthorizationAppleIDCredential에서 identity token 등을 받음
   - token등 을 KeyChain에 저장 ( 현재 PR에서는 여기까지 구현 )
   - 이후, Supabase에 전달

간단히 정리하면 아래와 같은 흐름이 되지 않을까 싶습니다. 
```
[iOS 앱] <--인증--> [Apple 서버]
           ↓ (identity token)
[Supabase] --검증--> [토큰 유효성 확인]
           ↓
    [Supabase 토큰 발급]
```

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?