### PR TITLE
MyStatsScene 에 사용될 뷰객체 수정 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/LongestRecordStackView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/LongestRecordStackView.swift
@@ -22,14 +22,14 @@ final class LongestRecordStackView: UIStackView {
       title: Constants.StringLiteral.leftViewTitle,
       groupName: "",
       recordCount: Int.zero,
-      date: [Date.now]
+      date: [""]
     )
     self.rightView = LongestRecordView(
       style: LongestRecordView.Configuration.dateRange,
       title: Constants.StringLiteral.rightViewTitle,
       groupName: nil,
       recordCount: Int.zero,
-      date: [Date.now, Date.now]
+      date: ["", ""]
     )
     
     self.bubbleLabel = BubbleLabel(
@@ -117,11 +117,11 @@ final class LongestRecordStackView: UIStackView {
     )
   }
   
-  func updateLeftView(groupName: String, recordCount: Int, dateRange: [Date]) {
+  func updateLeftView(groupName: String, recordCount: Int, dateRange: [String]) {
     self.leftView.update(groupName: groupName, recordCount: recordCount, dateRange: dateRange)
   }
   
-  func updateRightView(groupName: String? = nil, recordCount: Int, dateRange: [Date]) {
+  func updateRightView(groupName: String? = nil, recordCount: Int, dateRange: [String]) {
     self.rightView.update(groupName: groupName, recordCount: recordCount, dateRange: dateRange)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/LongestRecordStackView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/LongestRecordStackView.swift
@@ -39,6 +39,7 @@ final class LongestRecordStackView: UIStackView {
     )
     super.init(frame: CGRect.zero)
     self.setupAppearance()
+    self.setupShimmerable()
     self.setupBubbleLabel()
     self.setupButtonAction()
   }
@@ -55,6 +56,12 @@ final class LongestRecordStackView: UIStackView {
     self.alignment = UIStackView.Alignment.fill
     self.addArrangedSubview(self.leftView)
     self.addArrangedSubview(self.rightView)
+  }
+  
+  private func setupShimmerable() {
+    self.isShimmering = true
+    self.leftView.isShimmering = true
+    self.rightView.isShimmering = true
   }
   
   private func setupBubbleLabel() {

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsPeriodicSummaryView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsPeriodicSummaryView.swift
@@ -27,6 +27,7 @@ final class MyStatsPeriodicSummaryView: UIView {
     )
     super.init(frame: CGRect.zero)
     self.setupView()
+    self.setupShimmerable()
   }
   
   @available(*, unavailable)
@@ -100,5 +101,9 @@ final class MyStatsPeriodicSummaryView: UIView {
         self.summaryView.heightAnchor.constraint(equalToConstant: Constants.Layout.summaryViewHeight)
       ]
     )
+  }
+  
+  private func setupShimmerable() {
+    self.summaryView.isShimmering = true
   }
 }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsSceneConstants.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  MyStatsSceneConstants.swift
+//
 //
 //  Created by SONG on 11/18/24.
 //

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsSceneConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 enum Constant {
   enum Layout {
     static let topMargin: CGFloat = 15.0
-    static let horizontalMargin: CGFloat = 10.0
+    static let horizontalMargin: CGFloat = 22.0
     static let gardenViewHeight: CGFloat = 120.0
     static let longestRecordsViewHeight: CGFloat = 125.0
     static let summaryViewViewHeight: CGFloat = 150.0

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
@@ -45,6 +45,7 @@ final class MyStatsView: UIView {
     self.setupGardenView()
     self.setupLongestRecordsStackView()
     self.setupPeriodicSummaryView()
+    self.setupShimmerable()
   }
   
   private func setupProfileView() {
@@ -193,13 +194,19 @@ extension MyStatsView {
     let fixedSentence = Constant.StringLiteral.keepingDesctription
     return "\(userName)\(fixedSuffix)\(fixedNextLine)\(dayCount)\(fixedSentence)"
   }
+  
+  private func setupShimmerable() {
+    self.profileView.isShimmering = true
+    self.gardenView.isShimmering = true
+    self.longestRecordStackView.isShimmering = true
+    self.periodicSummaryView.isShimmering = true
+  }
 }
 
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {
   let view = MyStatsView()
-
   view.usingAutolayout()
   NSLayoutConstraint.activate([
     view.widthAnchor.constraint(equalToConstant: 380),

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
@@ -139,9 +139,9 @@ final class MyStatsView: UIView {
 
 // MARK: Update
 extension MyStatsView {
-  func updateProfileView(userImage: UIImage, userName: String, dayCount: Int, dateRange: [Date]) {
-    let startDate = dateRange.first?.toStringDefaultFormat()
-    let endDate = dateRange.last?.toStringDefaultFormat()
+  func updateProfileView(userImage: UIImage, userName: String, dayCount: Int, dateRange: [String]) {
+    let startDate = dateRange.first
+    let endDate = dateRange.last
     
     var dateRangeString: String
     
@@ -165,11 +165,11 @@ extension MyStatsView {
     self.gardenView.configure(with: pomodoroRecordCollection)
   }
   
-  func updateLeftRecordStackView(groupName: String, recordCount: Int, dateRange: [Date]) {
+  func updateLeftRecordStackView(groupName: String, recordCount: Int, dateRange: [String]) {
     self.longestRecordStackView.updateLeftView(groupName: groupName, recordCount: recordCount, dateRange: dateRange)
   }
   
-  func updateRightRecordStackView(recordCount: Int, dateRange: [Date]) {
+  func updateRightRecordStackView(recordCount: Int, dateRange: [String]) {
     self.longestRecordStackView.updateRightView(recordCount: recordCount, dateRange: dateRange)
   }
   

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
@@ -197,7 +197,6 @@ extension MyStatsView {
   
   private func setupShimmerable() {
     self.profileView.isShimmering = true
-    self.gardenView.isShimmering = true
     self.longestRecordStackView.isShimmering = true
     self.periodicSummaryView.isShimmering = true
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
@@ -30,7 +30,7 @@ public final class LongestRecordView: UIView {
     title: String,
     groupName: String?,
     recordCount: Int,
-    date: [Date]
+    date: [String]
   ) {
     self.style = style
     self.titleLabel = UILabel()
@@ -59,7 +59,7 @@ public final class LongestRecordView: UIView {
   public func update(
     groupName: String?,
     recordCount: Int,
-    dateRange: [Date]
+    dateRange: [String]
   ) {
     self.setupGroupNameLabel(with: groupName)
     self.setupRecordLabel(with: recordCount)
@@ -72,7 +72,7 @@ extension LongestRecordView {
     title: String,
     groupName: String?,
     recordCount: Int,
-    dateRange: [Date]
+    dateRange: [String]
   ) {
     self.setupTitleView(with: title)
     self.setupLeafSymbolImageView()
@@ -239,14 +239,14 @@ extension LongestRecordView {
     )
   }
   
-  private func setupDateLabel(with date: [Date]) {
+  private func setupDateLabel(with date: [String]) {
     var text: String = ""
     switch self.style {
     case .pomo:
-      text = date.first?.toStringDefaultFormat() ?? ""
+      text = date.first ?? ""
     case .dateRange:
-      let startDate = date.first?.toStringDefaultFormat() ?? ""
-      let endDate = date.last?.toStringDefaultFormat() ?? ""
+      let startDate = date.first ?? ""
+      let endDate = date.last ?? ""
       text = "\(startDate) ~ \(endDate)"
     }
 
@@ -280,7 +280,7 @@ extension LongestRecordView {
     title: "최장 집중 기록",
     groupName: "아아아아아아",
     recordCount: 9,
-    date: [Date.now]
+    date: ["1111.11.11"]
   )
   
   let view2 = LongestRecordView(
@@ -288,7 +288,7 @@ extension LongestRecordView {
     title: "최장 연속 기록",
     groupName: nil,
     recordCount: 30,
-    date: [Date.now, Date.now]
+    date: ["9900.99.99", "9999.99.99"]
   )
   
   view1.usingAutolayout()

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/LongestRecordView.swift
@@ -262,6 +262,7 @@ extension LongestRecordView {
     let labels = [self.groupNameLabel, self.recordLabel, self.dateLabel].compactMap { $0 }
     
     for label in labels {
+      label.layer.cornerRadius = 5.0
       label.isShimmering = true
     }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/MyStatsSummaryView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/MyStatsSummaryView.swift
@@ -153,6 +153,7 @@ final class TitleDescriptionView: UIView {
   }
   
   private func setupShimmerable() {
+    self.descriptionLabel.layer.cornerRadius = 5.0
     self.isShimmering = true
     self.descriptionLabel.isShimmering = true
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #686
- 빌드에러 방지를 위해 #665에 머지된 후, develop에 머지될 예정입니다. 

## 🎉 변경 사항

- 날짜관련 데이터타입을 Date -> String으로 변경합니다. 
  - 뷰객체 / 컴포넌트 내에서 Date타입을 String으로 변경하여 사용하는 방식을 버리고, presenter에서 viewModel 생성시 Date -> String으로의 변환이 이루어지는 방식을 채택할 예정입니다. 
  
- 쉬머링 이펙트를 적용시킵니다. 
  - 쉬머링 이펙트 재귀탐색 조건에 맞춰 isShimmering 속성을 true로 세팅해줍니다. 
  
## 📌 PR Point

### 결과화면 

<img width="387" alt="스크린샷 2024-11-23 오후 5 07 13" src="https://github.com/user-attachments/assets/96a50f28-3f5a-4f24-8f98-31dbf965a8f5">

<img width="376" alt="스크린샷 2024-11-23 오후 5 01 40" src="https://github.com/user-attachments/assets/916fedc7-52ff-41af-987a-568d7f78bc9a">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?