### PR TITLE
로그인 흐름 수정 

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/AuthenticationServices.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/AuthenticationServices.swift
@@ -52,8 +52,8 @@ extension AppleLoginManager: ASAuthorizationControllerDelegate {
         )
         
         Task {
-          let isExistingUser = try await self.requestVerificationToSupabase()
-          self.delegate?.appleLoginDidComplete(with: .success(isExistingUser))
+          let isMember = try await self.requestVerificationToSupabase()
+          self.delegate?.appleLoginDidComplete(with: .success(isMember))
         }
       } catch let error {
         self.delegate?.appleLoginDidComplete(with: .failure(error))

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/AuthenticationServices.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/AuthenticationServices.swift
@@ -8,7 +8,7 @@
 import AuthenticationServices
 
 public protocol AppleLoginManagerDelegate: AnyObject {
-  func appleLoginDidComplete(with result: Result<ASAuthorizationAppleIDCredential, Error>)
+  func appleLoginDidComplete(with result: Result<Bool, Error>)
 }
 
 public final class AppleLoginManager: NSObject {
@@ -44,11 +44,38 @@ extension AppleLoginManager: ASAuthorizationControllerDelegate {
     didCompleteWithAuthorization authorization: ASAuthorization
   ) {
     if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
-      self.delegate?.appleLoginDidComplete(with: .success(appleIDCredential))
+      do {
+        try KeychainManager.shared.saveLoginData(
+          identifier: appleIDCredential.user,
+          identifyToken: appleIDCredential.identityToken ?? Data(),
+          email: appleIDCredential.email
+        )
+        
+        Task {
+          let isExistingUser = try await self.requestVerificationToSupabase()
+          self.delegate?.appleLoginDidComplete(with: .success(isExistingUser))
+        }
+      } catch let error {
+        self.delegate?.appleLoginDidComplete(with: .failure(error))
+      }
     }
   }
   
   public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
     self.delegate?.appleLoginDidComplete(with: .failure(error))
+  }
+}
+
+extension AppleLoginManager {
+  func requestVerificationToSupabase() async throws -> Bool {
+    if let token = try KeychainManager.shared.load(forKey: "identity_token") {
+      // HTTP 로그인 요청
+      // response에 기존 / 신규 유저 여부 포함
+    }
+    
+    // supaBase 인증 성공 && 기존유저 -> true
+    // supaBase 인증 성공 && 신규유저 -> false
+    // supaBase 인증 실패 -> throw Error
+    return true
   }
 }

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/KeychainManager.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/KeychainManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Security
 
-public final class KeychainManager {
+public final class KeychainManager: Sendable {
   public static let shared = KeychainManager()
   
   private init() {}

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
@@ -27,13 +27,13 @@ public final class AppCore {
   public func getStarted() {
     self.destination = !dependency.userDefaults.hasShownFirstLaunchOnboarding
     ? .onboarding { [weak self] flag in
-      if flag {
+      if flag { // 기존유저 로그인 끝난 뒤 목적지 == 홈
         self?.destination = .home
       } else {
-        
+        // 신규유저 로그인 끝난 뒤, 약관동의 "완료"버튼을 누르면 여기로 옵니다. 목적지 SignUpScene으로 전환 ( SignUpSceneBuilder() )
       }
     }
-    : .home
+    : .home // 로그인 case 생기면, 로그인 플로우가 들어갈 예정 
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
@@ -7,7 +7,7 @@ import Foundation
 public final class AppCore {
   public var dependency: Dependency
   public enum Destination {
-    case onboarding((Bool) -> Void)
+    case onboarding((Bool, Bool) -> Void)
     case home // Binding HomeInteractor
     // case login
     case none
@@ -26,14 +26,14 @@ public final class AppCore {
   // MARK: 앱시작시 무조건 먼저 호출해야하는 메소드
   public func getStarted() {
     self.destination = !dependency.userDefaults.hasShownFirstLaunchOnboarding
-    ? .onboarding { [weak self] flag in
-      if flag { // 기존유저 로그인 끝난 뒤 목적지 == 홈
+    ? .onboarding { [weak self] isMember, isEventAndPromotionalAgreed in
+      if isMember {
         self?.destination = .home
       } else {
-        // 신규유저 로그인 끝난 뒤, 약관동의 "완료"버튼을 누르면 여기로 옵니다. 목적지 SignUpScene으로 전환 ( SignUpSceneBuilder() )
+        _ = isEventAndPromotionalAgreed
       }
     }
-    : .home // 로그인 case 생기면, 로그인 플로우가 들어갈 예정 
+    : .home
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppRouter.swift
@@ -22,7 +22,7 @@ public final class AppRouter {
     }
   }
   
-  private func buildOnBoardingFlows(_ completion: @escaping (Bool) -> Void) -> [UIViewController] {
+  private func buildOnBoardingFlows(_ completion: @escaping (Bool, Bool) -> Void) -> [UIViewController] {
     let onboarding = IntroOnBoardingViewController()
     let tutroial = TutorialOnBoardingViewController()
     let login = LoginViewController()
@@ -34,18 +34,10 @@ public final class AppRouter {
       navigationController?.pushViewController(login, animated: true)
     }
 
-    login.afterLoginAction = { [weak login] isExistingUser in
-      if isExistingUser {
-        completion(true)
-      } else {
-        login?.showTermAgreementViewForRoutingToSignUpScene()
-      }
-    }
+    login.afterLoginAction = { completion(true, false) }
     
     login.doneButtonAction = { isEventAndPromotionalInformationAgreed in
-      _ = isEventAndPromotionalInformationAgreed
-      // TODO: 광고성 알림 수신 여부(isEventAndPromotionalInformationAgreed)를 SignUpScene의 payload로 받게 되어있음.
-      completion(false)
+      completion(false, isEventAndPromotionalInformationAgreed)
     }
     
     return [onboarding]

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppRouter.swift
@@ -22,7 +22,7 @@ public final class AppRouter {
     }
   }
   
-  private func buildOnBoardingFlows(_ completion: (Bool) -> Void) -> [UIViewController] {
+  private func buildOnBoardingFlows(_ completion: @escaping (Bool) -> Void) -> [UIViewController] {
     let onboarding = IntroOnBoardingViewController()
     let tutroial = TutorialOnBoardingViewController()
     let login = LoginViewController()
@@ -33,7 +33,20 @@ public final class AppRouter {
     tutroial.endAction = { [weak navigationController] in
       navigationController?.pushViewController(login, animated: true)
     }
-    // TODO: - Login Control Flow
+
+    login.afterLoginAction = { [weak login] isExistingUser in
+      if isExistingUser {
+        completion(true)
+      } else {
+        login?.showTermAgreementViewForRoutingToSignUpScene()
+      }
+    }
+    
+    login.doneButtonAction = { isEventAndPromotionalInformationAgreed in
+      _ = isEventAndPromotionalInformationAgreed
+      // TODO: 광고성 알림 수신 여부(isEventAndPromotionalInformationAgreed)를 SignUpScene의 payload로 받게 되어있음.
+      completion(false)
+    }
     
     return [onboarding]
   }

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/IntroOnBoardingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/IntroOnBoardingViewController.swift
@@ -101,7 +101,8 @@ extension IntroOnBoardingViewController {
       dummyView.topAnchor.constraint(
         equalTo: self.mainImageView.bottomAnchor
       ),
-      dummyView.bottomAnchor.constraint(equalTo: self.startButton.topAnchor)
+      dummyView.bottomAnchor.constraint(equalTo: self.startButton.topAnchor),
+      dummyView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
     ])
     
     self.leafLabelStackView.usingAutolayout()

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/LoginViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/LoginViewController.swift
@@ -143,8 +143,8 @@ extension LoginViewController: ASAuthorizationControllerPresentationContextProvi
 extension LoginViewController: AppleLoginManagerDelegate {
   public func appleLoginDidComplete(with result: Result<Bool, Error>) {
     switch result {
-    case .success(let isExistingUser):
-      self.afterLoginAction?(isExistingUser)
+    case .success(let isMember):
+      if isMember {
         self.afterLoginAction?()
       } else {
         self.showTermAgreementViewForRoutingToSignUpScene()

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/LoginViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/LoginViewController.swift
@@ -20,6 +20,9 @@ public final class LoginViewController: UIViewController {
   private let termAgreementView: TermsAgreementView
   
   private let loger = Logger()
+  
+  public var afterLoginAction: ((Bool) -> Void)?
+  public var doneButtonAction: ((Bool) -> Void)?
   // MARK: - Object lifecycle
   
   public init() {
@@ -109,7 +112,7 @@ extension LoginViewController {
     self.appleLoginManager?.delegate = self
   }
   
-  private func showTermAgreementView() {
+  public func showTermAgreementViewForRoutingToSignUpScene() {
     self.termAgreementView.isHidden = false
     UIView.animate(withDuration: 0.5) {
       self.dimmingView.alpha = 1
@@ -138,22 +141,11 @@ extension LoginViewController: ASAuthorizationControllerPresentationContextProvi
 }
 
 extension LoginViewController: AppleLoginManagerDelegate {
-  public func appleLoginDidComplete(with result: Result<ASAuthorizationAppleIDCredential, Error>) {
+  public func appleLoginDidComplete(with result: Result<Bool, Error>) {
     switch result {
-    case .success(let credential):
-      do {
-        try KeychainManager.shared.saveLoginData(
-          identifier: credential.user,
-          identifyToken: credential.identityToken ?? Data(),
-          email: credential.email
-        )
-        
-        // TODO: 신규회원인지 기존회원인지 판별
-        self.showTermAgreementView()
-      } catch {
-        self.loger.log("Keychain에 저장 실패: \(error)")
-      }
-      
+    case .success(let isExistingUser):
+      self.afterLoginAction?(isExistingUser)
+
     case .failure(let error):
       self.loger.log("Apple Login 실패: \(error)")
     }
@@ -187,18 +179,7 @@ extension LoginViewController: TermsAgreementViewDelegate {
     didTapDoneButton isEventAndPromotionalInformationAgreed: Bool
   ) {
     self.hideTermAgreementView()
-    do {
-      if let loginData = try KeychainManager.shared.getLoginData() {
-        //        self.router?.routeToSignUpScene(
-        //          userIdentifier: loginData.identifier,
-        //          userEmailAddress: loginData.email,
-        //          agreeOptionalCondition: isEventAndPromotionalInformationAgreed
-        //        )
-        // try KeychainManager.shared.clearLoginData()
-      }
-    } catch {
-      self.loger.log("Keychain에 저장된 데이터 뽑아오기 실패: \(error)")
-    }
+    self.doneButtonAction?(isEventAndPromotionalInformationAgreed)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/LoginViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/LoginViewController.swift
@@ -21,7 +21,7 @@ public final class LoginViewController: UIViewController {
   
   private let loger = Logger()
   
-  public var afterLoginAction: ((Bool) -> Void)?
+  public var afterLoginAction: (() -> Void)?
   public var doneButtonAction: ((Bool) -> Void)?
   // MARK: - Object lifecycle
   
@@ -145,7 +145,10 @@ extension LoginViewController: AppleLoginManagerDelegate {
     switch result {
     case .success(let isExistingUser):
       self.afterLoginAction?(isExistingUser)
-
+        self.afterLoginAction?()
+      } else {
+        self.showTermAgreementViewForRoutingToSignUpScene()
+      }
     case .failure(let error):
       self.loger.log("Apple Login 실패: \(error)")
     }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #722 
## 🎉 변경 사항
- 로그인 흐름이 AppCore 위에서 동작할 수 있도록 수정합니다. 

## 📌 PR Point

> AppleLoginManager에서 기존회원인지 아니면 신규회원인지 값을 전달받게 되겠죠?
LoginViewController내부에서 전달 받은 값을 클로저 속성으로 Bool값을 전달만 하면 될 거 같습니다.

⬆️ 이 코멘트를 토대로, 구현해보았습니다. 

### #661 브랜치에서 #722를 뽑아 작업했습니다. 현재 PR의 리뷰가 끝나면, #715 의 상황을 보고 적절하게 머지하겠습니다. 

1) AppleLoginManager 변경사항 
- 애플로그인을 시도하고, apple로 부터 받은 identifierToken으로 ToDoGarden에 로그인을 시도합니다. (인터랙터 역할과 비슷하게 동작)
- supabase에서 검증과정을 거칠테고, 검증에 성공하면, 그에 대한 응답에 `기존 유저` 인지, `신규 유저`인지에 대한 데이터를 확인하여 
  `기존 유저`: 
                     SignUp절차 필요없음. 바로 홈화면으로 가면 됨. completion 에 `true` 전달 
                     
  `신규 유저`: 
                     1) SignUp절차 필요함. TermAgreementView를 표시.
                     2) TermAgreementView의 "완료" 버튼을 누르면, completion 에 `false`전달
                     
<img width="368" alt="스크린샷 2024-12-08 오후 8 36 45" src="https://github.com/user-attachments/assets/18012e60-8f08-4500-9df9-2ece3916d5b5">

++ TermAgreementView의 선택사항인 광고성 수신동의 여부를 SignUpScene에 Payload로 전달하는 작업 추가해야함. 

2) AppRouter 변경사항 
```swift
private func buildOnBoardingFlows(_ completion: @escaping (Bool) -> Void)
```
- 다른 클로저 내에서 completion을 쓰기위해  escaping 마킹 추가 

3) 기타 사소한 수정 
- 레이아웃 이슈 (보라색 느낌표) 해결 
- KeyChainManager Sendable 채택 
   

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?