### PR TITLE
TutorialOnboardingVC BubbleLabel 적용

### DIFF
--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
@@ -113,3 +113,47 @@ extension TutorialOnBoardingViewController {
   }
 }
 
+extension TutorialOnBoardingViewController: BubbleLabelDelegate {
+  public func didTap() {
+    if !self.leftBubbleLabel.isHidden {
+      self.animateLeftBubbleLabel()
+    } else if !self.rightBubbleLabel.isHidden {
+      self.animateRightBubbleLabel()
+    }
+  }
+  
+  private func animateLeftBubbleLabel() {
+    UIView.animate(
+      withDuration: 0.5,
+      animations: { [weak self] in
+        self?.leftBubbleLabel.alpha = 0
+      },
+      completion: { _ in
+        self.leftBubbleLabel.isHidden = true
+        self.rightBubbleLabel.isHidden = false
+        self.showRightBubbleLabel()
+      }
+    )
+  }
+  
+  private func showRightBubbleLabel() {
+    UIView.animate(
+      withDuration: 0.5,
+      animations: { [weak self] in
+        self?.rightBubbleLabel.alpha = 1
+      }
+    )
+  }
+  
+  private func animateRightBubbleLabel() {
+    UIView.animate(
+      withDuration: 0.5,
+      animations: { [weak self] in
+        self?.rightBubbleLabel.alpha = 0
+      },
+      completion: { _ in
+        self.rightBubbleLabel.isHidden = true
+      }
+    )
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
@@ -8,7 +8,38 @@
 import UIKit
 
 import ToDoGardenUIComponent
+import ToDoGardenUIResource
 
-class TutorialOnBoardingViewController: UIViewController {
+final class TutorialOnBoardingViewController: UIViewController {
+  private let cell: ManageGroupTableViewCell
+  private let leftBubbleLabel: BubbleLabel
+  private let rightBubbleLabel: BubbleLabel
   
+  init() {
+    self.cell = ManageGroupTableViewCell(
+      style: UITableViewCell.CellStyle.default,
+      reuseIdentifier: ManageGroupTableViewCell.identifier
+    )
+    self.leftBubbleLabel = BubbleLabel(
+      tailPosition: BubbleLabel.TailPosition.left,
+      iconImage: UIImage.addButton,
+      text: Constant.StringLiteral.leftBubbleTitle
+    )
+    self.rightBubbleLabel = BubbleLabel(
+      tailPosition: BubbleLabel.TailPosition.right,
+      iconImage: UIImage.timerButtonImage,
+      text: Constant.StringLiteral.rightBubbleTitle
+    )
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.view.backgroundColor = UIColor.white
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
@@ -41,5 +41,75 @@ final class TutorialOnBoardingViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.view.backgroundColor = UIColor.white
+    self.setupCell()
+    self.setupBubbleLabels()
   }
 }
+
+extension TutorialOnBoardingViewController {
+  private func setupCell() {
+    self.cell.isUserInteractionEnabled = false
+    self.cell.applyModelSecondary(
+      id: UUID(),
+      groupName: Constant.StringLiteral.groupName,
+      progressColor: UIColor.red,
+      progressRate: 0.5
+    )
+    self.cell.usingAutolayout()
+    self.view.addSubview(self.cell)
+    
+    NSLayoutConstraint.activate(
+      [
+        self.cell.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+        self.cell.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
+        self.cell.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+        self.cell.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
+      ]
+    )
+  }
+  
+  private func setupBubbleLabels() {
+    self.leftBubbleLabel.delegate = self
+    self.rightBubbleLabel.delegate = self
+    
+    self.view.addSubview(self.leftBubbleLabel)
+    self.view.addSubview(self.rightBubbleLabel)
+    
+    self.leftBubbleLabel.usingAutolayout()
+    self.rightBubbleLabel.usingAutolayout()
+    
+    self.setBubbleConstraints()
+    
+    self.leftBubbleLabel.alpha = 1
+    self.rightBubbleLabel.alpha = 0
+  }
+  
+  private func setBubbleConstraints() {
+    guard let groupNameButton = self.cell.groupNameButton,
+      let rightImageButton = self.cell.rightImageButton else {
+      return
+    }
+    
+    let constant = Constant.Layout.self
+    NSLayoutConstraint.activate([
+      self.leftBubbleLabel.topAnchor.constraint(
+        equalTo: groupNameButton.bottomAnchor,
+        constant: constant.bubbleLabelMargin
+      ),
+      self.leftBubbleLabel.leadingAnchor.constraint(
+        equalTo: groupNameButton.trailingAnchor,
+        constant: constant.leftBubbleLabelLeading
+      ),
+      self.rightBubbleLabel.topAnchor.constraint(
+        equalTo: rightImageButton.bottomAnchor,
+        constant: constant.bubbleLabelMargin
+      ),
+      self.rightBubbleLabel.trailingAnchor.constraint(
+        equalTo: rightImageButton.centerXAnchor,
+        constant: constant.rightBubbleLabelTrailing
+      )
+    ])
+    self.leftBubbleLabel.isHidden = false
+  }
+}
+

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
@@ -157,3 +157,12 @@ extension TutorialOnBoardingViewController: BubbleLabelDelegate {
     )
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let viewController = TutorialOnBoardingViewController()
+  let navi = UINavigationController(rootViewController: viewController)
+  return navi
+}
+#endif

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
@@ -128,10 +128,10 @@ extension TutorialOnBoardingViewController: BubbleLabelDelegate {
       animations: { [weak self] in
         self?.leftBubbleLabel.alpha = 0
       },
-      completion: { _ in
-        self.leftBubbleLabel.isHidden = true
-        self.rightBubbleLabel.isHidden = false
-        self.showRightBubbleLabel()
+      completion: { [weak self] _ in
+        self?.leftBubbleLabel.isHidden = true
+        self?.rightBubbleLabel.isHidden = false
+        self?.showRightBubbleLabel()
       }
     )
   }
@@ -151,8 +151,8 @@ extension TutorialOnBoardingViewController: BubbleLabelDelegate {
       animations: { [weak self] in
         self?.rightBubbleLabel.alpha = 0
       },
-      completion: { _ in
-        self.rightBubbleLabel.isHidden = true
+      completion: { [weak self] _ in
+        self?.rightBubbleLabel.isHidden = true
       }
     )
   }

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/Views/OnBoardingSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/Views/OnBoardingSceneConstants.swift
@@ -12,6 +12,10 @@ enum Constant {
     static let space: CGFloat = 26.0
     static let multiplier: CGFloat = 0.2
     static let aspectRatio: CGFloat = 456 / 375
+    
+    static let bubbleLabelMargin: CGFloat = 5.0
+    static let leftBubbleLabelLeading: CGFloat = -44.0
+    static let rightBubbleLabelTrailing: CGFloat = 39.0
   }
   enum StringLiteral {
     static let buttonTitle: String = "시작하기"
@@ -24,5 +28,8 @@ enum Constant {
     
     static let thirdLineTitle: String = "열정을 불태우기"
     static let thirdLineDescription: String = "투두가든을 통해 당신의 열정을 불태우세요!"
+    
+    static let leftBubbleTitle: String = "를 눌러 ToDo를 추가할 수 있어요"
+    static let rightBubbleTitle: String = "뽀모도로 타이머를 이용하여\n집중력을 향상시킬 수 있어요"
   }
 }

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/Views/OnBoardingSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/Views/OnBoardingSceneConstants.swift
@@ -31,5 +31,7 @@ enum Constant {
     
     static let leftBubbleTitle: String = "를 눌러 ToDo를 추가할 수 있어요"
     static let rightBubbleTitle: String = "뽀모도로 타이머를 이용하여\n집중력을 향상시킬 수 있어요"
+    
+    static let groupName: String = "그룹 1"
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManageGroupTableViewCell.swift
@@ -14,8 +14,8 @@ public final class ManageGroupTableViewCell: UITableViewCell, ManageGroupTableVi
   private var configuration: ManageGroupTableViewCell.Configuration?
   
   private var progressCircle: CircularProgressView?
-  private var groupNameButton: UIButton?
-  private var rightImageButton: UIButton?
+  public var groupNameButton: UIButton?
+  public var rightImageButton: UIButton?
   
   private var rightButtonActionHandler: ((UUID, String, UIColor) -> Void)?
   private var groupNameButtonActionHandler: ((UUID) -> Void)?


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #654 

## 🎉 변경 사항

<img width="427" alt="스크린샷 2024-11-11 오후 5 49 31" src="https://github.com/user-attachments/assets/72e5796f-3d87-4d73-b1ce-fe7dc3161081">

- TutorialOnboardingVC에서 사용될 BubbleLabel에 대한 설정을 했습니다. 

## 📌 PR Point

### 말풍선 등장 / 사라짐 구현 
![말풍선 튜토리얼](https://github.com/user-attachments/assets/c68ec890-54fc-40b3-ac25-a1a2fe209d6c)

- public으로 바뀐 groupNameButton, rightImageButton에 레이아웃을 맞췄습니다. 
- 디바이스에 따라 화면 크기에 따라 동적인 위치에 말풍선이 정확하게 표시됩니다. 
- ↓ 레이블의 길이가 변경되어도 대응된 레이아웃으로 표시됩니다. 

<img width="204" alt="스크린샷 2024-11-11 오후 5 53 50" src="https://github.com/user-attachments/assets/da3a7bc9-b49b-4202-942b-468cfaffe5cb">

### 홈화면 준비 관련 
- 홈화면과 합체 계획은 아래와 같습니다. 

<img width="515" alt="스크린샷 2024-11-11 오후 6 01 16" src="https://github.com/user-attachments/assets/c7db6995-0834-42a8-9993-fe0063cc0863">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?