### PR TITLE
MyStatsScene VIP 사전준비 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Package.swift
@@ -28,11 +28,15 @@ let package = Package(
     .target(
       name: "MyStatsSceneAPI",
       dependencies: [
+        "MyStatsSceneEntity",
         .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI")
       ]
     ),
     .target(
-      name: "MyStatsSceneEntity"
+      name: "MyStatsSceneEntity",
+      dependencies: [
+        .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI") // TODO: - PomodoroRecordCollection 이관 예정
+      ]
     ),
     .target(
       name: "MyStatsScene",

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsSceneBuilder.swift
@@ -13,10 +13,10 @@ import MyStatsSceneEntity
 public struct MyStatsSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
-    let someWorker: MyStatsWorkable
+    let myStatsWorker: MyStatsWorkable
     
-    public init(someWorker: MyStatsWorkable) {
-      self.someWorker = someWorker
+    public init(myStatsWorker: MyStatsWorkable) {
+      self.myStatsWorker = myStatsWorker
     }
   }
   
@@ -44,7 +44,7 @@ extension MyStatsSceneBuilder {
   /// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
   private func configureVIPCycle(for viewController: MyStatsViewController) -> MyStatsViewController {
-    let interactor = MyStatsInteractor(someWorker: self.dependency.someWorker)
+    let interactor = MyStatsInteractor(myStatsWorker: self.dependency.myStatsWorker)
     let presenter = MyStatsPresenter()
     let router = MyStatsRouter()
     viewController.interactor = interactor

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsViewController.swift
@@ -11,7 +11,7 @@ import MyStatsSceneAPI
 import MyStatsSceneEntity
 
 protocol MyStatsDisplayLogic: AnyObject {
-  func displaySomething(viewModel: MyStats.Something.ViewModel)
+  func displayMyStatsView(viewModel: MyStats.LoadMyStatsViewData.ViewModel)
 }
 
 class MyStatsViewController: UIViewController, MyStatsViewControllable {
@@ -21,9 +21,12 @@ class MyStatsViewController: UIViewController, MyStatsViewControllable {
   var interactor: MyStatsBusinessLogic?
   var router: (MyStatsRoutingLogic & MyStatsDataPassing)?
   
+  var myStatsView: MyStatsView
+  
   // MARK: - Object lifecycle
   
   init() {
+    self.myStatsView = MyStatsView()
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -36,14 +39,16 @@ class MyStatsViewController: UIViewController, MyStatsViewControllable {
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    self.doSomething()
+    self.view.backgroundColor = UIColor.white
+    self.title = "나의 가든"
+    self.setupMyStatsView()
   }
 }
 
 // MARK: - Confirm display logic protocol
 
 extension MyStatsViewController: MyStatsDisplayLogic {
-  func displaySomething(viewModel: MyStats.Something.ViewModel) {
+  func displayMyStatsView(viewModel: MyStats.LoadMyStatsViewData.ViewModel) {
     // self.nameTextField.text = viewModel.name
   }
 }
@@ -51,8 +56,28 @@ extension MyStatsViewController: MyStatsDisplayLogic {
 // MARK: - Request to interactor
 
 extension MyStatsViewController {
-  func doSomething() {
-    let request = MyStats.Something.Request()
-    self.interactor?.doSomething(request: request)
+  func loadMyStatsViewData() {
+    self.myStatsView.startShimmering()
+    let request = MyStats.LoadMyStatsViewData.Request()
+  }
+}
+
+extension MyStatsViewController {
+  private func setupMyStatsView() {
+    self.view.addSubview(self.myStatsView)
+    self.setupConstraints()
+  }
+  
+  private func setupConstraints() {
+    self.myStatsView.usingAutolayout()
+    
+    NSLayoutConstraint.activate(
+      [
+        self.myStatsView.widthAnchor.constraint(equalTo: self.view.widthAnchor),
+        self.myStatsView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+        self.myStatsView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 15.0),
+        self.myStatsView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor)
+      ]
+    )
   }
 }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsViewController.swift
@@ -21,7 +21,7 @@ class MyStatsViewController: UIViewController, MyStatsViewControllable {
   var interactor: MyStatsBusinessLogic?
   var router: (MyStatsRoutingLogic & MyStatsDataPassing)?
   
-  var myStatsView: MyStatsView
+  private var myStatsView: MyStatsView
   
   // MARK: - Object lifecycle
   

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneEntity/MyStatsModels.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneEntity/MyStatsModels.swift
@@ -5,21 +5,194 @@
 //  Created by SONG on 11/13/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit
+
+import ToDoGardenUIComponent // TODO: - PomodoroRecordCollection 이관 예정
 
 public enum MyStats {
   
   // MARK: Use cases
   
-  public enum Something {
+  public enum LoadMyStatsViewData {
     public struct Request {
       public init() { }
     }
-    public struct Response {
-      public init() { }
+    
+    public struct Response: Sendable {
+      public let profileViewData: FetchedProfileViewData
+      public let longestRecordViewData: FetchedLongestRecordViewData
+      public let summaryViewData: FetchedSummaryViewData
+      
+      public init(
+        profileViewData: FetchedProfileViewData,
+        longestRecordViewData: FetchedLongestRecordViewData,
+        summaryViewData: FetchedSummaryViewData
+      ) {
+        self.profileViewData = profileViewData
+        self.longestRecordViewData = longestRecordViewData
+        self.summaryViewData = summaryViewData
+      }
     }
+    
     public struct ViewModel {
-      public init() { }
+      public let profileViewModel: ProfileViewModel
+      public let gardenViewModel: GardenViewModel
+      public let longestRecordViewModel: LongestRecordViewModel
+      public let summaryViewModel: SummaryViewModel
+      
+      public init(
+        profileViewModel: ProfileViewModel,
+        gardenViewModel: GardenViewModel,
+        longestRecordViewModel: LongestRecordViewModel,
+        summaryViewModel: SummaryViewModel
+      ) {
+        self.profileViewModel = profileViewModel
+        self.gardenViewModel = gardenViewModel
+        self.longestRecordViewModel = longestRecordViewModel
+        self.summaryViewModel = summaryViewModel
+      }
+    }
+  }
+}
+
+extension MyStats {
+  public struct ProfileViewModel: Sendable {
+    public let myName: String
+    public let myImage: UIImage
+    public let continuousRecordCount: Int
+    public let continuousRecordStartDate: String
+    public let continuousRecordEndDate: String
+    
+    public init(
+      myName: String,
+      myImage: UIImage,
+      continuousRecordCount: Int,
+      continuousRecordStartDate: String,
+      continuousRecordEndDate: String
+    ) {
+      self.myName = myName
+      self.myImage = myImage
+      self.continuousRecordCount = continuousRecordCount
+      self.continuousRecordStartDate = continuousRecordStartDate
+      self.continuousRecordEndDate = continuousRecordEndDate
+    }
+  }
+  
+  public struct GardenViewModel: Sendable {
+    public let pomodoroCollection: PomodoroRecordCollection
+    
+    public init(pomodoroCollection: PomodoroRecordCollection) {
+      self.pomodoroCollection = pomodoroCollection
+    }
+  }
+  
+  public struct LongestRecordViewModel: Sendable {
+    public let concentratedRecordGroupName: String
+    public let concentratedRecordCount: Int
+    public let concentratedRecordDate: String
+    
+    public let longestContinuousRecordCount: Int
+    public let longestContinuousRecordStartDate: String
+    public let longestContinuousRecordEndDate: String
+    
+    public init(
+      concentratedRecordGroupName: String,
+      concentratedRecordCount: Int,
+      concentratedRecordDate: String,
+      longestContinuousRecordCount: Int,
+      longestContinuousRecordStartDate: String,
+      longestContinuousRecordEndDate: String
+    ) {
+      self.concentratedRecordGroupName = concentratedRecordGroupName
+      self.concentratedRecordCount = concentratedRecordCount
+      self.concentratedRecordDate = concentratedRecordDate
+      self.longestContinuousRecordCount = longestContinuousRecordCount
+      self.longestContinuousRecordStartDate = longestContinuousRecordStartDate
+      self.longestContinuousRecordEndDate = longestContinuousRecordEndDate
+    }
+  }
+
+  public struct SummaryViewModel: Sendable {
+    public let concentratedTime: String
+    public let completedCount: String
+    
+    public init(
+      concentratedTime: String,
+      completedCount: String
+    ) {
+      self.concentratedTime = concentratedTime
+      self.completedCount = completedCount
+    }
+  }
+  
+  public struct Payload {
+    public let myName: String
+    public let myImage: UIImage
+    public let myGarden: PomodoroRecordCollection
+    
+    public init(myName: String, myImage: UIImage, myGarden: PomodoroRecordCollection) {
+      self.myName = myName
+      self.myImage = myImage
+      self.myGarden = myGarden
+    }
+  }
+}
+
+// MARK: Data Models
+
+extension MyStats {
+  public struct FetchedProfileViewData: Sendable {
+    public let continuousRecordCount: Int
+    public let continuousRecordStartDate: Date
+    public let continuousRecordEndDate: Date
+    
+    public init(
+      continuousRecordCount: Int,
+      continuousRecordStartDate: Date,
+      continuousRecordEndDate: Date
+    ) {
+      self.continuousRecordCount = continuousRecordCount
+      self.continuousRecordStartDate = continuousRecordStartDate
+      self.continuousRecordEndDate = continuousRecordEndDate
+    }
+  }
+
+  public struct FetchedLongestRecordViewData: Sendable {
+    public let concentratedRecordGroupName: String
+    public let concentratedRecordCount: Int
+    public let concentratedRecordDate: Date
+    
+    public let longestContinuousRecordCount: Int
+    public let longestContinuousRecordStartDate: Date
+    public let longestContinuousRecordEndDate: Date
+    
+    public init(
+      concentratedRecordGroupName: String,
+      concentratedRecordCount: Int,
+      concentratedRecordDate: Date,
+      longestContinuousRecordCount: Int,
+      longestContinuousRecordStartDate: Date,
+      longestContinuousRecordEndDate: Date
+    ) {
+      self.concentratedRecordGroupName = concentratedRecordGroupName
+      self.concentratedRecordCount = concentratedRecordCount
+      self.concentratedRecordDate = concentratedRecordDate
+      self.longestContinuousRecordCount = longestContinuousRecordCount
+      self.longestContinuousRecordStartDate = longestContinuousRecordStartDate
+      self.longestContinuousRecordEndDate = longestContinuousRecordEndDate
+    }
+  }
+
+  public struct FetchedSummaryViewData: Sendable {
+    public let concentratedTime: Int
+    public let completedCount: Double
+    
+    public init(
+      concentratedTime: Int,
+      completedCount: Double
+    ) {
+      self.concentratedTime = concentratedTime
+      self.completedCount = completedCount
     }
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #688 
- 연관된 작업의 양이 많아 #665 에 머지시킨 뒤, develop에 일괄 머지시킬 예정입니다. 

## 🎉 변경 사항
- 빌드에러가 나지 않는 선에서 템플릿 자동생성된 이름들 (ex: someWorker) 리네임 
- 엔터티 정의 (API 명세에 따라 변경가능성 있음) 
- MyStatsView 표시 

## 📌 PR Point
- 사실상 원활한 리뷰를 위해 files Changed를 줄이려는 목적이 살짝 존재하는 PR입니다 ^^... 
- PomodoroRecordCollection가 ToDoGardenUIComponent안에 있어서, PomodoroRecordCollection을 사용하는 곳에 ToDoGardenUIComponent와의 의존성이 존재하는 경우가 있습니다.  추후에 지워질 예정인 라인에 대해서 주석으로 표시 해놓았습니다. 
- 빌드에러 방지를 위해 VC과 인터랙터와의 연결을 해놓지 않은 상태입니다.  `MyStatsModels` 위주로 리뷰해주시면 될 것 같습니다. 
   
## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?