### PR TITLE
 SearchGardenScene UI 개선 및 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AddGardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AddGardenView.swift
@@ -14,6 +14,8 @@ public final class AddGardenView: UIView {
   private let titleLabel: UILabel
   public let cancelButton: UIButton
   public let addButton: UIButton
+  private var profileView: Styled.Row
+  private var gardenView: GardenView
   typealias Constants = Constant.AddGardenView
   
   public init(
@@ -29,14 +31,23 @@ public final class AddGardenView: UIView {
       buttonType: ToDoGardenBoxButton.Configuration.tertiaryRoundRectButton
     )
     
+    self.profileView = Styled.Row(
+      configuration: Styled.Row.Configuration.profile(
+        .init(
+          style: Styled.Row.Configuration.ProfileModel.Style.myStats,
+          title: userNickname,
+          description: userIntroduction,
+          image: userImage
+        )
+      )
+    )
+    
+    self.gardenView = GardenView()
+    self.gardenView.configure(with: pomodoroCollection)
+    
     super.init(frame: CGRect.zero)
     self.setupAppearance()
-    self.setupSubViews(
-      userNickname: userNickname,
-      userIntroduction: userIntroduction,
-      userImage: userImage,
-      pomodoroCollection: pomodoroCollection
-    )
+    self.setupSubViews()
   }
   
   @available(*, unavailable)
@@ -47,6 +58,30 @@ public final class AddGardenView: UIView {
   override public var intrinsicContentSize: CGSize {
     return Constants.Layout.size
   }
+  
+  public func update(
+    userNickname: String,
+    userIntroduction: String,
+    userImage: UIImage?,
+    pomodoroCollection: PomodoroRecordCollection
+  ) {
+    self.profileView.removeFromSuperview()
+    
+    self.profileView = Styled.Row(
+      configuration: Styled.Row.Configuration.profile(
+        .init(
+          style: Styled.Row.Configuration.ProfileModel.Style.myStats,
+          title: userNickname,
+          description: userIntroduction,
+          image: userImage
+        )
+      )
+    )
+    self.addSubview(self.profileView)
+    self.setupProfileViewConstraints()
+    
+    self.gardenView.configure(with: pomodoroCollection)
+  }
 }
 
 extension AddGardenView {
@@ -55,22 +90,16 @@ extension AddGardenView {
     self.layer.cornerRadius = Constants.Layout.cornerRadius
   }
   
-  private func setupSubViews(
-    userNickname: String,
-    userIntroduction: String,
-    userImage: UIImage?,
-    pomodoroCollection: PomodoroRecordCollection
-  ) {
-    
+  private func setupSubViews() {
     self.setupTitleLabel()
     self.setupCancelButton()
     self.setupAddButton()
-    self.setupProfileView(
-      userNickname: userNickname,
-      userIntroduction: userIntroduction,
-      userImage: userImage
-    )
-    self.setupGardenView(pomodoroCollection: pomodoroCollection)
+    
+    self.addSubview(self.profileView)
+    self.addSubview(self.gardenView)
+    
+    self.setupProfileViewConstraints()
+    self.setupGardenViewConstraints()
   }
   
   private func setupTitleLabel() {
@@ -119,24 +148,13 @@ extension AddGardenView {
     )
   }
   
-  private func setupProfileView(userNickname: String, userIntroduction: String, userImage: UIImage?) {
-    let profileView = Styled.Row(
-      configuration: Styled.Row.Configuration.profile(
-        .init(
-          style: Styled.Row.Configuration.ProfileModel.Style.myStats,
-          title: userNickname,
-          description: userIntroduction,
-          image: userImage
-        )
-      )
-    )
-    self.addSubview(profileView)
-    profileView.usingAutolayout()
+  private func setupProfileViewConstraints() {
+    self.profileView.usingAutolayout()
     NSLayoutConstraint.activate(
       [
-        profileView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-        profileView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-        profileView.topAnchor.constraint(
+        self.profileView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.profileView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        self.profileView.topAnchor.constraint(
           equalTo: self.titleLabel.bottomAnchor,
           constant: Constants.Layout.commonHorizontalMargin
         )
@@ -144,22 +162,19 @@ extension AddGardenView {
     )
   }
   
-  private func setupGardenView(pomodoroCollection: PomodoroRecordCollection) {
-    let gardenView = GardenView()
-    gardenView.configure(with: pomodoroCollection)
-    self.addSubview(gardenView)
-    gardenView.usingAutolayout()
+  private func setupGardenViewConstraints() {
+    self.gardenView.usingAutolayout()
     NSLayoutConstraint.activate(
       [
-        gardenView.leadingAnchor.constraint(
+        self.gardenView.leadingAnchor.constraint(
           equalTo: self.leadingAnchor,
           constant: Constants.Layout.commonHorizontalMargin
         ),
-        gardenView.trailingAnchor.constraint(
+        self.gardenView.trailingAnchor.constraint(
           equalTo: self.trailingAnchor,
           constant: -Constants.Layout.commonHorizontalMargin
         ),
-        gardenView.bottomAnchor.constraint(
+        self.gardenView.bottomAnchor.constraint(
           equalTo: self.addButton.topAnchor,
           constant: Constants.GardenView.Layout.verticalMargin
         )
@@ -195,6 +210,13 @@ extension AddGardenView {
   view.usingAutolayout()
   view.widthAnchor.constraint(equalToConstant: 320).isActive = true
   view.heightAnchor.constraint(equalToConstant: 390).isActive = true
+  
+  view.update(
+    userNickname: "zxc",
+    userIntroduction: "asdasdasdasdasdasd",
+    userImage: nil,
+    pomodoroCollection: PomodoroRecordCollection()
+  )
   return view
 }
 #endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AddGardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AddGardenView.swift
@@ -65,20 +65,13 @@ public final class AddGardenView: UIView {
     userImage: UIImage?,
     pomodoroCollection: PomodoroRecordCollection
   ) {
-    self.profileView.removeFromSuperview()
-    
-    self.profileView = Styled.Row(
-      configuration: Styled.Row.Configuration.profile(
-        .init(
-          style: Styled.Row.Configuration.ProfileModel.Style.myStats,
-          title: userNickname,
-          description: userIntroduction,
-          image: userImage
-        )
+    self.profileView.configuration = Styled.Row.Configuration.profile(
+      Styled.Row.Configuration.ProfileModel(
+        style: Styled.Row.Configuration.ProfileModel.Style.myStats,
+        title: userNickname,
+        description: userIntroduction
       )
     )
-    self.addSubview(self.profileView)
-    self.setupProfileViewConstraints()
     
     self.gardenView.configure(with: pomodoroCollection)
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DefaultModalNavigationBar.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DefaultModalNavigationBar.swift
@@ -1,0 +1,114 @@
+//
+//  CustomNavigationBar.swift
+//
+//
+//  Created by SONG on 11/26/24.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+
+public protocol DefaultModalNavigationBarDelegate: AnyObject {
+  func didTapRightButton()
+}
+
+public final class DefaultModalNavigationBar: UIView {
+  private let titleLabel: UILabel
+  private let rightButton: UIButton
+  private let grabberView: UIView
+  public weak var delegate: DefaultModalNavigationBarDelegate?
+  typealias Constants = Constant.DefaultModalNavigationBar
+  
+  public init(title: String, rightButtonTitle: String) {
+    self.titleLabel = UILabel()
+    self.rightButton = UIButton(type: UIButton.ButtonType.system)
+    self.grabberView = UIView()
+    super.init(frame: CGRect.zero)
+    self.setupAppearance()
+    self.setupSubviews(title: title, rightButtonTitle: rightButtonTitle)
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupAppearance() {
+    self.backgroundColor = UIColor.white
+  }
+  
+  private func setupSubviews(title: String, rightButtonTitle: String) {
+    self.setupGrabberView()
+    self.setupTitleLabel(with: title)
+    self.setupDoneButton(with: rightButtonTitle)
+  }
+  
+  private func setupGrabberView() {
+    self.addSubview(self.grabberView)
+    self.grabberView.usingAutolayout()
+    self.grabberView.layer.cornerRadius = Constants.GrabberView.cornerRadius
+    self.grabberView.backgroundColor = UIColor.lightGray
+    
+    NSLayoutConstraint.activate(
+      [
+        self.grabberView.topAnchor.constraint(equalTo: self.topAnchor, constant: Constants.GrabberView.topMargin),
+        self.grabberView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+        self.grabberView.widthAnchor.constraint(equalToConstant: Constants.GrabberView.width),
+        self.grabberView.heightAnchor.constraint(equalToConstant: Constants.GrabberView.height)
+      ]
+    )
+  }
+  
+  private func setupTitleLabel(with title: String) {
+    self.titleLabel.attributedText = title.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardHeadBold,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    )
+    self.titleLabel.textAlignment = NSTextAlignment.center
+    self.addSubview(self.titleLabel)
+    self.titleLabel.usingAutolayout()
+    
+    NSLayoutConstraint.activate(
+      [
+        self.titleLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+        self.titleLabel.topAnchor.constraint(
+          equalTo: self.topAnchor,
+          constant: Constants.TitleLabel.topMargin
+        )
+      ]
+    )
+  }
+  
+  private func setupDoneButton(with rightButtonTitle: String) {
+    let buttonTitle = rightButtonTitle.applyTextAttributes(
+      attributes: [
+        NSAttributedString.Key.font: UIFont.pretendardBodyRegular,
+        NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenDark
+      ]
+    )
+    self.rightButton.setAttributedTitle(buttonTitle, for: UIControl.State.normal)
+    self.rightButton.addAction(
+      UIAction { [weak self] _ in self?.doneButtonTapped() },
+      for: UIControl.Event.touchUpInside
+    )
+    self.addSubview(self.rightButton)
+    self.rightButton.usingAutolayout()
+    
+    NSLayoutConstraint.activate(
+      [
+        self.rightButton.trailingAnchor.constraint(
+          equalTo: self.trailingAnchor,
+          constant: Constants.RightButton.trailing
+        ),
+        self.rightButton.centerYAnchor.constraint(equalTo: self.titleLabel.centerYAnchor)
+      ]
+    )
+  }
+  
+  private func doneButtonTapped() {
+    self.delegate?.didTapRightButton()
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
@@ -29,6 +29,10 @@ final public class SearchGardenTableView: UITableView {
     self.diffableDataSource.apply(snapshot, animatingDifferences: true)
   }
   
+  public func userForCell(at indexPath: IndexPath) -> SearchGardenUser? {
+    return self.diffableDataSource.itemIdentifier(for: indexPath)
+  }
+  
   private func configureDataSource() {
     self.diffableDataSource = UITableViewDiffableDataSource<
       SearchGardenSection,

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
@@ -45,7 +45,7 @@ final public class SearchGardenTableView: UITableView {
         return nil
       }
       
-      let cell = tableRow.build(
+      tableRow.update(
         configuration: Styled.Row.Configuration.profile(
           .init(
             style: .searchRow,
@@ -55,7 +55,8 @@ final public class SearchGardenTableView: UITableView {
           )
         )
       )
-      return cell
+
+      return tableRow
     }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/TableRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/TableRow.swift
@@ -8,6 +8,7 @@ public class TableRow: UITableViewCell {
     self.contentView.subviews.forEach { subview in
       subview.removeFromSuperview()
     }
+    // TODO: 좀 더 저렴한 방법 고민
   }
   
   private func setupRow(configuration: Styled.Row.Configuration) -> Styled.Row {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/TableRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/TableRow.swift
@@ -2,50 +2,61 @@ import Combine
 import UIKit
 
 public class TableRow: UITableViewCell {
+  private let row: Styled.Row
   
-  public override func prepareForReuse() {
-    super.prepareForReuse()
-    self.contentView.subviews.forEach { subview in
-      subview.removeFromSuperview()
-    }
-    // TODO: 좀 더 저렴한 방법 고민
+  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    self.row = Styled.Row(
+      configuration: .profile(
+        .init(
+          style: .searchRow,
+          title: "",
+          description: ""
+        )
+      )
+    )
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+    self.setupRow()
   }
   
-  private func setupRow(configuration: Styled.Row.Configuration) -> Styled.Row {
-    let newRow = Styled.Row(configuration: configuration)
-    newRow.usingAutolayout()
-    self.contentView.addSubview(newRow)
-    
-    NSLayoutConstraint.activate([
-      newRow.topAnchor.constraint(equalTo: self.contentView.topAnchor),
-      newRow.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
-      newRow.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor),
-      newRow.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor)
-    ])
-    
-    self.selectionStyle = UITableViewCell.SelectionStyle.none
-    return newRow
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
   }
   
-  public func build(configuration: Styled.Row.Configuration) -> Self {
-    _ = self.setupRow(configuration: configuration)
-    return self
+  public func update(configuration: Styled.Row.Configuration) {
+    self.row.configuration = configuration
   }
   
   public func build<T>(
     configuration: Styled.Row.Configuration,
     keyPath: KeyPath<Styled.Row.Configuration, T>
   ) -> AnyPublisher<T, Never>? {
-    let setupRow = self.setupRow(configuration: configuration)
-    return setupRow.$configuration
+    return self.row.$configuration
       .map(keyPath)
       .eraseToAnyPublisher()
+  }
+  
+  private func setupRow() {
+    self.row.usingAutolayout()
+    self.contentView.addSubview(self.row)
+    
+    NSLayoutConstraint.activate(
+      [
+        self.row.topAnchor.constraint(equalTo: self.contentView.topAnchor),
+        self.row.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
+        self.row.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor),
+        self.row.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor)
+      ]
+    )
+    
+    self.selectionStyle = UITableViewCell.SelectionStyle.none
   }
 }
 
 @available(iOS 17.0, *)
 #Preview {
-  let cell = TableRow().build(
+  let tableRow = TableRow()
+  tableRow.update(
     configuration: .profile(
       .init(
         style: .searchRow,
@@ -54,5 +65,6 @@ public class TableRow: UITableViewCell {
       )
     )
   )
-  return cell
+  
+  return tableRow
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/TableRow.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/TableRow.swift
@@ -2,6 +2,14 @@ import Combine
 import UIKit
 
 public class TableRow: UITableViewCell {
+  
+  public override func prepareForReuse() {
+    super.prepareForReuse()
+    self.contentView.subviews.forEach { subview in
+      subview.removeFromSuperview()
+    }
+  }
+  
   private func setupRow(configuration: Styled.Row.Configuration) -> Styled.Row {
     let newRow = Styled.Row(configuration: configuration)
     newRow.usingAutolayout()

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+DefaultModalNavigationBar.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+DefaultModalNavigationBar.swift
@@ -1,0 +1,25 @@
+//
+//  Constant+DefaultModalNavigationBar.swift
+//
+//
+//  Created by SONG on 11/26/24.
+//
+
+import Foundation
+
+extension Constant.DefaultModalNavigationBar {
+  public enum GrabberView {
+    public static let cornerRadius: CGFloat = 5.0
+    public static let topMargin: CGFloat = 10.0
+    public static let width: CGFloat = 36.0
+    public static let height: CGFloat = 4.0
+  }
+  
+  public enum TitleLabel {
+    public static let topMargin: CGFloat = 34.0
+  }
+  
+  public enum RightButton {
+    public static let trailing: CGFloat = -16.0
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -48,4 +48,5 @@ public enum Constant {
   public enum MyStatsSummaryView { }
   public enum SearchGardenTextField { }
   public enum AddGardenView { }
+  public enum DefaultModalNavigationBar { }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #701 

## 🎉 변경 사항
- SearchGardenScene에서 쓰일 UI에 대한 작업을 진행하였습니다. 

## 📌 PR Point

### ModalNavigationBar 추가 
- ↓ 내비바가 어색하다...
<img width="320" alt="스크린샷 2024-11-26 오후 4 06 44" src="https://github.com/user-attachments/assets/b0726028-2d30-48ae-807c-70accc9e9d99">

-> NavigationBar에 대한 설정을 씬델에서 적용시키기 때문에 커스텀이 까다로움
-> 하단라인 제거 / 버튼 커스텀이 기대대로 되지 않음 (마개조필요)
-> 모달 손잡이 (grabber) 같은 경우도 마찬가지 

그래서 DefaultModalNavigationBar 를 만들어서 적용하였습니다. 몇몇 화면에서 재사용 가능해보입니다. (ex: 피드백 작성하기 등)

![스크린샷 2024-11-26 오후 4 13 23](https://github.com/user-attachments/assets/d3ec6b3f-d0d8-409f-bcf0-7008c95a8121)

### 필요한 메서드 추가 
- TableRow : prepareForReuse() 정의 -> reuse시 cell이 겹쳐보이는 현상 방지 
- AddGardenView : update() 정의 -> 표시될 내용 변경시, 다시 생성하는게 아닌 이미 생성된 AddGardenView의 내용만 교체
- SearchGardenTableView : userForCell() 정의 -> cell이 터치되었을 시, 해당 cell에 대한 정보 리턴 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?