### PR TITLE
HTTPClientAPI 구현체 추가

### DIFF
--- a/ToDo-Garden/TDFoundation/Package.swift
+++ b/ToDo-Garden/TDFoundation/Package.swift
@@ -14,6 +14,10 @@ let package = Package(
     Product.library(
       name: "HTTPClientAPI",
       targets: ["HTTPClientAPI"]
+    ),
+    Product.library(
+      name: "HTTPClient",
+      targets: ["HTTPClient"]
     )
   ],
   dependencies: [
@@ -22,6 +26,10 @@ let package = Package(
   targets: [
     Target.target(
       name: "HTTPClientAPI"
+    ),
+    Target.target(
+      name: "HTTPClient",
+      dependencies: ["HTTPClientAPI"]
     ),
     Target.target(
       name: "TDFoundation",

--- a/ToDo-Garden/TDFoundation/Package.swift
+++ b/ToDo-Garden/TDFoundation/Package.swift
@@ -39,6 +39,13 @@ let package = Package(
           package: "ToDoGardenUI"
         )
       ]
+    ),
+    Target.testTarget(
+      name: "HTTPClientTests",
+      dependencies: [
+        "HTTPClientAPI",
+        "HTTPClient"
+      ]
     )
   ]
 )

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClient/HTTPClient.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClient/HTTPClient.swift
@@ -22,6 +22,20 @@ public struct HTTPClient: Sendable, HTTPClientAPI {
   }
   
   // swiftlint:disable function_body_length identifier_name
+  /// HTTP 작업을 수행합니다.
+  ///
+  /// 작업은 세 단계로 구성됩니다:
+  /// 1. 입력을 `HTTPRequest`로 변환합니다.
+  /// 2. 미들웨어로 감싼 `ClientTransport`를 호출하여 HTTP 호출을 수행합니다.
+  /// 3. 수신받은 `HTTPResposne`를 출력으로 변환합니다.
+  /// 발생한 모든 오류를 감싸고 적절한 컨텍스트(`HTTPClientErrorContext`)를 첨부합니다.
+  ///
+  /// - Parameters:
+  ///   - input: 작업별 입력 값입니다.
+  ///   - serializer: 제공된 입력 값에서 `HTTPRequest`를 새성합니다.
+  ///   - deserializer: 제공된 `HTTPResponse`를 기반으로 출력 값을 생성합니다.
+  /// - Returns: `deserializer`에서 생성된 출력 값을 반환합니다.
+  /// - Throws: HTTP 작업 프로세스의 어느 부분이든 실패하면 `HTTPClientErrorContext` 오류가 발생합니다.
   public func send<Input, Output>(
     input: Input,
     serializer: @Sendable (Input) throws -> HTTPRequest,

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClient/HTTPClient.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClient/HTTPClient.swift
@@ -23,4 +23,25 @@ extension HTTPClient {
       throw mapError(error)
     }
   }
+  
+  @Sendable private func makeError(
+    request: HTTPRequest? = nil,
+    response: HTTPResponse? = nil,
+    error: any Error
+  ) -> HTTPClientErrorContext {
+    let underlyingError: any Error
+    
+    if let clientError = error as? HTTPClientError,
+      let unwrappedUnderlyingError = clientError.underlyingError {
+      underlyingError = unwrappedUnderlyingError
+    } else {
+      underlyingError = error
+    }
+    
+    return HTTPClientErrorContext(
+      request: request,
+      response: response,
+      underlyingError: underlyingError
+    )
+  }
 }

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClient/HTTPClient.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClient/HTTPClient.swift
@@ -13,7 +13,7 @@ public struct HTTPClient: Sendable {
 }
 
 extension HTTPClient {
-  @Sendable func wrappingErrors<Result>(
+  @Sendable private func wrappingErrors<Result>(
     work: () async throws -> Result,
     mapError: (any Error) -> HTTPClientErrorContext
   ) async throws -> Result {

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClient/HTTPClient.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClient/HTTPClient.swift
@@ -9,7 +9,7 @@ import Foundation
 
 import HTTPClientAPI
 
-public struct HTTPClient: Sendable {
+public struct HTTPClient: Sendable, HTTPClientAPI {
   public var transport: any ClientTransport
   public var middlewares: [any ClientMiddleware]
   
@@ -20,6 +20,63 @@ public struct HTTPClient: Sendable {
     self.transport = transport
     self.middlewares = middlewares
   }
+  
+  // swiftlint:disable function_body_length identifier_name
+  public func send<Input, Output>(
+    input: Input,
+    serializer: @Sendable (Input) throws -> HTTPRequest,
+    deserializer: @Sendable (HTTPResponse) throws -> Output
+  ) async throws -> Output where Input: Sendable, Output: Sendable {
+    let request: HTTPRequest = try await self.wrappingErrors {
+      return try serializer(input)
+    } mapError: { _ in
+      return self.makeError(error: HTTPClientError.serializationError)
+    }
+    
+    var next: @Sendable (HTTPRequest) async throws -> HTTPResponse = { _request in
+      return try await self.wrappingErrors {
+        return try await self.transport.send(request: _request)
+      } mapError: { error in
+        return self.makeError(
+          request: request,
+          error: HTTPClientError.transportFailed(error)
+        )
+      }
+    }
+    
+    for middleWare in self.middlewares.reversed() {
+      let temp = next
+      next = { _request in
+        return try await self.wrappingErrors {
+          return try await middleWare.intercept(
+            request: _request,
+            next: temp
+          )
+        } mapError: { error in
+          return self.makeError(
+            request: request,
+            error: HTTPClientError.middlewareFailed(
+              middlewareType: type(of: middleWare),
+              error
+            )
+          )
+        }
+      }
+    }
+    
+    let response = try await next(request)
+    
+    return try await self.wrappingErrors {
+      return try deserializer(response)
+    } mapError: { _ in
+      return self.makeError(
+        request: request,
+        response: response,
+        error: HTTPClientError.deserializationError
+      )
+    }
+  }
+  // swiftlint:enable function_body_length identifier_name
 }
 
 extension HTTPClient {

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClient/HTTPClient.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClient/HTTPClient.swift
@@ -13,4 +13,14 @@ public struct HTTPClient: Sendable {
 }
 
 extension HTTPClient {
+  @Sendable func wrappingErrors<Result>(
+    work: () async throws -> Result,
+    mapError: (any Error) -> HTTPClientErrorContext
+  ) async throws -> Result {
+    do {
+      return try await work()
+    } catch {
+      throw mapError(error)
+    }
+  }
 }

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClient/HTTPClient.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClient/HTTPClient.swift
@@ -10,6 +10,16 @@ import Foundation
 import HTTPClientAPI
 
 public struct HTTPClient: Sendable {
+  public var transport: any ClientTransport
+  public var middlewares: [any ClientMiddleware]
+  
+  public init(
+    transport: any ClientTransport,
+    middlewares: [any ClientMiddleware]
+  ) {
+    self.transport = transport
+    self.middlewares = middlewares
+  }
 }
 
 extension HTTPClient {

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClient/HTTPClient.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClient/HTTPClient.swift
@@ -1,0 +1,16 @@
+//
+//  HTTPClient.swift
+//  TDFoundation
+//
+//  Created by Noah on 11/7/24.
+//
+
+import Foundation
+
+import HTTPClientAPI
+
+public struct HTTPClient: Sendable {
+}
+
+extension HTTPClient {
+}

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClient/URLSessionTransport.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClient/URLSessionTransport.swift
@@ -1,0 +1,55 @@
+//
+//  URLSessionTransport.swift
+//  TDFoundation
+//
+//  Created by Noah on 11/11/24.
+//
+
+import Foundation
+
+import HTTPClientAPI
+
+private final class URLRequestBuilder {
+  private let request: HTTPRequest
+  private var urlComponents: URLComponents?
+  typealias HTTPBody = Data
+  
+  init(request: HTTPRequest) {
+    self.request = request
+    self.urlComponents = URLComponents(
+      url: self.request.endPoint,
+      resolvingAgainstBaseURL: true
+    )
+  }
+  
+  /// 주어진 `HTTPRequest`를 기반으로 `URLRequest`와 요청 본문을 생성합니다.
+  /// - Returns: 생성된 `URLRequest`와 요청 본문을 튜플 형태로 반환합니다.
+  func build() throws -> (URLRequest, HTTPBody?) {
+    if self.request.queryItems.isEmpty == false {
+      self.urlComponents?.queryItems = self.request.queryItems.map {
+        URLQueryItem(name: $0.key, value: String(describing: $0.value))
+      }
+    }
+    
+    return try self.makeURLRequest()
+  }
+}
+
+extension URLRequestBuilder {
+  private func makeURLRequest() throws -> (URLRequest, HTTPBody?) {
+    guard let url = self.urlComponents?.url
+    else {
+      throw HTTPClientError.badURL(
+        self.urlComponents?.url?.absoluteString ?? self.request.endPoint.absoluteString
+      )
+    }
+    
+    var urlRequest = URLRequest(url: url)
+    self.request.header.forEach {
+      urlRequest.setValue($0.value, forHTTPHeaderField: $0.key)
+    }
+    urlRequest.httpMethod = self.request.method.rawValue
+    
+    return (urlRequest, request.body)
+  }
+}

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClient/URLSessionTransport.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClient/URLSessionTransport.swift
@@ -9,6 +9,53 @@ import Foundation
 
 import HTTPClientAPI
 
+public struct URLSessionTransport: Sendable, ClientTransport {
+  private let urlSession: URLSession
+  
+  public init(urlSession: URLSession) {
+    self.urlSession = urlSession
+  }
+  
+  /// HTTPRequest를 보내고 결과로 받은 HTTP 응답을 반환합니다.
+  ///
+  /// - Parameter request: `HTTPRequest`
+  /// - Returns: 통신의 결과로 `HTTPResponse`를 반환합니다.
+  /// - Throws: HTTP 요청 수행 중 오류가 발생한 경우 오류를 throw 합니다.
+  public func send(request: HTTPRequest) async throws -> HTTPResponse {
+    let (urlRequest, httpBody) = try URLRequestBuilder(request: request).build()
+    let (data, response): (Data, URLResponse)
+    
+    try Task.checkCancellation()
+    if let httpBody {
+      (data, response) = try await self.urlSession.upload(for: urlRequest, from: httpBody)
+    } else {
+      (data, response) = try await self.urlSession.data(for: urlRequest)
+    }
+    try Task.checkCancellation()
+    
+    guard let httpResponse = response as? HTTPURLResponse
+    else {
+      throw HTTPClientError.notHTTPResponse(response)
+    }
+    
+    var responseHeader: [String: String] = [:]
+    
+    for (headerKey, headerValue) in httpResponse.allHeaderFields {
+      guard let key = headerKey as? String,
+        let value = headerValue as? String
+      else { continue }
+      
+      responseHeader[key] = value
+    }
+    
+    return HTTPResponse(
+      statusCode: httpResponse.statusCode,
+      header: responseHeader,
+      body: data
+    )
+  }
+}
+
 private final class URLRequestBuilder {
   private let request: HTTPRequest
   private var urlComponents: URLComponents?

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPClientError.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPClientError.swift
@@ -18,7 +18,14 @@ public enum HTTPClientError: Error, Sendable {
   
   public var underlyingError: (any Error)? {
     switch self {
-    case HTTPClientError.transportFailed(let error), HTTPClientError.middlewareFailed(_, let error): return error
+    case HTTPClientError.transportFailed(let error):
+      return error
+    case HTTPClientError.middlewareFailed(_, let error):
+      if let error = error as? HTTPClientErrorContext {
+        return error.underlyingError
+      }
+      
+      return error
     default: return nil
     }
   }

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPRequest.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPRequest.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// HTTP 요청 정보를 표현하는 HTTPRequest 구조체입니다.
 /// HTTP request method, end point url, 요청 헤더, 쿼리 파라미터, 요청 본문을 가질 수 있습니다.
-public struct HTTPRequest: Sendable {
+public struct HTTPRequest: Sendable, Equatable {
   public let method: HTTPMethod
   public let endPoint: URL
   public let header: [String: String]

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPRequest.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPRequest.swift
@@ -19,9 +19,9 @@ public struct HTTPRequest: Sendable, Equatable {
   public init(
     method: HTTPMethod,
     endPoint: URL,
-    header: [String: String],
-    queryItems: [String: String],
-    body: Data?
+    header: [String: String] = [:],
+    queryItems: [String: String] = [:],
+    body: Data? = nil
   ) {
     self.method = method
     self.endPoint = endPoint

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPResponse.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPResponse.swift
@@ -16,8 +16,8 @@ public struct HTTPResponse: Sendable {
   
   public init(
     statusCode: Int,
-    header: [String: String],
-    body: Data?
+    header: [String: String] = [:],
+    body: Data? = nil
   ) {
     self.statusCode = statusCode
     self.header = header

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPResponse.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPResponse.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// HTTP 응답을 표현하는 구조체입니다.
 /// 상태코드, 응답 헤더, 본문을 가질 수 있습니다.
-public struct HTTPResponse: Sendable {
+public struct HTTPResponse: Sendable, Equatable {
   public let statusCode: Int
   public let header: [String: String]
   public let body: Data?

--- a/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/HTTPClientTests.swift
+++ b/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/HTTPClientTests.swift
@@ -115,6 +115,55 @@ struct HTTPClientTests {
       )
     }
   }
+  
+  @Test("middleware error throw test")
+  private func middlewareErrorThrowTest() async throws {
+    // Given
+    let givenURL = try #require(URL(string: "test url"))
+    let expectedRequest: HTTPRequest = HTTPRequest(
+      method: HTTPMethod.get,
+      endPoint: givenURL,
+      header: [:],
+      queryItems: [:],
+      body: nil
+    )
+    let expectedError = HTTPClientErrorContext(
+      request: expectedRequest,
+      underlyingError: self.middlewareMock.error
+    )
+    self.middlewareMock.isThrowError = true
+    
+    // Then
+    await #expect(
+      throws: expectedError,
+      "기대하는 에러와 일치하지 않습니다."
+    ) {
+      // When
+      try await self.sut.send(
+        input: Void(),
+        serializer: { _ in
+          return expectedRequest
+        },
+        deserializer: { _ in
+          return Void()
+        }
+      )
+    }
+  }
+}
+
+extension HTTPClientErrorContext: Equatable {
+  /// test를 위한 구현입니다.
+  public static func == (
+    lhs: HTTPClientErrorContext,
+    rhs: HTTPClientErrorContext
+  ) -> Bool {
+    let request = lhs.request == lhs.request
+    let response = lhs.response == rhs.response
+    let underlyingError = (lhs.underlyingError as NSError) == (rhs.underlyingError as NSError)
+    
+    return request && response && underlyingError
+  }
 }
 
 // swiftlint:enable function_body_length

--- a/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/HTTPClientTests.swift
+++ b/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/HTTPClientTests.swift
@@ -53,6 +53,31 @@ struct HTTPClientTests {
     #expect(self.middlewareMock.isIntercepterCalled)
     #expect(self.middlewareMock.interceptedRequest == expectedInterceptedRequest)
   }
+  
+  @Test("serializer error throw test")
+  private func serializerErrorThrowTest() async throws {
+    // Given
+    let expectedError = HTTPClientErrorContext(
+      underlyingError: HTTPClientError.serializationError
+    )
+    
+    // Then
+    await #expect(
+      throws: expectedError,
+      "serialization error를 throw 해야합니다."
+    ) {
+      // when
+      try await self.sut.send(
+        input: Void(),
+        serializer: { _ in
+          throw NSError(domain: "Error thrown by the serializer", code: 99999)
+        },
+        deserializer: { _ in
+          return Void()
+        }
+      )
+    }
+  }
 }
 
 // swiftlint:enable function_body_length

--- a/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/HTTPClientTests.swift
+++ b/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/HTTPClientTests.swift
@@ -4,5 +4,55 @@
 //
 //  Created by Noah on 11/13/24.
 //
+// swiftlint:disable function_body_length
 
 import Foundation
+import Testing
+
+import HTTPClient
+import HTTPClientAPI
+
+struct HTTPClientTests {
+  private let sut: HTTPClient
+  private let transportMock: ClientTransportMock
+  private let middlewareMock: ClientMiddlewareMock
+  
+  init() {
+    self.transportMock = ClientTransportMock()
+    self.middlewareMock = ClientMiddlewareMock()
+    self.sut = HTTPClient(
+      transport: self.transportMock,
+      middlewares: [self.middlewareMock]
+    )
+  }
+  
+  @Test("is middleware intercepting request")
+  private func middlewareInterceptRequest() async throws {
+    // Given
+    let givenURL = try #require(URL(string: "test url"))
+    let expectedInterceptedRequest: HTTPRequest = HTTPRequest(
+      method: HTTPMethod.get,
+      endPoint: givenURL,
+      header: [:],
+      queryItems: [:],
+      body: nil
+    )
+    
+    // When
+    try await self.sut.send(
+      input: Void(),
+      serializer: { _ in
+        return expectedInterceptedRequest
+      },
+      deserializer: { _ in
+        return
+      }
+    )
+    
+    // Then
+    #expect(self.middlewareMock.isIntercepterCalled)
+    #expect(self.middlewareMock.interceptedRequest == expectedInterceptedRequest)
+  }
+}
+
+// swiftlint:enable function_body_length

--- a/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/HTTPClientTests.swift
+++ b/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/HTTPClientTests.swift
@@ -1,0 +1,8 @@
+//
+//  HTTPClientTests.swift
+//  TDFoundation
+//
+//  Created by Noah on 11/13/24.
+//
+
+import Foundation

--- a/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/HTTPClientTests.swift
+++ b/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/HTTPClientTests.swift
@@ -78,6 +78,43 @@ struct HTTPClientTests {
       )
     }
   }
+  
+  @Test("deserializer error throw test")
+  private func deserializerErrorThrowTest() async throws {
+    // Given
+    let givenURL = try #require(URL(string: "test url"))
+    let expectedRequest: HTTPRequest = HTTPRequest(
+      method: HTTPMethod.get,
+      endPoint: givenURL,
+      header: [:],
+      queryItems: [:],
+      body: nil
+    )
+    let expectedResponse: HTTPResponse = HTTPResponse(statusCode: 200)
+    self.transportMock.expectedResponse = expectedResponse
+    let expectedError = HTTPClientErrorContext(
+      request: expectedRequest,
+      response: expectedResponse,
+      underlyingError: HTTPClientError.deserializationError
+    )
+    
+    // Then
+    await #expect(
+      throws: expectedError,
+      "deserialization error를 throw 해야합니다."
+    ) {
+      // when
+      try await self.sut.send(
+        input: Void(),
+        serializer: { _ in
+          return expectedRequest
+        },
+        deserializer: { _ in
+          throw NSError(domain: "Error thrown by the deserializer", code: 99999)
+        }
+      )
+    }
+  }
 }
 
 // swiftlint:enable function_body_length

--- a/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/HTTPClientTests.swift
+++ b/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/HTTPClientTests.swift
@@ -150,6 +150,41 @@ struct HTTPClientTests {
       )
     }
   }
+  
+  @Test("client transport error throw test")
+  private func clientTransportErrorThrowTest() async throws {
+    // Given
+    let givenURL = try #require(URL(string: "test url"))
+    let expectedRequest: HTTPRequest = HTTPRequest(
+      method: HTTPMethod.get,
+      endPoint: givenURL,
+      header: [:],
+      queryItems: [:],
+      body: nil
+    )
+    let expectedError = HTTPClientErrorContext(
+      request: expectedRequest,
+      underlyingError: self.transportMock.error
+    )
+    self.transportMock.isThrowError = true
+    
+    // Then
+    await #expect(
+      throws: expectedError,
+      "기대하는 에러와 일치하지 않습니다."
+    ) {
+      // When
+      try await self.sut.send(
+        input: Void(),
+        serializer: { _ in
+          return expectedRequest
+        },
+        deserializer: { _ in
+          return Void()
+        }
+      )
+    }
+  }
 }
 
 extension HTTPClientErrorContext: Equatable {

--- a/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/TestDouble/ClientMiddlewareMock.swift
+++ b/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/TestDouble/ClientMiddlewareMock.swift
@@ -1,0 +1,30 @@
+//
+//  ClientMiddlewareMock.swift
+//  TDFoundation
+//
+//  Created by Noah on 11/15/24.
+//
+
+import Foundation
+
+import HTTPClientAPI
+
+final class ClientMiddlewareMock: ClientMiddleware {
+  nonisolated(unsafe) var isIntercepterCalled: Bool = false
+  nonisolated(unsafe) var interceptedRequest: HTTPRequest?
+  nonisolated(unsafe) var isThrowError: Bool = false
+  let error = NSError(domain: "Error thrown by the client middleware mock", code: 99999)
+  
+  func intercept(
+    request: HTTPRequest,
+    next: (HTTPRequest) async throws -> HTTPResponse
+  ) async throws -> HTTPResponse {
+    guard isThrowError == false
+    else { throw self.error }
+    
+    self.interceptedRequest = request
+    self.isIntercepterCalled = true
+    
+    return try await next(request)
+  }
+}

--- a/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/TestDouble/ClientTransportMock.swift
+++ b/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/TestDouble/ClientTransportMock.swift
@@ -1,0 +1,33 @@
+//
+//  ClientTransportMock.swift
+//  TDFoundation
+//
+//  Created by Noah on 11/15/24.
+//
+
+import Foundation
+
+import HTTPClientAPI
+
+final class ClientTransportMock: ClientTransport {
+  nonisolated(unsafe) var isThrowError: Bool = false
+  nonisolated(unsafe) var expectedResponse: HTTPResponse?
+  nonisolated(unsafe) var defaultResponse: HTTPResponse = HTTPResponse(
+    statusCode: 0,
+    header: [:],
+    body: nil
+  )
+  let error = NSError(domain: "Error thrown by the client transport mock", code: 99999)
+  
+  func send(request: HTTPRequest) async throws -> HTTPResponse {
+    guard isThrowError == false
+    else { throw self.error }
+  
+    guard let expectedResponse
+    else {
+      return self.defaultResponse
+    }
+    
+    return expectedResponse
+  }
+}

--- a/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/TestDouble/URLProtocolMock.swift
+++ b/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/TestDouble/URLProtocolMock.swift
@@ -1,0 +1,40 @@
+//
+//  URLProtocolMock.swift
+//  TDFoundation
+//
+//  Created by Noah on 11/18/24.
+//
+
+import Foundation
+import Testing
+
+final class URLProtocolMock: URLProtocol, @unchecked Sendable {
+  nonisolated(unsafe) static var requestHandler: (
+    @Sendable () throws -> (URLResponse, Data)
+  )?
+  
+  override class func canInit(with request: URLRequest) -> Bool {
+    return true
+  }
+  
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    return request
+  }
+  
+  override func startLoading() {
+    #expect(throws: Never.self) {
+      let requestHandler = try #require(Self.requestHandler)
+      let (expectedResponse, expectedResponseData) = try requestHandler()
+      self.client?.urlProtocol(
+        self,
+        didReceive: expectedResponse,
+        cacheStoragePolicy: URLCache.StoragePolicy.notAllowed
+      )
+      self.client?.urlProtocol(self, didLoad: expectedResponseData)
+      self.client?.urlProtocolDidFinishLoading(self)
+    }
+  }
+  
+  override func stopLoading() {
+  }
+}

--- a/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/TestDouble/URLProtocolMock.swift
+++ b/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/TestDouble/URLProtocolMock.swift
@@ -13,11 +13,11 @@ final class URLProtocolMock: URLProtocol, @unchecked Sendable {
     @Sendable () throws -> (URLResponse, Data)
   )?
   
-  override class func canInit(with request: URLRequest) -> Bool {
+  override static func canInit(with request: URLRequest) -> Bool {
     return true
   }
   
-  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest {
     return request
   }
   

--- a/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/URLSessionTransportTests.swift
+++ b/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/URLSessionTransportTests.swift
@@ -60,6 +60,49 @@ struct URLSessionTransportTests {
     // Then
     #expect(response == expectedResponse)
   }
+  
+  @Test("URLSession에서 HTTPURLResponse가 아닌 응답을 받았을 때 올바른 에러를 반환하는가")
+  private func notHTTPURLResponseReturned() async throws {
+    // Given
+    let testURL = try #require(URL(string: "test url"))
+    let request = HTTPRequest(
+      method: HTTPMethod.get,
+      endPoint: testURL
+    )
+    let expectedResponse = URLResponse()
+    let expectedError = HTTPClientError.notHTTPResponse(expectedResponse)
+    URLProtocolMock.requestHandler = {
+      return (expectedResponse, Data())
+    }
+    
+    // Then
+    await #expect(throws: expectedError) {
+      // When
+      _ = try await self.sut.send(request: request)
+    }
+  }
+}
+
+extension HTTPClientError: Equatable {
+  // test를 위한 구현입니다.
+  public static func == (
+    lhs: HTTPClientError,
+    rhs: HTTPClientError
+  ) -> Bool {
+    switch (lhs, rhs) {
+    case (
+      HTTPClientError.notHTTPResponse(let lhsResponse),
+      HTTPClientError.notHTTPResponse(let rhsResponse)
+    ):
+      return lhsResponse.url == rhsResponse.url
+      && lhsResponse.mimeType == rhsResponse.mimeType
+      && lhsResponse.expectedContentLength == rhsResponse.expectedContentLength
+      && lhsResponse.suggestedFilename == rhsResponse.suggestedFilename
+      && lhsResponse.textEncodingName == rhsResponse.textEncodingName
+    default:
+      return false
+    }
+  }
 }
 
 // swiftlint:enable function_body_length

--- a/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/URLSessionTransportTests.swift
+++ b/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/URLSessionTransportTests.swift
@@ -12,6 +12,7 @@ import Testing
 import HTTPClient
 import HTTPClientAPI
 
+@Suite(ParallelizationTrait.serialized)
 struct URLSessionTransportTests {
   private let sut: URLSessionTransport
   

--- a/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/URLSessionTransportTests.swift
+++ b/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/URLSessionTransportTests.swift
@@ -1,0 +1,64 @@
+//
+//  URLSessionTransportTests.swift
+//  TDFoundation
+//
+//  Created by Noah on 11/15/24.
+//
+// swiftlint:disable function_body_length
+
+import Foundation
+import Testing
+
+import HTTPClient
+import HTTPClientAPI
+
+struct URLSessionTransportTests {
+  private let sut: URLSessionTransport
+  
+  init() {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [URLProtocolMock.self]
+    self.sut = URLSessionTransport(urlSession: URLSession(configuration: configuration))
+  }
+  
+  @Test("URLSession에서 HTTPURLResponse를 수신받았을 때 올바른 HTTPResponse를 반환하는가")
+  private func returnCorrectHTTPResponse() async throws {
+    // Given
+    let testURL = try #require(URL(string: "test url"))
+    let queryItems = ["name": "noah"]
+    let request = HTTPRequest(
+      method: HTTPMethod.get,
+      endPoint: testURL,
+      header: ["test": "header"],
+      queryItems: queryItems
+    )
+    let expectedResponse = HTTPResponse(
+      statusCode: 200,
+      header: ["test": "header"],
+      body: Data()
+    )
+    var urlComponents = URLComponents(url: testURL, resolvingAgainstBaseURL: true)
+    urlComponents?.queryItems = [URLQueryItem(name: "name", value: "noah")]
+    let expectedURL = try #require(urlComponents?.url)
+    let expectedHTTPURLResponse = try #require(
+      HTTPURLResponse(
+        url: expectedURL,
+        statusCode: expectedResponse.statusCode,
+        httpVersion: nil,
+        headerFields: expectedResponse.header
+      )
+    )
+    let expectedResponseData = try #require(expectedResponse.body)
+    URLProtocolMock.requestHandler = {
+      return (expectedHTTPURLResponse, expectedResponseData)
+    }
+    
+    // When
+    let response = try await self.sut.send(request: request)
+    
+    // Then
+    #expect(response == expectedResponse)
+  }
+}
+
+// swiftlint:enable function_body_length

--- a/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/URLSessionTransportTests.swift
+++ b/ToDo-Garden/TDFoundation/Tests/HTTPClientTests/URLSessionTransportTests.swift
@@ -81,6 +81,24 @@ struct URLSessionTransportTests {
       _ = try await self.sut.send(request: request)
     }
   }
+  
+  @Test("task cancel 시 sut에서 Cancellation Error를 반환하는 가")
+  private func throwCancellationError() async throws {
+    // Given
+    let testURL = try #require(URL(string: "test url"))
+    let request = HTTPRequest(
+      method: HTTPMethod.get,
+      endPoint: testURL
+    )
+    let task = Task {
+      await #expect(throws: CancellationError.self) {
+        let response = try await self.sut.send(request: request)
+        return response
+      }
+    }
+    task.cancel()
+    await task.value
+  }
 }
 
 extension HTTPClientError: Equatable {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #637 
## 🎉 변경 사항
- [x] HTTPClient 라이브러리 추가
- [x] HTTPClient 구현
- [x] Middleware 구현
- [x] 통일된 에러 반환
- [x] HTTPClient 테스트 작성
- [x] URLSessionTransport 구현
- [x] URLSession과의 상호작용을 위한 URLProtocol mocking
- [x] URLSessionTransport 테스트 작성
## 📌 PR Point

### HTTPClient
HTTP 관련 요청과 응답을 처리할 수 있는 HTTPClient 구현체를 구현하였습니다.
HTTP 요청과 응답을 처리할 수 있는 함수의 시그니처는 아래와 같습니다.

```swift
public func send<Input, Output>(
    input: Input,
    serializer: @Sendable (Input) throws -> HTTPRequest,
    deserializer: @Sendable (HTTPResponse) throws -> Output
)
```
HTTP 작업 요청 수행은 총 3단계로 이루어집니다.
1. 입력을 `HTTPRequest`로 변환합니다.
2. 미들웨어로 감싼 `ClientTransport`를 호출하여 HTTP 호출을 수행합니다.
3. 수신받은 `HTTPResponse`를 출력으로 변환합니다.

미들웨어: HTTP 요청 전송 전에 요청을 읽고 수정하거나, 전송 후에 응답을 읽고 수정할 수 있도록 하는 역할을 수행합니다.
(예: Authorization header 추가 etc)

HTTP 요청 수행 중 오류가 발생한 경우, 요청 당시의 request, response와 함께 오류의 원인을 포함하는`HTTPClientErrorContext`로 감싸 throw 하도록 하여 오류의 원인을 쉽게 파악할 수 있도록 하였습니다.

### URLSessionTransport
HTTPRequest를 보내고 결과로 받은 HTTP 응답을 반환하는 프로토콜을 URLSession을 이용해 구현한 구현체입니다.

## 🧪 테스트
### HTTPClientTests
1. 미들웨어가 보낸 요청을 잘 intercept 하는지에 대한 테스트를 작성하였습니다.
2. serializer에서 에러가 발생할 경우 올바른 오류를 반환하는지에 대한 테스트를 작성하였습니다.
3. deserializer에서 에러가 발생할 경우 올바른 오류를 반환하는지에 대한 테스트를 작성하였습니다.
4. client transport에서 에러가 발생할 경우 올바른 오류를 반환하는지에 대한 테스트를 작성하였습니다.

### URLSessionTransportTests
URLSession과의 상호작용을 올바르게 하는지에 대한 테스트를 작성하기 위해 URLProtocol을 mocking하여 테스트를 진행하였습니다.

1. URLSession에서 HTTPURLResponse를 수신받았을 때 HTTPResponse를 올바르게 반환하는지에 대한 테스트를 작성하였습니다.
2. HTTPURLResponse가 아닌 응답을 받았을 때 올바른 에러를 반환하는지에 대한 테스트를 작성하였습니다.
  - URLSession에서 URLProtocol에 제공한 URLResponse가 제공한 URLRespnose가 아닌 URLSession 내부적으로 변환된 새로운 인스턴스를 반환하여 Equatable 채택 시 인스턴스의 동일성이 아닌 속성의 구조적 동등성을 비교하도록 하였습니다.
3. URLSessionTransport를 실행하는 상위 task가 cancel 되었을 경우, URLSessionTransport에서 Cancellation Error를 반환하는지에 대한 테스트를 작성하였습니다.

### ✅ 테스트 결과

|테스트 결과|
|---|
|<img width="683" alt="Screenshot 2024-11-18 at 1 03 03 PM" src="https://github.com/user-attachments/assets/68c97331-c1c8-4806-a8b2-0f7dda94399d">|



🎉 주요 테스트 커버리지는 아래와 같습니다.

HTTPClient: `100%`
URLSessionTransport: `93.3%`

평균: `96.65%`




## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?