### PR TITLE
인트로VC 추가 구현

### DIFF
--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/IntroOnBoardingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/IntroOnBoardingViewController.swift
@@ -50,6 +50,7 @@ extension IntroOnBoardingViewController {
     self.addMainImageView()
     self.addStartButton()
     self.addStackView()
+    self.setupButtonAction()
   }
   
   private func addMainImageView() {
@@ -122,6 +123,17 @@ extension IntroOnBoardingViewController {
       ),
       self.startButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
     ])
+  }
+  
+  private func setupButtonAction() {
+    self.startButton.addAction(
+      UIAction { [weak self] _ in
+        let tutorialViewController = TutorialOnBoardingViewController()
+        
+        self?.navigationController?.pushViewController(tutorialViewController, animated: true)
+      },
+      for: UIControl.Event.touchUpInside
+    )
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/IntroOnBoardingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/IntroOnBoardingViewController.swift
@@ -48,8 +48,8 @@ public final class IntroOnBoardingViewController: UIViewController {
 extension IntroOnBoardingViewController {
   private func setupViews() {
     self.addMainImageView()
-    self.addStackView()
     self.addStartButton()
+    self.addStackView()
   }
   
   private func addMainImageView() {
@@ -66,8 +66,8 @@ extension IntroOnBoardingViewController {
   
   private func setupConstraints() {
     self.setupMainImageViewConstraints()
-    self.setupStackViewConstraints()
     self.setupStartButtonConstraints()
+    self.setupStackViewConstraints()
   }
   
   private func setupMainImageViewConstraints() {
@@ -87,12 +87,26 @@ extension IntroOnBoardingViewController {
   }
   
   private func setupStackViewConstraints() {
+    let dummyView = UIView()
+    self.view.addSubview(dummyView)
+    dummyView.usingAutolayout()
+    
+    NSLayoutConstraint.activate([
+      dummyView.widthAnchor.constraint(
+        equalToConstant: CGFloat.zero
+      ),
+      dummyView.topAnchor.constraint(
+        equalTo: self.mainImageView.bottomAnchor
+      ),
+      dummyView.bottomAnchor.constraint(equalTo: self.startButton.topAnchor)
+    ])
+    
     self.stackView.usingAutolayout()
     
     NSLayoutConstraint.activate([
       self.stackView.centerYAnchor.constraint(
-        equalTo: self.view.centerYAnchor,
-        constant: self.view.bounds.height * Constant.Layout.multiplier
+        equalTo: dummyView.centerYAnchor,
+        constant: -Constant.Layout.space / 2
       ),
       self.stackView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
     ])

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/IntroOnBoardingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/IntroOnBoardingViewController.swift
@@ -13,13 +13,13 @@ import ToDoGardenUIResource
 public final class IntroOnBoardingViewController: UIViewController {
   // private let mainImageView: AnimationImageView
   private let mainImageView: UIImageView
-  private let stackView: LeafLabelStackView
+  private let leafLabelStackView: LeafLabelStackView
   private let startButton: ToDoGardenBoxButton
   
   public init() {
     // self.mainImageView = AnimationImageView(jsonURL: URL.onBoardingURL)
     self.mainImageView = UIImageView(image: UIImage.onBoarding)
-    self.stackView = LeafLabelStackView()
+    self.leafLabelStackView = LeafLabelStackView()
     self.startButton = ToDoGardenBoxButton(
       title: Constant.StringLiteral.buttonTitle,
       buttonType: ToDoGardenBoxButton.Configuration.primaryRoundRectButton
@@ -58,7 +58,7 @@ extension IntroOnBoardingViewController {
   }
   
   private func addStackView() {
-    self.view.addSubview(self.stackView)
+    self.view.addSubview(self.leafLabelStackView)
   }
   
   private func addStartButton() {
@@ -102,14 +102,14 @@ extension IntroOnBoardingViewController {
       dummyView.bottomAnchor.constraint(equalTo: self.startButton.topAnchor)
     ])
     
-    self.stackView.usingAutolayout()
+    self.leafLabelStackView.usingAutolayout()
     
     NSLayoutConstraint.activate([
-      self.stackView.centerYAnchor.constraint(
+      self.leafLabelStackView.centerYAnchor.constraint(
         equalTo: dummyView.centerYAnchor,
         constant: -Constant.Layout.space / 2
       ),
-      self.stackView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
+      self.leafLabelStackView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
     ])
   }
   

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/Views/LeafLabelStackView.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/Views/LeafLabelStackView.swift
@@ -24,33 +24,17 @@ final class LeafLabelStackView: UIStackView {
   }
   
   private func setupViews() {
-    let titles = [
-      Constant.StringLiteral.firstLineTitle,
-      Constant.StringLiteral.secondLineTitle,
-      Constant.StringLiteral.thirdLineTitle
+    let titlesAndDescriptions = [
+      (Constant.StringLiteral.firstLineTitle, Constant.StringLiteral.firstLineDescription),
+      (Constant.StringLiteral.secondLineTitle, Constant.StringLiteral.secondLineDescription),
+      (Constant.StringLiteral.thirdLineTitle, Constant.StringLiteral.thirdLineDescription)
     ]
     
-    let descriptions = [
-      Constant.StringLiteral.firstLineDescription,
-      Constant.StringLiteral.secondLineDescription,
-      Constant.StringLiteral.thirdLineDescription
-    ]
-    
-    for (index, title) in titles.enumerated() {
-      let leafLabel = self.buildLeafLabel(
-        titleText: title,
-        descriptionText: descriptions[index]
-      )
+    for (title, description) in titlesAndDescriptions {
+      let leafLabel = LeafLabel(titleText: title, descriptionText: description)
       self.addArrangedSubview(leafLabel)
     }
     
     self.sizeToFit()
-  }
-  
-  // TODO: LeafLabel이 머지되면 사라질 메서드 입니다. LeafLabel의 생성자로 대체될 예정
-  private func buildLeafLabel(titleText: String, descriptionText: String) -> UILabel {
-    let label = UILabel()
-    label.text = "\(titleText)\n\(descriptionText)"
-    return label
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LeafLabel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LeafLabel.swift
@@ -39,7 +39,7 @@ public final class LeafLabel: UIView {
   
   public override var intrinsicContentSize: CGSize {
     return CGSize(
-      width: UIView.noIntrinsicMetric,
+      width: Constant.LeafLabel.width,
       height: Constant.LeafLabel.height
     )
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+LeafLabel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+LeafLabel.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension Constant.LeafLabel {
+  public static let width: CGFloat = 301.0
   public static let height: CGFloat = 34.0
   public static let labelLeading: CGFloat = 10.0
   public static let logoLength: CGFloat = 25.0


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #657 

## 🎉 변경 사항
- LeafLabel 추가 
- StartButton 액션 추가 (화면이동) 
- 레이아웃 제약 수정 

## 📌 PR Point

<img width="234" alt="스크린샷 2024-11-12 오후 1 29 54" src="https://github.com/user-attachments/assets/bcf94098-99c1-4d66-ba97-248547504b56">

<img width="241" alt="스크린샷 2024-11-12 오후 1 30 16" src="https://github.com/user-attachments/assets/78978b79-2f11-4f14-80cf-eb8b0e0e5516">

- 디바이스별로 일관적인 레이아웃을 제공하기 위해 레이아웃 제약을 수정하였습니다. 
- LeafLabel을 추가하였습니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?