### PR TITLE
add toast view

### DIFF
--- a/ToDo-Garden/TDUtility/Sources/TDUtility/UIViewController+ToastView.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/UIViewController+ToastView.swift
@@ -1,10 +1,64 @@
 //
-//  Untitled.swift
+//  UIViewController+ToastView.swift
 //  TDUtility
 //
 //  Created by SONG on 11/30/24.
 //
 
+import UIKit
+
+public extension UIViewController {
+  func showToast(
+    message: String,
+    backgroundColor: UIColor = UIColor.black.withAlphaComponent(0.7),
+    textColor: UIColor = UIColor.white
+  ) {
+    let toastView = getToastView(message: message, backgroundColor: backgroundColor, textColor: textColor)
+    self.view.addSubview(toastView)
+    setupToastViewConstraints(toastView: toastView)
+    animateToastView(toastView: toastView)
+  }
+  
+  private func getToastView(message: String, backgroundColor: UIColor, textColor: UIColor) -> ToastView {
+    if let existingToastView = self.view.subviews.first(where: { $0 is ToastView }) as? ToastView {
+      existingToastView.messageLabel.text = message
+      existingToastView.backgroundColor = backgroundColor
+      existingToastView.alpha = 0.0
+      return existingToastView
+    } else {
+      return ToastView(message: message, backgroundColor: backgroundColor, textColor: textColor)
+    }
+  }
+  
+  private func setupToastViewConstraints(toastView: ToastView) {
+    toastView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      toastView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+      toastView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
+      toastView.leadingAnchor.constraint(greaterThanOrEqualTo: self.view.leadingAnchor, constant: 20),
+      toastView.trailingAnchor.constraint(lessThanOrEqualTo: self.view.trailingAnchor, constant: -20)
+    ])
+  }
+  
+  private func animateToastView(toastView: ToastView) {
+    UIView.animate(
+      withDuration: 0.3,
+      animations: {
+        toastView.alpha = 1.0
+      },
+      completion: { _ in
+        UIView.animate(
+          withDuration: 0.3,
+          delay: 2.0,
+          options: [],
+          animations: {
+            toastView.alpha = 0.0
+          }
+        )
+      }
+    )
+  }
+}
 
 final class ToastView: UIView {
   let messageLabel: UILabel

--- a/ToDo-Garden/TDUtility/Sources/TDUtility/UIViewController+ToastView.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/UIViewController+ToastView.swift
@@ -39,25 +39,6 @@ public extension UIViewController {
       toastView.trailingAnchor.constraint(lessThanOrEqualTo: self.view.trailingAnchor, constant: -20)
     ])
   }
-  
-  private func animateToastView(toastView: ToastView) {
-    UIView.animate(
-      withDuration: 0.3,
-      animations: {
-        toastView.alpha = 1.0
-      },
-      completion: { _ in
-        UIView.animate(
-          withDuration: 0.3,
-          delay: 2.0,
-          options: [],
-          animations: {
-            toastView.alpha = 0.0
-          }
-        )
-      }
-    )
-  }
 }
 
 final class ToastView: UIView {
@@ -73,6 +54,25 @@ final class ToastView: UIView {
     self.setupView(backgroundColor: backgroundColor)
     self.configureMessageLabel(message: message, textColor: textColor)
     self.setupConstraints()
+  }
+  
+  func animateToastView() {
+    UIView.animate(
+      withDuration: 0.3,
+      animations: {
+        self.alpha = 1.0
+      },
+      completion: { _ in
+        UIView.animate(
+          withDuration: 0.3,
+          delay: 2.0,
+          options: [],
+          animations: {
+            self.alpha = 0.0
+          }
+        )
+      }
+    )
   }
   
   private func setupView(backgroundColor: UIColor) {

--- a/ToDo-Garden/TDUtility/Sources/TDUtility/UIViewController+ToastView.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/UIViewController+ToastView.swift
@@ -1,0 +1,7 @@
+//
+//  Untitled.swift
+//  TDUtility
+//
+//  Created by SONG on 11/30/24.
+//
+

--- a/ToDo-Garden/TDUtility/Sources/TDUtility/UIViewController+ToastView.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/UIViewController+ToastView.swift
@@ -5,3 +5,51 @@
 //  Created by SONG on 11/30/24.
 //
 
+
+final class ToastView: UIView {
+  let messageLabel: UILabel
+  
+  init(
+    message: String,
+    backgroundColor: UIColor = UIColor.black.withAlphaComponent(0.7),
+    textColor: UIColor = UIColor.white
+  ) {
+    self.messageLabel = UILabel()
+    super.init(frame: CGRect.zero)
+    self.setupView(backgroundColor: backgroundColor)
+    self.configureMessageLabel(message: message, textColor: textColor)
+    self.setupConstraints()
+  }
+  
+  private func setupView(backgroundColor: UIColor) {
+    self.backgroundColor = backgroundColor
+    self.alpha = 0.0
+    self.layer.cornerRadius = 10
+    self.clipsToBounds = true
+  }
+  
+  private func configureMessageLabel(message: String, textColor: UIColor) {
+    self.messageLabel.text = message
+    self.messageLabel.textColor = textColor
+    self.messageLabel.font = UIFont.systemFont(ofSize: 15)
+    self.messageLabel.numberOfLines = 0
+    self.messageLabel.textAlignment = NSTextAlignment.center
+    
+    self.addSubview(self.messageLabel)
+    self.messageLabel.translatesAutoresizingMaskIntoConstraints = false
+  }
+  
+  private func setupConstraints() {
+    NSLayoutConstraint.activate([
+      self.messageLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 10),
+      self.messageLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -10),
+      self.messageLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 10),
+      self.messageLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -10)
+    ])
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/ToDo-Garden/TDUtility/Sources/TDUtility/UIViewController+ToastView.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/UIViewController+ToastView.swift
@@ -13,10 +13,10 @@ public extension UIViewController {
     backgroundColor: UIColor = UIColor.black.withAlphaComponent(0.7),
     textColor: UIColor = UIColor.white
   ) {
-    let toastView = getToastView(message: message, backgroundColor: backgroundColor, textColor: textColor)
+    let toastView = self.getToastView(message: message, backgroundColor: backgroundColor, textColor: textColor)
     self.view.addSubview(toastView)
-    setupToastViewConstraints(toastView: toastView)
-    animateToastView(toastView: toastView)
+    self.setupToastViewConstraints(toastView: toastView)
+    toastView.animateToastView()
   }
   
   private func getToastView(message: String, backgroundColor: UIColor, textColor: UIColor) -> ToastView {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #710 
## 🎉 변경 사항
- UIViewController를 확장하여 ToastView를 띄우는 기능을 구현했습니다. 

## 📌 PR Point

### 사용자에게 간단한 정보를 제공하고자 할 때 유용하게 쓰고자 만들었습니다. 
### TDUtility를 import하고 , VC에서 showToast() 메서드로 접근할 수 있습니다. 
### showToast() 호출시, 이미 추가되어있는 ToastView가 있는지 없는지 검사한 뒤 동작합니다. 
   - 이미 존재하면 update / 최초 호출이라 존재하지 않으면 addSubview진행 
### 2초간 보여졌다 사라집니다. 
   
### 결과화면 
![Simulator Screen Recording - iPhone 16 Pro - 2024-11-30 at 18 50 14](https://github.com/user-attachments/assets/f57bb332-dab7-413b-b132-b3e6b666ab4f)


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?