### PR TITLE
린트룰 준수 관련 수정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/TimerScene/Tests/TimerSceneTests/TimerSceneTests.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Tests/TimerSceneTests/TimerSceneTests.swift
@@ -199,7 +199,7 @@ struct MockPresenter: TimerScenePresentationLogic {
   
   init(
     updateViewState: ((_: Bool) -> Void)? = { _ in XCTFail() },
-    configureTimerSettings: ((_: TimerSceneEntity.TimerScene.BottomSheetStatus, _: Double) -> Void)? =  { _, _ in XCTFail("configureTimerSettings") },
+    configureTimerSettings: ((_: TimerSceneEntity.TimerScene.BottomSheetStatus, _: Double) -> Void)? = { _, _ in XCTFail("configureTimerSettings") },
     updateTimeState: ((_: Double, _: TimerSceneEntity.TimerScene.CircularProgressRange) -> Void)? = { _, _ in XCTFail("updateTimeState") },
     showAlert: ((_: TimerSceneEntity.TimerScene.TimerAlertStatus) -> Void)? = { _ in XCTFail("showAlert") },
     presentBottomSheet: ((_: TimerSceneEntity.TimerScene.BottomSheetStatus) -> Void)? = { _ in XCTFail("presentBottomSheet") },

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
@@ -2,7 +2,7 @@ import UIKit
 
 import ToDoGardenUIConstant
 
-// swiftlint:disable function_body_length opening_brace
+// swiftlint:disable function_body_length
 extension Styled.Row {
   func buildTodoListStyle(stack: UIStackView, model: Configuration.TodoListModel) {
     self.buildStack(
@@ -48,15 +48,12 @@ extension Styled.Row {
       selecetdViewUpdateAction(text, isSelected)
     }
     
-    return (
-      zStack,
-      { [weak textField, weak selectedView] isSelected in
-        let flag = textField?.text?.isEmpty ?? true
-        textField?.isHidden = flag ? isSelected : true
-        selectedView?.isHidden = flag ? !isSelected : false
-        selecetdViewUpdateAction(textField?.text, isSelected)
-      }
-    )
+    return (zStack, { [weak textField, weak selectedView] isSelected in
+      let flag = textField?.text?.isEmpty ?? true
+      textField?.isHidden = flag ? isSelected : true
+      selectedView?.isHidden = flag ? !isSelected : false
+      selecetdViewUpdateAction(textField?.text, isSelected)
+    })
   }
   
   private func buildTextField(text: String?, color: UIColor, isSelected: Bool) -> Styled.TextField {
@@ -95,12 +92,9 @@ extension Styled.Row {
     let stack = UIHStackView(arrangedSubviews: [strikeThroughLabel, imageView])
     stack.isHidden = !model.isSelected
     
-    return (
-      stack,
-      { [weak strikeThroughLabel] in
-        strikeThroughLabel?.update(text: $0, animated: $1)
-      }
-    )
+    return (stack, { [weak strikeThroughLabel] in
+      strikeThroughLabel?.update(text: $0, animated: $1)
+    })
   }
   
   private func buildStrikethroughLabel(text: String?) -> StrikethroughView {
@@ -177,4 +171,4 @@ private extension UITextField {
   third.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
   return stack
 }
-// swiftlint:enable function_body_length opening_brace
+// swiftlint:enable function_body_length

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
@@ -2,7 +2,7 @@ import UIKit
 
 import ToDoGardenUIConstant
 
-// swiftlint:disable function_body_length
+// swiftlint:disable function_body_length opening_brace
 extension Styled.Row {
   func buildTodoListStyle(stack: UIStackView, model: Configuration.TodoListModel) {
     self.buildStack(
@@ -177,4 +177,4 @@ private extension UITextField {
   third.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
   return stack
 }
-// swiftlint:enable function_body_length
+// swiftlint:enable function_body_length opening_brace


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #743 
## 🎉 변경 사항
- 린트룰에 걸리는 녀석들에 대한 조치를 취했습니다. 
## 📌 PR Point
- 공백 2칸 -> 1칸으로 변경
- 여는괄호 규칙 위반 -> 예쁜각이 안보여서 disable 시키려 했지만, github-bot에 의해 disable/enable 주석 자체에 lint위반이 떠서 안예쁜 모양이지만 조건에 만족시켰습니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?