### PR TITLE
prepare rest api signup

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/AuthenticationServices.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/AuthenticationServices.swift
@@ -52,7 +52,6 @@ extension AppleLoginManager: ASAuthorizationControllerDelegate {
     if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
       do {
         try KeychainManager.shared.saveLoginData(
-          identifier: appleIDCredential.user,
           identifyToken: appleIDCredential.identityToken ?? Data()
         )
         
@@ -105,9 +104,11 @@ extension AppleLoginManager {
         }
         
         let loginResponse = try JSONDecoder().decode(LoginResponseDTO.self, from: data)
+        
         try KeychainManager.shared.saveAccessToken(
           accessToken: loginResponse.accessToken,
-          refreshToken: loginResponse.refreshToken
+          refreshToken: loginResponse.refreshToken,
+          userIdentifier: loginResponse.user.id
         )
         
         let isExistingUser = false
@@ -132,10 +133,20 @@ struct LoginRequestDTO: Sendable, Codable {
 struct LoginResponseDTO: Sendable, Codable {
   let accessToken: String
   let refreshToken: String
+  let user: UserDTO
   
   enum CodingKeys: String, CodingKey {
     case accessToken = "access_token"
     case refreshToken = "refresh_token"
+    case user
   }
+}
+
+struct UserDTO: Sendable, Codable {
+  let id: String
+}
+
+struct IsExistingUserRequestDTO: Sendable, Codable {
+
 }
 // swiftlint: enable identifier_name

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/KeychainManager.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/KeychainManager.swift
@@ -14,10 +14,10 @@ public final class KeychainManager: Sendable {
   private init() {}
   
   public enum KeychainKey {
-    static let userIdentifier = "user_identifier"
-    static let identifyToken = "identity_token"
-    static let accessToken = "access_token"
-    static let refreshToken = "refresh_token"
+    public static let userIdentifier = "user_identifier"
+    public static let identifyToken = "identity_token"
+    public static let accessToken = "access_token"
+    public static let refreshToken = "refresh_token"
     // MARK: - 필요한 키값을 직접 추가하세요
   }
   
@@ -92,10 +92,9 @@ public final class KeychainManager: Sendable {
 // MARK: - Login / 인증 관련
 
 extension KeychainManager {
-  public func saveLoginData(identifier: String, identifyToken: Data) throws {
+  public func saveLoginData(identifyToken: Data) throws {
     try self.clearLoginData()
     
-    try self.create(Data(identifier.utf8), forKey: KeychainKey.userIdentifier)
     try self.create(identifyToken, forKey: KeychainKey.identifyToken)
   }
   
@@ -105,26 +104,27 @@ extension KeychainManager {
       let tokenData = try self.load(forKey: KeychainKey.identifyToken),
       let identifyToken = String(data: tokenData, encoding: String.Encoding.utf8)
     else {
-      throw KeychainError.unknownError
+      throw KeychainError.unknownKeyChainError
     }
     return (identifier, identifyToken)
   }
   
   public func clearLoginData() throws {
-    try self.delete(forKey: KeychainKey.userIdentifier)
     try self.delete(forKey: KeychainKey.identifyToken)
   }
   
-  public func saveAccessToken(accessToken: String, refreshToken: String) throws {
-    try self.clearLoginData()
+  public func saveAccessToken(accessToken: String, refreshToken: String, userIdentifier: String) throws {
+    try self.clearAccessToken()
     
-    try self.create(Data(accessToken.utf8), forKey: KeychainKey.userIdentifier)
-    try self.create(Data(refreshToken.utf8), forKey: KeychainKey.identifyToken)
+    try self.create(Data(accessToken.utf8), forKey: KeychainKey.accessToken)
+    try self.create(Data(refreshToken.utf8), forKey: KeychainKey.refreshToken)
+    try self.create(Data(userIdentifier.utf8), forKey: KeychainKey.userIdentifier)
   }
   
   public func clearAccessToken() throws {
     try self.delete(forKey: KeychainKey.accessToken)
     try self.delete(forKey: KeychainKey.refreshToken)
+    try self.delete(forKey: KeychainKey.userIdentifier)
   }
 }
 
@@ -132,5 +132,5 @@ public enum KeychainError: Error {
   case nonExistentKey
   case alreadyExistentKey
   case unhandledError(status: OSStatus)
-  case unknownError
+  case unknownKeyChainError
 }

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
@@ -19,6 +19,7 @@ public enum URLConstants {
 // swiftlint:disable all
 extension URLConstants.Auth {
   public static let appleLoginURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/auth/v1/token?grant_type=id_token")!
-  public static let signUpURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/signup")!
+  public static let signUpURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/sign_up")!
+  public static let isExitingUserURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/validate_user")!
 }
 // swiftlint:enable all

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
@@ -20,6 +20,7 @@ public enum URLConstants {
 extension URLConstants.Auth {
   public static let appleLoginURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/auth/v1/token?grant_type=id_token")!
   public static let signUpURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/sign_up")!
-  public static let isExitingUserURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/validate_user")!
+  public static let validateUserURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/validate_user")!
+  // ↑ 기존유저/신규유저 체크 URL
 }
 // swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/AppCore/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.10
 import PackageDescription
 
 let package = Package(
@@ -18,6 +18,10 @@ let package = Package(
     Package.Dependency.package(
       name: "OnBoardingScene",
       path: "../OnBoardingScene"
+    ),
+    Package.Dependency.package(
+      name: "SignUpScene",
+      path: "../SignUpScene"
     )
   ],
   targets: [
@@ -35,6 +39,10 @@ let package = Package(
         Target.Dependency.product(
           name: "HTTPClient",
           package: "TDFoundation"
+        ),
+        Target.Dependency.product(
+          name: "SignUpScene",
+          package: "SignUpScene"
         )
       ]
     ),

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
@@ -11,6 +11,7 @@ public final class AppCore {
     case onboarding((Bool, Bool) -> Void)
     case home // Binding HomeInteractor
     // case login
+    case signUp(Bool, () -> Void)
     case none
   }
   var destination: Destination {
@@ -38,7 +39,9 @@ public final class AppCore {
       if isMember {
         self?.destination = .home
       } else {
-        _ = isEventAndPromotionalAgreed
+        self?.destination = .signUp(isEventAndPromotionalAgreed) { [weak self] in
+          self?.destination = .home // 회원가입 완료하면 바로 홈으로
+        }
       }
     }
     : .home

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppRouter.swift
@@ -2,6 +2,8 @@ import UIKit
 
 import HTTPClientAPI
 import OnBoardingScene
+import SignUpScene
+import SignUpSceneAPI
 
 @MainActor
 public final class AppRouter {
@@ -18,11 +20,21 @@ public final class AppRouter {
     case .onboarding(let completion):
       self.navigationController.viewControllers = self.buildOnBoardingFlows(completion, with: httpClient)
       
+    case .signUp(let isEventAndPromotionalInformationAgreed, let completion):
+      self.navigationController.pushViewController(
+        self.buildSignUpSecne(
+          completion,
+          isEventAndPromotionalInformationAgreed,
+          with: httpClient
+        ),
+        animated: false
+      )
     case .none:
       break
     }
   }
   
+  // completion 1번째 파라미터 == 기존유저인가? , 2번째 파라미터 == 광고성 알림 허용인가?
   private func buildOnBoardingFlows(
     _ completion: @escaping (Bool, Bool) -> Void,
     with httpClient: HTTPClientAPI
@@ -37,14 +49,42 @@ public final class AppRouter {
     tutroial.endAction = { [weak navigationController] in
       navigationController?.pushViewController(login, animated: true)
     }
-
-    login.afterLoginAction = { completion(false, false) }
-    // TODO: 1번째 파라미터 == 기존유저인가? , 2번째 파라미터 == 광고성 알림 허용인가?
+    
+    login.afterLoginAction = { isExistingUser in
+      completion(isExistingUser, false)
+    }
     
     login.doneButtonAction = { isEventAndPromotionalInformationAgreed in
       completion(false, isEventAndPromotionalInformationAgreed)
     }
     
     return [onboarding]
+  }
+  
+  private func buildSignUpSecne(
+    _ completion: @escaping () -> Void,
+    _ isEventAndPromotionalInformationAgreed: Bool,
+    with httpClient: HTTPClientAPI
+  ) -> UIViewController {
+    let worker = SignUpWorker(httpClient: httpClient)
+    let builder = SignUpSceneBuilder(dependency: .init(signUpWorker: worker))
+    let signUp: SignUpViewControllable = builder.build(
+      with: SignUpScenePayload(
+        agreeOptionalCondition: isEventAndPromotionalInformationAgreed
+      )
+    )
+    signUp.modalPresentationStyle = .overFullScreen
+    signUp.afterSignUpAction = completion
+    return signUp
+  }
+}
+
+extension AppRouter {
+  struct SignUpScenePayload: SignUpScenePayloadable {
+    let agreeOptionalCondition: Bool
+    
+    init(agreeOptionalCondition: Bool) {
+      self.agreeOptionalCondition = agreeOptionalCondition
+    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/LoginViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/LoginViewController.swift
@@ -19,7 +19,7 @@ public final class LoginViewController: UIViewController {
   private let dimmingView: UIView
   private let termAgreementView: TermsAgreementView
   
-  public var afterLoginAction: (() -> Void)?
+  public var afterLoginAction: ((Bool) -> Void)?
   public var doneButtonAction: ((Bool) -> Void)?
   // MARK: - Object lifecycle
   
@@ -143,7 +143,7 @@ extension LoginViewController: AppleLoginManagerDelegate {
     switch result {
     case .success(let isMember):
       if isMember {
-        self.afterLoginAction?()
+        self.afterLoginAction?(isMember)
       } else {
         self.showTermAgreementViewForRoutingToSignUpScene()
       }
@@ -186,13 +186,7 @@ extension LoginViewController: TermsAgreementViewDelegate {
 
 extension LoginViewController {
   private func handleError(_ error: Error) {
-    if error is KeychainError {
-      
-    } else if error is HTTPClientError {
-      
-    } else {
-      
-    }
+    debugPrint("\(error) on LoginViewController")
     self.showToast(message: error.localizedDescription)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
   ],
   dependencies: [
     .package(name: "ToDoGardenUI", path: "../ToDoGardenUI"),
-    .package(path: "../TDUtility")
+    .package(path: "../TDUtility"),
+    .package(path: "../TDFoundation")
   ],
   targets: [
     .target(
@@ -40,6 +41,7 @@ let package = Package(
         .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
         "SignUpSceneAPI",
         "SignUpSceneEntity",
+        .product(name: "TDFoundation", package: "TDFoundation"),
         .product(name: "TDUtility", package: "TDUtility"),
         .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI"),
         .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI")

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpInteractor.swift
@@ -11,7 +11,7 @@ import SignUpSceneAPI
 import SignUpSceneEntity
 
 protocol SignUpDataStore {
-  // var name: String { get set }
+  var isEventAndPromotionalInformationAgreed: Bool { get }
 }
 
 protocol SignUpBusinessLogic {
@@ -19,13 +19,18 @@ protocol SignUpBusinessLogic {
 }
 
 class SignUpInteractor: SignUpDataStore {
-  // var name: String = ""
+  var isEventAndPromotionalInformationAgreed: Bool = false
   var presenter: SignUpPresentationLogic?
   private let signUpWorker: SignUpWorkable
+  private var tasks: [TaskKey: Task<Void, Never>] = [:]
   
-  // TODO: 파라미터 명 바꾸기
-  init(someWorker: SignUpWorkable) {
-    self.signUpWorker = someWorker
+  init(signUpWorker: SignUpWorkable) {
+    self.signUpWorker = signUpWorker
+  }
+  
+  func cancelTask(for key: TaskKey) {
+    self.tasks[key]?.cancel()
+    self.tasks[key] = nil
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpInteractor.swift
@@ -22,15 +22,9 @@ class SignUpInteractor: SignUpDataStore {
   var isEventAndPromotionalInformationAgreed: Bool = false
   var presenter: SignUpPresentationLogic?
   private let signUpWorker: SignUpWorkable
-  private var tasks: [TaskKey: Task<Void, Never>] = [:]
   
   init(signUpWorker: SignUpWorkable) {
     self.signUpWorker = signUpWorker
-  }
-  
-  func cancelTask(for key: TaskKey) {
-    self.tasks[key]?.cancel()
-    self.tasks[key] = nil
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpRouter.swift
@@ -10,7 +10,7 @@ import Foundation
 import SignUpSceneAPI
 
 protocol SignUpRoutingLogic {
-  func routeToSomewhere()
+  func exitSignUpScene()
 }
 
 protocol SignUpDataPassing {
@@ -20,27 +20,14 @@ protocol SignUpDataPassing {
 class SignUpRouter: SignUpDataPassing {
   weak var viewController: SignUpViewController?
   var dataStore: SignUpDataStore?
-  private let nextSceneBuilder: NextSceneBuildable
   
-  init(nextSceneBuilder: NextSceneBuildable) {
-    self.nextSceneBuilder = nextSceneBuilder
-  }
+  init() { }
 }
 
 // MARK: - Routing
 
 extension SignUpRouter: SignUpRoutingLogic {
-  func routeToSomewhere() {
-    let destinationViewController = self.nextSceneBuilder.build(with: NextScenePayload())
-    
-    self.viewController?.present(destinationViewController, animated: true)
-  }
-}
-
-// MARK: - Declare Payload for scene
-
-extension SignUpRouter {
-  struct NextScenePayload: NextScenePayloadable {
-    // var name: String
+  func exitSignUpScene() {
+    self.viewController?.navigationController?.popViewController(animated: true)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpSceneBuilder.swift
@@ -13,12 +13,10 @@ import SignUpSceneEntity
 public struct SignUpSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
-    let someWorker: SignUpWorkable
-    let nextSceneBuilder: NextSceneBuildable
+    let signUpWorker: SignUpWorkable
     
-    public init(someWorker: SignUpWorkable, nextSceneBuilder: NextSceneBuildable) {
-      self.someWorker = someWorker
-      self.nextSceneBuilder = nextSceneBuilder
+    public init(signUpWorker: SignUpWorkable) {
+      self.signUpWorker = signUpWorker
     }
   }
   
@@ -46,9 +44,9 @@ extension SignUpSceneBuilder {
   /// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
   private func configureVIPCycle(for viewController: SignUpViewController) -> SignUpViewController {
-    let interactor = SignUpInteractor(someWorker: self.dependency.someWorker)
+    let interactor = SignUpInteractor(signUpWorker: self.dependency.signUpWorker)
     let presenter = SignUpPresenter()
-    let router = SignUpRouter(nextSceneBuilder: self.dependency.nextSceneBuilder)
+    let router = SignUpRouter()
     viewController.interactor = interactor
     viewController.router = router
     interactor.presenter = presenter

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpViewController.swift
@@ -26,6 +26,7 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
   private let signUpScrollView: SignUpScrollView
   private let bottomButton: ToDoGardenBoxButton
   
+  public var afterSignUpAction: (() -> Void)?
   // MARK: - Object lifecycle
   
   init() {
@@ -36,6 +37,11 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
     )
     super.init(nibName: nil, bundle: nil)
     self.setup()
+  }
+  
+  public override func viewIsAppearing(_ animated: Bool) {
+    super.viewIsAppearing(animated)
+    self.navigationController?.navigationBar.isHidden = false
   }
   
   @available(*, unavailable)
@@ -117,7 +123,7 @@ final class SignUpViewController: UIViewController, SignUpViewControllable {
   
   private func exitSignUpFlow() {
     // TODO: Router
-    self.navigationController?.popViewController(animated: true)
+    self.router?.exitSignUpScene()
   }
   
   private func backButtonTapped() {

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/SignUpWorker.swift
@@ -7,12 +7,18 @@
 
 import Foundation
 
+import HTTPClientAPI
 import SignUpSceneAPI
 import SignUpSceneEntity
+import TDFoundation
 import TDUtility
 
 public struct SignUpWorker: SignUpWorkable {
-  public init() {}
+  private let httpClient: HTTPClientAPI
+  
+  public init(httpClient: HTTPClientAPI) {
+    self.httpClient = httpClient
+  }
   
   public func checkStringValidation(text: String?, currentPageIndex: Int) -> SignUp.ValidationState {
     guard let text else {
@@ -21,6 +27,7 @@ public struct SignUpWorker: SignUpWorkable {
     switch currentPageIndex {
     case 0:
       if StringValidationChecker.isValidID(text) {
+        // TODO: 사용중인 아이디 체크
         return SignUp.ValidationState.valid
       } else {
         return SignUp.ValidationState.invalid

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpScene/Views/SignUpScrollView.swift
@@ -141,6 +141,14 @@ final class SignUpScrollView: UIScrollView {
     return self.inputViews[self.currentPageIndex].textInputView.getEditingText()
   }
   
+  func getCompletedTexts() -> [String] {
+    var result = [String]()
+    for idx in 0 ..< self.inputViews.count {
+      result.append(self.inputViews[idx].textInputView.getEditingText() ?? "")
+    }
+    return result
+  }
+  
   // MARK: Page Controls
   func goToNextPage() {
     let nextPageIndex = self.currentPageIndex + 1
@@ -193,5 +201,13 @@ final class SignUpScrollView: UIScrollView {
     
     self.changeButtonDelegate?.changeButtonTitle(pageIndex: self.currentPageIndex)
     self.inputViews[self.currentPageIndex].textInputView.setBecomeFirstRespoder()
+  }
+  
+  func setBecomeFirstResponder() {
+    self.inputViews[self.currentPageIndex].textInputView.setBecomeFirstRespoder()
+  }
+  
+  func setResignFirstResponder() {
+    self.inputViews[self.currentPageIndex].textInputView.setResignFirstResponder()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpSceneAPI/SignUpSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpSceneAPI/SignUpSceneBuildable.swift
@@ -9,8 +9,6 @@ import Foundation
 
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
 public protocol SignUpScenePayloadable {
-  var userIdentifier: String { get }
-  var userEmailAddress: String? { get }
   var agreeOptionalCondition: Bool { get }
 }
 

--- a/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpSceneAPI/SignUpViewControllable.swift
+++ b/ToDo-Garden/ToDo-Garden/SignUpScene/Sources/SignUpSceneAPI/SignUpViewControllable.swift
@@ -8,4 +8,5 @@
 import ToDoGardenUIAPI
 
 public protocol SignUpViewControllable: ViewControllable {
+  var afterSignUpAction: (() -> Void)? { get set }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/InputTextValidationView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/InputTextValidationView.swift
@@ -62,6 +62,10 @@ public final class InputTextValidationView: UIView {
   public func setBecomeFirstRespoder() {
     self.textInputView.setBecomeFirstResoponder()
   }
+  
+  public func setResignFirstResponder() {
+    self.textInputView.setResignFirstResponder()
+  }
 }
 
 // MARK: - Validation Text Moving Animation

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -112,6 +112,10 @@ extension TextInputView {
   func setBecomeFirstResoponder() {
     _ = self.inputTextField.becomeFirstResponder()
   }
+  
+  func setResignFirstResponder() {
+    _ = self.inputTextField.resignFirstResponder()
+  }
 }
 
 // MARK: TextField Delegate Functions


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #746 
## 🎉 변경 사항
- API 연동을 위한 사전작업 입니다. 

## 📌 PR Point

### 파일체인지가 많다고 놀라지 마세요! 대부분 슬랙으로 이야기한 내용들이 기반된 수정사항입니다. 
- 네트워킹 부분은 포함시키지 않았습니다. 
- 사실상 로직적인 부분은 AppCore와 SignUpScene을 연결하는 부분 정도입니다. 
- URL 변경 , DTO 변경, 프로토콜 명세 변경 및 적용, 패키지 의존성 수정, 템플릿 생성시 자동생성된 코드 제거 등이 대부분입니다. 
- 아래 설명을 읽어보시면, 우리가 나눴던 이야기를 기반으로 18개의 파일체인지 중 13~15개는 그냥 슥슥 보고 넘기실 수 있을 것 같습니다. 

### AppleLoginManager 수정 
- apple로 부터 직접 받은 userIdentifier는 UUID 포맷이 아닙니다. 
- 이제 apple과 supaBase 통신 이후, supaBase에서 생성된 userID를 사용합니다. 
- accessToken을 발급받는 response에 딸려오는 것을 추출하여 키체인에 저장합니다. 
- 그로 인한 메서드 수정과 DTO 수정을 했습니다. 

### KeyChainManager 수정 
- supaBase에서 생성된 userID를 사용함에 따른 변경사항을 반영합니다. 
- KeyChainKey의 접근제어를 public으로 변경합니다. 

### URLConstant 수정 
- 주말간 소통으로 인해 일부 api에 변경이 있었고, 새로운 url로 api를 새로 팠습니다. 그에 대한 변경사항을 반영합니다. 

### AppCore 수정
- SignUpScene은 예외적으로 Home과 탭바에 연결되지 않는 특이한 VIP입니다. SignUpScene를 사용하기 위해 패키지 의존성을 추가합니다. 
- Destination에 .signUp 케이스를 추가하여, AppRouter에서 signUp으로 이동합니다. 그리고 signUpSceneBuilder에 NextScene으로 Home이 들어가는게 아닌, signUp이 끝나면 다시 AppRouter로 돌아와서, AppRouter -> home 으로 라우팅됩니다. 
- SignUp이 성공적으로 완료되면, AppRouter를 통해 home으로 이동하는 클로저가 트리거 됩니다. 

### LoginVC 수정 
- 클로저로 Bool값을 전달합니다. (기존유저(true)인지, 신규유저(false)인지) 

### SignUpScene 수정 
- httpClinetAPI를 장착하기 위해 worker를 수정하였습니다. 그러기 위해 패키지 의존성을 수정합니다. 
- 템플릿 생성시 자동생성된 코드를 제거하고, 의미있는 코드로 대체합니다. 
- AppCore에 연결하기 위해 SceneBuilder를 수정하였습니다.
- AppCore에 signUp이 성공하면 트리거 될 클로저를 선언하였습니다. signUp씬을 탈출하는 exitSignUpScene() 을 정의합니다. 그래서 signUpVC에 수정이 생겼습니다. 

### UI수정 
- SignUpScene의 UI에 키보드를 내리는 기능을 추가합니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?