### PR TITLE
화면전환 애니메이션 구현

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
@@ -18,6 +18,55 @@ public final class PageTransition: NSObject, UIViewControllerAnimatedTransitioni
     self.transitionDuration = transitionDuration
     self.viewControllers = viewControllers
   }
+  
+  public func transitionDuration(using transitionContext: (any UIViewControllerContextTransitioning)?) -> TimeInterval {
+    return self.transitionDuration
+  }
+  
+  // swiftlint:disable function_body_length large_tuple
+  public func animateTransition(using transitionContext: any UIViewControllerContextTransitioning) {
+    guard
+      let (fromViewController, fromView, fromIndex) = self.getTransitionInfo(
+        for: UITransitionContextViewControllerKey.from,
+        context: transitionContext
+      ),
+      let (_, toView, toIndex) = self.getTransitionInfo(
+        for: UITransitionContextViewControllerKey.to,
+        context: transitionContext
+      )
+    else {
+      transitionContext.completeTransition(false)
+      return
+    }
+    
+    let frame = transitionContext.initialFrame(for: fromViewController)
+    var toFrameStart = frame
+    let offsetX = frame.width * 0.1
+    toFrameStart.origin.x = toIndex > fromIndex
+      ? frame.origin.x + offsetX
+      : frame.origin.x - offsetX
+    toView.frame = toFrameStart
+    transitionContext.containerView.addSubview(toView)
+    transitionContext.containerView.addSubview(fromView)
+    
+    UIView.animate(
+      withDuration: self.transitionDuration,
+      delay: 0,
+      usingSpringWithDamping: 0.8,
+      initialSpringVelocity: 0.7,
+      options: [UIView.AnimationOptions.curveEaseInOut],
+      animations: {
+        fromView.layer.opacity = 0
+        toView.frame = frame
+        toView.layer.opacity = 1
+      },
+      completion: { success in
+        fromView.removeFromSuperview()
+        transitionContext.completeTransition(success)
+      }
+    )
+  }
+}
 
 extension PageTransition {
   private func getTransitionInfo(
@@ -31,6 +80,7 @@ extension PageTransition {
     
     return (viewController, view, index)
   }
+  // swiftlint:enable function_body_length large_tuple
   
   private func getIndex(for targetViewController: UIViewController) -> Int? {
     for (index, viewController) in self.viewControllers.enumerated() where viewController == targetViewController {

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
@@ -18,4 +18,12 @@ public final class PageTransition: NSObject, UIViewControllerAnimatedTransitioni
     self.transitionDuration = transitionDuration
     self.viewControllers = viewControllers
   }
+
+extension PageTransition {
+  private func getIndex(for targetViewController: UIViewController) -> Int? {
+    for (index, viewController) in self.viewControllers.enumerated() where viewController == targetViewController {
+      return index
+    }
+    return nil
+  }
 }

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
@@ -1,0 +1,8 @@
+//
+//  PageTransition.swift
+//  TDFoundation
+//
+//  Created by Noah on 11/19/24.
+//
+
+import UIKit

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
@@ -20,6 +20,18 @@ public final class PageTransition: NSObject, UIViewControllerAnimatedTransitioni
   }
 
 extension PageTransition {
+  private func getTransitionInfo(
+    for key: UITransitionContextViewControllerKey,
+    context: UIViewControllerContextTransitioning
+  ) -> (UIViewController, UIView, Int)? {
+    guard let viewController = context.viewController(forKey: key),
+      let view = viewController.view,
+      let index = self.getIndex(for: viewController)
+    else { return nil }
+    
+    return (viewController, view, index)
+  }
+  
   private func getIndex(for targetViewController: UIViewController) -> Int? {
     for (index, viewController) in self.viewControllers.enumerated() where viewController == targetViewController {
       return index

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
@@ -6,3 +6,16 @@
 //
 
 import UIKit
+
+public final class PageTransition: NSObject, UIViewControllerAnimatedTransitioning {
+  private let transitionDuration: TimeInterval
+  private let viewControllers: [UIViewController]
+  
+  public init(
+    transitionDuration: TimeInterval = 0.5,
+    viewControllers: [UIViewController]
+  ) {
+    self.transitionDuration = transitionDuration
+    self.viewControllers = viewControllers
+  }
+}

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
@@ -50,8 +50,8 @@ public final class PageTransition: NSObject, UIViewControllerAnimatedTransitioni
       : frame.origin.x - toFrameOffsetX
     toView.frame = toFrameStart
     fromFrameEnd.origin.x = toIndex > fromIndex
-    ? frame.origin.x - fromFrameOffsetX
-    : frame.origin.x + fromFrameOffsetX
+      ? frame.origin.x - fromFrameOffsetX
+      : frame.origin.x + fromFrameOffsetX
     
     transitionContext.containerView.addSubview(fromView)
     transitionContext.containerView.addSubview(toView)

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
@@ -12,7 +12,7 @@ public final class PageTransition: NSObject, UIViewControllerAnimatedTransitioni
   private let viewControllers: [UIViewController]
   
   public init(
-    transitionDuration: TimeInterval = 0.5,
+    transitionDuration: TimeInterval = 0.35,
     viewControllers: [UIViewController]
   ) {
     self.transitionDuration = transitionDuration

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
@@ -41,13 +41,20 @@ public final class PageTransition: NSObject, UIViewControllerAnimatedTransitioni
     
     let frame = transitionContext.initialFrame(for: fromViewController)
     var toFrameStart = frame
-    let offsetX = frame.width * 0.1
+    var fromFrameEnd = frame
+    
+    let toFrameOffsetX = frame.width * 0.1
+    let fromFrameOffsetX = frame.width * 0.1
     toFrameStart.origin.x = toIndex > fromIndex
-      ? frame.origin.x + offsetX
-      : frame.origin.x - offsetX
+      ? frame.origin.x + toFrameOffsetX
+      : frame.origin.x - toFrameOffsetX
     toView.frame = toFrameStart
-    transitionContext.containerView.addSubview(toView)
+    fromFrameEnd.origin.x = toIndex > fromIndex
+    ? frame.origin.x - fromFrameOffsetX
+    : frame.origin.x + fromFrameOffsetX
+    
     transitionContext.containerView.addSubview(fromView)
+    transitionContext.containerView.addSubview(toView)
     
     UIView.animate(
       withDuration: self.transitionDuration,
@@ -57,8 +64,9 @@ public final class PageTransition: NSObject, UIViewControllerAnimatedTransitioni
       options: [UIView.AnimationOptions.curveEaseInOut],
       animations: {
         fromView.layer.opacity = 0
-        toView.frame = frame
         toView.layer.opacity = 1
+        fromView.frame = fromFrameEnd
+        toView.frame = frame
       },
       completion: { success in
         fromView.removeFromSuperview()


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #682 
## 🎉 변경 사항
- [x] 페이지를 쓸어넘기는 듯한 애니메이션 구현(PageTransition)
## 📌 PR Point
독특한 사용자 경험을 선사하기 위해 탭바 전환 시 아래의 넷플릭스 화면전환과 같이 화면을 넘기는 듯한 애니메이션을 구현하였습니다.

|넷플릭스 탭간 화면 전환 효과|
|---|
|<img src="https://github.com/user-attachments/assets/85bd712b-05c5-4016-b1d4-2e9bf23edd42" width="200px" />|

구현하기 위해 프레임 단위로 애니메이션을 살펴본 결과 

|전환 대상 화면 시작 지점|
|---|
|<img src="https://github.com/user-attachments/assets/2b0c658e-fd29-4391-8049-9c5985c2dcf1" width="300px" />|

현재 탭이 전환하려고 하는 탭의 index보다 작은 경우 전환 대상 화면의 시작지점이 전환을 시작한 화면 `frame.origin.x`로 부터 frame 너비의 약 10% 오른쪽에서부터 시작하는 것을 확인할 수 있습니다.

반대로 현재 탭이 전환하려고 하는 탭의 index보다 큰 경우에는 전환 대상 화면의 시작지점이 전환을 시작한 화면 `frame.origin.x`로 부터 frame 너비의 약 10% 왼쪽부터 시작하는 것을 확인할 수 있습니다.

이를 통해 아래와 같이 toView의 시작 frame을 지정해주었습니다.

```swift
let toFrameOffsetX = frame.width * 0.1
toFrameStart.origin.x = toIndex > fromIndex
  ? frame.origin.x + toFrameOffsetX
  : frame.origin.x - toFrameOffsetX
```

또한 화면이 넘어가는 듯한 효과를 주기 위해 fromView 역시 함께 이동하는 방향으로 frame을 지정해주었습니다.

|Netflix|Demo|
|---|---|
|<img src="https://github.com/user-attachments/assets/85bd712b-05c5-4016-b1d4-2e9bf23edd42" width="200px" />|<img src="https://github.com/user-attachments/assets/434c932b-ff80-422c-a1eb-c0f3ec084b39" width="200px" />| 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?