### PR TITLE
my stats view 추가 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/LongestRecordStackView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/LongestRecordStackView.swift
@@ -14,19 +14,19 @@ final class LongestRecordStackView: UIStackView {
   private let rightView: LongestRecordView
   private let bubbleLabel: BubbleLabel
   
-  private let constants = Constant.LongestRecordStackView.self
+  private typealias Constants = Constant.LongestRecordStackView
   
   init() {
     self.leftView = LongestRecordView(
       style: LongestRecordView.Configuration.pomo,
-      title: self.constants.StringLiteral.leftViewTitle,
+      title: Constants.StringLiteral.leftViewTitle,
       groupName: "",
       recordCount: Int.zero,
       date: [Date.now]
     )
     self.rightView = LongestRecordView(
       style: LongestRecordView.Configuration.dateRange,
-      title: self.constants.StringLiteral.rightViewTitle,
+      title: Constants.StringLiteral.rightViewTitle,
       groupName: nil,
       recordCount: Int.zero,
       date: [Date.now, Date.now]
@@ -35,7 +35,7 @@ final class LongestRecordStackView: UIStackView {
     self.bubbleLabel = BubbleLabel(
       tailPosition: BubbleLabel.TailPosition.left,
       iconImage: UIImage.leafImage,
-      text: self.constants.StringLiteral.bubbleLabelTitle
+      text: Constants.StringLiteral.bubbleLabelTitle
     )
     super.init(frame: CGRect.zero)
     self.setupAppearance()
@@ -51,7 +51,7 @@ final class LongestRecordStackView: UIStackView {
   private func setupAppearance() {
     self.axis = NSLayoutConstraint.Axis.horizontal
     self.distribution = UIStackView.Distribution.fillEqually
-    self.spacing = self.constants.Layout.spacing
+    self.spacing = Constants.Layout.spacing
     self.alignment = UIStackView.Alignment.fill
     self.addArrangedSubview(self.leftView)
     self.addArrangedSubview(self.rightView)
@@ -72,11 +72,11 @@ final class LongestRecordStackView: UIStackView {
       [
         self.bubbleLabel.topAnchor.constraint(
           equalTo: infoButton.bottomAnchor,
-          constant: self.constants.Layout.topMargin
+          constant: Constants.Layout.topMargin
         ),
         self.bubbleLabel.leadingAnchor.constraint(
           equalTo: infoButton.leadingAnchor,
-          constant: self.constants.Layout.leading
+          constant: Constants.Layout.leading
         )
       ]
     )
@@ -100,14 +100,14 @@ final class LongestRecordStackView: UIStackView {
   
   private func showBubbleLabel() {
     self.bubbleLabel.isHidden = false
-    UIView.animate(withDuration: self.constants.Animation.duration) {
+    UIView.animate(withDuration: Constants.Animation.duration) {
       self.bubbleLabel.alpha = 1
     }
   }
   
   private func hideBubbleLabel() {
     UIView.animate(
-      withDuration: self.constants.Animation.duration,
+      withDuration: Constants.Animation.duration,
       animations: {
         self.bubbleLabel.alpha = 0
       },

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/LongestRecordStackView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/LongestRecordStackView.swift
@@ -1,0 +1,133 @@
+//
+//  LongestRecordStackView.swift
+//
+//
+//  Created by SONG on 11/18/24.
+//
+
+import UIKit
+
+import ToDoGardenUIComponent
+
+final class LongestRecordStackView: UIStackView {
+  private let leftView: LongestRecordView
+  private let rightView: LongestRecordView
+  private let bubbleLabel: BubbleLabel
+  
+  private let constants = Constant.LongestRecordStackView.self
+  
+  init() {
+    self.leftView = LongestRecordView(
+      style: LongestRecordView.Configuration.pomo,
+      title: self.constants.StringLiteral.leftViewTitle,
+      groupName: "",
+      recordCount: Int.zero,
+      date: [Date.now]
+    )
+    self.rightView = LongestRecordView(
+      style: LongestRecordView.Configuration.dateRange,
+      title: self.constants.StringLiteral.rightViewTitle,
+      groupName: nil,
+      recordCount: Int.zero,
+      date: [Date.now, Date.now]
+    )
+    
+    self.bubbleLabel = BubbleLabel(
+      tailPosition: BubbleLabel.TailPosition.left,
+      iconImage: UIImage.leafImage,
+      text: self.constants.StringLiteral.bubbleLabelTitle
+    )
+    super.init(frame: CGRect.zero)
+    self.setupAppearance()
+    self.setupBubbleLabel()
+    self.setupButtonAction()
+  }
+  
+  @available(*, unavailable)
+  required init(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupAppearance() {
+    self.axis = NSLayoutConstraint.Axis.horizontal
+    self.distribution = UIStackView.Distribution.fillEqually
+    self.spacing = self.constants.Layout.spacing
+    self.alignment = UIStackView.Alignment.fill
+    self.addArrangedSubview(self.leftView)
+    self.addArrangedSubview(self.rightView)
+  }
+  
+  private func setupBubbleLabel() {
+    guard let infoButton = self.leftView.informationButton else {
+      return
+    }
+    
+    self.addSubview(self.bubbleLabel)
+    self.bubbleLabel.usingAutolayout()
+    self.bubbleLabel.alpha = CGFloat.zero
+    self.bubbleLabel.isHidden = true
+    self.bubbleLabel.delegate = self
+    
+    NSLayoutConstraint.activate(
+      [
+        self.bubbleLabel.topAnchor.constraint(
+          equalTo: infoButton.bottomAnchor,
+          constant: self.constants.Layout.topMargin
+        ),
+        self.bubbleLabel.leadingAnchor.constraint(
+          equalTo: infoButton.leadingAnchor,
+          constant: self.constants.Layout.leading
+        )
+      ]
+    )
+  }
+  
+  private func setupButtonAction() {
+    self.leftView.informationButton?.addAction(
+      UIAction { [weak self] _ in
+        self?.didInfoButtonTap()
+      },
+      for: UIControl.Event.touchUpInside)
+  }
+  
+  private func didInfoButtonTap() {
+    if bubbleLabel.isHidden {
+      self.showBubbleLabel()
+    } else {
+      self.hideBubbleLabel()
+    }
+  }
+  
+  private func showBubbleLabel() {
+    self.bubbleLabel.isHidden = false
+    UIView.animate(withDuration: self.constants.Animation.duration) {
+      self.bubbleLabel.alpha = 1
+    }
+  }
+  
+  private func hideBubbleLabel() {
+    UIView.animate(
+      withDuration: self.constants.Animation.duration,
+      animations: {
+        self.bubbleLabel.alpha = 0
+      },
+      completion: { _ in
+        self.bubbleLabel.isHidden = true
+      }
+    )
+  }
+  
+  func updateLeftView(groupName: String, recordCount: Int, dateRange: [Date]) {
+    self.leftView.update(groupName: groupName, recordCount: recordCount, dateRange: dateRange)
+  }
+  
+  func updateRightView(groupName: String? = nil, recordCount: Int, dateRange: [Date]) {
+    self.rightView.update(groupName: groupName, recordCount: recordCount, dateRange: dateRange)
+  }
+}
+
+extension LongestRecordStackView: BubbleLabelDelegate {
+  func didTap() {
+    self.hideBubbleLabel()
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsPeriodicSummaryView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsPeriodicSummaryView.swift
@@ -1,0 +1,104 @@
+//
+//  MyStatsPeriodicSummaryView.swift
+//  
+//
+//  Created by SONG on 11/18/24.
+//
+
+import UIKit
+
+import ToDoGardenUIComponent
+
+final class MyStatsPeriodicSummaryView: UIView {
+  private let titleLabel: UILabel
+  private let segmentedControl: PeriodSegmentedControl
+  private let summaryView: MyStatsSummaryView
+  
+  private let constants = Constant.MyStatsPeriodicSummaryView.self
+  
+  init() {
+    self.titleLabel = UILabel()
+    self.segmentedControl = PeriodSegmentedControl()
+    self.summaryView = MyStatsSummaryView(
+      leftTitle: self.constants.StringLiteral.leftViewTitle,
+      leftDescription: self.constants.StringLiteral.leftViewDesc,
+      rightTitle: self.constants.StringLiteral.rightViewTitle,
+      rightDescription: self.constants.StringLiteral.rightViewDesc
+    )
+    super.init(frame: CGRect.zero)
+    self.setupView()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  public func updateSummaryView(
+    leftTitle: String? = nil,
+    leftDescription: String,
+    rightTitle: String? = nil,
+    rightDescription: String
+  ) {
+    self.summaryView.updateLeftView(title: leftTitle, description: leftDescription)
+    self.summaryView.updateRightView(title: rightTitle, description: rightDescription)
+  }
+  
+  private func setupView() {
+    self.setupTitleLabel()
+    self.setupSegmentedControl()
+    self.setupSummaryView()
+  }
+  
+  private func setupTitleLabel() {
+    let title = self.constants.StringLiteral.headerTitle
+    self.titleLabel.attributedText = title.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardHeadBold,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    )
+    
+    self.addSubview(self.titleLabel)
+    self.titleLabel.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        self.titleLabel.topAnchor.constraint(equalTo: self.topAnchor),
+        self.titleLabel.leadingAnchor.constraint(
+          equalTo: self.leadingAnchor,
+          constant: self.constants.Layout.horizontalMargin
+        )
+      ]
+    )
+  }
+  
+  private func setupSegmentedControl() {
+    self.addSubview(self.segmentedControl)
+    self.segmentedControl.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        self.segmentedControl.centerYAnchor.constraint(equalTo: self.titleLabel.centerYAnchor),
+        self.segmentedControl.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: -self.constants.Layout.horizontalMargin
+        )
+      ]
+    )
+  }
+  
+  private func setupSummaryView() {
+    self.addSubview(self.summaryView)
+    self.summaryView.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        self.summaryView.topAnchor.constraint(
+          equalTo: self.titleLabel.bottomAnchor,
+          constant: self.constants.Layout.topMargin
+        ),
+        self.summaryView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.summaryView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        self.summaryView.heightAnchor.constraint(equalToConstant: self.constants.Layout.summaryViewHeight)
+      ]
+    )
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsPeriodicSummaryView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsPeriodicSummaryView.swift
@@ -14,16 +14,16 @@ final class MyStatsPeriodicSummaryView: UIView {
   private let segmentedControl: PeriodSegmentedControl
   private let summaryView: MyStatsSummaryView
   
-  private let constants = Constant.MyStatsPeriodicSummaryView.self
+  private typealias Constants = Constant.MyStatsPeriodicSummaryView
   
   init() {
     self.titleLabel = UILabel()
     self.segmentedControl = PeriodSegmentedControl()
     self.summaryView = MyStatsSummaryView(
-      leftTitle: self.constants.StringLiteral.leftViewTitle,
-      leftDescription: self.constants.StringLiteral.leftViewDesc,
-      rightTitle: self.constants.StringLiteral.rightViewTitle,
-      rightDescription: self.constants.StringLiteral.rightViewDesc
+      leftTitle: Constants.StringLiteral.leftViewTitle,
+      leftDescription: Constants.StringLiteral.leftViewDesc,
+      rightTitle: Constants.StringLiteral.rightViewTitle,
+      rightDescription: Constants.StringLiteral.rightViewDesc
     )
     super.init(frame: CGRect.zero)
     self.setupView()
@@ -51,7 +51,7 @@ final class MyStatsPeriodicSummaryView: UIView {
   }
   
   private func setupTitleLabel() {
-    let title = self.constants.StringLiteral.headerTitle
+    let title = Constants.StringLiteral.headerTitle
     self.titleLabel.attributedText = title.applyTextAttributes(
       attributes: [
         NSAttributedString.Key.font: UIFont.pretendardHeadBold,
@@ -66,7 +66,7 @@ final class MyStatsPeriodicSummaryView: UIView {
         self.titleLabel.topAnchor.constraint(equalTo: self.topAnchor),
         self.titleLabel.leadingAnchor.constraint(
           equalTo: self.leadingAnchor,
-          constant: self.constants.Layout.horizontalMargin
+          constant: Constants.Layout.horizontalMargin
         )
       ]
     )
@@ -80,7 +80,7 @@ final class MyStatsPeriodicSummaryView: UIView {
         self.segmentedControl.centerYAnchor.constraint(equalTo: self.titleLabel.centerYAnchor),
         self.segmentedControl.trailingAnchor.constraint(
           equalTo: self.trailingAnchor,
-          constant: -self.constants.Layout.horizontalMargin
+          constant: -Constants.Layout.horizontalMargin
         )
       ]
     )
@@ -93,11 +93,11 @@ final class MyStatsPeriodicSummaryView: UIView {
       [
         self.summaryView.topAnchor.constraint(
           equalTo: self.titleLabel.bottomAnchor,
-          constant: self.constants.Layout.topMargin
+          constant: Constants.Layout.topMargin
         ),
         self.summaryView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
         self.summaryView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-        self.summaryView.heightAnchor.constraint(equalToConstant: self.constants.Layout.summaryViewHeight)
+        self.summaryView.heightAnchor.constraint(equalToConstant: Constants.Layout.summaryViewHeight)
       ]
     )
   }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsSceneConstants.swift
@@ -1,0 +1,59 @@
+//
+//  File.swift
+//  
+//
+//  Created by SONG on 11/18/24.
+//
+
+import Foundation
+
+enum Constant {
+  enum Layout {
+    static let topMargin: CGFloat = 15.0
+    static let horizontalMargin: CGFloat = 10.0
+    static let gardenViewHeight: CGFloat = 120.0
+    static let longestRecordsViewHeight: CGFloat = 125.0
+    static let summaryViewViewHeight: CGFloat = 150.0
+  }
+  
+  enum StringLiteral {
+    static let suffix: String = " 님,"
+    static let nextLine: String = "\n"
+    static let keepingDesctription: String = "일 연속으로 기록 유지중이에요"
+  }
+  
+  enum LongestRecordStackView {
+    enum Layout {
+      static let topMargin: CGFloat = 5.0
+      static let spacing: CGFloat = 10.0
+      static let leading: CGFloat = -25
+    }
+    
+    enum StringLiteral {
+      static let leftViewTitle: String = "최장 집중 기록"
+      static let rightViewTitle: String = "최장 연속 기록"
+      static let bubbleLabelTitle: String = "집중시간+휴식시간=1뽀모"
+    }
+    
+    enum Animation {
+      static let duration: CGFloat = 0.3
+    }
+  }
+  
+  enum MyStatsPeriodicSummaryView {
+    enum Layout {
+      static let horizontalMargin: CGFloat = 5.0
+      static let topMargin: CGFloat = 17.0
+      static let summaryViewHeight: CGFloat = 103.0
+    }
+    
+    enum StringLiteral {
+      static let leftViewTitle: String = "평균 집중 시간"
+      static let leftViewDesc: String = "0시간 0분"
+      static let rightViewTitle: String = "평균 완료 수"
+      static let rightViewDesc: String = "0개 목표"
+      static let headerTitle: String = "요약"
+    }
+  }
+}
+

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsSceneConstants.swift
@@ -56,4 +56,3 @@ enum Constant {
     }
   }
 }
-

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
@@ -1,0 +1,210 @@
+//
+//  MyStatsView.swift
+//
+//
+//  Created by SONG on 11/17/24.
+//
+
+import UIKit
+
+import TDFoundationExtension
+import ToDoGardenUIComponent
+
+final class MyStatsView: UIView {
+  private let profileView: Styled.Row
+  private let gardenView: GardenView
+  private let longestRecordStackView: LongestRecordStackView
+  private let periodicSummaryView: MyStatsPeriodicSummaryView
+  
+  private let constants = Constant.Layout.self
+  
+  init() {
+    self.profileView = Styled.Row(configuration: .profile(
+      .init(
+        style: .myStats,
+        title: "asdasd\nasdasdasd",
+        description: "asdasd"
+        )
+      )
+    )
+    self.gardenView = GardenView()
+    self.longestRecordStackView = LongestRecordStackView()
+    self.periodicSummaryView = MyStatsPeriodicSummaryView()
+    super.init(frame: CGRect.zero)
+    self.setupView()
+    self.backgroundColor = .toDoGardenLightRed
+  }
+  
+  @available(*, unavailable)
+  required init(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupView() {
+    self.setupProfileView()
+    self.setupGardenView()
+    self.setupLongestRecordsStackView()
+    self.setupPeriodicSummaryView()
+  }
+  
+  private func setupProfileView() {
+    self.profileView.usingAutolayout()
+    self.addSubview(self.profileView)
+    
+    NSLayoutConstraint.activate(
+      [
+        self.profileView.topAnchor.constraint(equalTo: self.topAnchor),
+        self.profileView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.profileView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+      ]
+    )
+  }
+  
+  private func setupGardenView() {
+    self.gardenView.usingAutolayout()
+    self.addSubview(self.gardenView)
+
+    NSLayoutConstraint.activate(
+      [
+        self.gardenView.topAnchor.constraint(
+          equalTo: self.profileView.bottomAnchor,
+          constant: constants.topMargin
+        ),
+        self.gardenView.leadingAnchor.constraint(
+          equalTo: self.leadingAnchor,
+          constant: constants.horizontalMargin
+        ),
+        self.gardenView.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: -constants.horizontalMargin
+        ),
+        self.gardenView.heightAnchor.constraint(equalToConstant: constants.gardenViewHeight)
+      ]
+    )
+  }
+  
+  private func setupLongestRecordsStackView() {
+    self.longestRecordStackView.usingAutolayout()
+    self.addSubview(self.longestRecordStackView)
+
+    NSLayoutConstraint.activate(
+      [
+        self.longestRecordStackView.topAnchor.constraint(
+          equalTo: self.gardenView.bottomAnchor,
+          constant: self.constants.topMargin
+        ),
+        self.longestRecordStackView.leadingAnchor.constraint(
+          equalTo: self.leadingAnchor,
+          constant: self.constants.horizontalMargin
+        ),
+        self.longestRecordStackView.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: -self.constants.horizontalMargin
+        ),
+        self.longestRecordStackView.heightAnchor.constraint(
+          equalToConstant: self.constants.longestRecordsViewHeight
+        )
+      ]
+    )
+  }
+  
+  private func setupPeriodicSummaryView() {    
+    let dummyView = UIView()
+    dummyView.usingAutolayout()
+    self.addSubview(dummyView)
+    self.periodicSummaryView.usingAutolayout()
+    self.addSubview(self.periodicSummaryView)
+
+    NSLayoutConstraint.activate(
+      [
+        dummyView.topAnchor.constraint(equalTo: self.longestRecordStackView.bottomAnchor),
+        dummyView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+        
+        self.periodicSummaryView.centerYAnchor.constraint(equalTo: dummyView.centerYAnchor),
+        self.periodicSummaryView.leadingAnchor.constraint(
+          equalTo: self.leadingAnchor,
+          constant: self.constants.horizontalMargin
+        ),
+        self.periodicSummaryView.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: -self.constants.horizontalMargin
+        ),
+        self.periodicSummaryView.heightAnchor.constraint(
+          equalToConstant: self.constants.summaryViewViewHeight
+        )
+      ]
+    )
+  }
+}
+
+// MARK: Update
+extension MyStatsView {
+  func updateProfileView(userImage: UIImage, userName: String, dayCount: Int, dateRange: [Date]) {
+    let startDate = dateRange.first?.toStringDefaultFormat()
+    let endDate = dateRange.last?.toStringDefaultFormat()
+    
+    var dateRangeString: String
+    
+    if startDate == nil || endDate == nil || startDate == endDate {
+      dateRangeString = ""
+    } else {
+      dateRangeString = "\(startDate ?? "") ~ \(endDate ?? "")"
+    }
+    
+    self.profileView.configuration = .profile(
+      .init(
+        style: .myStats,
+        title: self.makeTitleString(userName: userName, dayCount: dayCount),
+        description: dateRangeString,
+        image: userImage
+      )
+    )
+  }
+  
+  func updateGardenView(pomodoroRecordCollection: PomodoroRecordCollection) {
+    self.gardenView.configure(with: pomodoroRecordCollection)
+  }
+  
+  func updateLeftRecordStackView(groupName: String, recordCount: Int, dateRange: [Date]) {
+    self.longestRecordStackView.updateLeftView(groupName: groupName, recordCount: recordCount, dateRange: dateRange)
+  }
+  
+  func updateRightRecordStackView(recordCount: Int, dateRange: [Date]) {
+    self.longestRecordStackView.updateRightView(recordCount: recordCount, dateRange: dateRange)
+  }
+  
+  func updatePeriodicSummaryView(
+    leftTitle: String? = nil,
+    leftDescription: String,
+    rightTitle: String? = nil,
+    rightDescription: String
+  ) {
+    self.periodicSummaryView.updateSummaryView(
+      leftTitle: leftTitle,
+      leftDescription: leftDescription,
+      rightTitle: rightTitle,
+      rightDescription: rightDescription
+    )
+  }
+  
+  private func makeTitleString(userName: String, dayCount: Int) -> String {
+    let fixedSuffix = Constant.StringLiteral.suffix
+    let fixedNextLine = Constant.StringLiteral.nextLine
+    let fixedSentence = Constant.StringLiteral.keepingDesctription
+    return "\(userName)\(fixedSuffix)\(fixedNextLine)\(dayCount)\(fixedSentence)"
+  }
+}
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let view = MyStatsView()
+
+  view.usingAutolayout()
+  NSLayoutConstraint.activate([
+    view.widthAnchor.constraint(equalToConstant: 380),
+    view.heightAnchor.constraint(equalToConstant: 700)
+  ])
+  return view
+}
+#endif

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
@@ -32,7 +32,7 @@ final class MyStatsView: UIView {
     self.periodicSummaryView = MyStatsPeriodicSummaryView()
     super.init(frame: CGRect.zero)
     self.setupView()
-    self.backgroundColor = .toDoGardenLightRed
+    self.backgroundColor = UIColor.white
   }
   
   @available(*, unavailable)


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #672 

## 🎉 변경 사항
- MyStatsView를 추가합니다. 

## 📌 PR Point

### MyStatsScene에 사용될 UI들을 조합한 한 판의 뷰입니다. 
<img width="222" alt="스크린샷 2024-11-18 오후 1 27 18" src="https://github.com/user-attachments/assets/4851ba7e-a686-4108-a76e-cdfb7a5211b9">

<img width="467" alt="스크린샷 2024-11-18 오후 1 41 33" src="https://github.com/user-attachments/assets/59242090-39a3-45d3-96f9-f086237bb7ce">

- (서브뷰들의 네이밍이 좀 조잡하네요 ... ^^ ㅋ)

-  Shimmer 이펙트를 사용할 때, 스택뷰보다 UIView를 이용하는게 편해서 UIView로 만들었습니다. 

### 다양한 디바이스에서 일관적인 UI를 표시합니다. 
<img width="398" alt="스크린샷 2024-11-18 오후 1 28 44" src="https://github.com/user-attachments/assets/0a7174d3-ad2f-474f-9dac-5dc349424171">

- MyStatsView 전체의 height에 따라`요약`레이블 상단의 여백이 늘었다 줄었다 함. 

### 피그마 디자인과 다른부분 수정예정입니다.
<img width="235" alt="스크린샷 2024-11-18 오후 1 29 00" src="https://github.com/user-attachments/assets/907f1d45-a045-4aa1-98c8-cd4a86ae45e6">

### update 메서드를 뚫어 놓았습니다. 

- 각 뷰객체에 대하여 외부에서 update 시킬 수 있습니다. 일단 가짜 데이터를 집어넣어 VC에 깔아놓고 Shimmer를 걸어놓은 뒤, 데이터 준비가 완료되면 update 메서드로 처리할 생각입니다. 

- 이미 만들어져 있는 컴포넌트들을 조합한 결과를 담은 PR이라 오토레이아웃 / 뷰 표시 관련 코드가 대부분입니다 !
 
## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?