### PR TITLE
RootTabBar 설정

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/PageTransition.swift
@@ -63,8 +63,6 @@ public final class PageTransition: NSObject, UIViewControllerAnimatedTransitioni
       initialSpringVelocity: 0.7,
       options: [UIView.AnimationOptions.curveEaseInOut],
       animations: {
-        fromView.layer.opacity = 0
-        toView.layer.opacity = 1
         fromView.frame = fromFrameEnd
         toView.frame = frame
       },

--- a/ToDo-Garden/ToDo-Garden.xcodeproj/project.pbxproj
+++ b/ToDo-Garden/ToDo-Garden.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		4FC8C1082B8336A100BA223E /* ToDoGardenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoGardenTests.swift; sourceTree = "<group>"; };
 		4FC8C10F2B83375500BA223E /* ToDo-GardenTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "ToDo-GardenTestPlan.xctestplan"; sourceTree = "<group>"; };
 		4FC8C14A2B87562600BA223E /* ToDoGardenUI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = ToDoGardenUI; sourceTree = "<group>"; };
+		4FD2D0132CF56C3B0040E747 /* RootTabBar */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RootTabBar; sourceTree = "<group>"; };
 		4FDA5E382B4FF1E4006506ED /* Asset.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Asset.xcassets; sourceTree = "<group>"; };
 		4FEB41402C36864D00E3682A /* ShareGardenScene */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = ShareGardenScene; sourceTree = "<group>"; };
 		631CD21F2C609FAD0000F78E /* SettingScene */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SettingScene; sourceTree = "<group>"; };
@@ -164,6 +165,7 @@
 		4F0DF12A2B4EABCE00097B7D /* ToDo-Garden */ = {
 			isa = PBXGroup;
 			children = (
+				4FD2D0132CF56C3B0040E747 /* RootTabBar */,
 				E4EED7D52CEB5130006B145D /* SearchGardenScene */,
 				E440FDE72CE4878100775512 /* MyStatsScene */,
 				E4FE64602CDF49DE00AB04EF /* OnBoardingScene */,

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Package.swift
@@ -12,9 +12,33 @@ let package = Package(
       targets: ["RootTabBar"]
     )
   ],
+  dependencies: [
+    Package.Dependency.package(
+      name: "ToDoGardenUI",
+      path: "../ToDoGardenUI"
+    ),
+    Package.Dependency.package(
+      name: "TDFoundation",
+      path: "../TDFoundation"
+    )
+  ],
   targets: [
     Target.target(
-      name: "RootTabBar"
+      name: "RootTabBar",
+      dependencies: [
+        Target.Dependency.product(
+          name: "ToDoGardenUIAPI",
+          package: "ToDoGardenUI"
+        ),
+        Target.Dependency.product(
+          name: "ToDoGardenUIResource",
+          package: "ToDoGardenUI"
+        ),
+        Target.Dependency.product(
+          name: "TDFoundation",
+          package: "TDFoundation"
+        )
+      ]
     )
   ]
 )

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/Constant.swift
@@ -18,9 +18,15 @@ extension Constant.Layout {
 }
 
 extension Constant.StringLiteral {
-  
+  enum RootTabBarController { }
 }
 
 extension Constant.Layout.RootTabBar {
   static let imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: -3, right: 0)
+}
+
+extension Constant.StringLiteral.RootTabBarController {
+  static let homeTabTitle = "홈"
+  static let shareTabTitle = "공유"
+  static let settingsTabTitle = "설정"
 }

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/Constant.swift
@@ -1,0 +1,26 @@
+//
+//  Constant.swift
+//  RootTabBar
+//
+//  Created by Noah on 11/28/24.
+//
+
+import Foundation
+import struct UIKit.UIEdgeInsets
+
+enum Constant {
+  enum Layout { }
+  enum StringLiteral { }
+}
+
+extension Constant.Layout {
+  enum RootTabBar { }
+}
+
+extension Constant.StringLiteral {
+  
+}
+
+extension Constant.Layout.RootTabBar {
+  static let imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: -3, right: 0)
+}

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBar.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBar.swift
@@ -32,7 +32,7 @@ extension RootTabBarController {
     
     private func adjustTabBarItemImageInsets() {
       self.items?.forEach { item in
-        item.imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: -3, right: 0)
+        item.imageInsets = LayoutConstant.imageInsets
       }
     }
     
@@ -42,4 +42,8 @@ extension RootTabBarController {
       self.layer.addSublayer(self.topSeparatorLineLayer)
     }
   }
+}
+
+extension RootTabBarController.RootTabBar {
+  typealias LayoutConstant = Constant.Layout.RootTabBar
 }

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBar.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBar.swift
@@ -1,2 +1,45 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book
+//
+//  RootTabBar.swift
+//  RootTabBar
+//
+//  Created by Noah on 11/27/24.
+//
+
+import UIKit
+
+extension RootTabBarController {
+  final class RootTabBar: UITabBar {
+    private let topSeparatorLineLayer: CALayer = {
+      let topSeparatorLineLayer = CALayer()
+      topSeparatorLineLayer.backgroundColor = UIColor.toDoGardenGreenBackground.cgColor
+      return topSeparatorLineLayer
+    }()
+    
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+      self.setupTabBarAppearance()
+    }
+    
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+      super.layoutSubviews()
+      self.topSeparatorLineLayer.frame.size = CGSize(width: self.bounds.width, height: 1)
+      self.adjustTabBarItemImageInsets()
+    }
+    
+    private func adjustTabBarItemImageInsets() {
+      self.items?.forEach { item in
+        item.imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: -3, right: 0)
+      }
+    }
+    
+    private func setupTabBarAppearance() {
+      self.tintColor = UIColor.toDoGardenGreenDark
+      self.backgroundColor = UIColor.white
+      self.layer.addSublayer(self.topSeparatorLineLayer)
+    }
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBar.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBar.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import ToDoGardenUIResource
+
 extension RootTabBarController {
   final class RootTabBar: UITabBar {
     private let topSeparatorLineLayer: CALayer = {

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 public final class RootTabBarController: UITabBarController {
+  private let rootTabBar = RootTabBar()
   private let tabItems: [RootTab]
   
   public init(tabItems: [RootTab]) {
@@ -18,6 +19,11 @@ public final class RootTabBarController: UITabBarController {
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+  
+  public override func loadView() {
+    super.loadView()
+    self.setValue(self.rootTabBar, forKey: "tabBar")
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
@@ -8,5 +8,24 @@
 import UIKit
 
 public final class RootTabBarController: UITabBarController {
+  private let tabItems: [RootTab]
+  
+  public init(tabItems: [RootTab]) {
+    self.tabItems = tabItems
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+extension RootTabBarController {
+  public enum RootTab {
+    case home(index: Int, viewController: UIViewController)
+    case share(index: Int, viewController: UIViewController)
+    case settings(index: Int, viewController: UIViewController)
+  }
   
 }

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import ToDoGardenUIResource
+
 public final class RootTabBarController: UITabBarController {
   private let rootTabBar = RootTabBar()
   private let bounceAnimation: CAKeyframeAnimation = {
@@ -22,6 +24,7 @@ public final class RootTabBarController: UITabBarController {
   public init(tabItems: [RootTab]) {
     self.tabItems = tabItems
     super.init(nibName: nil, bundle: nil)
+    self.setup()
   }
   
   @available(*, unavailable)
@@ -51,6 +54,20 @@ extension RootTabBarController {
     case settings(index: Int, viewController: UIViewController)
   }
   
+  private func homeTabBarItemStyle(for tabBarItem: UITabBarItem) {
+    tabBarItem.image = UIImage.homeTabBarItemImage
+    tabBarItem.title = "홈"
+  }
+  
+  private func shareTabBarItemStyle(for tabBarItem: UITabBarItem) {
+    tabBarItem.image = UIImage.shareTabBarItemImage
+    tabBarItem.title = "공유"
+  }
+  
+  private func settingsTabBarItemStyle(for tabBarItem: UITabBarItem) {
+    tabBarItem.image = UIImage.settingsTabBarItemImage
+    tabBarItem.title = "설정"
+  }
   
   private func getSelectedTabBarImageView(in selectedTabBarButton: UIView) -> UIImageView? {
     let selectedImageView = selectedTabBarButton.subviews
@@ -58,5 +75,57 @@ extension RootTabBarController {
       .first
     
     return selectedImageView
+  }
+  
+  private func setup() {
+    self.setupViewControllers()
+    self.setupAppearance()
+  }
+  
+  private func setupViewControllers() {
+    var viewControllers = [UIViewController]()
+    for tabItem in self.tabItems {
+      switch tabItem {
+      case RootTab
+        .home(_, let viewController),
+        RootTab
+          .share(_, let viewController),
+        RootTab
+          .settings(_, let viewController):
+        viewControllers.append(viewController)
+      }
+    }
+    self.viewControllers = viewControllers
+  }
+  
+  private func setupAppearance() {
+    self.view.backgroundColor = UIColor.white
+    self.setupTabBarStyles()
+  }
+  
+  private func setupTabBarStyles() {
+    for tabItem in tabItems {
+      switch tabItem {
+      case RootTab.home(let index, _):
+        self.tabBarItem(atIndex: index)
+          .map { self.homeTabBarItemStyle(for: $0) }
+      case RootTab.share(let index, _):
+        self.tabBarItem(atIndex: index)
+          .map { self.shareTabBarItemStyle(for: $0) }
+      case RootTab.settings(let index, _):
+        self.tabBarItem(atIndex: index)
+          .map { self.settingsTabBarItemStyle(for: $0) }
+      }
+    }
+  }
+  
+  private func tabBarItem(atIndex index: Int) -> UITabBarItem? {
+    if index < (self.tabBar.items?.count ?? 0) {
+      if let item = self.tabBar.items?[index] {
+        return item
+      }
+    }
+    
+    return nil
   }
 }

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import TDFoundation
 import ToDoGardenUIResource
 
 public final class RootTabBarController: UITabBarController {
@@ -25,6 +26,7 @@ public final class RootTabBarController: UITabBarController {
     self.tabItems = tabItems
     super.init(nibName: nil, bundle: nil)
     self.setup()
+    self.delegate = self
   }
   
   @available(*, unavailable)
@@ -44,6 +46,17 @@ public final class RootTabBarController: UITabBarController {
       let selectedImageView = self.getSelectedTabBarImageView(in: tabBarButtton)
       selectedImageView?.layer.add(self.bounceAnimation, forKey: nil)
     }
+
+extension RootTabBarController: UITabBarControllerDelegate {
+  public func tabBarController(
+    _ tabBarController: UITabBarController,
+    animationControllerForTransitionFrom fromVC: UIViewController,
+    to toVC: UIViewController
+  ) -> (any UIViewControllerAnimatedTransitioning)? {
+    guard let viewControllers = tabBarController.viewControllers
+    else { return nil }
+    
+    return PageTransition(viewControllers: viewControllers)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
@@ -12,6 +12,7 @@ import ToDoGardenUIAPI
 import ToDoGardenUIResource
 
 public final class RootTabBarController: UITabBarController, HapticFeedbackable {
+  typealias StringLiteral = Constant.StringLiteral.RootTabBarController
   private let rootTabBar = RootTabBar()
   private let bounceAnimation: CAKeyframeAnimation = {
     let bounceAnimation = CAKeyframeAnimation(keyPath: "transform.scale")
@@ -73,17 +74,17 @@ extension RootTabBarController {
   
   private func homeTabBarItemStyle(for tabBarItem: UITabBarItem) {
     tabBarItem.image = UIImage.homeTabBarItemImage
-    tabBarItem.title = "홈"
+    tabBarItem.title = StringLiteral.homeTabTitle
   }
   
   private func shareTabBarItemStyle(for tabBarItem: UITabBarItem) {
     tabBarItem.image = UIImage.shareTabBarItemImage
-    tabBarItem.title = "공유"
+    tabBarItem.title = StringLiteral.shareTabTitle
   }
   
   private func settingsTabBarItemStyle(for tabBarItem: UITabBarItem) {
     tabBarItem.image = UIImage.settingsTabBarItemImage
-    tabBarItem.title = "설정"
+    tabBarItem.title = StringLiteral.settingsTabTitle
   }
   
   private func getSelectedTabBarImageView(in selectedTabBarButton: UIView) -> UIImageView? {

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
@@ -9,6 +9,14 @@ import UIKit
 
 public final class RootTabBarController: UITabBarController {
   private let rootTabBar = RootTabBar()
+  private let bounceAnimation: CAKeyframeAnimation = {
+    let bounceAnimation = CAKeyframeAnimation(keyPath: "transform.scale")
+    bounceAnimation.values = [1.0, 1.4, 0.9, 1.02, 1.0]
+    bounceAnimation.duration = TimeInterval(0.3)
+    bounceAnimation.calculationMode = CAAnimationCalculationMode.cubic
+    
+    return bounceAnimation
+  }()
   private let tabItems: [RootTab]
   
   public init(tabItems: [RootTab]) {
@@ -25,6 +33,15 @@ public final class RootTabBarController: UITabBarController {
     super.loadView()
     self.setValue(self.rootTabBar, forKey: "tabBar")
   }
+  
+  public override func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
+    if let index = tabBar.items?.firstIndex(of: item),
+      index + 1 <= tabBar.subviews.count {
+      let tabBarButtton = tabBar.subviews[index + 1]
+      let selectedImageView = self.getSelectedTabBarImageView(in: tabBarButtton)
+      selectedImageView?.layer.add(self.bounceAnimation, forKey: nil)
+    }
+  }
 }
 
 extension RootTabBarController {
@@ -34,4 +51,12 @@ extension RootTabBarController {
     case settings(index: Int, viewController: UIViewController)
   }
   
+  
+  private func getSelectedTabBarImageView(in selectedTabBarButton: UIView) -> UIImageView? {
+    let selectedImageView = selectedTabBarButton.subviews
+      .compactMap { $0.subviews.first?.subviews.first as? UIImageView }
+      .first
+    
+    return selectedImageView
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
@@ -8,9 +8,10 @@
 import UIKit
 
 import TDFoundation
+import ToDoGardenUIAPI
 import ToDoGardenUIResource
 
-public final class RootTabBarController: UITabBarController {
+public final class RootTabBarController: UITabBarController, HapticFeedbackable {
   private let rootTabBar = RootTabBar()
   private let bounceAnimation: CAKeyframeAnimation = {
     let bounceAnimation = CAKeyframeAnimation(keyPath: "transform.scale")
@@ -46,6 +47,9 @@ public final class RootTabBarController: UITabBarController {
       let selectedImageView = self.getSelectedTabBarImageView(in: tabBarButtton)
       selectedImageView?.layer.add(self.bounceAnimation, forKey: nil)
     }
+    self.triggerHapticFeedback(type: HapticFeedbackType.selection)
+  }
+}
 
 extension RootTabBarController: UITabBarControllerDelegate {
   public func tabBarController(

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBarController.swift
@@ -1,0 +1,12 @@
+//
+//  RootTabBarController.swift
+//  RootTabBar
+//
+//  Created by Noah on 11/26/24.
+//
+
+import UIKit
+
+public final class RootTabBarController: UITabBarController {
+  
+}


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #675 
## 🎉 변경 사항
- [x] 탭 아이템 설정
- [x] 탭 화면전환 효과 설정
- [x] 탭 전환 시 햅틱 피드백 설정
## 📌 PR Point
- 탭 선택 시 사용자가 탭 간 구분감을 느낄 수 있도록 하게 하기 위해 UISelectionFeedbackGenerator를 이용해 햅틱 피드백을 설정하였습니다.
- 탭 선택 시 탭 아이콘 이미지에 scale을 늘였다가 줄이는 애니메이션을 설정하였습니다.
- Tab간 화면전환(transition) 애니메이션 설정
  - PageTransition에서 구현한 화면전환 애니메이션을 RootTabBarController 화면 전환 시 적용되도록 하였습니다.

|Demo|
|---|
|<img src="https://github.com/user-attachments/assets/80b2d026-dd06-4bbb-a79c-44ac1c2b698e" width="200" />|


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?