### PR TITLE
Fix styled row

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/StrikethroughView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/StrikethroughView.swift
@@ -31,10 +31,13 @@ final class StrikethroughView: UIView {
     self.strikethroughLayer.frame = self.bounds
   }
   
-  func update(_ text: String?) {
+  func update(text: String?, animated: Bool = true) {
     self.label.text = text
     self.invalidateIntrinsicContentSize()
-    self.strikethroughLayer.animate()
+    self.strikethroughLayer.isHidden = !animated
+    if animated {
+      self.strikethroughLayer.animate()
+    }
   }
   
   private func prepareView(_ color: UIColor) {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Row.swift
@@ -38,6 +38,7 @@ extension Styled {
     @Published public var configuration: Configuration
     @Published public var isSelected: Bool = false
     var cancellables: Set<AnyCancellable> = []
+    var tasks: [Task<Void, Never>] = []
     
     private var stackView: UIStackView!
     
@@ -60,6 +61,8 @@ extension Styled {
     
     public func resetState() {
       self.cancellables = []
+      self.tasks.forEach { $0.cancel() }
+      self.tasks = []
       for subview in self.stackView.arrangedSubviews {
         subview.removeFromSuperview()
       }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
@@ -37,9 +37,15 @@ extension Styled.Row {
     }
     /// textField가 resign될 경우, textField의 텍스트 여부에 따라서 textField를 숨길지, selectedView를 보여줄지 결정하게 됩니다.
     textField.resignHandler = { [weak self, weak textField, weak selectedView] in
-      textField?.isHidden = !(textField?.text?.isEmpty ?? true)
-      selectedView?.isHidden = (textField?.text?.isEmpty ?? true)
-      selecetdViewUpdateAction(textField?.text, self?.configuration.todoListModel?.isSelected ?? true)
+      let text = self?.configuration.todoListModel?.text
+      textField?.text = self?.configuration.todoListModel?.text
+      
+      let textIsEmpty = text?.isEmpty ?? true
+      textField?.isHidden = !textIsEmpty
+      selectedView?.isHidden = textIsEmpty
+      
+      let isSelected = self?.configuration.todoListModel?.isSelected ?? true
+      selecetdViewUpdateAction(text, isSelected)
     }
     
     return (
@@ -67,7 +73,11 @@ extension Styled.Row {
       guard
         let textField = action.sender as? UITextField
       else { return }
-      self?.configuration.todoListModel?.text = textField.text
+      let isSelected = self?.configuration.todoListModel?.isSelected ?? false
+      let isEmpty = textField.text?.isEmpty ?? true
+      if !isSelected || !isEmpty {
+        self?.configuration.todoListModel?.text = textField.text
+      }
     }
     textField.addAction(action, for: .editingChanged)
     
@@ -121,6 +131,10 @@ extension Styled.Row {
         else { return }
         if self?.configuration.todoListModel?.text?.isEmpty ?? true {
           checkBox.isActionBlocked = false
+          let flag = (self?.configuration.todoListModel?.isSelected ?? true)
+          if flag {
+            handler(false)
+          }
         } else {
           checkBox.isActionBlocked = true
           handler(checkBox.isSelected)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
@@ -2,14 +2,15 @@ import UIKit
 
 import ToDoGardenUIConstant
 
+// swiftlint:disable function_body_length
 extension Styled.Row {
   func buildTodoListStyle(stack: UIStackView, model: Configuration.TodoListModel) {
     self.buildStack(
       stack: stack,
       edgeInsets: Constant.Styled.Row.ToDoList.stackEdgeInsets
     )
-    let (zStack, zStackHandler) = self.buildZStack(model: model)
-    let checkBox = self.buildCheckBox(color: model.foregroundColor, zStackHandler)
+    let (zStack, checkBoxAction) = self.buildZStack(model: model)
+    let checkBox = self.buildCheckBox(color: model.foregroundColor, checkBoxAction)
     stack.addArrangedSubview(checkBox)
     self.setupCheckBoxConstraints(checkBox)
     
@@ -28,20 +29,31 @@ extension Styled.Row {
     let zStack = UIStackView(arrangedSubviews: [textField])
     let (selectedView, selecetdViewUpdateAction) = buildSelectedView(model: model)
     zStack.addArrangedSubview(selectedView)
+    /// selectedView를 누르게 되면 selectedView를 숨기고 textField를 노출시킵니다.
+    selectedView.addTapGesture { [weak selectedView, weak textField] in
+      selectedView?.isHidden = true
+      textField?.isHidden = false
+      _ = textField?.becomeFirstResponder()
+    }
+    /// textField가 resign될 경우, textField의 텍스트 여부에 따라서 textField를 숨길지, selectedView를 보여줄지 결정하게 됩니다.
+    textField.resignHandler = { [weak self, weak textField, weak selectedView] in
+      textField?.isHidden = !(textField?.text?.isEmpty ?? true)
+      selectedView?.isHidden = (textField?.text?.isEmpty ?? true)
+      selecetdViewUpdateAction(textField?.text, self?.configuration.todoListModel?.isSelected ?? true)
+    }
     
     return (
       zStack,
       { [weak textField, weak selectedView] isSelected in
-        textField?.isHidden = isSelected
-        selectedView?.isHidden = !isSelected
-        if isSelected {
-          selecetdViewUpdateAction(textField?.text)
-        }
+        let flag = textField?.text?.isEmpty ?? true
+        textField?.isHidden = flag ? isSelected : true
+        selectedView?.isHidden = flag ? !isSelected : false
+        selecetdViewUpdateAction(textField?.text, isSelected)
       }
     )
   }
   
-  private func buildTextField(text: String?, color: UIColor, isSelected: Bool) -> UITextField {
+  private func buildTextField(text: String?, color: UIColor, isSelected: Bool) -> Styled.TextField {
     let textField = Styled.TextField(configuration: .groupEdit(.todoList(mainColor: color)))
     let placeholderText = " 할 일을 입력해주세요."
     textField.attributedPlaceholder = NSAttributedString(
@@ -67,7 +79,7 @@ extension Styled.Row {
     textField.widthAnchor.constraint(equalToConstant: Constant.Styled.Row.ToDoList.textFieldWidth).isActive = true
   }
   
-  private func buildSelectedView(model: Configuration.TodoListModel) -> (UIView, (String?) -> Void) {
+  private func buildSelectedView(model: Configuration.TodoListModel) -> (UIView, (String?, Bool) -> Void) {
     let strikeThroughLabel = self.buildStrikethroughLabel(text: model.text)
     let imageView = self.buildAlarmImage(hasAlarm: model.hasAlert)
     let stack = UIHStackView(arrangedSubviews: [strikeThroughLabel, imageView])
@@ -76,7 +88,7 @@ extension Styled.Row {
     return (
       stack,
       { [weak strikeThroughLabel] in
-        strikeThroughLabel?.update($0)
+        strikeThroughLabel?.update(text: $0, animated: $1)
       }
     )
   }
@@ -131,5 +143,13 @@ extension Styled.Row {
 
 @available(iOS 17.0, *)
 #Preview {
-  Styled.Row(configuration: .todoList(.init(foregroundColor: .orange, hasAlert: true)))
+  let first = Styled.Row(configuration: .todoList(.init(foregroundColor: .orange, hasAlert: true)))
+  let second = Styled.Row(configuration: .todoList(.init(foregroundColor: .toDoGardenGreenDark, hasAlert: false)))
+  let third = Styled.Row(configuration: .todoList(.init(foregroundColor: .blue, hasAlert: false)))
+  let stack = UIVStackView(arrangedSubviews: [first, second, third])
+  first.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+  second.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+  third.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+  return stack
 }
+// swiftlint:enable function_body_length

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
@@ -43,10 +43,13 @@ extension Styled.Row {
   
   private func buildTextField(text: String?, color: UIColor, isSelected: Bool) -> UITextField {
     let textField = Styled.TextField(configuration: .groupEdit(.todoList(mainColor: color)))
-    textField.placeholder = "할 일을 입력해주세요."
+    let placeholderText = " 할 일을 입력해주세요."
+    textField.attributedPlaceholder = NSAttributedString(
+      string: placeholderText,
+      attributes: [NSAttributedString.Key.foregroundColor: UIColor.toDoGardenGreenGray]
+    )
     textField.text = text
-    textField.font = UIFont.pretendardDetailLight
-    textField.textColor = UIColor.toDoGardenGray
+    textField.font = UIFont.pretendardDetailRegular12
     textField.isHidden = isSelected
     let action = UIAction { [weak self] action in
       guard

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
@@ -69,17 +69,17 @@ extension Styled.Row {
     textField.text = text
     textField.font = UIFont.pretendardDetailRegular12
     textField.isHidden = isSelected
-    let action = UIAction { [weak self] action in
-      guard
-        let textField = action.sender as? UITextField
-      else { return }
-      let isSelected = self?.configuration.todoListModel?.isSelected ?? false
-      let isEmpty = textField.text?.isEmpty ?? true
-      if !isSelected || !isEmpty {
-        self?.configuration.todoListModel?.text = textField.text
+    let task = Task {
+      for await text in textField.stream {
+        guard !Task.isCancelled else { return }
+        let isSelected = self.configuration.todoListModel?.isSelected ?? false
+        let isEmpty = text?.isEmpty ?? true
+        if !isSelected || !isEmpty {
+          self.configuration.todoListModel?.text = text
+        }
       }
     }
-    textField.addAction(action, for: .editingChanged)
+    self.tasks.append(task)
     
     return textField
   }
@@ -152,6 +152,17 @@ extension Styled.Row {
       checkBox.widthAnchor.constraint(equalToConstant: Constant.Styled.Row.ToDoList.buttonSize.width),
       checkBox.heightAnchor.constraint(equalToConstant: Constant.Styled.Row.ToDoList.buttonSize.height)
     ])
+  }
+}
+
+private extension UITextField {
+  var stream: AsyncStream<String?> {
+    NotificationCenter.default
+      .publisher(for: UITextField.textDidChangeNotification, object: self)
+      .debounce(for: 0.3, scheduler: DispatchQueue.main)
+      .compactMap { ($0.object as? UITextField)?.text }
+      .eraseToAnyPublisher()
+      .asyncStream
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/Style/GroupEdit.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/Style/GroupEdit.swift
@@ -4,6 +4,7 @@ import ToDoGardenUIConstant
 
 extension Styled.TextField {
   func buildGroupEditStyle(model: Configuration.GroupEditModel) {
+    self.textColor = UIColor.toDoGardenGreenDark
     self.buildClearButton(model: model)
     self.buildBottomLine(color: model.mainColor)
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/TextFieldStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/TextFieldStyle.swift
@@ -26,6 +26,8 @@ extension Styled {
     var bottomLine: UIProgressView!
     var cancellables: Set<AnyCancellable> = []
     
+    var resignHandler: (() -> Void)?
+    
     public init(configuration: Configuration) {
       self.configuration = configuration
       super.init(frame: CGRect.zero)
@@ -51,7 +53,7 @@ extension Styled {
     }
     
     public override func becomeFirstResponder() -> Bool {
-      configuration.groupEditModel.map { model in
+      self.configuration.groupEditModel.map { model in
         switch model.bottomLineDisplayMode {
         case Configuration.GroupEditModel.DisPlayMode.always,
           Configuration.GroupEditModel.DisPlayMode.editing:
@@ -71,7 +73,7 @@ extension Styled {
     }
 
     public override func resignFirstResponder() -> Bool {
-      configuration.groupEditModel.map { model in
+      self.configuration.groupEditModel.map { model in
         switch model.bottomLineDisplayMode {
         case Configuration.GroupEditModel.DisPlayMode.always:
           self.bottomLine.setProgress(0.0, animated: false)
@@ -80,6 +82,8 @@ extension Styled {
           self.bottomLine.setProgress(0.0, animated: false)
         }
       }
+      self.resignHandler?()
+
       return super.resignFirstResponder()
     }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIView+Extension.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/UIView+Extension.swift
@@ -38,3 +38,24 @@ extension UIView {
     ])
   }
 }
+
+extension UIView {
+  func addTapGesture(_ action: @escaping () -> Void) {
+    self.addGestureRecognizer(_TapGesutureRecognizer(action: action))
+  }
+  
+  private final class _TapGesutureRecognizer: UITapGestureRecognizer {
+    private var _action: () -> Void
+    
+    init(action: @escaping () -> Void) {
+      self._action = action
+      super.init(target: nil, action: nil)
+      self.addTarget(self, action: #selector(self.action))
+    }
+    
+    @objc
+    private func action() {
+      self._action()
+    }
+  }
+}


### PR DESCRIPTION
## 💡 관련 이슈
#733 

## 🎉 변경 사항
예외 상황에 대해서 처리했습니다.
- 텍스트 필드를 통해 텍스트를 추가하고 다른 동작을 할 경우, 텍스트 필드는 사라지고 Label이 노출되도록 수정

- 버튼이 눌린 상태에서 텍스트를 지우고, 다른 동작을 실행할 경우
기존의 값을 사용해서 다시 채우도록 구현, 버튼을 풀리지 않습니다.

- debounce 처리
x버튼을 사용하지 않고 키보드로 한자씩 지울 경우 기존 코드의 경우 마지막 한글자가 남지만, 디바운스를 적용함으로써 해당 케이스에선 전부 다지워진 형태로 처리했습니다.

## 궁금한 점
처음 뷰를 생성하고 빈 상태로 다른 작업을 하게 될 경우, 해당 이벤트에 대해서도 처리하는게 좋을까요?

## 번외
다시 뷰를 만든다면, TypeState 패턴을 사용해서 만들 거 같습니다.
내부적으로 다른 뷰 클래스를 둠으로써 상태값을 사용하기 편하게 만들고요.
수정하기도 너무 어렵고 상태를 붙잡고 수정하는 부분들이 섞여서 저 말고 다른 사람이 수정하려면 너무 많이 고생할 거 같습니다.;;

## 📝 셀프체크리스트
- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?