### PR TITLE
SearchGardenTextField 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UITextField+SearchGardenTextField.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UITextField+SearchGardenTextField.swift
@@ -1,0 +1,56 @@
+//
+//  UITextField+SearchGardenTextField.swift
+//
+//  Created by SONG on 11/24/24.
+//
+
+import UIKit.UITextField
+
+import ToDoGardenUIConstant
+
+extension UITextField {
+  public func applySearchGardenStyle() -> UITextField {
+    self.configureAppearance()
+    self.addPaddingWithImage()
+    self.addEditingAction()
+    return self
+  }
+  
+  private func configureAppearance() {
+    self.backgroundColor = UIColor.toDoGardenGreenBackground
+    self.layer.cornerRadius = Constant.SearchGardenTextField.Layout.cornerRadius
+    self.placeholder = Constant.SearchGardenTextField.StringLiteral.defaultPlaceHolder
+  }
+  
+  private func addEditingAction() {
+    let primaryAction = UIAction { [weak self] _ in
+      self?.becomeFirstResponder()
+    }
+    
+    self.addAction(primaryAction, for: UIControl.Event.editingDidBegin)
+  }
+  
+  private func addPaddingWithImage() {
+    let constants = Constant.SearchGardenTextField.Layout.self
+    let paddingView = UIView(frame: constants.paddingViewRect)
+    
+    let imageView = UIImageView(image: UIImage.magnifyingGlassImage)
+    imageView.frame = constants.imageViewRect
+    imageView.contentMode = UIView.ContentMode.center
+    imageView.clipsToBounds = true
+    imageView.tintColor = UIColor.toDoGardenGreenDark
+    
+    paddingView.addSubview(imageView)
+    self.leftView = paddingView
+    self.leftViewMode = UITextField.ViewMode.always
+  }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+  let view = UITextField().applySearchGardenStyle()
+  view.usingAutolayout()
+  view.heightAnchor.constraint(equalToConstant: 32).isActive = true
+  view.widthAnchor.constraint(equalToConstant: 338).isActive = true
+  return view
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UITextField+SearchGardenTextField.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UITextField+SearchGardenTextField.swift
@@ -7,6 +7,7 @@
 import UIKit.UITextField
 
 import ToDoGardenUIConstant
+import ToDoGardenUIResource
 
 extension UITextField {
   public func applySearchGardenStyle() -> UITextField {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SearchGardenTextField.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+SearchGardenTextField.swift
@@ -1,0 +1,31 @@
+//
+//  Constant+SearchGardenTextField.swift
+//
+//
+//  Created by SONG on 11/24/24.
+//
+
+import Foundation
+
+extension Constant.SearchGardenTextField {
+  public enum Layout {
+    public static let cornerRadius: CGFloat = 15.0
+    public static let paddingViewRect = CGRect(
+      x: 0.0,
+      y: 0.0,
+      width: 40.0,
+      height: 24.0
+    )
+    
+    public static let imageViewRect = CGRect(
+      x: 7.0,
+      y: 0.0,
+      width: 24.0,
+      height: 24.0
+    )
+  }
+  
+  public enum StringLiteral {
+    public static let defaultPlaceHolder = "아이디를 입력해주세요"
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -46,4 +46,5 @@ public enum Constant {
   public enum BubbleLabel { }
   public enum LongestRecordView { }
   public enum MyStatsSummaryView { }
+  public enum SearchGardenTextField { }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIImage+ToDoGarden.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIResource/UIImage+ToDoGarden.swift
@@ -141,4 +141,8 @@ extension UIImage {
   public static let settingsTabBarItemImage = UIImage(
     resource: .settingsTabIcon
   )
+  
+  public static let magnifyingGlassImage = UIImage(
+    systemName: "magnifyingglass"
+  )
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #696 

## 🎉 변경 사항
- SearchGardenTextField를 추가합니다. 

## 📌 PR Point

<img width="231" alt="스크린샷 2024-11-24 오후 8 59 42" src="https://github.com/user-attachments/assets/ead93f74-cc1f-40e2-b13e-7107dd909bd7">

- UITextField를 확장하여 구현하였습니다.
- 특별한 기능은 없는 간단한 뷰입니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?