### PR TITLE
add search row

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
@@ -223,10 +223,21 @@ extension Styled.Row {
     )
   )
   row4.backgroundColor = .lightGray
-
+  
+  let row5 = Styled.Row(
+    configuration: .profile(
+      .init(
+        style: .searchRow,
+        title: "SearchRow",
+        description: "@userID"
+      )
+    )
+  )
+  row5.backgroundColor = .white
+  
   let stack = UIVStackView(
     arrangedSubviews: [
-      row, row2, row3, row4
+      row, row2, row3, row4, row5
     ]
   )
 
@@ -235,6 +246,7 @@ extension Styled.Row {
   row3.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
   row4.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
   row4.heightAnchor.constraint(equalToConstant: 110).isActive = true
+  row5.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
   
   stack.alignment = .leading
   stack.backgroundColor = .green

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
@@ -101,9 +101,12 @@ extension Styled.Row.Configuration {
 extension Styled.Row.Configuration.ProfileModel {
   public enum Style {
     var axis: NSLayoutConstraint.Axis {
-      self == Self.shareRow || self == Self.searchRow
-      ? NSLayoutConstraint.Axis.horizontal
-      : NSLayoutConstraint.Axis.vertical
+      switch self {
+      case Self.shareRow, Self.searchRow:
+        return NSLayoutConstraint.Axis.horizontal
+      default:
+        return NSLayoutConstraint.Axis.vertical
+      }
     }
     
     var innerPadding: NSDirectionalEdgeInsets {
@@ -112,25 +115,27 @@ extension Styled.Row.Configuration.ProfileModel {
         return NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
       case Self.shareProfile:
         return NSDirectionalEdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 36)
-      case Self.shareRow:
-        return NSDirectionalEdgeInsets(top: 6, leading: 25, bottom: 6, trailing: 25)
-      case Self.myStats:
-        return NSDirectionalEdgeInsets(top: 6, leading: 25, bottom: 6, trailing: 25)
-      case Self.searchRow:
+      case Self.shareRow, Self.myStats, Self.searchRow:
         return NSDirectionalEdgeInsets(top: 6, leading: 25, bottom: 6, trailing: 25)
       }
     }
     
     var defaultImage: UIImage {
-      self == Self.shareRow || self == Self.searchRow
-      ? UIImage.defaultFriendProfileImage
-      : UIImage.defaultProfileImage
+      switch self {
+      case Self.shareRow, Self.searchRow:
+        return UIImage.defaultFriendProfileImage
+      default:
+        return UIImage.defaultProfileImage
+      }
     }
     
     var imageSize: CGSize {
-      self == Self.shareRow || self == Self.searchRow
-      ? CGSize(width: 36, height: 36)
-      : CGSize(width: 56, height: 56)
+      switch self {
+      case Self.shareRow, Self.searchRow:
+        return CGSize(width: 36, height: 36)
+      default:
+        return CGSize(width: 56, height: 56)
+      }
     }
     
     var profileImageTrailingPadding: CGFloat {
@@ -149,15 +154,21 @@ extension Styled.Row.Configuration.ProfileModel {
     }
     
     var titleFont: UIFont {
-      self == Self.shareRow || self == Self.searchRow
-      ? UIFont.pretendardBodySemiBold15
-      : UIFont.pretendardHeadBold
+      switch self {
+      case Self.shareRow, Self.searchRow:
+        return UIFont.pretendardBodySemiBold15
+      default:
+        return UIFont.pretendardHeadBold
+      }
     }
     
     var descriptionFont: UIFont {
-      self == Self.shareRow || self == Self.searchRow
-      ? UIFont.pretendardBodyMedium
-      : UIFont.pretendardDetailLight
+      switch self {
+      case Self.shareRow, Self.searchRow:
+        return UIFont.pretendardBodyMedium
+      default:
+        return UIFont.pretendardDetailLight
+      }
     }
     
     case setting

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
@@ -101,7 +101,7 @@ extension Styled.Row.Configuration {
 extension Styled.Row.Configuration.ProfileModel {
   public enum Style {
     var axis: NSLayoutConstraint.Axis {
-      self == Self.shareRow
+      self == Self.shareRow || self == Self.searchRow
       ? NSLayoutConstraint.Axis.horizontal
       : NSLayoutConstraint.Axis.vertical
     }
@@ -116,17 +116,19 @@ extension Styled.Row.Configuration.ProfileModel {
         return NSDirectionalEdgeInsets(top: 6, leading: 25, bottom: 6, trailing: 25)
       case Self.myStats:
         return NSDirectionalEdgeInsets(top: 6, leading: 25, bottom: 6, trailing: 25)
+      case Self.searchRow:
+        return NSDirectionalEdgeInsets(top: 6, leading: 25, bottom: 6, trailing: 25)
       }
     }
     
     var defaultImage: UIImage {
-      self == Self.shareRow
+      self == Self.shareRow || self == Self.searchRow
       ? UIImage.defaultFriendProfileImage
       : UIImage.defaultProfileImage
     }
     
     var imageSize: CGSize {
-      self == Self.shareRow
+      self == Self.shareRow || self == Self.searchRow
       ? CGSize(width: 36, height: 36)
       : CGSize(width: 56, height: 56)
     }
@@ -141,17 +143,19 @@ extension Styled.Row.Configuration.ProfileModel {
         return 6
       case Self.myStats:
         return 15
+      case Self.searchRow:
+        return 10
       }
     }
     
     var titleFont: UIFont {
-      self == Self.shareRow
+      self == Self.shareRow || self == Self.searchRow
       ? UIFont.pretendardBodySemiBold15
       : UIFont.pretendardHeadBold
     }
     
     var descriptionFont: UIFont {
-      self == Self.shareRow
+      self == Self.shareRow || self == Self.searchRow
       ? UIFont.pretendardBodyMedium
       : UIFont.pretendardDetailLight
     }
@@ -160,5 +164,6 @@ extension Styled.Row.Configuration.ProfileModel {
     case shareProfile
     case shareRow
     case myStats
+    case searchRow
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
@@ -19,7 +19,7 @@ extension Styled.Row {
     
     return stack
   }
-
+  
   // swiftlint:disable function_body_length
   private func buildProfileSubviews(model: Configuration.ProfileModel) -> [UIView] {
     let profileImageView = self.buildImageView(
@@ -41,7 +41,8 @@ extension Styled.Row {
       forwardImage
     ]
     
-    if model.style == Configuration.ProfileModel.Style.myStats {
+    if model.style == Configuration.ProfileModel.Style.myStats ||
+      model.style == Configuration.ProfileModel.Style.searchRow {
       subviews = [
         profileImageView,
         profileImageTrailingPadding,
@@ -59,16 +60,30 @@ extension Styled.Row {
   }
   
   private func buildInnerStack(model: Configuration.ProfileModel) -> UIStackView {
+    var descriptionLabel: UILabel
+    
     let titleLabel = self.buildTextLabel(
       text: model.title,
       font: model[style: \.titleFont],
       textColor: UIColor.toDoGardenGreenDark
     )
-    let descriptionLabel = self.buildTextLabel(
-      text: model.description,
-      font: model[style: \.descriptionFont],
-      textColor: UIColor.toDoGardenGreenDark
-    )
+    
+    switch model.style {
+    case .searchRow:
+      descriptionLabel = self.buildTextLabel(
+        text: model.description,
+        font: model[style: \.descriptionFont],
+        textColor: UIColor.gray
+      )
+      
+    default:
+      descriptionLabel = self.buildTextLabel(
+        text: model.description,
+        font: model[style: \.descriptionFont],
+        textColor: UIColor.toDoGardenGreenDark
+      )
+    }
+    
     self.bindingProfileInnerTitleState(
       titleLabel: titleLabel,
       descriptionLabel: descriptionLabel
@@ -85,6 +100,13 @@ extension Styled.Row {
         spacing.heightAnchor.constraint(equalToConstant: 8).isActive = true
       } else {
         spacing.heightAnchor.constraint(equalToConstant: 3).isActive = true
+      }
+    } else {
+      if model.style == Configuration.ProfileModel.Style.searchRow {
+        stack.alignment = UIStackView.Alignment.center
+        stack.distribution = UIStackView.Distribution.fill
+        spacing.widthAnchor.constraint(equalToConstant: 10).isActive = true
+        stack.addArrangedSubview(UIView())
       }
     }
     

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/TableRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/TableRow.swift
@@ -33,3 +33,17 @@ public class TableRow: UITableViewCell {
       .eraseToAnyPublisher()
   }
 }
+
+@available(iOS 17.0, *)
+#Preview {
+  let cell = TableRow().build(
+    configuration: .profile(
+      .init(
+        style: .searchRow,
+        title: "searchRow",
+        description: "@userID"
+      )
+    )
+  )
+  return cell
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/TableRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/TableRow.swift
@@ -2,22 +2,33 @@ import Combine
 import UIKit
 
 public class TableRow: UITableViewCell {
+  private func setupRow(configuration: Styled.Row.Configuration) -> Styled.Row {
+    let newRow = Styled.Row(configuration: configuration)
+    newRow.usingAutolayout()
+    self.contentView.addSubview(newRow)
+    
+    NSLayoutConstraint.activate([
+      newRow.topAnchor.constraint(equalTo: self.contentView.topAnchor),
+      newRow.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
+      newRow.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor),
+      newRow.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor)
+    ])
+    
+    self.selectionStyle = UITableViewCell.SelectionStyle.none
+    return newRow
+  }
+  
+  public func build(configuration: Styled.Row.Configuration) -> Self {
+    _ = self.setupRow(configuration: configuration)
+    return self
+  }
+  
   public func build<T>(
     configuration: Styled.Row.Configuration,
     keyPath: KeyPath<Styled.Row.Configuration, T>
-  ) -> AnyPublisher<T, Never> {
-    selectionStyle = UITableViewCell.SelectionStyle.none
-    let row = Styled.Row(configuration: configuration)
-    row.usingAutolayout()
-    contentView.addSubview(row)
-    NSLayoutConstraint.activate([
-      row.topAnchor.constraint(equalTo: contentView.topAnchor),
-      row.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-      row.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-      row.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
-    ])
-    
-    return row.$configuration
+  ) -> AnyPublisher<T, Never>? {
+    let setupRow = self.setupRow(configuration: configuration)
+    return setupRow.$configuration
       .map(keyPath)
       .eraseToAnyPublisher()
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #678 

## 🎉 변경 사항
- searchRow를 추가합니다. 

## 📌 PR Point
### Styled.Row에 searchRow case를 추가하였습니다. 
![스크린샷 2024-11-18 오후 11 32 37](https://github.com/user-attachments/assets/dea4b0fe-7ec0-4612-9a90-7ca81beab17f)

### TableViewCell로 활용하기 위해 만들어져있는 TableRow를 이용하였습니다. 
- 기존에 존재하던 build() 메서드에 포함되어 있던  
   1) row를 생성하여 contentView에 배치 
   2) 키패스로 관찰할 값을 지정하여 값 추적 
   
저는 위 두 기능중 1번기능만 필요해서 1번 기능만 포함된 build() 와, 1+2 기능이 모두 포함된 기존의 build()를 다시 정의해놓았습니다.
즉, 파라미터와 반환타입이 다른 두개의 build() 가 존재합니다. 

@GangWoon 도 한번 확인해주시길 바랍니다. 

```swift
public class TableRow: UITableViewCell {
  private func setupRow(configuration: Styled.Row.Configuration) -> Styled.Row {
    let newRow = Styled.Row(configuration: configuration)
    newRow.usingAutolayout()
    self.contentView.addSubview(newRow)
    
    NSLayoutConstraint.activate([
      newRow.topAnchor.constraint(equalTo: self.contentView.topAnchor),
      newRow.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
      newRow.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor),
      newRow.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor)
    ])
    
    self.selectionStyle = UITableViewCell.SelectionStyle.none
    return newRow
  }
  
  public func build(configuration: Styled.Row.Configuration) -> Self {
    _ = self.setupRow(configuration: configuration)
    return self
  }
  
  // ↓기존에 존재하던 메서드와 똑같이 동작
  public func build<T>(
    configuration: Styled.Row.Configuration,
    keyPath: KeyPath<Styled.Row.Configuration, T>
  ) -> AnyPublisher<T, Never>? {
    let setupRow = self.setupRow(configuration: configuration)
    return setupRow.$configuration
      .map(keyPath)
      .eraseToAnyPublisher()
  }
}
```

### 프리뷰로 확인 가능합니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?