### PR TITLE
설정 & 유저정보 Scene 다크모드 UI 버그 수정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -134,6 +134,7 @@ extension SettingViewController {
   }
 
   private func setupSettingCollectionView() {
+    self.settingCollectionView.backgroundColor = UIColor.toDoGardenWhite
     self.setupSettingCollectionViewRegistration()
     self.settingCollectionView.isScrollEnabled = false
     self.settingCollectionViewDataSource = self.makeDiffableDataSource(with: self.settingCollectionView)

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -257,6 +257,7 @@ extension UserInfoSceneViewController {
   }
 
   private func setupUserInfoCollectionView() {
+    self.userInfoCollectionView.backgroundColor = UIColor.toDoGardenWhite
     self.userInfoCollectionView.isScrollEnabled = false
     self.userInfoCollectionViewDataSource = self.makeDiffableDataSource(with: self.userInfoCollectionView)
     self.userInfoCollectionView.dataSource = self.userInfoCollectionViewDataSource


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #720

## 🎉 변경 사항
- 설정화면과 유저 정보화면에 있는 CollectionView의 backgroundColor에 todogardenwhite를 적용했습니다.

## 📌 PR Point
- 문제의 원인이 collectionView의 백그라운드 색상이 설정되지 않음을 확인했습니다.
- 추가적으로, 유저 정보화면에서도 같은 현상이 보여 함께 수정하였습니다.

 ### GIF
- Scene마다 라이트 <-> 다크 모드 변화를 GIF를 첨부하였습니다.
- 모드 전환시 텍스트가 바뀌는 Label은 테스트용으로, 실제로 코드에는 반영되어 있지 않습니다.

|설정 Scene|유저정보 Scene|
|--|--|
|<img width="250" src="https://github.com/user-attachments/assets/49f6f401-ef1e-4e24-a7c5-6d0ede21ee0c">|<img width="250" src="https://github.com/user-attachments/assets/c1424a01-ef2c-4409-9410-a5765a8085db">|


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?