### PR TITLE
longest record view 개선

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
@@ -14,6 +14,7 @@ import ToDoGardenUIResource
 public final class LongestRecordView: UIView {
   private let titleLabel: UILabel
   private let labelStackView: UIVStackView
+  private let style: LongestRecordView.Configuration
   
   public var informationButton: UIButton?
   
@@ -29,6 +30,7 @@ public final class LongestRecordView: UIView {
     recordCount: Int,
     date: [Date]
   ) {
+    self.style = style
     self.titleLabel = UILabel()
     self.labelStackView = UIVStackView(
       alignment: UIStackView.Alignment.trailing,

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
@@ -13,7 +13,9 @@ import ToDoGardenUIResource
 
 public final class LongestRecordView: UIView {
   private let titleLabel: UILabel
-  private let labelStackView: UIVStackView
+  private var groupNameLabel: UILabel?
+  private var recordLabel: UILabel
+  private var dateLabel: UILabel
   private let style: LongestRecordView.Configuration
   
   public var informationButton: UIButton?
@@ -32,45 +34,55 @@ public final class LongestRecordView: UIView {
   ) {
     self.style = style
     self.titleLabel = UILabel()
-    self.labelStackView = UIVStackView(
-      alignment: UIStackView.Alignment.trailing,
-      spacing: 1.0,
-      arrangedSubviews: []
-    )
+    self.groupNameLabel = UILabel()
+    self.recordLabel = UILabel()
+    self.dateLabel = UILabel()
     super.init(frame: CGRect.zero)
     self.backgroundColor = UIColor.white
     self.layer.cornerRadius = Constant.LongestRecordView.Layout.cornerRadius
     self.layer.borderWidth = Constant.LongestRecordView.Layout.borderWidth
     self.layer.borderColor = UIColor.toDoGardenGreenGray.cgColor
     self.setupViews(
-      style: style,
       title: title,
       groupName: groupName,
       recordCount: recordCount,
-      date: date
+      dateRange: date
     )
+    self.setupShimmerable()
   }
   
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+  
+  public func update(
+    groupName: String?,
+    recordCount: Int,
+    dateRange: [Date]
+  ) {
+    self.setupGroupNameLabel(with: groupName)
+    self.setupRecordLabel(with: recordCount)
+    self.setupDateLabel(with: dateRange)
+  }
 }
 
 extension LongestRecordView {
   private func setupViews(
-    style: LongestRecordView.Configuration,
     title: String,
     groupName: String?,
     recordCount: Int,
-    date: [Date]
+    dateRange: [Date]
   ) {
-    self.setupTitleView(style: style, with: title)
-    self.setupLabelStackView(style: style, groupName: groupName, recordCount: recordCount, date: date)
+    self.setupTitleView(with: title)
     self.setupLeafSymbolImageView()
+    self.setupGroupNameLabel(with: groupName)
+    self.setupRecordLabel(with: recordCount)
+    self.setupDateLabel(with: dateRange)
+    self.setupLabelsConstraints()
   }
   
-  private func setupTitleView(style: LongestRecordView.Configuration, with title: String) {
+  private func setupTitleView(with title: String) {
     self.titleLabel.attributedText = title.applyTextAttributes(
       attributes: [
         NSAttributedString.Key.font: UIFont.pretendardBodySemiBold,
@@ -82,7 +94,7 @@ extension LongestRecordView {
     self.titleLabel.usingAutolayout()
     
     self.setupTitleLabelConstraints()
-    self.setupInformationButton(style: style)
+    self.setupInformationButton()
   }
   
   private func setupTitleLabelConstraints() {
@@ -95,8 +107,8 @@ extension LongestRecordView {
     )
   }
   
-  private func setupInformationButton(style: LongestRecordView.Configuration) {
-    switch style {
+  private func setupInformationButton() {
+    switch self.style {
     case .pomo:
       self.informationButton = UIButton()
       guard let informationButton = self.informationButton else { return }
@@ -124,46 +136,50 @@ extension LongestRecordView {
     )
   }
   
-  private func setupLabelStackView(
-    style: LongestRecordView.Configuration,
-    groupName: String?,
-    recordCount: Int,
-    date: [Date]
-  ) {
-    self.addSubview(self.labelStackView)
-    self.labelStackView.usingAutolayout()
+  private func setupLabelsConstraints() {
     
-    self.addLabelsToStackView(style: style, groupName: groupName, recordCount: recordCount, date: date)
-    self.setupLabelStackViewConstraints()
-  }
-  
-  private func addLabelsToStackView(
-    style: LongestRecordView.Configuration,
-    groupName: String?,
-    recordCount: Int,
-    date: [Date]
-  ) {
-    let groupNameLabel = self.buildGroupNameLabel(with: groupName)
-    let recordLabel = self.buildRecordLabel(style: style, with: recordCount)
-    let dateLabel = self.buildDateLabel(style: style, with: date)
+    self.addSubview(self.dateLabel)
+    self.dateLabel.usingAutolayout()
+    self.setupDateLabelConstraints()
     
-    let labels = [groupNameLabel, recordLabel, dateLabel]
+    self.addSubview(self.recordLabel)
+    self.recordLabel.usingAutolayout()
+    self.setupRecordLabelConstraints()
     
-    for label in labels {
-      guard let label = label else {
-        continue
-      }
-      
-      self.labelStackView.addArrangedSubview(label)
+    if let groupNameLabel = self.groupNameLabel {
+      self.addSubview(groupNameLabel)
+      groupNameLabel.usingAutolayout()
+      self.setupGroupNameLabelConstraints(groupNameLabel)
     }
+
   }
   
-  private func setupLabelStackViewConstraints() {
+  private func setupGroupNameLabelConstraints(_ label: UILabel) {
     let constant = Constant.LongestRecordView.LabelStackView.Layout.self
     NSLayoutConstraint.activate(
       [
-        self.labelStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: constant.commonMargin),
-        self.labelStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: constant.commonMargin)
+        label.bottomAnchor.constraint(equalTo: self.recordLabel.topAnchor, constant: -1),
+        label.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: constant.commonMargin)
+      ]
+    )
+  }
+  
+  private func setupRecordLabelConstraints() {
+    let constant = Constant.LongestRecordView.LabelStackView.Layout.self
+    NSLayoutConstraint.activate(
+      [
+        self.recordLabel.bottomAnchor.constraint(equalTo: self.dateLabel.topAnchor, constant: -1),
+        self.recordLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: constant.commonMargin)
+      ]
+    )
+  }
+  
+  private func setupDateLabelConstraints() {
+    let constant = Constant.LongestRecordView.LabelStackView.Layout.self
+    NSLayoutConstraint.activate(
+      [
+        self.dateLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: constant.commonMargin),
+        self.dateLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: constant.commonMargin)
       ]
     )
   }
@@ -191,26 +207,23 @@ extension LongestRecordView {
 }
 
 extension LongestRecordView {
-  private func buildGroupNameLabel(with groupName: String?) -> UILabel? {
+  private func setupGroupNameLabel(with groupName: String?) {
     guard let groupName = groupName else {
-      return nil
+      return
     }
-    
-    let label = UILabel(frame: CGRect.zero)
-    label.attributedText = groupName.applyTextAttributes(
+
+    self.groupNameLabel?.attributedText = groupName.applyTextAttributes(
       attributes: [
         NSAttributedString.Key.font: UIFont.pretendardDetailLight10,
         NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenGray
       ]
     )
-    
-    return label
   }
   
-  private func buildRecordLabel(style: LongestRecordView.Configuration, with recordCount: Int) -> UILabel {
+  private func setupRecordLabel(with recordCount: Int) {
     var text: String
     var unit: String
-    switch style {
+    switch self.style {
     case .pomo:
       unit = Constant.LongestRecordView.StringLiteral.pomo
     case .dateRange:
@@ -218,20 +231,17 @@ extension LongestRecordView {
     }
     text = "\(recordCount)\(unit)"
     
-    let label = UILabel(frame: CGRect.zero)
-    label.attributedText = text.applyTextAttributes(
+    self.recordLabel.attributedText = text.applyTextAttributes(
       attributes: [
         NSAttributedString.Key.font: UIFont.pretendardHeadBold,
         NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
       ]
     )
-    
-    return label
   }
   
-  private func buildDateLabel(style: LongestRecordView.Configuration, with date: [Date]) -> UILabel {
+  private func setupDateLabel(with date: [Date]) {
     var text: String = ""
-    switch style {
+    switch self.style {
     case .pomo:
       text = date.first?.toStringDefaultFormat() ?? ""
     case .dateRange:
@@ -239,16 +249,21 @@ extension LongestRecordView {
       let endDate = date.last?.toStringDefaultFormat() ?? ""
       text = "\(startDate) ~ \(endDate)"
     }
-    
-    let label = UILabel(frame: CGRect.zero)
-    label.attributedText = text.applyTextAttributes(
+
+    self.dateLabel.attributedText = text.applyTextAttributes(
       attributes: [
         NSAttributedString.Key.font: UIFont.pretendardDetailLight10,
         NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGray3
       ]
     )
+  }
+  
+  private func setupShimmerable() {
+    let labels = [self.groupNameLabel, self.recordLabel, self.dateLabel].compactMap { $0 }
     
-    return label
+    for label in labels {
+      label.isShimmering = true
+    }
   }
 }
 
@@ -278,7 +293,8 @@ extension LongestRecordView {
   
   view1.usingAutolayout()
   view2.usingAutolayout()
-
+  view2.startShimmering()
+  
   stackView.addArrangedSubview(view1)
   stackView.addArrangedSubview(view2)
   


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #670 
## 🎉 변경 사항
- 쉬머링 이펙트를 적용시킵니다.
- update 메서드를 추가합니다. 
## 📌 PR Point

- 쉬머링 이펙트 사용시, 스택뷰에 어레인지된 서브뷰에 대해서 재귀적 탐색이 정상적으로 동작하지 않는 현상이 발생하였고, 스택뷰를 없애고 시도해보니 정상동작하는 것을 확인했습니다.
- 그래서 기존의 스택뷰를 제거하고, 단일 레이블을 배치하여 UI를 표시합니다. (with 쉬머링 이펙트) 
- update 메서드를 추가합니다. 

### 실행화면
 
<img width="290" alt="스크린샷 2024-11-17 오후 9 06 55" src="https://github.com/user-attachments/assets/5a2b55f9-b067-446c-8ee9-b70f796b9934">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?