### PR TITLE
add mystats summary view

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/MyStatsSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/MyStatsSummaryView.swift
@@ -1,0 +1,203 @@
+//
+//  MyStatsSummaryView.swift
+//
+//
+//  Created by SONG on 11/17/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+import ToDoGardenUIResource
+
+public final class MyStatsSummaryView: UIView {
+  private let verticalLine: UIView
+  private let leftView: TitleDescriptionView
+  private let rightView: TitleDescriptionView
+  
+  public init(
+    leftTitle: String,
+    leftDescription: String,
+    rightTitle: String,
+    rightDescription: String
+  ) {
+    self.verticalLine = UIView()
+    self.leftView = TitleDescriptionView()
+    self.rightView = TitleDescriptionView()
+    super.init(frame: CGRect.zero)
+    self.backgroundColor = UIColor.white
+    self.layer.cornerRadius = Constant.MyStatsSummaryView.Layout.cornerRadius
+    self.layer.borderColor = UIColor.toDoGardenGreenGray.cgColor
+    self.layer.borderWidth = 1
+    
+    self.setupView(
+      leftTitle: leftTitle,
+      leftDescription: leftDescription,
+      rightTitle: rightTitle,
+      rightDescription: rightDescription
+    )
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  public func updateLeftView(title: String? = nil, description: String?) {
+    if let title = title {
+      self.leftView.updateTitleLabel(text: title)
+    }
+    
+    if let description = description {
+      self.leftView.updateDescriptionLabel(text: description)
+    }
+  }
+  
+  public func updateRightView(title: String? = nil, description: String?) {
+    if let title = title {
+      self.rightView.updateTitleLabel(text: title)
+    }
+    
+    if let description = description {
+      self.rightView.updateDescriptionLabel(text: description)
+    }
+  }
+  
+  private func setupView(
+    leftTitle: String,
+    leftDescription: String,
+    rightTitle: String,
+    rightDescription: String
+  ) {
+    self.verticalLine.backgroundColor = UIColor.toDoGardenGreenGray
+    
+    self.updateLeftView(title: leftTitle, description: leftDescription)
+    self.updateRightView(title: rightTitle, description: rightDescription)
+    
+    self.addSubview(self.verticalLine)
+    self.addSubview(self.leftView)
+    self.addSubview(self.rightView)
+    
+    self.setupVerticalLineConstraints()
+    self.setupLeftViewConstraints()
+    self.setupRightViewConstraints()
+  }
+  
+  private func setupVerticalLineConstraints() {
+    self.verticalLine.usingAutolayout()
+    let constant = Constant.MyStatsSummaryView.Layout.self
+    NSLayoutConstraint.activate([
+      self.verticalLine.widthAnchor.constraint(equalToConstant: 2),
+      self.verticalLine.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+      self.verticalLine.topAnchor.constraint(equalTo: self.topAnchor, constant: constant.verticalLineMargin),
+      self.verticalLine.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -constant.verticalLineMargin)
+    ])
+  }
+  
+  private func setupLeftViewConstraints() {
+    self.leftView.usingAutolayout()
+    let constant = Constant.MyStatsSummaryView.Layout.self
+    NSLayoutConstraint.activate([
+      self.leftView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: constant.commonMargin),
+      self.leftView.topAnchor.constraint(equalTo: self.topAnchor, constant: constant.commonMargin),
+      self.leftView.trailingAnchor.constraint(equalTo: self.verticalLine.leadingAnchor, constant: -constant.commonMargin),
+      self.leftView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -constant.commonMargin)
+    ])
+  }
+  
+  private func setupRightViewConstraints() {
+    self.rightView.usingAutolayout()
+    let constant = Constant.MyStatsSummaryView.Layout.self
+    NSLayoutConstraint.activate([
+      self.rightView.leadingAnchor.constraint(equalTo: self.verticalLine.trailingAnchor, constant: constant.commonMargin),
+      self.rightView.topAnchor.constraint(equalTo: self.topAnchor, constant: constant.commonMargin),
+      self.rightView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -constant.commonMargin),
+      self.rightView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -constant.commonMargin)
+    ])
+  }
+}
+
+class TitleDescriptionView: UIView {
+  private let titleLabel: UILabel
+  private let descriptionLabel: UILabel
+  
+  override init(frame: CGRect) {
+    self.titleLabel = UILabel()
+    self.titleLabel.usingAutolayout()
+    
+    self.descriptionLabel = UILabel()
+    self.descriptionLabel.usingAutolayout()
+    
+    super.init(frame: frame)
+    self.setupView()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupView() {
+    self.addSubview(self.titleLabel)
+    self.addSubview(self.descriptionLabel)
+    
+    self.setupTitleLabelConstraints()
+    self.setupDescriptionLabelConstraints()
+  }
+  
+  private func setupTitleLabelConstraints() {
+    let constant = Constant.MyStatsSummaryView.Layout.self
+    NSLayoutConstraint.activate([
+      self.titleLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: constant.labelMargin),
+      self.titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: constant.labelMargin)
+    ])
+  }
+  
+  private func setupDescriptionLabelConstraints() {
+    let constant = Constant.MyStatsSummaryView.Layout.self
+    NSLayoutConstraint.activate([
+      self.descriptionLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -constant.commonMargin),
+      self.descriptionLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -constant.labelMargin)
+    ])
+  }
+  
+  func updateTitleLabel(text: String) {
+    self.titleLabel.attributedText = text.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font : UIFont.pretendardBodySemiBold,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    )
+  }
+  
+  func updateDescriptionLabel(text: String) {
+    self.descriptionLabel.attributedText = text.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font : UIFont.pretendardHeadBold,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    )
+  }
+}
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let view = MyStatsSummaryView(
+    leftTitle: "평균 집중 시간",
+    leftDescription: "3시간 50분",
+    rightTitle: "평균 완료 수",
+    rightDescription: "3개 목표"
+  )
+  
+  view.usingAutolayout()
+  
+  NSLayoutConstraint.activate(
+    [
+      view.widthAnchor.constraint(equalToConstant: 331.0),
+      view.heightAnchor.constraint(equalToConstant: 103)
+    ]
+  )
+  return view
+}
+#endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/MyStatsSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/MyStatsSummaryView.swift
@@ -43,24 +43,21 @@ public final class MyStatsSummaryView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
   
-  public func updateLeftView(title: String? = nil, description: String?) {
+  public func updateLeftView(title: String? = nil, description: String) {
     if let title = title {
       self.leftView.updateTitleLabel(text: title)
     }
     
-    if let description = description {
-      self.leftView.updateDescriptionLabel(text: description)
-    }
+    self.leftView.updateDescriptionLabel(text: description)
   }
   
-  public func updateRightView(title: String? = nil, description: String?) {
+  public func updateRightView(title: String? = nil, description: String) {
     if let title = title {
       self.rightView.updateTitleLabel(text: title)
     }
+    self.rightView.updateDescriptionLabel(text: description)
     
-    if let description = description {
-      self.rightView.updateDescriptionLabel(text: description)
-    }
+  }
   }
   
   private func setupView(

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/MyStatsSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/MyStatsSummaryView.swift
@@ -25,11 +25,7 @@ public final class MyStatsSummaryView: UIView {
     self.leftView = TitleDescriptionView()
     self.rightView = TitleDescriptionView()
     super.init(frame: CGRect.zero)
-    self.backgroundColor = UIColor.white
-    self.layer.cornerRadius = Constant.MyStatsSummaryView.Layout.cornerRadius
-    self.layer.borderColor = UIColor.toDoGardenGreenGray.cgColor
-    self.layer.borderWidth = 1
-    
+    self.setupAppearance()
     self.setupView(
       leftTitle: leftTitle,
       leftDescription: leftDescription,
@@ -58,6 +54,12 @@ public final class MyStatsSummaryView: UIView {
     self.rightView.updateDescriptionLabel(text: description)
     
   }
+  
+  private func setupAppearance() {
+    self.backgroundColor = UIColor.white
+    self.layer.cornerRadius = Constant.MyStatsSummaryView.Layout.cornerRadius
+    self.layer.borderColor = UIColor.toDoGardenGreenGray.cgColor
+    self.layer.borderWidth = 1
   }
   
   private func setupView(

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/MyStatsSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/MyStatsSummaryView.swift
@@ -147,8 +147,15 @@ class TitleDescriptionView: UIView {
     self.addSubview(self.titleLabel)
     self.addSubview(self.descriptionLabel)
     
+    self.setupShimmerable()
+    
     self.setupTitleLabelConstraints()
     self.setupDescriptionLabelConstraints()
+  }
+  
+  private func setupShimmerable() {
+    self.isShimmering = true
+    self.descriptionLabel.isShimmering = true
   }
   
   private func setupTitleLabelConstraints() {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/MyStatsSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/MyStatsSummaryView.swift
@@ -123,7 +123,7 @@ public final class MyStatsSummaryView: UIView {
   }
 }
 
-class TitleDescriptionView: UIView {
+final class TitleDescriptionView: UIView {
   private let titleLabel: UILabel
   private let descriptionLabel: UILabel
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/MyStatsSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/MyStatsSummaryView.swift
@@ -100,7 +100,10 @@ public final class MyStatsSummaryView: UIView {
     NSLayoutConstraint.activate([
       self.leftView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: constant.commonMargin),
       self.leftView.topAnchor.constraint(equalTo: self.topAnchor, constant: constant.commonMargin),
-      self.leftView.trailingAnchor.constraint(equalTo: self.verticalLine.leadingAnchor, constant: -constant.commonMargin),
+      self.leftView.trailingAnchor.constraint(
+        equalTo: self.verticalLine.leadingAnchor,
+        constant: -constant.commonMargin
+      ),
       self.leftView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -constant.commonMargin)
     ])
   }
@@ -109,7 +112,10 @@ public final class MyStatsSummaryView: UIView {
     self.rightView.usingAutolayout()
     let constant = Constant.MyStatsSummaryView.Layout.self
     NSLayoutConstraint.activate([
-      self.rightView.leadingAnchor.constraint(equalTo: self.verticalLine.trailingAnchor, constant: constant.commonMargin),
+      self.rightView.leadingAnchor.constraint(
+        equalTo: self.verticalLine.trailingAnchor,
+        constant: constant.commonMargin
+      ),
       self.rightView.topAnchor.constraint(equalTo: self.topAnchor, constant: constant.commonMargin),
       self.rightView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -constant.commonMargin),
       self.rightView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -constant.commonMargin)
@@ -164,7 +170,7 @@ class TitleDescriptionView: UIView {
   func updateTitleLabel(text: String) {
     self.titleLabel.attributedText = text.applyTextAttributes(
       attributes: [
-        NSAttributedString.Key.font : UIFont.pretendardBodySemiBold,
+        NSAttributedString.Key.font: UIFont.pretendardBodySemiBold,
         NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
       ]
     )
@@ -173,7 +179,7 @@ class TitleDescriptionView: UIView {
   func updateDescriptionLabel(text: String) {
     self.descriptionLabel.attributedText = text.applyTextAttributes(
       attributes: [
-        NSAttributedString.Key.font : UIFont.pretendardHeadBold,
+        NSAttributedString.Key.font: UIFont.pretendardHeadBold,
         NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
       ]
     )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+MyStatsSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+MyStatsSummaryView.swift
@@ -1,0 +1,17 @@
+//
+//  Constant+MyStatsSummaryView.swift
+//
+//
+//  Created by SONG on 11/17/24.
+//
+
+import Foundation
+
+extension Constant.MyStatsSummaryView {
+  public enum Layout {
+    public static let cornerRadius = 10.0
+    public static let verticalLineMargin = 23.5
+    public static let labelMargin = 5.0
+    public static let commonMargin = 10.0
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -45,4 +45,5 @@ public enum Constant {
   public enum LeafLabel { }
   public enum BubbleLabel { }
   public enum LongestRecordView { }
+  public enum MyStatsSummaryView { }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #668 

## 🎉 변경 사항

- ↓ 이녀석을 추가합니다. 
<img width="325" alt="스크린샷 2024-11-17 오후 3 31 20" src="https://github.com/user-attachments/assets/c1061973-0c3c-4c33-9681-947a8da84086">

## 📌 PR Point

### 있는 줄 알았는데 없었습니다. 

### 이니셜라이저를 통해 레이블 텍스트 설정 가능합니다. 
```swift
  let view = MyStatsSummaryView(
    leftTitle: "평균 집중 시간",
    leftDescription: "3시간 50분",
    rightTitle: "평균 완료 수",
    rightDescription: "3개 목표"
  )
```

### 생성 후에도 update메서드로 업데이트 가능합니다. 
<img width="403" alt="스크린샷 2024-11-17 오후 3 33 42" src="https://github.com/user-attachments/assets/cddb762b-77de-4a8f-ba77-0f279792f4ad">

### 프리뷰로 확인가능합니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?