### PR TITLE
search garden tableview 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenSection+User.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenSection+User.swift
@@ -1,0 +1,30 @@
+//
+//  SearchGardenSection+User.swift
+//
+//
+//  Created by SONG on 11/23/24.
+//
+
+import UIKit
+
+enum SearchGardenSection {
+  case main
+}
+
+public struct SearchGardenUser {
+  public let userNickname: String
+  public let userID: String
+  public let userImage: UIImage?
+
+  public init(userNickname: String, userID: String, userImage: UIImage?) {
+    self.userNickname = userNickname
+    self.userID = userID
+    self.userImage = userImage
+  }
+}
+
+extension SearchGardenUser: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.userID)
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
@@ -1,0 +1,79 @@
+//
+//  SearchGardenTableView.swift
+//
+//
+//  Created by SONG on 11/23/24.
+//
+
+import UIKit
+
+final public class SearchGardenTableView: UITableView {
+  private var diffableDataSource: UITableViewDiffableDataSource<SearchGardenSection, SearchGardenUser>!
+  
+  public override init(frame: CGRect, style: UITableView.Style) {
+    super.init(frame: frame, style: style)
+    self.configureDataSource()
+    self.register(TableRow.self, forCellReuseIdentifier: TableRow.identifier)
+    self.separatorStyle = UITableViewCell.SeparatorStyle.none
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  public func updateData(with users: [SearchGardenUser]) {
+    var snapshot = NSDiffableDataSourceSnapshot<SearchGardenSection, SearchGardenUser>()
+    snapshot.appendSections([SearchGardenSection.main])
+    snapshot.appendItems(users)
+    self.diffableDataSource.apply(snapshot, animatingDifferences: true)
+  }
+  
+  private func configureDataSource() {
+    self.diffableDataSource = UITableViewDiffableDataSource<
+      SearchGardenSection,
+      SearchGardenUser
+    >(tableView: self) { (tableView, indexPath, userData) -> TableRow? in
+      guard let tableRow = tableView.dequeueReusableCell(
+        withIdentifier: TableRow.identifier,
+        for: indexPath
+      ) as? TableRow else {
+        return nil
+      }
+      
+      let cell = tableRow.build(
+        configuration: Styled.Row.Configuration.profile(
+          .init(
+            style: .searchRow,
+            title: userData.userNickname,
+            description: "@" + userData.userID,
+            image: userData.userImage
+          )
+        )
+      )
+      return cell
+    }
+  }
+}
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let view = SearchGardenTableView(frame: CGRect.zero, style: UITableView.Style.plain)
+  view.usingAutolayout()
+  NSLayoutConstraint.activate([
+    view.widthAnchor.constraint(equalToConstant: 370),
+    view.heightAnchor.constraint(equalToConstant: 700)
+  ])
+  
+  view.updateData(
+    with: [
+      SearchGardenUser(userNickname: "흥민갓", userID: "hmzzang123", userImage: nil),
+      SearchGardenUser(userNickname: "인성맨", userID: "nomercy", userImage: nil),
+      SearchGardenUser(userNickname: "흥민갓", userID: "missyouharrykane", userImage: nil),
+      SearchGardenUser(userNickname: "초절정꽃미남", userID: "mrhandsome", userImage: nil)
+    ]
+  )
+  return view
+}
+#endif


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #692 

## 🎉 변경 사항
- SearchGardenTableView를 추가합니다. 

## 📌 PR Point

### 별다른 기능이 없는 매우 간단한 테이블뷰입니다. 

<img width="230" alt="스크린샷 2024-11-23 오후 8 02 15" src="https://github.com/user-attachments/assets/e247e011-16e9-4fd7-9779-58e430cb0e28">

-> cell의 height / 터치시 동작은 delegate를 통해 설정할 생각입니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?