### PR TITLE
ToDoCheckBoxButton cornerRadius 동적 사이즈 적용

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -19,7 +19,7 @@ public final class ToDoCheckBoxButton: UIButton, HapticFeedbackable {
   private var mainColor: UIColor
   private var checkmarkDrawingLayer: CAShapeLayer
 
-  @ExecuteOnce private var setAnimation: (() -> Void)?
+  @ExecuteOnce private var setupUIForSize: (() -> Void)?
 
   public init() {
     self.mainColor = UIColor.toDoGardenGreenDark
@@ -35,7 +35,7 @@ public final class ToDoCheckBoxButton: UIButton, HapticFeedbackable {
 
   public override func draw(_ rect: CGRect) {
     super.draw(rect)
-    self.setAnimation = {
+    self.setupUIForSize = {
       self.setupAnimationPath()
     }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -12,6 +12,9 @@ import ToDoGardenUIAPI
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
+/// 눌렀을 때 체크박스 애니메이션을 보여주는 버튼입니다.
+/// - 투두 체크박스, 약관 동의 버튼에 사용됩니다.
+/// - 사이즈는 반드시 가로:세로 비율이 1:1이어야 합니다.
 public final class ToDoCheckBoxButton: UIButton, HapticFeedbackable {
   private var mainColor: UIColor
   private var checkmarkDrawingLayer: CAShapeLayer

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -37,6 +37,7 @@ public final class ToDoCheckBoxButton: UIButton, HapticFeedbackable {
     super.draw(rect)
     self.setupUIForSize = {
       self.setupAnimationPath()
+      self.setupCornerRadius()
     }
   }
 
@@ -95,13 +96,17 @@ extension ToDoCheckBoxButton {
   private func setupLayer() {
     self.layer.masksToBounds = true
     self.layer.borderWidth = Constant.ToDoCheckBoxButton.Layout.borderWidth
-    self.layer.cornerRadius = Constant.ToDoCheckBoxButton.Layout.cornerRadius
   }
 }
 
 // MARK: Set up Animation
 
 extension ToDoCheckBoxButton {
+  private func setupCornerRadius() {
+    let cornerRadius = Constant.ToDoCheckBoxButton.Layout.cornerRadius * self.bounds.width
+    self.layer.cornerRadius = cornerRadius
+  }
+
   private func setupAnimationLayerUI() {
     self.checkmarkDrawingLayer.lineWidth = Constant.ToDoCheckBoxButton.Layout.lineWidth
     self.checkmarkDrawingLayer.fillColor = UIColor.clear.cgColor

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoCheckBoxButton.swift
@@ -103,7 +103,7 @@ extension ToDoCheckBoxButton {
 
 extension ToDoCheckBoxButton {
   private func setupCornerRadius() {
-    let cornerRadius = Constant.ToDoCheckBoxButton.Layout.cornerRadius * self.bounds.width
+    let cornerRadius = Constant.ToDoCheckBoxButton.Layout.cornerRadiusRatio * self.bounds.width
     self.layer.cornerRadius = cornerRadius
   }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
@@ -20,7 +20,7 @@ extension Constant.ToDoCheckBoxButton.Size {
 
 extension Constant.ToDoCheckBoxButton.Layout {
   public static let borderWidth: CGFloat = 0.6
-  public static let cornerRadius: CGFloat = 3.0 / 18.0
+  public static let cornerRadiusRatio: CGFloat = 3.0 / 18.0
   public static let lineWidth: CGFloat = 1.0
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoCheckBoxButton.swift
@@ -20,7 +20,7 @@ extension Constant.ToDoCheckBoxButton.Size {
 
 extension Constant.ToDoCheckBoxButton.Layout {
   public static let borderWidth: CGFloat = 0.6
-  public static let cornerRadius: CGFloat = 3.0
+  public static let cornerRadius: CGFloat = 3.0 / 18.0
   public static let lineWidth: CGFloat = 1.0
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #725

## 🎉 변경 사항
- ToDoCheckBoxButton의 cornerRadius를 사이즈에 맞게 설정하도록 수정하였습니다.
- 선언부에 가로:세로 비율 제약조건에 대한 설명을 주석으로 추가하였습니다.

## 📌 PR Point
- 사이즈가 달라지더라도, cornerRaidus가 figma에 명시된 비율에 맞게 적용되도록 수정하였습니다.
  - figma 기준 `width: 18` 일 때, `cornerRadius: 3`

- 사이즈를 50x50으로 설정했을 때 cornerRadius 적용 Before/After를 캡쳐했습니다.

|Before|After|
|--|--|
|<img src="https://github.com/user-attachments/assets/29f80bc8-22f1-47ab-a347-14e6bb418c32">|<img src="https://github.com/user-attachments/assets/3dc28464-313f-4641-90da-f76203626928">|


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?