### PR TITLE
UserInfoScene 수정된 닉네임 리로드 VIP 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneInteractor.swift
@@ -64,6 +64,7 @@ extension EditUserNameSceneInteractor: EditUserNameSceneBusinessLogic {
 
       do {
         try await self.editUserNameWorker.requestEditUserName(userName)
+        self.userName = userName
 
         try Task.checkCancellation()
         await self.presenter?.presentEditUserNameResult(nil)

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameScenePresenter.swift
@@ -23,7 +23,7 @@ final class EditUserNameScenePresenter {
 
 extension EditUserNameScenePresenter: EditUserNameScenePresentationLogic {
   func presentEditUserNameResult(_ error: Error?) {
-    if error != nil {
+    if error == nil {
       self.viewController?.displayEditUserNameSuccess()
     }
   }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -24,6 +24,7 @@ protocol UserInfoSceneBusinessLogic {
   func withdrawMembership()
   func signOut()
   func reloadUserIntroduction(_ introduction: String?)
+  func reloadUserName(_ userName: String)
 }
 
 final class UserInfoSceneInteractor: UserInfoSceneDataStore {
@@ -130,6 +131,11 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
     } else {
       self.presenter?.presentEmptyUserIntroduction()
     }
+  }
+
+  func reloadUserName(_ userName: String) {
+    self.userName = userName
+    self.presenter?.presentChangedUserName(userName)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -19,6 +19,7 @@ protocol UserInfoScenePresentationLogic {
   func presentSignOutResult(response: UserInfoScene.SignOut.Response)
   func presentChangedUserIntroduction(_ userIntroduction: String)
   func presentEmptyUserIntroduction()
+  func presentChangedUserName(_ userName: String)
 }
 
 final class UserInfoScenePresenter {
@@ -72,6 +73,10 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
   func presentEmptyUserIntroduction() {
     let placeholderText = UserInfoSceneTheme.StringLiteral.UserInfoCollectionView.userIntroductionPlaceholderText
     self.viewController?.displayEmptyUserIntroduction(placeholderText)
+  }
+
+  func presentChangedUserName(_ userName: String) {
+    self.viewController?.displayChangedUserName(userName)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -129,15 +129,21 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
   }
 
   func displayEmptyUserIntroduction(_ placeholderText: String) {
-    self.updateUserIntroduction(placeholderText)
+    self.updateReloadedUserInfo(placeholderText, isUserName: false)
   }
 
-  private func updateUserIntroduction(_ introduction: String) {
-    guard let userIntroductionCell = self.userInfoCollectionView.cellForItem(
-      at: IndexPath(row: 1, section: 0)
+  func displayChangedUserName(_ userName: String) {
+    self.updateReloadedUserInfo(userName, isUserName: true)
+  }
+
+  private func updateReloadedUserInfo(_ value: String, isUserName: Bool) {
+    let row = isUserName ? 0 : 1
+    let indexPath = IndexPath(row: row, section: 0)
+    guard let cell = self.userInfoCollectionView.cellForItem(
+      at: indexPath
     ) as? UserInfoCollectionViewCell else { return }
 
-    userIntroductionCell.updateDescription(introduction)
+    cell.updateDescription(value)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -26,6 +26,7 @@ protocol UserInfoSceneDisplayLogic: AnyObject {
   func displaySignOutResult(viewModel: UserInfoScene.SignOut.ViewModel)
   func displayChangedUserIntroduction(_ introduction: String)
   func displayEmptyUserIntroduction(_ placeholderText: String)
+  func displayChangedUserName(_ userName: String)
 }
 
 final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewControllable {
@@ -125,7 +126,7 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
   }
 
   func displayChangedUserIntroduction(_ introduction: String) {
-    self.updateUserIntroduction(introduction)
+    self.updateReloadedUserInfo(introduction, isUserName: false)
   }
 
   func displayEmptyUserIntroduction(_ placeholderText: String) {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -149,7 +149,7 @@ extension UserInfoSceneViewController: EditUserIntroductionDelegate, EditUserNam
   }
 
   func userNameDidEdited(_ userName: String) {
-    // TODO: - 변경된 닉네임 전달 Business Logic 호출 예정
+    self.interactor?.reloadUserName(userName)
   }
 
   func didSelectEditProfileButton() {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #634 

## 🎉 변경 사항
- UserInfoScene에 수정된 닉네임을 리로드하는 VIP를 추가하였습니다.

## 📌 PR Point
- 닉네임 수정화면에서 수정된 닉네임을 다시 불러오는 기능을 추가하였습니다.
- EditUserNameScene에서 일부 로직들이 잘못 설정되어 있어 수정하였습니다.
  - 수정된 부분에 코멘트로 설명을 추가하였습니다.

### 동작 GIF
<img width="300" src="https://github.com/user-attachments/assets/e05fe691-60a7-46f6-b822-9c67e133bcb3">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?