### PR TITLE
Longest record view 추가 

### DIFF
--- a/ToDo-Garden/TDUtility/Sources/TDFoundationExtension/Date+Extension.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDFoundationExtension/Date+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  Date+Extension.swift
+//
+//
+//  Created by SONG on 11/12/24.
+//
+
+import Foundation
+
+public extension Date {
+  func toStringDefaultFormat() -> String {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy.MM.dd"
+    return dateFormatter.string(from: self)
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
@@ -197,7 +197,7 @@ extension LongestRecordView {
     let label = UILabel(frame: CGRect.zero)
     label.attributedText = groupName.applyTextAttributes(
       attributes: [
-        NSAttributedString.Key.font: UIFont.pretendardDetailLight,
+        NSAttributedString.Key.font: UIFont.pretendardDetailLight10,
         NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenGray
       ]
     )
@@ -241,7 +241,7 @@ extension LongestRecordView {
     let label = UILabel(frame: CGRect.zero)
     label.attributedText = text.applyTextAttributes(
       attributes: [
-        NSAttributedString.Key.font: UIFont.pretendardDetailLight,
+        NSAttributedString.Key.font: UIFont.pretendardDetailLight10,
         NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGray3
       ]
     )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
@@ -7,9 +7,38 @@
 
 import UIKit
 
-import ToDoGardenUIResource
 import TDFoundationExtension
+import ToDoGardenUIResource
 
 public final class LongestRecordView: UIView {
+  private let titleLabel: UILabel
+  private let labelStackView: UIStackView
   
+  public var informationButton: UIButton?
+  
+  public enum Configuration {
+    case pomo
+    case dateRange
+  }
+  
+  public init(
+    style: LongestRecordView.Configuration,
+    title: String,
+    groupName: String? = nil,
+    recordCount: Int,
+    date: [Date]
+  ) {
+    self.titleLabel = UILabel()
+    self.labelStackView = UIStackView(frame: CGRect.zero)
+    super.init(frame: CGRect.zero)
+    self.backgroundColor = UIColor.white
+    self.layer.cornerRadius = 10.0
+    self.layer.borderWidth = 1.0
+    self.layer.borderColor = UIColor.toDoGardenGreenGray.cgColor
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
@@ -35,10 +35,211 @@ public final class LongestRecordView: UIView {
     self.layer.cornerRadius = 10.0
     self.layer.borderWidth = 1.0
     self.layer.borderColor = UIColor.toDoGardenGreenGray.cgColor
+    self.setupViews(
+      style: style,
+      title: title,
+      groupName: groupName,
+      recordCount: recordCount,
+      date: date
+    )
   }
   
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+}
+
+extension LongestRecordView {
+  private func setupViews(
+    style: LongestRecordView.Configuration,
+    title: String,
+    groupName: String?,
+    recordCount: Int,
+    date: [Date]
+  ) {
+    self.setupTitleView(style: style, with: title)
+    self.setupLabelStackView(style: style, groupName: groupName, recordCount: recordCount, date: date)
+    self.setupLeafSymbolImageView()
+  }
+  
+  private func setupTitleView(style: LongestRecordView.Configuration, with title: String) {
+    self.titleLabel.attributedText = title.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardBodySemiBold,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    )
+    
+    self.addSubview(self.titleLabel)
+    self.titleLabel.usingAutolayout()
+    
+    self.setupTitleLabelConstraints()
+    self.setupInformationButton(style: style)
+  }
+  
+  private func setupTitleLabelConstraints() {
+    NSLayoutConstraint.activate(
+      [
+        self.titleLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 10.0),
+        self.titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 12.0)
+      ]
+    )
+  }
+  
+  private func setupInformationButton(style: LongestRecordView.Configuration) {
+    switch style {
+    case .pomo:
+      self.informationButton = UIButton()
+      guard let informationButton = self.informationButton else { return }
+      
+      informationButton.tintColor = UIColor.toDoGardenGreenDark
+      informationButton.usingAutolayout()
+      informationButton.setImage(UIImage.informationMark, for: UIControl.State.normal)
+      self.addSubview(informationButton)
+      self.setupInformationButtonConstraints(informationButton)
+      
+    case .dateRange:
+      return
+    }
+  }
+  
+  private func setupInformationButtonConstraints(_ button: UIButton) {
+    NSLayoutConstraint.activate(
+      [
+        button.leadingAnchor.constraint(equalTo: self.titleLabel.trailingAnchor, constant: 3.0),
+        button.centerYAnchor.constraint(equalTo: self.titleLabel.centerYAnchor),
+        button.widthAnchor.constraint(equalToConstant: 12.0),
+        button.heightAnchor.constraint(equalToConstant: 12.0)
+      ]
+    )
+  }
+  
+  private func setupLabelStackView(
+    style: LongestRecordView.Configuration,
+    groupName: String?,
+    recordCount: Int,
+    date: [Date]
+  ) {
+    self.labelStackView.axis = NSLayoutConstraint.Axis.vertical
+    self.labelStackView.alignment = UIStackView.Alignment.trailing
+    self.labelStackView.spacing = 1.0
+    
+    self.addSubview(self.labelStackView)
+    self.labelStackView.usingAutolayout()
+    
+    self.addLabelsToStackView(style: style, groupName: groupName, recordCount: recordCount, date: date)
+    self.setupLabelStackViewConstraints()
+  }
+  
+  private func addLabelsToStackView(
+    style: LongestRecordView.Configuration,
+    groupName: String?,
+    recordCount: Int,
+    date: [Date]
+  ) {
+    let groupNameLabel = self.buildGroupNameLabel(with: groupName)
+    let recordLabel = self.buildRecordLabel(style: style, with: recordCount)
+    let dateLabel = self.buildDateLabel(style: style, with: date)
+    
+    let labels = [groupNameLabel, recordLabel, dateLabel]
+    
+    for label in labels {
+      guard let label = label else {
+        continue
+      }
+      
+      self.labelStackView.addArrangedSubview(label)
+    }
+  }
+  
+  private func setupLabelStackViewConstraints() {
+    NSLayoutConstraint.activate(
+      [
+        self.labelStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -12.0),
+        self.labelStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -12.0)
+      ]
+    )
+  }
+  
+  private func setupLeafSymbolImageView() {
+    let imageView = UIImageView(image: UIImage.leafSymbolImage)
+    imageView.alpha = 0.5
+    self.addSubview(imageView)
+    imageView.usingAutolayout()
+    
+    self.setupLeafSymbolImageViewConstraints(imageView)
+  }
+  
+  private func setupLeafSymbolImageViewConstraints(_ imageView: UIImageView) {
+    NSLayoutConstraint.activate(
+      [
+        imageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15.0),
+        imageView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -21.0),
+        imageView.widthAnchor.constraint(equalToConstant: 30.0),
+        imageView.heightAnchor.constraint(equalToConstant: 38.0)
+      ]
+    )
+  }
+}
+
+extension LongestRecordView {
+  private func buildGroupNameLabel(with groupName: String?) -> UILabel? {
+    guard let groupName = groupName else {
+      return nil
+    }
+    
+    let label = UILabel(frame: CGRect.zero)
+    label.attributedText = groupName.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardDetailLight,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenGray
+      ]
+    )
+    
+    return label
+  }
+  
+  private func buildRecordLabel(style: LongestRecordView.Configuration, with recordCount: Int) -> UILabel {
+    var text: String
+    
+    switch style {
+    case .pomo:
+      text = "\(recordCount)뽀모"
+    case .dateRange:
+      text = "\(recordCount)일"
+    }
+    
+    let label = UILabel(frame: CGRect.zero)
+    label.attributedText = text.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardHeadBold,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    )
+    
+    return label
+  }
+  
+  private func buildDateLabel(style: LongestRecordView.Configuration, with date: [Date]) -> UILabel {
+    var text: String = ""
+    switch style {
+    case .pomo:
+      text = date.first?.toStringDefaultFormat() ?? ""
+    case .dateRange:
+      let startDate = date.first?.toStringDefaultFormat() ?? ""
+      let endDate = date.last?.toStringDefaultFormat() ?? ""
+      text = "\(startDate) ~ \(endDate)"
+    }
+    
+    let label = UILabel(frame: CGRect.zero)
+    label.attributedText = text.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardDetailLight,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGray3
+      ]
+    )
+    
+    return label
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import TDFoundationExtension
+import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 public final class LongestRecordView: UIView {
@@ -24,7 +25,7 @@ public final class LongestRecordView: UIView {
   public init(
     style: LongestRecordView.Configuration,
     title: String,
-    groupName: String? = nil,
+    groupName: String?,
     recordCount: Int,
     date: [Date]
   ) {
@@ -32,8 +33,8 @@ public final class LongestRecordView: UIView {
     self.labelStackView = UIStackView(frame: CGRect.zero)
     super.init(frame: CGRect.zero)
     self.backgroundColor = UIColor.white
-    self.layer.cornerRadius = 10.0
-    self.layer.borderWidth = 1.0
+    self.layer.cornerRadius = Constant.LongestRecordView.Layout.cornerRadius
+    self.layer.borderWidth = Constant.LongestRecordView.Layout.borderWidth
     self.layer.borderColor = UIColor.toDoGardenGreenGray.cgColor
     self.setupViews(
       style: style,
@@ -79,10 +80,11 @@ extension LongestRecordView {
   }
   
   private func setupTitleLabelConstraints() {
+    let constant = Constant.LongestRecordView.TitleLabel.Layout.self
     NSLayoutConstraint.activate(
       [
-        self.titleLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 10.0),
-        self.titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 12.0)
+        self.titleLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: constant.top),
+        self.titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: constant.leading)
       ]
     )
   }
@@ -105,12 +107,13 @@ extension LongestRecordView {
   }
   
   private func setupInformationButtonConstraints(_ button: UIButton) {
+    let constant = Constant.LongestRecordView.InfoButton.Layout.self
     NSLayoutConstraint.activate(
       [
-        button.leadingAnchor.constraint(equalTo: self.titleLabel.trailingAnchor, constant: 3.0),
+        button.leadingAnchor.constraint(equalTo: self.titleLabel.trailingAnchor, constant: constant.leading),
         button.centerYAnchor.constraint(equalTo: self.titleLabel.centerYAnchor),
-        button.widthAnchor.constraint(equalToConstant: 12.0),
-        button.heightAnchor.constraint(equalToConstant: 12.0)
+        button.widthAnchor.constraint(equalToConstant: constant.length),
+        button.heightAnchor.constraint(equalToConstant: constant.length)
       ]
     )
   }
@@ -154,10 +157,11 @@ extension LongestRecordView {
   }
   
   private func setupLabelStackViewConstraints() {
+    let constant = Constant.LongestRecordView.LabelStackView.Layout.self
     NSLayoutConstraint.activate(
       [
-        self.labelStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -12.0),
-        self.labelStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -12.0)
+        self.labelStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: constant.commonMargin),
+        self.labelStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: constant.commonMargin)
       ]
     )
   }
@@ -172,12 +176,13 @@ extension LongestRecordView {
   }
   
   private func setupLeafSymbolImageViewConstraints(_ imageView: UIImageView) {
+    let constant = Constant.LongestRecordView.LeafSymbol.Layout.self
     NSLayoutConstraint.activate(
       [
-        imageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15.0),
-        imageView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -21.0),
-        imageView.widthAnchor.constraint(equalToConstant: 30.0),
-        imageView.heightAnchor.constraint(equalToConstant: 38.0)
+        imageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: constant.leading),
+        imageView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: constant.bottom),
+        imageView.widthAnchor.constraint(equalToConstant: constant.width),
+        imageView.heightAnchor.constraint(equalToConstant: constant.height)
       ]
     )
   }
@@ -202,13 +207,14 @@ extension LongestRecordView {
   
   private func buildRecordLabel(style: LongestRecordView.Configuration, with recordCount: Int) -> UILabel {
     var text: String
-    
+    var unit: String
     switch style {
     case .pomo:
-      text = "\(recordCount)뽀모"
+      unit = Constant.LongestRecordView.StringLiteral.pomo
     case .dateRange:
-      text = "\(recordCount)일"
+      unit = Constant.LongestRecordView.StringLiteral.day
     }
+    text = "\(recordCount)\(unit)"
     
     let label = UILabel(frame: CGRect.zero)
     label.attributedText = text.applyTextAttributes(

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
@@ -243,3 +243,43 @@ extension LongestRecordView {
     return label
   }
 }
+
+@available(iOS 17.0, *)
+#Preview {
+  let stackView = UIStackView()
+  stackView.axis = .horizontal
+  stackView.spacing = 7.0
+  stackView.distribution = .fillEqually
+  
+  let view1 = LongestRecordView(
+    style: .pomo,
+    title: "최장 집중 기록",
+    groupName: "아아아아아아",
+    recordCount: 9,
+    date: [Date.now]
+  )
+  
+  let view2 = LongestRecordView(
+    style: .dateRange,
+    title: "최장 연속 기록",
+    groupName: nil,
+    recordCount: 30,
+    date: [Date.now, Date.now]
+  )
+  
+  view1.usingAutolayout()
+  view2.usingAutolayout()
+
+  stackView.addArrangedSubview(view1)
+  stackView.addArrangedSubview(view2)
+  
+  stackView.usingAutolayout()
+  NSLayoutConstraint.activate(
+    [
+      stackView.widthAnchor.constraint(equalToConstant: 332),
+      stackView.heightAnchor.constraint(equalToConstant: 125)
+    ]
+  )
+  
+  return stackView
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
@@ -13,7 +13,7 @@ import ToDoGardenUIResource
 
 public final class LongestRecordView: UIView {
   private let titleLabel: UILabel
-  private let labelStackView: UIStackView
+  private let labelStackView: UIVStackView
   
   public var informationButton: UIButton?
   
@@ -30,7 +30,11 @@ public final class LongestRecordView: UIView {
     date: [Date]
   ) {
     self.titleLabel = UILabel()
-    self.labelStackView = UIStackView(frame: CGRect.zero)
+    self.labelStackView = UIVStackView(
+      alignment: UIStackView.Alignment.trailing,
+      spacing: 1.0,
+      arrangedSubviews: []
+    )
     super.init(frame: CGRect.zero)
     self.backgroundColor = UIColor.white
     self.layer.cornerRadius = Constant.LongestRecordView.Layout.cornerRadius
@@ -124,10 +128,6 @@ extension LongestRecordView {
     recordCount: Int,
     date: [Date]
   ) {
-    self.labelStackView.axis = NSLayoutConstraint.Axis.vertical
-    self.labelStackView.alignment = UIStackView.Alignment.trailing
-    self.labelStackView.spacing = 1.0
-    
     self.addSubview(self.labelStackView)
     self.labelStackView.usingAutolayout()
     
@@ -252,9 +252,10 @@ extension LongestRecordView {
 
 @available(iOS 17.0, *)
 #Preview {
-  let stackView = UIStackView()
-  stackView.axis = .horizontal
-  stackView.spacing = 7.0
+  let stackView = UIHStackView(
+    alignment: UIStackView.Alignment.fill,
+    arrangedSubviews: []
+  )
   stackView.distribution = .fillEqually
   
   let view1 = LongestRecordView(

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
@@ -1,0 +1,15 @@
+//
+//  LongestRecordView.swift
+//
+//
+//  Created by SONG on 11/12/24.
+//
+
+import UIKit
+
+import ToDoGardenUIResource
+import TDFoundationExtension
+
+public final class LongestRecordView: UIView {
+  
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+LongestRecordView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+LongestRecordView.swift
@@ -1,0 +1,49 @@
+//
+//  Constant+LongestRecordView.swift
+//
+//
+//  Created by SONG on 11/12/24.
+//
+
+import Foundation
+
+extension Constant.LongestRecordView {
+  public enum Layout {
+    public static let cornerRadius: CGFloat = 10.0
+    public static let borderWidth: CGFloat = 1.0
+  }
+  
+  public enum StringLiteral {
+    public static let pomo = "뽀모"
+    public static let day = "일"
+  }
+
+  public enum TitleLabel {
+    public enum Layout {
+      public static let top: CGFloat = 10.0
+      public static let leading: CGFloat = 12.0
+    }
+  }
+  
+  public enum InfoButton {
+    public enum Layout {
+      public static let length: CGFloat = 12.0
+      public static let leading: CGFloat = 3.0
+    }
+  }
+  
+  public enum LabelStackView {
+    public enum Layout {
+      public static let commonMargin: CGFloat = -12.0
+    }
+  }
+  
+  public enum LeafSymbol {
+    public enum Layout {
+      public static let leading: CGFloat = 15.0
+      public static let bottom: CGFloat = -21.0
+      public static let width: CGFloat = 30.0
+      public static let height: CGFloat = 38.0
+    }
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -44,4 +44,5 @@ public enum Constant {
   public enum AnimationImageView { }
   public enum LeafLabel { }
   public enum BubbleLabel { }
+  public enum LongestRecordView { }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIFont+ToDoGarden.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIFont+ToDoGarden.swift
@@ -80,6 +80,11 @@ extension UIFont {
 		size: 12
 	) ?? UIFont.systemFont(ofSize: 12, weight: .light)
   
+  public static let pretendardDetailLight10: UIFont = UIFont(
+    name: PretendardFont.light.name,
+    size: 10
+  ) ?? UIFont.systemFont(ofSize: 10, weight: .light)
+  
   public static let pretendardDetailRegular5: UIFont = UIFont(
     name: PretendardFont.regular.name,
     size: 5

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIImage+ToDoGarden.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIImage+ToDoGarden.swift
@@ -125,4 +125,8 @@ extension UIImage {
   public static let onBoarding = UIImage(
     resource: .onBoarding
   )
+  
+  public static let informationMark = UIImage(
+    systemName: "info.circle"
+  )
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #659 
## 🎉 변경 사항
-  longest record view를 추가합니다

## 📌 PR Point

### enum으로 스타일을 나누어 구현하였습니다. 
<img width="318" alt="스크린샷 2024-11-12 오후 5 44 59" src="https://github.com/user-attachments/assets/65ebffb1-8216-4d5d-a2f1-087a8c7c15a2">

### ↓ 아래와 같이 생성 가능합니다. 
```swift 
  let view1 = LongestRecordView(
    style: .pomo,
    title: "최장 집중 기록",
    groupName: "아아아아아아",
    recordCount: 9,
    date: [Date.now]
  )
  
  let view2 = LongestRecordView(
    style: .dateRange,
    title: "최장 연속 기록",
    groupName: nil,
    recordCount: 30,
    date: [Date.now, Date.now]
  )
```

### 결과 화면
<img width="230" alt="스크린샷 2024-11-12 오후 5 47 07" src="https://github.com/user-attachments/assets/9441f2b5-6311-455b-856a-7c817c9155e3">

- 프리뷰를 통해 확인 가능합니다 ! 
- 단순한 뷰라서 설명할게 딱히..  ^^;ㅎ

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?