### PR TITLE
CalendarViewDateSelectionDelegate 프로토콜 추가

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
@@ -23,7 +23,7 @@ public class CalendarView: UIView {
   private var heightConstraint: NSLayoutConstraint
   
   let dateCollectionView: UICollectionView
-  var calendarViewDelegate: CalendarViewControllable
+  var calendarViewDelegate: CalendarViewDelegate
 
   public weak var dateSelectionDelegate: CalendarViewDateSelectionDelegate?
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
@@ -9,6 +9,10 @@ import UIKit
 
 import ToDoGardenUIConstant
 
+public protocol CalendarViewDateSelectionDelegate: AnyObject {
+  func didSelectDate(_ date: Date)
+}
+
 public class CalendarView: UIView {
   private let model: Model
   private var isLayoutSubviewsCalled: Bool
@@ -20,7 +24,9 @@ public class CalendarView: UIView {
   
   let dateCollectionView: UICollectionView
   var calendarViewDelegate: CalendarViewControllable
-  
+
+  public weak var dateSelectionDelegate: CalendarViewDateSelectionDelegate?
+
   public init(model: Model) {
     self.model = model
     self.isLayoutSubviewsCalled = false

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
@@ -23,7 +23,7 @@ public class CalendarView: UIView {
   private var heightConstraint: NSLayoutConstraint
   
   let dateCollectionView: UICollectionView
-  var calendarViewDelegate: CalendarViewDelegate
+  var calendarViewDelegate: CalendarViewManager
 
   public weak var dateSelectionDelegate: CalendarViewDateSelectionDelegate?
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
@@ -118,6 +118,7 @@ extension CalendarView: CalendarScrollSendable {
 
 extension CalendarView {
   private func setupUI() {
+    self.backgroundColor = UIColor.toDoGardenWhite
     self.setupBorder()
     self.setupMonthLabel()
     self.setupBackButton()

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
@@ -72,10 +72,17 @@ extension CalendarView {
   private func setup() {
     self.setupUI()
     self.setupCollectionViewScrollDelegate()
+    self.setupDateSelectionDelegate()
   }
   
   func setupCollectionViewScrollDelegate() {
     self.calendarViewDelegate.scrollDelegate = self
+  }
+
+  private func setupDateSelectionDelegate() {
+    self.calendarViewDelegate.dateSelectionClosure = { (selectedDate: Date) in
+      self.dateSelectionDelegate?.didSelectDate(selectedDate)
+    }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
@@ -11,7 +11,8 @@ import ToDoGardenUIConstant
 
 protocol CalendarViewDelegate: UICollectionViewDelegate {
   var scrollDelegate: CalendarScrollSendable? { get set }
-  
+  var dateSelectionClosure: ((Date) -> Void)? { get set }
+
   func fetchWeekdaySymbols() -> [String]
   func getCollectionViewHeight() -> CGFloat
   func scrollCalendar(to scrollDirection: CalendarScrollDirection, animated: Bool)
@@ -33,7 +34,8 @@ class CalendarViewSingleSelectionDelegate: NSObject {
   
   weak var scrollDelegate: CalendarScrollSendable?
   var afterReloadSection: (() -> Void)?
-  
+  var dateSelectionClosure: ((Date) -> Void)?
+
   init(
     collectionView: UICollectionView,
     collectionViewLayoutModel: CalendarView.Model.CollectionViewLayout,
@@ -287,7 +289,11 @@ extension CalendarViewSingleSelectionDelegate {
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     guard let selectedNewItem = self.collectionViewDataSource.itemIdentifier(for: indexPath)
     else { return }
-    
+
+    if self.selectedItem != selectedNewItem {
+      self.dateSelectionClosure?(selectedNewItem.date)
+    }
+
     guard let scrollDirection = getScrollDirection(selectedItem: selectedNewItem, section: indexPath)
     else { return }
     

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import ToDoGardenUIConstant
 
-protocol CalendarViewControllable: UICollectionViewDelegate {
+protocol CalendarViewDelegate: UICollectionViewDelegate {
   var scrollDelegate: CalendarScrollSendable? { get set }
   
   func fetchWeekdaySymbols() -> [String]
@@ -55,7 +55,7 @@ class CalendarViewSingleSelectionDelegate: NSObject {
 
 // MARK: CalendarViewControllable Protocol
 
-extension CalendarViewSingleSelectionDelegate: CalendarViewControllable {
+extension CalendarViewSingleSelectionDelegate: CalendarViewDelegate {
   func fetchWeekdaySymbols() -> [String] {
     return self.calendarDataGenerator.fetchWeekdaySymbols()
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import ToDoGardenUIConstant
 
-protocol CalendarViewDelegate: UICollectionViewDelegate {
+protocol CalendarViewManager: UICollectionViewDelegate {
   var scrollDelegate: CalendarScrollSendable? { get set }
   var dateSelectionClosure: ((Date) -> Void)? { get set }
 
@@ -57,7 +57,7 @@ class CalendarViewSingleSelectionDelegate: NSObject {
 
 // MARK: CalendarViewControllable Protocol
 
-extension CalendarViewSingleSelectionDelegate: CalendarViewDelegate {
+extension CalendarViewSingleSelectionDelegate: CalendarViewManager {
   func fetchWeekdaySymbols() -> [String] {
     return self.calendarDataGenerator.fetchWeekdaySymbols()
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #727 

## 🎉 변경 사항
- CalendarView에서 선택된 날짜를 전달하는 프로토콜을 추가하였습니다.
- 캘린더 뷰 Delegate 객체의 네이밍을 수정하였습니다.

## 📌 PR Point
### 1. CalendarViewDateSelectionDelegate 프로토콜
- 선택된 날짜를 채택한 외부에 전달하는 프로토콜입니다.
- 사용법은 다음과 같습니다.
```swift
class SomeViewController: UIViewController, CalendarviewDateSelectionDelegate {
  let calendarView = CalendarView()

  override func viewDidLoad() {
    calendarView.dateSelectionDelegate = self
  }

  func didSelectDate(_ date: Date) {
    print(date)
  }
}
``` 

### 2. CalendarViewControllable 네이밍 수정
- CalendarView에서 delegate 역할을 하는 CalendarViewControllable의 네이밍을 수정하였습니다.
- suffix가 Scene의 ViewControllable을 연상시켜 수정하였습니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?