### PR TITLE
apply rest api on loginflow

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPClientError.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPClientError.swift
@@ -16,7 +16,6 @@ public enum HTTPClientError: Error, Sendable {
   case transportFailed(any Error)
   case middlewareFailed(middlewareType: Any.Type, any Error)
   case badStatusCode(Int)
-  case badJSON
   
   public var underlyingError: (any Error)? {
     switch self {

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPClientError.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPClientError.swift
@@ -16,6 +16,7 @@ public enum HTTPClientError: Error, Sendable {
   case transportFailed(any Error)
   case middlewareFailed(middlewareType: Any.Type, any Error)
   case badStatusCode(Int)
+  case badJSON
   
   public var underlyingError: (any Error)? {
     switch self {

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPClientError.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPClientError.swift
@@ -15,6 +15,7 @@ public enum HTTPClientError: Error, Sendable {
   case notHTTPResponse(URLResponse)
   case transportFailed(any Error)
   case middlewareFailed(middlewareType: Any.Type, any Error)
+  case badStatusCode(Int)
   
   public var underlyingError: (any Error)? {
     switch self {

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/AuthenticationServices.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/AuthenticationServices.swift
@@ -101,7 +101,7 @@ extension AppleLoginManager {
         }
         
         guard let data = response.body else {
-          throw HTTPClientError.badJSON
+          throw HTTPClientError.deserializationError
         }
         
         let loginResponse = try JSONDecoder().decode(LoginResponseDTO.self, from: data)

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/AuthenticationServices.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/AuthenticationServices.swift
@@ -56,9 +56,9 @@ extension AppleLoginManager: ASAuthorizationControllerDelegate {
           identifyToken: appleIDCredential.identityToken ?? Data()
         )
         
-        Task {
-          let isMember = try await self.requestVerificationToSupabase()
-          self.delegate?.appleLoginDidComplete(with: .success(isMember))
+        Task { [weak self] in
+          let isMember = try await self?.requestVerificationToSupabase()
+          self?.delegate?.appleLoginDidComplete(with: .success(isMember ?? false))
         }
       } catch let error {
         self.delegate?.appleLoginDidComplete(with: .failure(error))

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/AuthenticationServices.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/AuthenticationServices.swift
@@ -12,11 +12,6 @@ public protocol AppleLoginManagerDelegate: AnyObject {
   func appleLoginDidComplete(with result: Result<Bool, Error>)
 }
 
-public protocol AppleLoginManagerAPI: AnyObject {
-  var delegate: AppleLoginManagerDelegate? { get set }
-  func performAppleLogin()
-}
-
 public final class AppleLoginManager: NSObject {
   private var authController: ASAuthorizationController?
   private weak var presentationContextProvider: ASAuthorizationControllerPresentationContextProviding?

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/AuthenticationServices.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/AuthenticationServices.swift
@@ -6,17 +6,28 @@
 //
 
 import AuthenticationServices
+import HTTPClientAPI
 
 public protocol AppleLoginManagerDelegate: AnyObject {
   func appleLoginDidComplete(with result: Result<Bool, Error>)
+}
+
+public protocol AppleLoginManagerAPI: AnyObject {
+  var delegate: AppleLoginManagerDelegate? { get set }
+  func performAppleLogin()
 }
 
 public final class AppleLoginManager: NSObject {
   private var authController: ASAuthorizationController?
   private weak var presentationContextProvider: ASAuthorizationControllerPresentationContextProviding?
   public weak var delegate: AppleLoginManagerDelegate?
+  private let httpClient: HTTPClientAPI
   
-  public init(presentationContextProvider: ASAuthorizationControllerPresentationContextProviding) {
+  public init(
+    presentationContextProvider: ASAuthorizationControllerPresentationContextProviding,
+    httpClient: HTTPClientAPI
+  ) {
+    self.httpClient = httpClient
     super.init()
     self.presentationContextProvider = presentationContextProvider
     self.setupAuthController()
@@ -47,8 +58,7 @@ extension AppleLoginManager: ASAuthorizationControllerDelegate {
       do {
         try KeychainManager.shared.saveLoginData(
           identifier: appleIDCredential.user,
-          identifyToken: appleIDCredential.identityToken ?? Data(),
-          email: appleIDCredential.email
+          identifyToken: appleIDCredential.identityToken ?? Data()
         )
         
         Task {
@@ -66,16 +76,71 @@ extension AppleLoginManager: ASAuthorizationControllerDelegate {
   }
 }
 
+// swiftlint: disable function_body_length
 extension AppleLoginManager {
   func requestVerificationToSupabase() async throws -> Bool {
-    if let token = try KeychainManager.shared.load(forKey: "identity_token") {
-      // HTTP 로그인 요청
-      // response에 기존 / 신규 유저 여부 포함
-    }
+    guard let token = try String(data: KeychainManager.shared.load(
+      forKey: KeychainManager.KeychainKey.identifyToken) ?? Data(), encoding: .utf8
+    ) else { throw KeychainError.nonExistentKey }
     
+    let result = try await self.httpClient.send(
+      input: LoginRequestDTO(
+        id_token: token,
+        provider: "apple"
+      ),
+      serializer: { data in
+        let jsonData = try JSONEncoder().encode(data)
+        
+        return HTTPRequest(
+          method: .post,
+          endPoint: URLConstants.Auth.appleLoginURL,
+          header: [
+            "Content-Type": "application/json"
+          ],
+          body: jsonData
+        )
+      },
+      deserializer: { response in
+        guard response.statusCode >= 200 && response.statusCode < 400 else {
+          throw HTTPClientError.badStatusCode(response.statusCode)
+        }
+        
+        guard let data = response.body else {
+          throw HTTPClientError.badJSON
+        }
+        
+        let loginResponse = try JSONDecoder().decode(LoginResponseDTO.self, from: data)
+        try KeychainManager.shared.saveAccessToken(
+          accessToken: loginResponse.accessToken,
+          refreshToken: loginResponse.refreshToken
+        )
+        
+        let isExistingUser = false
+        
+        return isExistingUser
+      }
+    )
     // supaBase 인증 성공 && 기존유저 -> true
     // supaBase 인증 성공 && 신규유저 -> false
     // supaBase 인증 실패 -> throw Error
-    return true
+    return result
   }
 }
+// swiftlint: enable function_body_length
+
+// swiftlint: disable identifier_name
+struct LoginRequestDTO: Sendable, Codable {
+  let id_token: String
+  let provider: String
+}
+
+struct LoginResponseDTO: Sendable, Codable {
+  let accessToken: String
+  let refreshToken: String
+  
+  enum CodingKeys: String, CodingKey {
+    case accessToken = "access_token"
+    case refreshToken = "refresh_token"
+  }
+}
+// swiftlint: enable identifier_name

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/KeychainManager.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/KeychainManager.swift
@@ -13,10 +13,11 @@ public final class KeychainManager: Sendable {
   
   private init() {}
   
-  private enum KeychainKey {
+  public enum KeychainKey {
     static let userIdentifier = "user_identifier"
-    static let userEmail = "user_email"
     static let identifyToken = "identity_token"
+    static let accessToken = "access_token"
+    static let refreshToken = "refresh_token"
     // MARK: - 필요한 키값을 직접 추가하세요
   }
   
@@ -88,47 +89,48 @@ public final class KeychainManager: Sendable {
   }
 }
 
-// MARK: - Login 관련
+// MARK: - Login / 인증 관련
 
 extension KeychainManager {
-  public func saveLoginData(identifier: String, identifyToken: Data, email: String?) throws {
+  public func saveLoginData(identifier: String, identifyToken: Data) throws {
     try self.clearLoginData()
     
     try self.create(Data(identifier.utf8), forKey: KeychainKey.userIdentifier)
     try self.create(identifyToken, forKey: KeychainKey.identifyToken)
-    
-    if let email = email {
-      try self.create(Data(email.utf8), forKey: KeychainKey.userEmail)
-    } else {
-      try self.create(Data(), forKey: KeychainKey.userEmail)
-    }
   }
   
-  // swiftlint:disable large_tuple
-  public func getLoginData() throws -> (identifier: String, identifyToken: String, email: String?)? {
+  public func getLoginData() throws -> (identifier: String, identifyToken: String) {
     guard let identifierData = try self.load(forKey: KeychainKey.userIdentifier),
       let identifier = String(data: identifierData, encoding: String.Encoding.utf8),
       let tokenData = try self.load(forKey: KeychainKey.identifyToken),
       let identifyToken = String(data: tokenData, encoding: String.Encoding.utf8)
     else {
-      return nil
+      throw KeychainError.unknownError
     }
-    
-    let emailData = try self.load(forKey: KeychainKey.userEmail)
-    let email = emailData.flatMap { String(data: $0, encoding: String.Encoding.utf8) }
-    return (identifier, identifyToken, email)
+    return (identifier, identifyToken)
   }
-  // swiftlint:enable large_tuple
   
   public func clearLoginData() throws {
     try self.delete(forKey: KeychainKey.userIdentifier)
-    try self.delete(forKey: KeychainKey.userEmail)
     try self.delete(forKey: KeychainKey.identifyToken)
+  }
+  
+  public func saveAccessToken(accessToken: String, refreshToken: String) throws {
+    try self.clearLoginData()
+    
+    try self.create(Data(accessToken.utf8), forKey: KeychainKey.userIdentifier)
+    try self.create(Data(refreshToken.utf8), forKey: KeychainKey.identifyToken)
+  }
+  
+  public func clearAccessToken() throws {
+    try self.delete(forKey: KeychainKey.accessToken)
+    try self.delete(forKey: KeychainKey.refreshToken)
   }
 }
 
-enum KeychainError: Error {
+public enum KeychainError: Error {
   case nonExistentKey
   case alreadyExistentKey
   case unhandledError(status: OSStatus)
+  case unknownError
 }

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
@@ -16,9 +16,9 @@ public enum URLConstants {
   public enum Timer { }
 }
 
-//swiftlint:disable all
+// swiftlint:disable all
 extension URLConstants.Auth {
   public static let appleLoginURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/auth/v1/token?grant_type=id_token")!
   public static let signUpURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/signup")!
 }
-//swiftlint:enable all
+// swiftlint:enable all

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
@@ -1,0 +1,24 @@
+//
+//  URLConstants.swift
+//  TDFoundation
+//
+//  Created by SONG on 12/18/24.
+//
+
+import Foundation
+
+public enum URLConstants {
+  public enum Auth { }
+  public enum ToDo { }
+  public enum Group { }
+  public enum Garden { }
+  public enum Profile { }
+  public enum Timer { }
+}
+
+//swiftlint:disable all
+extension URLConstants.Auth {
+  public static let appleLoginURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/auth/v1/token?grant_type=id_token")!
+  public static let signUpURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/signup")!
+}
+//swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/AppCore/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Package.swift
@@ -31,6 +31,10 @@ let package = Package(
         Target.Dependency.product(
           name: "OnBoardingScene",
           package: "OnBoardingScene"
+        ),
+        Target.Dependency.product(
+          name: "HTTPClient",
+          package: "TDFoundation"
         )
       ]
     ),

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
@@ -1,7 +1,8 @@
+import Foundation
+
+import HTTPClient
 import OnBoardingScene
 import TDFoundation
-
-import Foundation
 
 @MainActor
 public final class AppCore {
@@ -14,9 +15,16 @@ public final class AppCore {
   }
   var destination: Destination {
     didSet {
-      self.dependency.router.switchTo(self.destination)
+      self.dependency.router.switchTo(
+        self.destination,
+        httpClient: self.httpClient
+      )
     }
   }
+  private let httpClient = HTTPClient(
+    transport: URLSessionTransport(urlSession: URLSession.shared),
+    middlewares: [AuthenticationMiddleWare()]
+  )
   
   public init(dependency: Dependency) {
     self.dependency = dependency

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppRouter.swift
@@ -1,6 +1,7 @@
-import OnBoardingScene
-
 import UIKit
+
+import HTTPClientAPI
+import OnBoardingScene
 
 @MainActor
 public final class AppRouter {
@@ -8,24 +9,27 @@ public final class AppRouter {
     rootViewController: UIViewController()
   )
   
-  func switchTo(_ destination: AppCore.Destination) {
+  func switchTo(_ destination: AppCore.Destination, httpClient: HTTPClientAPI) {
     switch destination {
     case .home:
       self.navigationController.viewControllers = [
       ]
       
     case .onboarding(let completion):
-      self.navigationController.viewControllers = self.buildOnBoardingFlows(completion)
+      self.navigationController.viewControllers = self.buildOnBoardingFlows(completion, with: httpClient)
       
     case .none:
       break
     }
   }
   
-  private func buildOnBoardingFlows(_ completion: @escaping (Bool, Bool) -> Void) -> [UIViewController] {
+  private func buildOnBoardingFlows(
+    _ completion: @escaping (Bool, Bool) -> Void,
+    with httpClient: HTTPClientAPI
+  ) -> [UIViewController] {
     let onboarding = IntroOnBoardingViewController()
     let tutroial = TutorialOnBoardingViewController()
-    let login = LoginViewController()
+    let login = LoginViewController(with: httpClient)
     
     onboarding.addAction = { [weak navigationController] in
       navigationController?.pushViewController(tutroial, animated: true)
@@ -34,7 +38,8 @@ public final class AppRouter {
       navigationController?.pushViewController(login, animated: true)
     }
 
-    login.afterLoginAction = { completion(true, false) }
+    login.afterLoginAction = { completion(false, false) }
+    // TODO: 1번째 파라미터 == 기존유저인가? , 2번째 파라미터 == 광고성 알림 허용인가?
     
     login.doneButtonAction = { isEventAndPromotionalInformationAgreed in
       completion(false, isEventAndPromotionalInformationAgreed)

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/LoginViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/LoginViewController.swift
@@ -6,9 +6,9 @@
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
 import AuthenticationServices
-import OSLog
 import UIKit
 
+import HTTPClientAPI
 import TDFoundation
 import ToDoGardenUIComponent
 
@@ -19,17 +19,16 @@ public final class LoginViewController: UIViewController {
   private let dimmingView: UIView
   private let termAgreementView: TermsAgreementView
   
-  private let loger = Logger()
-  
   public var afterLoginAction: (() -> Void)?
   public var doneButtonAction: ((Bool) -> Void)?
   // MARK: - Object lifecycle
   
-  public init() {
+  public init(with httpClient: HTTPClientAPI) {
     self.appleLoginButton = AppleLoginButton()
     self.dimmingView = UIView()
     self.termAgreementView = TermsAgreementView()
     super.init(nibName: nil, bundle: nil)
+    self.setAppleLoginManager(with: httpClient)
   }
   
   @available(*, unavailable)
@@ -41,7 +40,6 @@ public final class LoginViewController: UIViewController {
   
   public override func viewDidLoad() {
     super.viewDidLoad()
-    self.setAppleLoginManager()
     self.setUI()
   }
   
@@ -107,8 +105,8 @@ extension LoginViewController {
     // TODO: 게스트 로그인
   }
   
-  private func setAppleLoginManager() {
-    self.appleLoginManager = AppleLoginManager(presentationContextProvider: self)
+  private func setAppleLoginManager(with httpClient: HTTPClientAPI) {
+    self.appleLoginManager = AppleLoginManager(presentationContextProvider: self, httpClient: httpClient)
     self.appleLoginManager?.delegate = self
   }
   
@@ -150,7 +148,7 @@ extension LoginViewController: AppleLoginManagerDelegate {
         self.showTermAgreementViewForRoutingToSignUpScene()
       }
     case .failure(let error):
-      self.loger.log("Apple Login 실패: \(error)")
+      self.handleError(error)
     }
   }
 }
@@ -186,10 +184,15 @@ extension LoginViewController: TermsAgreementViewDelegate {
   }
 }
 
-#if DEBUG
-@available(iOS 17.0, *)
-#Preview {
-  let view = LoginViewController()
-  return view
+extension LoginViewController {
+  private func handleError(_ error: Error) {
+    if error is KeychainError {
+      
+    } else if error is HTTPClientError {
+      
+    } else {
+      
+    }
+    self.showToast(message: error.localizedDescription)
+  }
 }
-#endif


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #736 
## 🎉 변경 사항
- 로그인 흐름을 구현합니다. 

## 📌 PR Point

### 구현 상세 
1) AppCore에 HTTPClient 구체타입을 선언하고, 이후 Router를 통해 하위 객체(프로토콜에 의존) 에 주입합니다. 
2) 키체인 매니저 수정 
   - 기존에는 이메일을 키체인에 저장하고 있었는데, 필요없을 것 같아 이메일관련 요소를 제거하였습니다.
   - 키체인에러 `unknownError`케이스를 추가합니다.  
   - 애플로그인에 성공하여, 수퍼베이스로 부터 엑세스토큰, 리프레시토큰을 받아오면, 키체인에 저장하는 메서드 추가 
3) 로그인씬이 사라지고, 온보딩씬과 통합되어 `LoginViewController`는 사실상 뷰컴포넌트 처럼 쓰이고 있습니다. (VIP없음) 
그렇기에 `AppleLoginManager`에서 로그인 통신흐름을 처리합니다. 
4) `.env`(apiKey) 는 PR에 포함시키지 않았습니다. 로컬에 두고 사용중입니다. 

DTO는 아래와 같이 일단은 만들어 봤습니다. 언더바관련해서 수정이 발생하면 코멘트 남겨주세요. 이 pr에서 변경 후에 머지하겠습니다. 

```swift
struct LoginRequestDTO: Sendable, Codable {
  let id_token: String
  let provider: String
}

struct LoginResponseDTO: Sendable, Codable {
  let accessToken: String
  let refreshToken: String
//let isExistingUser: Bool 필요
  
  enum CodingKeys: String, CodingKey {
    case accessToken = "access_token"
    case refreshToken = "refresh_token"
  }
}
```

### 요청사항 
아래 두가지 흐름을 구현할 예정입니다. 
- AppCore -> AppRouter -> OnBoarding -> Tutorial -> Login -> 기존유저야? == true -> Home 
- AppCore -> AppRouter -> OnBoarding -> Tutorial -> Login -> 기존유저야? == false -> 약관동의뷰 -> 사인업  

하지만 , 현재는 기존유저야? == false 로 고정시켜놓은 상태입니다. 기존유저인지 아닌지에 대한 Bool값을 accessToken,refreshToken 을 받을 때 같이 받았으면 합니다. 
- https://www.notion.so/Apple-Login-15778beec03181cbb885eb28ebe9fb51?pvs=4 이 case에 대한 응답에 `isExistingUser : Bool` 이 포함되었으면 합니다.

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?