### PR TITLE
AddGardenView 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AddGardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AddGardenView.swift
@@ -177,3 +177,20 @@ extension AddGardenView {
     )
   }
 }
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let view = AddGardenView(
+    userNickname: "울버린",
+    userIntroduction: "안녕하세욤ㄴㅇㅁㄴㅇㅁㄴㅇㅁㄴㅇㅁㄴㅁㄴㅇㅁㄴㅇㅁㄴㅇ",
+    userImage: nil,
+    pomodoroCollection: PomodoroRecordCollection()
+  )
+  
+  view.usingAutolayout()
+  view.widthAnchor.constraint(equalToConstant: 320).isActive = true
+  view.heightAnchor.constraint(equalToConstant: 390).isActive = true
+  return view
+}
+#endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AddGardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AddGardenView.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by SONG on 11/24/24.
+//
+
+import Foundation

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AddGardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AddGardenView.swift
@@ -1,8 +1,179 @@
 //
-//  File.swift
-//  
+//  AddGardenView.swift
+//
 //
 //  Created by SONG on 11/24/24.
 //
 
-import Foundation
+import UIKit
+
+import ToDoGardenUIConstant
+import ToDoGardenUIResource
+
+public final class AddGardenView: UIView {
+  private let titleLabel: UILabel
+  public let cancelButton: UIButton
+  public let addButton: UIButton
+  typealias Constants = Constant.AddGardenView
+  
+  public init(
+    userNickname: String,
+    userIntroduction: String,
+    userImage: UIImage?,
+    pomodoroCollection: PomodoroRecordCollection
+  ) {
+    self.titleLabel = UILabel()
+    self.cancelButton = UIButton(configuration: .borderless())
+    self.addButton = ToDoGardenBoxButton(
+      title: Constants.StringLiteral.addButtonTitle,
+      buttonType: .tertiaryRoundRectButton
+    )
+    
+    super.init(frame: CGRect.zero)
+    self.setupAppearance()
+    self.setupSubViews(
+      userNickname: userNickname,
+      userIntroduction: userIntroduction,
+      userImage: userImage,
+      pomodoroCollection: pomodoroCollection
+    )
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override public var intrinsicContentSize: CGSize {
+    return Constants.Layout.size
+  }
+}
+
+extension AddGardenView {
+  private func setupAppearance() {
+    self.backgroundColor = UIColor.white
+    self.layer.cornerRadius = Constants.Layout.cornerRadius
+  }
+  
+  private func setupSubViews(
+    userNickname: String,
+    userIntroduction: String,
+    userImage: UIImage?,
+    pomodoroCollection: PomodoroRecordCollection
+  ) {
+    
+    self.setupTitleLabel()
+    self.setupCancelButton()
+    self.setupAddButton()
+    self.setupProfileView(userNickname: userNickname, userIntroduction: userIntroduction, userImage: userImage)
+    self.setupGardenView(pomodoroCollection: pomodoroCollection)
+  }
+  
+  private func setupTitleLabel() {
+    let title = Constant.AddGardenView.StringLiteral.labelTitle
+    self.titleLabel.attributedText = title.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardHeadBold,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    )
+    
+    self.addSubview(self.titleLabel)
+    self.titleLabel.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        self.titleLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+        self.titleLabel.topAnchor.constraint(
+          equalTo: self.topAnchor,
+          constant: Constants.Layout.commonMargin
+        )
+      ]
+    )
+  }
+  
+  private func setupCancelButton() {
+    let title = Constants.StringLiteral.cancelButtonTitle
+    let attributedString = AttributedString(
+      title.applyTextAttributes(
+        attributes: [
+          NSAttributedString.Key.font: UIFont.pretendardBodyRegular,
+          NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+        ]
+      )
+    )
+    self.cancelButton.configuration?.attributedTitle = attributedString
+    self.addSubview(self.cancelButton)
+    self.cancelButton.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        self.cancelButton.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: -Constants.Layout.commonMargin
+        ),
+        self.cancelButton.centerYAnchor.constraint(equalTo: self.titleLabel.centerYAnchor)
+      ]
+    )
+  }
+  
+  private func setupProfileView(userNickname: String, userIntroduction: String, userImage: UIImage?) {
+    let profileView = Styled.Row(
+      configuration: Styled.Row.Configuration.profile(
+        .init(
+          style: .myStats,
+          title: userNickname,
+          description: userIntroduction,
+          image: userImage
+        )
+      )
+    )
+    self.addSubview(profileView)
+    profileView.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        profileView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        profileView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        profileView.topAnchor.constraint(
+          equalTo: self.titleLabel.bottomAnchor,
+          constant: Constants.Layout.commonHorizontalMargin
+        )
+      ]
+    )
+  }
+  
+  private func setupGardenView(pomodoroCollection: PomodoroRecordCollection) {
+    let gardenView = GardenView()
+    gardenView.configure(with: pomodoroCollection)
+    self.addSubview(gardenView)
+    gardenView.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        gardenView.leadingAnchor.constraint(
+          equalTo: self.leadingAnchor,
+          constant: Constants.Layout.commonHorizontalMargin
+        ),
+        gardenView.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: -Constants.Layout.commonHorizontalMargin
+        ),
+        gardenView.bottomAnchor.constraint(
+          equalTo: self.addButton.topAnchor,
+          constant: Constants.GardenView.Layout.verticalMargin
+        )
+      ]
+    )
+  }
+  
+  private func setupAddButton() {
+    self.addButton.usingAutolayout()
+    self.addSubview(self.addButton)
+    NSLayoutConstraint.activate(
+      [
+        self.addButton.bottomAnchor.constraint(
+          equalTo: self.bottomAnchor,
+          constant: Constants.AddButton.Layout.bottomMargin
+        ),
+        self.addButton.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+      ]
+    )
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AddGardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AddGardenView.swift
@@ -23,10 +23,10 @@ public final class AddGardenView: UIView {
     pomodoroCollection: PomodoroRecordCollection
   ) {
     self.titleLabel = UILabel()
-    self.cancelButton = UIButton(configuration: .borderless())
+    self.cancelButton = UIButton(configuration: UIButton.Configuration.borderless())
     self.addButton = ToDoGardenBoxButton(
       title: Constants.StringLiteral.addButtonTitle,
-      buttonType: .tertiaryRoundRectButton
+      buttonType: ToDoGardenBoxButton.Configuration.tertiaryRoundRectButton
     )
     
     super.init(frame: CGRect.zero)
@@ -65,7 +65,11 @@ extension AddGardenView {
     self.setupTitleLabel()
     self.setupCancelButton()
     self.setupAddButton()
-    self.setupProfileView(userNickname: userNickname, userIntroduction: userIntroduction, userImage: userImage)
+    self.setupProfileView(
+      userNickname: userNickname,
+      userIntroduction: userIntroduction,
+      userImage: userImage
+    )
     self.setupGardenView(pomodoroCollection: pomodoroCollection)
   }
   
@@ -119,7 +123,7 @@ extension AddGardenView {
     let profileView = Styled.Row(
       configuration: Styled.Row.Configuration.profile(
         .init(
-          style: .myStats,
+          style: Styled.Row.Configuration.ProfileModel.Style.myStats,
           title: userNickname,
           description: userIntroduction,
           image: userImage

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AddGardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AddGardenView.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by SONG on 11/24/24.
+//
+
+import Foundation

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AddGardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+AddGardenView.swift
@@ -1,8 +1,35 @@
 //
-//  File.swift
-//  
+//  Constant+AddGardenView.swift
+//
 //
 //  Created by SONG on 11/24/24.
 //
 
 import Foundation
+
+extension Constant.AddGardenView {
+  public enum Layout {
+    public static let size: CGSize = CGSize(width: 320.0, height: 390.0)
+    public static let cornerRadius: CGFloat = 20.0
+    public static let commonMargin: CGFloat = 26.0
+    public static let commonHorizontalMargin: CGFloat = 20.0
+  }
+  
+  public enum StringLiteral {
+    public static let addButtonTitle: String = "추가하기"
+    public static let cancelButtonTitle: String = "취소"
+    public static let labelTitle: String = "가든 추가"
+  }
+  
+  public enum GardenView {
+    public enum Layout {
+      public static let verticalMargin: CGFloat = -40.0
+    }
+  }
+  
+  public enum AddButton {
+    public enum Layout {
+      public static let bottomMargin: CGFloat = -30.0
+    }
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -46,4 +46,5 @@ public enum Constant {
   public enum BubbleLabel { }
   public enum LongestRecordView { }
   public enum MyStatsSummaryView { }
+  public enum AddGardenView { }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #694 

## 🎉 변경 사항

- AddGardenView를 추가합니다. 

## 📌 PR Point

### 결과 화면
![스크린샷 2024-11-24 오후 4 04 50](https://github.com/user-attachments/assets/9cc0afd7-8302-4d74-ab05-c048d3ab5d35) ![스크린샷 2024-11-24 오후 4 04 58](https://github.com/user-attachments/assets/5c84a813-2dcd-4b00-8f12-f33ac2705343)

-> PomodoroRecordCollection 데이터는 PR에 포함시키지 않았습니다. 
-> 해당 뷰에 포함된 두개의 버튼은 외부에서 접근하기 편하게 public으로 선언하였습니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?