### PR TITLE
투두 그룹 섹션 헤더 뷰 UI 구현

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoGroupSectionHeaderView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoGroupSectionHeaderView.swift
@@ -102,3 +102,22 @@ extension ToDoGroupSectionHeaderView {
     hStack.isLayoutMarginsRelativeArrangement = true
   }
 }
+
+@available(iOS 17.0, *)
+#Preview {
+  let view = ToDoGroupSectionHeaderView()
+  view.usingAutolayout()
+  
+  DispatchQueue.main.asyncAfter(
+    deadline: .now() + 0.5,
+    execute: {
+      view.update(
+        with: ToDoGroupSectionHeaderView.UIModel(
+          progressColor: UIColor.toDoGardenRed,
+          progressRate: 0.7,
+          groupTitle: "불어 독해"
+        )
+      )
+  })
+  return view
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoGroupSectionHeaderView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoGroupSectionHeaderView.swift
@@ -55,6 +55,22 @@ final class ToDoGroupSectionHeaderView: UICollectionReusableView {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+  
+  struct UIModel {
+    let progressColor: UIColor
+    let progressRate: Double
+    let groupTitle: String
+  }
+  
+  func update(with model: UIModel) {
+    self.progressView.setupProgressLayerStrokeColor(with: model.progressColor)
+    self.progressView.startAnimation(
+      duration: TimeInterval(0.5),
+      from: Float.zero,
+      to: Float(model.progressRate)
+    )
+    self.createToDoButton.updateTitle(with: model.groupTitle)
+  }
 }
 
 extension ToDoGroupSectionHeaderView {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoGroupSectionHeaderView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoGroupSectionHeaderView.swift
@@ -9,7 +9,7 @@ import UIKit
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
-final class ToDoGroupSectionHeaderView: UIView {
+final class ToDoGroupSectionHeaderView: UICollectionReusableView {
   typealias LayoutConstant = Constant.ToDoGroupSectionHeaderView.Layout
   
   private let contentView: UIView = {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoGroupSectionHeaderView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoGroupSectionHeaderView.swift
@@ -6,9 +6,12 @@
 //
 import UIKit
 
+import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
-final class ToDoGroupSectionHeaderView: UICollectionReusableView {
+final class ToDoGroupSectionHeaderView: UIView {
+  typealias LayoutConstant = Constant.ToDoGroupSectionHeaderView.Layout
+  
   private let contentView: UIView = {
     let contentView = UIView()
     contentView.backgroundColor = UIColor.white
@@ -20,12 +23,14 @@ final class ToDoGroupSectionHeaderView: UICollectionReusableView {
     let progressView = CircularProgressView(
       progressColor: UIColor.toDoGardenGray1,
       backgroundColor: UIColor.toDoGardenGray1,
-      lineWidth: 4.0
+      lineWidth: LayoutConstant.progressViewLineWidth
     )
     progressView.usingAutolayout()
+    
+    let progressViewSize = LayoutConstant.progressViewSize
     NSLayoutConstraint.activate([
-      progressView.widthAnchor.constraint(equalToConstant: 24),
-      progressView.heightAnchor.constraint(equalToConstant: 24)
+      progressView.widthAnchor.constraint(equalToConstant: progressViewSize.width),
+      progressView.heightAnchor.constraint(equalToConstant: progressViewSize.height)
     ])
     
     return progressView
@@ -38,9 +43,11 @@ final class ToDoGroupSectionHeaderView: UICollectionReusableView {
   private let timerImageView: UIImageView = {
     let timerImageView = UIImageView(image: UIImage.timerButtonImage)
     timerImageView.usingAutolayout()
+    
+    let timerImageViewSize = LayoutConstant.timerImageViewSize
     NSLayoutConstraint.activate([
-      timerImageView.widthAnchor.constraint(equalToConstant: 24),
-      timerImageView.heightAnchor.constraint(equalToConstant: 24)
+      timerImageView.widthAnchor.constraint(equalToConstant: timerImageViewSize.width),
+      timerImageView.heightAnchor.constraint(equalToConstant: timerImageViewSize.height)
     ])
     
     return timerImageView
@@ -95,10 +102,10 @@ extension ToDoGroupSectionHeaderView {
       ]
     )
     self.contentView.addSubview(hStack)
-    hStack.setCustomSpacing(4.0, after: self.progressView)
+    hStack.setCustomSpacing(LayoutConstant.progressViewSpacing, after: self.progressView)
     hStack.equalToParent()
     
-    hStack.layoutMargins = UIEdgeInsets(top: .zero, left: 31, bottom: .zero, right: 40)
+    hStack.layoutMargins = LayoutConstant.hStackLayoutMargins
     hStack.isLayoutMarginsRelativeArrangement = true
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoGroupSectionHeaderView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoGroupSectionHeaderView.swift
@@ -1,0 +1,88 @@
+//
+//  ToDoGroupSectionHeaderView.swift
+//  ToDoGardenUI
+//
+//  Created by Noah on 12/10/24.
+//
+import UIKit
+
+import ToDoGardenUIResource
+
+final class ToDoGroupSectionHeaderView: UICollectionReusableView {
+  private let contentView: UIView = {
+    let contentView = UIView()
+    contentView.backgroundColor = UIColor.white
+    
+    return contentView
+  }()
+  
+  private let progressView: CircularProgressView = {
+    let progressView = CircularProgressView(
+      progressColor: UIColor.toDoGardenGray1,
+      backgroundColor: UIColor.toDoGardenGray1,
+      lineWidth: 4.0
+    )
+    progressView.usingAutolayout()
+    NSLayoutConstraint.activate([
+      progressView.widthAnchor.constraint(equalToConstant: 24),
+      progressView.heightAnchor.constraint(equalToConstant: 24)
+    ])
+    
+    return progressView
+  }()
+  
+  private let createToDoButton: CreateToDoButton = CreateToDoButton(
+    model: CreateToDoButton.Model.primary
+  )
+  
+  private let timerImageView: UIImageView = {
+    let timerImageView = UIImageView(image: UIImage.timerButtonImage)
+    timerImageView.usingAutolayout()
+    NSLayoutConstraint.activate([
+      timerImageView.widthAnchor.constraint(equalToConstant: 24),
+      timerImageView.heightAnchor.constraint(equalToConstant: 24)
+    ])
+    
+    return timerImageView
+  }()
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    self.setup()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+extension ToDoGroupSectionHeaderView {
+  private func setup() {
+    self.setupLayout()
+  }
+  
+  private func setupLayout() {
+    self.addSubview(self.contentView)
+    self.contentView.equalToParent()
+    let spacer = UIView()
+    spacer.setContentHuggingPriority(
+      UILayoutPriority.defaultLow,
+      for: NSLayoutConstraint.Axis.horizontal
+    )
+    let hStack = UIHStackView(
+      arrangedSubviews: [
+        self.progressView,
+        self.createToDoButton,
+        spacer,
+        self.timerImageView
+      ]
+    )
+    self.contentView.addSubview(hStack)
+    hStack.setCustomSpacing(4.0, after: self.progressView)
+    hStack.equalToParent()
+    
+    hStack.layoutMargins = UIEdgeInsets(top: .zero, left: 31, bottom: .zero, right: 40)
+    hStack.isLayoutMarginsRelativeArrangement = true
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGroupSectionHeaderView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGroupSectionHeaderView.swift
@@ -1,0 +1,27 @@
+//
+//  Constant+ToDoGroupSectionHeaderView.swift
+//  ToDoGardenUI
+//
+//  Created by Noah on 12/17/24.
+//
+
+import Foundation
+
+import struct UIKit.UIGeometry.UIEdgeInsets
+
+extension Constant.ToDoGroupSectionHeaderView {
+  public enum Layout { }
+}
+
+extension Constant.ToDoGroupSectionHeaderView.Layout {
+  public static let progressViewLineWidth: CGFloat = 4
+  public static let progressViewSize: CGSize = CGSize(width: 24, height: 24)
+  public static let timerImageViewSize: CGSize = CGSize(width: 24, height: 24)
+  public static let progressViewSpacing: CGFloat = 4
+  public static let hStackLayoutMargins: UIEdgeInsets = UIEdgeInsets(
+    top: CGFloat.zero,
+    left: 31,
+    bottom: CGFloat.zero,
+    right: 40
+  )
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGroupSectionHeaderView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+ToDoGroupSectionHeaderView.swift
@@ -15,9 +15,9 @@ extension Constant.ToDoGroupSectionHeaderView {
 
 extension Constant.ToDoGroupSectionHeaderView.Layout {
   public static let progressViewLineWidth: CGFloat = 4
-  public static let progressViewSize: CGSize = CGSize(width: 24, height: 24)
+  public static let progressViewSize: CGSize = CGSize(width: 23, height: 23)
   public static let timerImageViewSize: CGSize = CGSize(width: 24, height: 24)
-  public static let progressViewSpacing: CGFloat = 4
+  public static let progressViewSpacing: CGFloat = 6
   public static let hStackLayoutMargins: UIEdgeInsets = UIEdgeInsets(
     top: CGFloat.zero,
     left: 31,

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -49,4 +49,5 @@ public enum Constant {
   public enum SearchGardenTextField { }
   public enum AddGardenView { }
   public enum DefaultModalNavigationBar { }
+  public enum ToDoGroupSectionHeaderView { }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- related: #718 

## 🎉 변경 사항
- [x] 투두 그룹 섹션 헤더 뷰 UI 구현
## 📌 PR Point
|Demo|
|---|
|<img src="https://github.com/user-attachments/assets/08f9467e-ee57-4700-ad19-e43b321936df" width="320" />|

투두목록의 그룹을 표현하는 투두 그룹 섹션 헤더 뷰 UI를 구현하였습니다.


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?