### PR TITLE
가든검색 api 연동 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenInteractor.swift
@@ -128,7 +128,7 @@ extension SearchGardenInteractor {
   
   struct CurrentState: Sendable {
     var page: Int = 0
-    var isEndPage: Bool = false
+    var isEndPage: Bool = true
     var inputText: String = ""
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenInteractor.swift
@@ -21,7 +21,7 @@ protocol SearchGardenBusinessLogic {
   func addGarden()
   func cancelTask(for key: SearchGardenInteractor.TaskKey)
   func loadSearchedGarden(request: SearchGarden.LoadSearchedGarden.Request)
-  func loadSearchedGardenContinue(request: SearchGarden.LoadSearchedGarden.Request)
+  func loadSearchedGardenContinue()
 }
 
 final class SearchGardenInteractor: SearchGardenDataStore {
@@ -103,12 +103,14 @@ extension SearchGardenInteractor: SearchGardenBusinessLogic {
     }
   }
   
-  func loadSearchedGardenContinue(request: SearchGarden.LoadSearchedGarden.Request) {
+  func loadSearchedGardenContinue() {
     guard !self.currentState.isEndPage else { return }
     
     self.currentState.page += 1
     self.loadSearchedGarden(
-      request: SearchGarden.LoadSearchedGarden.Request(inputText: self.currentState.inputText)
+      request: SearchGarden.LoadSearchedGarden.Request(
+        inputText: self.currentState.inputText
+      )
     )
   }
   

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenInteractor.swift
@@ -57,7 +57,7 @@ extension SearchGardenInteractor: SearchGardenBusinessLogic {
           userImage: request.userImage,
           fetchedData: fetchedData
         )
-        self.presenter?.presentUserDataForAddingGarden(response: response)
+        self.presenter?.presentLoadFriendGarden(response: response)
       } catch let error {
         self.handleError(error: error, task: TaskKey.loadUserDataForAddingGarden)
       }
@@ -73,7 +73,7 @@ extension SearchGardenInteractor: SearchGardenBusinessLogic {
         try Task.checkCancellation()
         try await self.searchGardenWorker.addGarden(userID: currentSelectedUser.userID)
         try Task.checkCancellation()
-        self.presenter?.presentResultOfAddingGarden()
+        self.presenter?.presentAddGarden()
       } catch let error {
         self.handleError(error: error, task: TaskKey.addGarden)
       }
@@ -94,7 +94,7 @@ extension SearchGardenInteractor: SearchGardenBusinessLogic {
         self.currentState.isEndPage = fetchedData.isEndPage
         try Task.checkCancellation()
         let response = SearchGarden.LoadSearchedGarden.Response(fetchedData: fetchedData)
-        self.presenter?.presentGardenForSearchingGarden(response: response)
+        self.presenter?.presentSearchedGarden(response: response)
       } catch is CancellationError {
         return // TODO: presenter에 error시 호출될 메서드 구현 예정
       } catch let error {

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenInteractor.swift
@@ -17,10 +17,11 @@ protocol SearchGardenDataStore {
 
 @MainActor
 protocol SearchGardenBusinessLogic {
-  func loadUserDataForAddingGarden(request: SearchGarden.LoadUserDataForAddingGarden.Request)
-  func addGarden(request: SearchGarden.AddGarden.Request)
+  func loadFriendGarden(request: SearchGarden.LoadFriendGarden.Request)
+  func addGarden()
   func cancelTask(for key: SearchGardenInteractor.TaskKey)
   func loadSearchedGarden(request: SearchGarden.LoadSearchedGarden.Request)
+  func loadSearchedGardenContinue(request: SearchGarden.LoadSearchedGarden.Request)
 }
 
 final class SearchGardenInteractor: SearchGardenDataStore {
@@ -28,7 +29,7 @@ final class SearchGardenInteractor: SearchGardenDataStore {
   private let searchGardenWorker: SearchGardenWorkable
   private var tasks: [TaskKey: Task<Void, Never>] = [:]
   private var currentSelectedUser: SearchGarden.CurrentSelectedUser?
-  private var recentPage: Int = 0
+  private var currentState = CurrentState()
   
   init(searchGardenWorker: SearchGardenWorkable) {
     self.searchGardenWorker = searchGardenWorker
@@ -43,76 +44,78 @@ final class SearchGardenInteractor: SearchGardenDataStore {
 // MARK: - Request to worker
 
 extension SearchGardenInteractor: SearchGardenBusinessLogic {
-  func loadUserDataForAddingGarden(request: SearchGarden.LoadUserDataForAddingGarden.Request) {
+  func loadFriendGarden(request: SearchGarden.LoadFriendGarden.Request) {
     self.tasks[TaskKey.loadUserDataForAddingGarden] = Task {
       defer { self.tasks[TaskKey.loadUserDataForAddingGarden] = nil }
       do {
         try Task.checkCancellation()
         self.currentSelectedUser = SearchGarden.CurrentSelectedUser(userID: request.userID)
-        let fetchedData = try await self.searchGardenWorker.fetchUserDataForAddingGarden(userID: request.userID)
+        let fetchedData = try await self.searchGardenWorker.loadFriendGarden(userID: request.userID)
         try Task.checkCancellation()
-        let response = SearchGarden.LoadUserDataForAddingGarden.Response(
+        let response = SearchGarden.LoadFriendGarden.Response(
           userID: request.userID,
           userImage: request.userImage,
           fetchedData: fetchedData
         )
         self.presenter?.presentUserDataForAddingGarden(response: response)
-      } catch is CancellationError {
-        return
-      } catch let error as HTTPClientError {
-        switch error {
-        default: return
-        }
-      } catch { return }
+      } catch let error {
+        self.handleError(error: error, task: TaskKey.loadUserDataForAddingGarden)
+      }
     }
   }
   
-  func addGarden(request: SearchGarden.AddGarden.Request) {
+  func addGarden() {
     guard let currentSelectedUser else { return }
     
     self.tasks[TaskKey.addGarden] = Task {
       defer { self.tasks[TaskKey.addGarden] = nil }
       do {
         try Task.checkCancellation()
-        let result = try await self.searchGardenWorker.requestToAddGarden(userID: currentSelectedUser.userID)
+        try await self.searchGardenWorker.addGarden(userID: currentSelectedUser.userID)
         try Task.checkCancellation()
-        let response = SearchGarden.AddGarden.Response(result: result)
-        self.presenter?.presentResultOfAddingGarden(response: response)
-      } catch is CancellationError {
-        return // TODO: presenter에 error시 호출될 메서드 구현 예정 
-      } catch let error as HTTPClientError {
-        switch error {
-        default: return // TODO: presenter에 error시 호출될 메서드 구현 예정
-        }
-      } catch { return } // TODO: presenter에 error시 호출될 메서드 구현 예정
+        self.presenter?.presentResultOfAddingGarden()
+      } catch let error {
+        self.handleError(error: error, task: TaskKey.addGarden)
+      }
     }
   }
   
   func loadSearchedGarden(request: SearchGarden.LoadSearchedGarden.Request) {
+    self.currentState.isEndPage = false
+    self.currentState.page = Int.zero
     self.tasks[TaskKey.loadSearchedGarden] = Task {
       defer { self.tasks[TaskKey.loadSearchedGarden] = nil }
       do {
         try Task.checkCancellation()
-        if request.isContinuous {
-          self.recentPage += 1
-        } else {
-          self.recentPage = Int.zero
-        }
-        let fetchedData = try await self.searchGardenWorker.fetchSearchedGardenData(
+        let fetchedData = try await self.searchGardenWorker.loadSearchedGardenList(
           inputText: request.inputText,
-          page: self.recentPage
+          page: self.currentState.page
         )
+        self.currentState.isEndPage = fetchedData.isEndPage
         try Task.checkCancellation()
         let response = SearchGarden.LoadSearchedGarden.Response(fetchedData: fetchedData)
         self.presenter?.presentGardenForSearchingGarden(response: response)
       } catch is CancellationError {
         return // TODO: presenter에 error시 호출될 메서드 구현 예정
-      } catch let error as HTTPClientError {
-        switch error {
-        default: return // TODO: presenter에 error시 호출될 메서드 구현 예정
-        }
-      } catch { return }
+      } catch let error {
+        self.handleError(error: error, task: TaskKey.loadSearchedGarden)
+      }
     }
+  }
+  
+  func loadSearchedGardenContinue(request: SearchGarden.LoadSearchedGarden.Request) {
+    guard !self.currentState.isEndPage else { return }
+    
+    self.currentState.page += 1
+    self.loadSearchedGarden(
+      request: SearchGarden.LoadSearchedGarden.Request(inputText: self.currentState.inputText)
+    )
+  }
+  
+  @MainActor
+  private func handleError(error: Error, task: TaskKey) {
+    debugPrint(error)
+    self.presenter?.presentErrorInfoToast(error: error)
   }
 }
 
@@ -121,5 +124,11 @@ extension SearchGardenInteractor {
     case loadUserDataForAddingGarden
     case addGarden
     case loadSearchedGarden
+  }
+  
+  struct CurrentState: Sendable {
+    var page: Int = 0
+    var isEndPage: Bool = false
+    var inputText: String = ""
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenPresenter.swift
@@ -11,9 +11,9 @@ import SearchGardenSceneEntity
 
 @MainActor
 protocol SearchGardenPresentationLogic {
-  func presentUserDataForAddingGarden(response: SearchGarden.LoadFriendGarden.Response)
-  func presentResultOfAddingGarden()
-  func presentGardenForSearchingGarden(response: SearchGarden.LoadSearchedGarden.Response)
+  func presentLoadFriendGarden(response: SearchGarden.LoadFriendGarden.Response)
+  func presentAddGarden()
+  func presentSearchedGarden(response: SearchGarden.LoadSearchedGarden.Response)
   func presentErrorInfoToast(error: Error)
 }
 
@@ -24,7 +24,7 @@ final class SearchGardenPresenter {
 // MARK: - Request to ViewController
 
 extension SearchGardenPresenter: SearchGardenPresentationLogic {
-  func presentUserDataForAddingGarden(response: SearchGarden.LoadFriendGarden.Response) {
+  func presentLoadFriendGarden(response: SearchGarden.LoadFriendGarden.Response) {
     let viewModel = SearchGarden.LoadFriendGarden.ViewModel(
       userImage: response.userImage,
       userNickname: response.fetchedData.data.nickname,
@@ -36,11 +36,11 @@ extension SearchGardenPresenter: SearchGardenPresentationLogic {
     self.viewController?.displayFriendGarden(viewModel: viewModel)
   }
   
-  func presentResultOfAddingGarden() {
+  func presentAddGarden() {
     self.viewController?.displayAddGarden()
   }
   
-  func presentGardenForSearchingGarden(response: SearchGarden.LoadSearchedGarden.Response) {
+  func presentSearchedGarden(response: SearchGarden.LoadSearchedGarden.Response) {
     let viewModel = SearchGarden.LoadSearchedGarden.ViewModel(
       fetchedData: response.fetchedData
     )

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenPresenter.swift
@@ -11,9 +11,10 @@ import SearchGardenSceneEntity
 
 @MainActor
 protocol SearchGardenPresentationLogic {
-  func presentUserDataForAddingGarden(response: SearchGarden.LoadUserDataForAddingGarden.Response)
-  func presentResultOfAddingGarden(response: SearchGarden.AddGarden.Response)
+  func presentUserDataForAddingGarden(response: SearchGarden.LoadFriendGarden.Response)
+  func presentResultOfAddingGarden()
   func presentGardenForSearchingGarden(response: SearchGarden.LoadSearchedGarden.Response)
+  func presentErrorInfoToast(error: Error)
 }
 
 final class SearchGardenPresenter {
@@ -23,24 +24,20 @@ final class SearchGardenPresenter {
 // MARK: - Request to ViewController
 
 extension SearchGardenPresenter: SearchGardenPresentationLogic {
-  func presentUserDataForAddingGarden(response: SearchGarden.LoadUserDataForAddingGarden.Response) {
-    let viewModel = SearchGarden.LoadUserDataForAddingGarden.ViewModel(
+  func presentUserDataForAddingGarden(response: SearchGarden.LoadFriendGarden.Response) {
+    let viewModel = SearchGarden.LoadFriendGarden.ViewModel(
       userImage: response.userImage,
-      userNickname: response.fetchedData.userNickname,
-      userIntroduction: response.fetchedData.userIntroduction,
-      userGarden: response.fetchedData.userGarden,
+      userNickname: response.fetchedData.data.nickname,
+      userIntroduction: response.fetchedData.data.introduction,
+      userGarden: response.fetchedData.data.pomodoroRecords,
       isButtonEnable: !response.fetchedData.isFriend
     )
     
-    self.viewController?.displayUserDataForAddingGarden(viewModel: viewModel)
+    self.viewController?.displayFriendGarden(viewModel: viewModel)
   }
   
-  func presentResultOfAddingGarden(response: SearchGarden.AddGarden.Response) {
-    let viewModel = SearchGarden.AddGarden.ViewModel(
-      isSuccess: response.result.isSuccess
-    )
-    
-    self.viewController?.displayResultOfAddingGarden(viewModel: viewModel)
+  func presentResultOfAddingGarden() {
+    self.viewController?.displayAddGarden()
   }
   
   func presentGardenForSearchingGarden(response: SearchGarden.LoadSearchedGarden.Response) {
@@ -48,6 +45,10 @@ extension SearchGardenPresenter: SearchGardenPresentationLogic {
       fetchedData: response.fetchedData
     )
     
-    self.viewController?.displayGardenForSearchingGarden(viewModel: viewModel)
+    self.viewController?.displaySearchedGarden(viewModel: viewModel)
+  }
+  
+  func presentErrorInfoToast(error: any Error) {
+    self.viewController?.displayErrorInfoToast(error: error)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenPresenter.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import SearchGardenSceneEntity
+import ToDoGardenUIComponent
 
 @MainActor
 protocol SearchGardenPresentationLogic {
@@ -29,7 +30,9 @@ extension SearchGardenPresenter: SearchGardenPresentationLogic {
       userImage: response.userImage,
       userNickname: response.fetchedData.data.nickname,
       userIntroduction: response.fetchedData.data.introduction,
-      userGarden: response.fetchedData.data.pomodoroRecords,
+      userGarden: self.convertToPomodoroRecord(
+        from: response.fetchedData.data.pomodoroRecords
+      ),
       isButtonEnable: !response.fetchedData.isFriend
     )
     
@@ -50,5 +53,15 @@ extension SearchGardenPresenter: SearchGardenPresentationLogic {
   
   func presentErrorInfoToast(error: any Error) {
     self.viewController?.displayErrorInfoToast(error: error)
+  }
+}
+
+extension SearchGardenPresenter {
+  private func convertToPomodoroRecord(from dtos: [SearchGarden.UserGarden]) -> [PomodoroRecord] {
+    var records: [PomodoroRecord] = []
+    for dto in dtos {
+      records.append(PomodoroRecord(date: dto.date.toDateISO8601Format(), pomodoroCount: dto.pomodoroCount))
+    }
+    return records
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenSceneBuilder.swift
@@ -31,10 +31,8 @@ extension SearchGardenSceneBuilder: SearchGardenSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
-  public func build(with payload: SearchGardenScenePayloadable) -> SearchGardenViewControllable {
+  public func build() -> SearchGardenViewControllable {
     let someViewController = self.configureVIPCycle(for: SearchGardenViewController())
-    self.setPayload(for: someViewController, with: payload)
-    
     return someViewController
   }
 }
@@ -55,13 +53,5 @@ extension SearchGardenSceneBuilder {
     router.dataStore = interactor
     
     return viewController
-  }
-  
-  /// ViewController에 런타임 파라미터 `payload`를 설정합니다.
-  /// - Parameters:
-  ///   - viewController: 런타임 의존성을 설정할 ViewController 객체입니다.
-  ///   - payload: 런타임에 전달할 의존성입니다.
-  private func setPayload(for viewController: SearchGardenViewController, with payload: SearchGardenScenePayloadable) {
-    // viewController.router?.dataStore?.name = payload.name
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -194,12 +194,11 @@ extension SearchGardenViewController {
 
 extension SearchGardenViewController: SearchGardenDisplayLogic {
   func displayFriendGarden(viewModel: SearchGarden.LoadFriendGarden.ViewModel) {
-    let pomodoroRecords = self.convertToPomodoroRecord(from: viewModel.userGarden)
     self.addGardenView.update(
       userNickname: viewModel.userNickname,
       userIntroduction: viewModel.userIntroduction ?? "",
       userImage: viewModel.userImage,
-      pomodoroCollection: PomodoroRecordCollection(pomodoroRecords: pomodoroRecords)
+      pomodoroCollection: PomodoroRecordCollection(pomodoroRecords: viewModel.userGarden)
     )
     
     self.addGardenView.addButton.isEnabled = viewModel.isButtonEnable

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -267,12 +267,9 @@ extension SearchGardenViewController: UITableViewDelegate {
   }
   
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    guard let tableView = scrollView as? UITableView else { return }
-    
     let offsetY = scrollView.contentOffset.y
     let contentHeight = scrollView.contentSize.height
-    let tableViewHeight = tableView.frame.height
-    if offsetY > contentHeight - tableViewHeight/2 {
+    if offsetY > contentHeight * 0.5 {
       let request = SearchGarden.LoadSearchedGarden.Request(inputText: "")
       self.interactor?.loadSearchedGardenContinue(request: request)
     }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -269,8 +269,7 @@ extension SearchGardenViewController: UITableViewDelegate {
     let offsetY = scrollView.contentOffset.y
     let contentHeight = scrollView.contentSize.height
     if offsetY > contentHeight * 0.5 {
-      let request = SearchGarden.LoadSearchedGarden.Request(inputText: "")
-      self.interactor?.loadSearchedGardenContinue(request: request)
+      self.interactor?.loadSearchedGardenContinue()
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -15,9 +15,10 @@ import ToDoGardenUIResource
 
 @MainActor
 protocol SearchGardenDisplayLogic: AnyObject {
-  func displayUserDataForAddingGarden(viewModel: SearchGarden.LoadUserDataForAddingGarden.ViewModel)
-  func displayResultOfAddingGarden(viewModel: SearchGarden.AddGarden.ViewModel)
-  func displayGardenForSearchingGarden(viewModel: SearchGarden.LoadSearchedGarden.ViewModel)
+  func displayFriendGarden(viewModel: SearchGarden.LoadFriendGarden.ViewModel)
+  func displayAddGarden()
+  func displaySearchedGarden(viewModel: SearchGarden.LoadSearchedGarden.ViewModel)
+  func displayErrorInfoToast(error: Error)
 }
 
 final class SearchGardenViewController: UIViewController, SearchGardenViewControllable {
@@ -104,8 +105,6 @@ extension SearchGardenViewController {
     self.searchGardenView.textField.delegate = self
     self.searchGardenView.textField.returnKeyType = .search
     self.searchGardenView.tableView.delegate = self
-    self.searchGardenView.tableView.updateData(with: MockData.preview) 
-    // TODO: ↑ 제거예정
     self.view.addSubview(self.searchGardenView)
     self.searchGardenView.usingAutolayout()
     
@@ -181,54 +180,67 @@ extension SearchGardenViewController {
       self.dimmingView.isHidden = true
     }
   }
+  
+  private func convertToPomodoroRecord(from dtos: [SearchGarden.UserGarden]) -> [PomodoroRecord] {
+    var records: [PomodoroRecord] = []
+    for dto in dtos {
+      records.append(PomodoroRecord(date: dto.date.toDateISO8601Format(), pomodoroCount: dto.pomodoroCount))
+    }
+    return records
+  }
 }
 
 // MARK: - Confirm display logic protocol
 
 extension SearchGardenViewController: SearchGardenDisplayLogic {
-  func displayUserDataForAddingGarden(viewModel: SearchGarden.LoadUserDataForAddingGarden.ViewModel) {
+  func displayFriendGarden(viewModel: SearchGarden.LoadFriendGarden.ViewModel) {
+    let pomodoroRecords = self.convertToPomodoroRecord(from: viewModel.userGarden)
     self.addGardenView.update(
       userNickname: viewModel.userNickname,
       userIntroduction: viewModel.userIntroduction ?? "",
       userImage: viewModel.userImage,
-      pomodoroCollection: viewModel.userGarden
+      pomodoroCollection: PomodoroRecordCollection(pomodoroRecords: pomodoroRecords)
     )
     
     self.addGardenView.addButton.isEnabled = viewModel.isButtonEnable
+    self.searchGardenView.textField.resignFirstResponder()
     self.showAddGardenView()
   }
   
-  func displayResultOfAddingGarden(viewModel: SearchGarden.AddGarden.ViewModel) {
+  func displayAddGarden() {
     self.hideAddGardenView()
   }
   
-  func displayGardenForSearchingGarden(viewModel: SearchGarden.LoadSearchedGarden.ViewModel) {
+  func displaySearchedGarden(viewModel: SearchGarden.LoadSearchedGarden.ViewModel) {
     self.loadingIndicator.isHidden = true
     self.loadingIndicator.pauseAnimation()
     self.searchGardenView.tableView.updateData(with: viewModel.fetchedData.searchedGardens)
+  }
+  
+  func displayErrorInfoToast(error: any Error) {
+    self.showToast(message: error.localizedDescription)
   }
 }
 
 // MARK: - Request to interactor
 
 extension SearchGardenViewController {
-  func loadUserDataForAddingGarden(userID: String, userImage: UIImage?) {
-    let request = SearchGarden.LoadUserDataForAddingGarden.Request(
+  func loadFriendGarden(userID: UUID, userImage: UIImage?) {
+    let request = SearchGarden.LoadFriendGarden.Request(
       userID: userID,
       userImage: userImage
     )
-    self.interactor?.loadUserDataForAddingGarden(request: request)
+    self.interactor?.loadFriendGarden(request: request)
   }
   
   func addGarden() {
-    let requset = SearchGarden.AddGarden.Request()
-    self.interactor?.addGarden(request: requset)
+    self.interactor?.addGarden()
   }
   
-  func loadSearchGarden(inputText: String, isCountinuous: Bool) {
+  func loadSearchedGarden(inputText: String, isCountinuous: Bool) {
     self.loadingIndicator.isHidden = false
     self.loadingIndicator.startAnimation()
-    let request = SearchGarden.LoadSearchedGarden.Request(inputText: inputText, isContinuous: isCountinuous)
+    let request = SearchGarden.LoadSearchedGarden.Request(inputText: inputText)
     self.interactor?.loadSearchedGarden(request: request)
     
   }
@@ -248,10 +260,22 @@ extension SearchGardenViewController: UITableViewDelegate {
       return
     }
     
-    self.loadUserDataForAddingGarden(
-      userID: userData.userID,
+    self.loadFriendGarden(
+      userID: userData.id,
       userImage: userData.userImage
     )
+  }
+  
+  func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    guard let tableView = scrollView as? UITableView else { return }
+    
+    let offsetY = scrollView.contentOffset.y
+    let contentHeight = scrollView.contentSize.height
+    let tableViewHeight = tableView.frame.height
+    if offsetY > contentHeight - tableViewHeight/2 {
+      let request = SearchGarden.LoadSearchedGarden.Request(inputText: "")
+      self.interactor?.loadSearchedGardenContinue(request: request)
+    }
   }
 }
 
@@ -262,7 +286,7 @@ extension SearchGardenViewController: UITextFieldDelegate {
     }
     
     self.interactor?.cancelTask(for: SearchGardenInteractor.TaskKey.loadSearchedGarden)
-    self.loadSearchGarden(inputText: inputText, isCountinuous: false)
+    self.loadSearchedGarden(inputText: inputText, isCountinuous: false)
     return true
   }
 }
@@ -271,13 +295,4 @@ extension SearchGardenViewController: DefaultModalNavigationBarDelegate {
   func didTapRightButton() {
     self.router?.dismissModal()
   }
-}
-
-@available(iOS 17.0, *)
-#Preview {
-  // 프로젝트 타겟에 SeachGardenScene 추가 필요.
-  // 앱루트 작업내용과 충돌할까봐 타겟에 포함시키지 않았음.
-  let viewController = SearchGardenViewController()
-  
-  return viewController
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenWorker.swift
@@ -5,48 +5,228 @@
 //  Created by SONG on 11/18/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit.UIImage
 
 import HTTPClientAPI
 import SearchGardenSceneAPI
 import SearchGardenSceneEntity
+import TDFoundation
 import ToDoGardenUIComponent // TODO: 제거 예정
 
 public struct SearchGardenWorker: SearchGardenWorkable {
+  private let httpclient: HTTPClientAPI
   
-  public init() {
+  public init(httpclient: HTTPClientAPI) {
+    self.httpclient = httpclient
   }
-  
-  public func fetchUserDataForAddingGarden(userID: String) async throws -> SearchGarden.FetchedUserDataForAddingGarden {
-    
-    return SearchGarden.FetchedUserDataForAddingGarden(
-      userNickname: "UserNickname",
-      userIntroduction: "UserIntroduction",
-      userGarden: PomodoroRecordCollection(),
-      isFriend: false
-    )
-    // HTTPClientError 를 던질예정
-  }
-  
-  public func requestToAddGarden(userID: String) async throws -> SearchGarden.ResultForAddingGarden {
-    return SearchGarden.ResultForAddingGarden(isSuccess: true)
-    // HTTPClientError 를 던질예정
-  }
-  public func fetchSearchedGardenData(
+
+  // swiftlint:disable function_body_length
+  public func loadSearchedGardenList(
     inputText: String,
     page: Int
-  ) async throws -> SearchGarden.FetchedGardenDataForSearching {
-    let result = getTextIncludedUser(inputText: inputText)
-    return SearchGarden.FetchedGardenDataForSearching(searchedGardens: result, page: 0, isEndPage: true)
-    // HTTPClientError 를 던질예정
+  ) async throws -> SearchGarden.SearchedGardenList {
+    var result: [SearchGardenUser] = []
+    let fetchedData = try await self.fetchSearchedGarden(
+      inputText: inputText,
+      page: page
+    )
+    guard let users = fetchedData.data else {
+      return SearchGarden.SearchedGardenList(
+        searchedGardens: [],
+        page: page,
+        isEndPage: fetchedData.isEndPage
+      )
+    }
+    
+    for user in users {
+      guard let id = UUID(uuidString: user.id) else {
+        throw HTTPClientError.deserializationError
+      }
+      
+      var userImage: UIImage?
+      if let urlString = user.imageurl, let url = URL(string: urlString) {
+        let imageData = try await self.downloadImage(imageURL: url)
+        userImage = UIImage(data: imageData)
+      } else {
+        userImage = nil
+      }
+      
+      result.append(
+        SearchGardenUser(
+          id: id,
+          nickname: user.nickname,
+          customId: user.customId,
+          userImage: userImage
+        )
+      )
+    }
+    
+    return SearchGarden.SearchedGardenList(
+      searchedGardens: result,
+      page: page,
+      isEndPage: fetchedData.isEndPage
+    )
   }
 }
 
-// TODO: ↓ 제거 예정
+// - MARK: 통신 수행 메서드
 extension SearchGardenWorker {
-  private func getTextIncludedUser(inputText: String) -> [SearchGardenUser] {
-    return MockData.preview.filter { user in
-      user.userID.contains(inputText)
+  public func loadFriendGarden(userID: UUID) async throws -> SearchGarden.LoadFriendGardenDTO.Response {
+    let request = try self.makeHTTPRequestForLoadingFriendGarden(userID: userID)
+    let result = try await self.httpclient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        try self.checkStatusCode(response: response)
+        let decodedBody: SearchGarden.LoadFriendGardenDTO.Response = try self.decodeBody(response: response)
+        return decodedBody
+      }
+    )
+    return result
+  }
+  
+  public func addGarden(userID: UUID) async throws {
+    let request = try self.makeHTTPRequestForAddingGarden(userID: userID)
+    try await self.httpclient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        try self.checkStatusCode(response: response)
+      }
+    )
+  }
+
+  private func fetchSearchedGarden(
+    inputText: String,
+    page: Int
+  ) async throws -> SearchGarden.SearchGardenUsersDTO.Response {
+    let httpRequest = try self.makeHTTPRequestForFetchingGarden(inputText: inputText, page: page)
+    
+    let fetchedData = try await self.httpclient.send(
+      input: httpRequest,
+      serializer: { $0 },
+      deserializer: { response in
+        try self.checkStatusCode(response: response)
+        let decodedBody: SearchGarden.SearchGardenUsersDTO.Response = try self.decodeBody(response: response)
+        return decodedBody
+      }
+    )
+    return fetchedData
+  }
+  
+  private func downloadImage(imageURL: URL) async throws -> Data {
+    let httpRequest = try self.makeHTTPRequestForLoadingImage(url: imageURL)
+    
+    let downloadedData = try await self.httpclient.send(
+      input: httpRequest,
+      serializer: { $0 },
+      deserializer: { response in
+        try self.checkStatusCode(response: response)
+        guard let data = response.body else {
+          throw HTTPClientError.deserializationError
+        }
+        
+        return data
+      }
+    )
+    return downloadedData
+  }
+}
+// swiftlint:enable function_body_length
+
+// - MARK: Make HTTPRequest
+// - TODO: apiKey 이외의 공통헤더 관련 작업하는 MiddleWare 도입예정
+extension SearchGardenWorker {
+  private func makeHTTPRequestForFetchingGarden(inputText: String, page: Int) throws -> HTTPRequest {
+    guard let accessToken = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken),
+      let accessTokenString = String(data: accessToken, encoding: .utf8) else {
+      throw KeychainError.nonExistentKey
     }
+    
+    return HTTPRequest(
+      method: .get,
+      endPoint: URLConstants.Garden.searchGarden,
+      header: [
+        "Content-Type": "application/json",
+        "Accept-Profile": "todogarden",
+        "Authorization": "Bearer \(accessTokenString)"
+      ],
+      queryItems: [
+        "pageindex": "\(page)",
+        "search_id": inputText
+      ]
+    )
+  }
+  
+  private func makeHTTPRequestForLoadingImage(url: URL) throws -> HTTPRequest {
+    guard let accessToken = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken),
+      let accessTokenString = String(data: accessToken, encoding: .utf8) else {
+      throw KeychainError.nonExistentKey
+    }
+    
+    return HTTPRequest(
+      method: .get,
+      endPoint: url,
+      header: [
+        "Content-Type": "application/json",
+        "Accept-Profile": "todogarden",
+        "Authorization": "Bearer \(accessTokenString)"
+      ]
+    )
+  }
+  
+  private func makeHTTPRequestForLoadingFriendGarden(userID: UUID) throws -> HTTPRequest {
+    guard let accessToken = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken),
+      let accessTokenString = String(data: accessToken, encoding: .utf8) else {
+      throw KeychainError.nonExistentKey
+    }
+    
+    return HTTPRequest(
+      method: .get,
+      endPoint: URLConstants.Garden.loadUserGarden,
+      header: [
+        "Content-Type": "application/json",
+        "Accept-Profile": "todogarden",
+        "Authorization": "Bearer \(accessTokenString)"
+      ],
+      queryItems: ["garden_id": userID.uuidString]
+    )
+  }
+  
+  private func makeHTTPRequestForAddingGarden(userID: UUID) throws -> HTTPRequest {
+    guard let accessToken = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken),
+      let accessTokenString = String(data: accessToken, encoding: .utf8) else {
+      throw KeychainError.nonExistentKey
+    }
+    
+    let body = try JSONEncoder().encode(SearchGarden.AddGardenDTO.Response(gardenId: userID.uuidString))
+    
+    return HTTPRequest(
+      method: .post,
+      endPoint: URLConstants.Garden.addGarden,
+      header: [
+        "Content-Type": "application/json",
+        "Accept-Profile": "todogarden",
+        "Content-Profile": "todogarden",
+        "Authorization": "Bearer \(accessTokenString)"
+      ],
+      body: body
+    )
+  }
+}
+
+extension SearchGardenWorker {
+  private func checkStatusCode(response: HTTPResponse) throws {
+    guard response.statusCode >= 200 && response.statusCode < 400 else {
+      throw HTTPClientError.badStatusCode(response.statusCode)
+    }
+  }
+  
+  private func decodeBody<T: Decodable>(response: HTTPResponse) throws -> T {
+    guard let data = response.body else {
+      throw HTTPClientError.deserializationError
+    }
+    
+    return try JSONDecoder().decode(T.self, from: data)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenWorker.swift
@@ -43,20 +43,20 @@ public struct SearchGardenWorker: SearchGardenWorkable {
         throw HTTPClientError.deserializationError
       }
       
-      var userImage: UIImage?
-      if let urlString = user.imageurl, let url = URL(string: urlString) {
-        let imageData = try await self.downloadImage(imageURL: url)
-        userImage = UIImage(data: imageData)
-      } else {
-        userImage = nil
-      }
+      //      var userImage: UIImage?
+      //      if let urlString = user.imageurl, let url = URL(string: urlString) {
+      //        let imageData = try await self.downloadImage(imageURL: url)
+      //        userImage = UIImage(data: imageData)
+      //      } else {
+      //        userImage = nil
+      //      }
       
       result.append(
         SearchGardenUser(
           id: id,
           nickname: user.nickname,
           customId: user.customId,
-          userImage: userImage
+          userImage: nil
         )
       )
     }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenSceneAPI/SearchGardenSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenSceneAPI/SearchGardenSceneBuildable.swift
@@ -7,14 +7,9 @@
 
 import Foundation
 
-/// 런타임에 전달받을 의존성을 선언한 구조체입니다.
-public protocol SearchGardenScenePayloadable {
-  // var name: String { get }
-}
-
 public protocol SearchGardenSceneBuildable {
   ///  VIP Cycle, 런타임 파라미터가 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 파라미터입니다.
   /// - Returns: 런타임 파라미터, VIP Cycle이 설정된 ViewController가 반환되도록 구현합니다.
-  func build(with payload: SearchGardenScenePayloadable) -> SearchGardenViewControllable
+  func build() -> SearchGardenViewControllable
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenSceneAPI/SearchGardenWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenSceneAPI/SearchGardenWorkable.swift
@@ -10,8 +10,8 @@ import Foundation
 import SearchGardenSceneEntity
 
 public protocol SearchGardenWorkable {
-  func fetchUserDataForAddingGarden(userID: String) async throws -> SearchGarden.FetchedUserDataForAddingGarden
+  func loadFriendGarden(userID: UUID) async throws -> SearchGarden.LoadFriendGardenDTO.Response
   
-  func requestToAddGarden(userID: String) async throws -> SearchGarden.ResultForAddingGarden
-  func fetchSearchedGardenData(inputText: String, page: Int) async throws -> SearchGarden.FetchedGardenDataForSearching
+  func addGarden(userID: UUID) async throws
+  func loadSearchedGardenList(inputText: String, page: Int) async throws -> SearchGarden.SearchedGardenList
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenSceneEntity/SearchGardenModels.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenSceneEntity/SearchGardenModels.swift
@@ -13,25 +13,25 @@ public enum SearchGarden {
   
   // MARK: Use cases
   
-  public enum LoadUserDataForAddingGarden {
+  public enum LoadFriendGarden {
     public struct Request: Sendable {
-      public let userID: String
+      public let userID: UUID
       public let userImage: UIImage?
       
-      public init(userID: String, userImage: UIImage?) {
+      public init(userID: UUID, userImage: UIImage?) {
         self.userID = userID
         self.userImage = userImage
       }
     }
     public struct Response: Sendable {
-      public let userID: String
+      public let userID: UUID
       public let userImage: UIImage?
-      public let fetchedData: FetchedUserDataForAddingGarden
+      public let fetchedData: LoadFriendGardenDTO.Response
       
       public init(
-        userID: String,
+        userID: UUID,
         userImage: UIImage?,
-        fetchedData: FetchedUserDataForAddingGarden
+        fetchedData: LoadFriendGardenDTO.Response
       ) {
         self.userID = userID
         self.userImage = userImage
@@ -42,14 +42,14 @@ public enum SearchGarden {
       public let userImage: UIImage?
       public let userNickname: String
       public let userIntroduction: String?
-      public let userGarden: PomodoroRecordCollection
+      public let userGarden: [UserGarden]
       public let isButtonEnable: Bool
       
       public init(
         userImage: UIImage?,
         userNickname: String,
         userIntroduction: String?,
-        userGarden: PomodoroRecordCollection,
+        userGarden: [UserGarden],
         isButtonEnable: Bool
       ) {
         self.userImage = userImage
@@ -61,44 +61,22 @@ public enum SearchGarden {
     }
   }
   
-  public enum AddGarden {
-    public struct Request: Sendable {
-      public init() { }
-    }
-    public struct Response: Sendable {
-      public let result: ResultForAddingGarden
-      
-      public init(result: ResultForAddingGarden) {
-        self.result = result
-      }
-    }
-    public struct ViewModel: Sendable {
-      public let isSuccess: Bool
-      
-      public init(isSuccess: Bool) {
-        self.isSuccess = isSuccess
-      }
-    }
-  }
-  
   public enum LoadSearchedGarden {
     public struct Request: Sendable {
       public let inputText: String
-      public let isContinuous: Bool
-      public init(inputText: String, isContinuous: Bool) {
+      public init(inputText: String) {
         self.inputText = inputText
-        self.isContinuous = isContinuous
       }
     }
     public struct Response: Sendable {
-      public let fetchedData: FetchedGardenDataForSearching
-      public init(fetchedData: FetchedGardenDataForSearching) {
+      public let fetchedData: SearchedGardenList
+      public init(fetchedData: SearchedGardenList) {
         self.fetchedData = fetchedData
       }
     }
     public struct ViewModel: Sendable {
-      public let fetchedData: FetchedGardenDataForSearching
-      public init(fetchedData: FetchedGardenDataForSearching) {
+      public let fetchedData: SearchedGardenList
+      public init(fetchedData: SearchedGardenList) {
         self.fetchedData = fetchedData
       }
     }
@@ -106,34 +84,83 @@ public enum SearchGarden {
 }
 
 extension SearchGarden {
-  public struct FetchedUserDataForAddingGarden: Sendable {
-    public let userNickname: String
-    public let userIntroduction: String?
-    public let userGarden: PomodoroRecordCollection
-    public let isFriend: Bool
+  public enum LoadFriendGardenDTO {
+    public struct Response: Sendable, Codable {
+      public let data: FriendGardenInfo
+      public let isFriend: Bool
+    }
     
-    public init(
-      userNickname: String,
-      userIntroduction: String?,
-      userGarden: PomodoroRecordCollection,
-      isFriend: Bool
-    ) {
-      self.userNickname = userNickname
-      self.userIntroduction = userIntroduction
-      self.userGarden = userGarden
-      self.isFriend = isFriend
+    public struct FriendGardenInfo: Sendable, Codable {
+      public let nickname: String
+      public let introduction: String?
+      public let pomodoroRecords: [UserGarden]
+      
+      public init(
+        nickname: String,
+        introduction: String?,
+        pomodororecords: [UserGarden]
+      ) {
+        self.nickname = nickname
+        self.introduction = introduction
+        self.pomodoroRecords = pomodororecords
+      }
     }
   }
   
-  public struct ResultForAddingGarden: Sendable {
-    public let isSuccess: Bool
+  public struct UserGarden: Sendable, Codable {
+    public let date: String
+    public let pomodoroCount: Int
     
-    public init(isSuccess: Bool) {
-      self.isSuccess = isSuccess
+    public init(date: String, pomodoroCount: Int) {
+      self.date = date
+      self.pomodoroCount = pomodoroCount
+    }
+  }
+}
+
+extension SearchGarden {
+  public enum AddGardenDTO {
+    public struct Response: Sendable, Codable {
+      public let gardenId: String
+      
+      public init(gardenId: String) {
+        self.gardenId = gardenId
+      }
+      enum CodingKeys: String, CodingKey {
+        case gardenId = "garden_id"
+      }
     }
   }
   
-  public struct FetchedGardenDataForSearching: Sendable {
+  public enum SearchGardenUsersDTO {
+    public struct Response: Sendable, Decodable {
+      public let data: [User]?
+      public let isEndPage: Bool
+      public init(data: [User], isEndPage: Bool) {
+        self.data = data
+        self.isEndPage = isEndPage
+      }
+      
+      public struct User: Sendable, Decodable {
+        public let id: String
+        public let imageurl: String?
+        public let nickname: String
+        public let customId: String
+      }
+    }
+  }
+}
+
+extension SearchGarden {
+  public struct CurrentSelectedUser: Sendable {
+    public let userID: UUID
+    
+    public init(userID: UUID) {
+      self.userID = userID
+    }
+  }
+  
+  public struct SearchedGardenList: Sendable {
     public let searchedGardens: [SearchGardenUser]
     public let page: Int
     public let isEndPage: Bool
@@ -142,16 +169,6 @@ extension SearchGarden {
       self.searchedGardens = searchedGardens
       self.page = page
       self.isEndPage = isEndPage
-    }
-  }
-}
-
-extension SearchGarden {
-  public struct CurrentSelectedUser: Sendable {
-    public let userID: String
-    
-    public init(userID: String) {
-      self.userID = userID
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenSceneEntity/SearchGardenModels.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenSceneEntity/SearchGardenModels.swift
@@ -42,14 +42,14 @@ public enum SearchGarden {
       public let userImage: UIImage?
       public let userNickname: String
       public let userIntroduction: String?
-      public let userGarden: [UserGarden]
+      public let userGarden: [PomodoroRecord]
       public let isButtonEnable: Bool
       
       public init(
         userImage: UIImage?,
         userNickname: String,
         userIntroduction: String?,
-        userGarden: [UserGarden],
+        userGarden: [PomodoroRecord],
         isButtonEnable: Bool
       ) {
         self.userImage = userImage


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #756 
## 🎉 변경 사항
  - REST api 명세에 맞춰, worker에서 통신을 합니다. 
  - 모델 / 메서드 / 파라미터 이름 수정, 타입 변경에 따른 변경사항이 있습니다.  
## 📌 PR Point

<img width="1036" alt="스크린샷 2025-01-07 오전 2 59 40" src="https://github.com/user-attachments/assets/35710215-e544-4865-b57b-aba9cfac8196" />

### useCase 이름 수정 
- REST api를 정리해 놓은 문서와 각 useCase의 이름을 일치시켰습니다. 
- 서버에서 오는 응답에 따라 일부 모델 속성 / 파라미터의 이름 / 타입이 변경되었습니다. 
- 이와 같은 변경사항들 때문에 파일체인지가 늘었습니다만... 의미있는 변경사항은 워커와 아래 내용정도입니다. 

### 인터랙터 
- 상태값 컨테이너인 CurrentState가 추가되었습니다. 

### 워커 
- 각 유스케이스에 대해 http통신을 수행합니다. ( 가든검색 / 가든계속검색 / 친구가든조회 / 가든친구추가 )
- 이미지 캐싱객체와 공통헤더 미들웨어가 적용될 예정입니다. 

### 뷰컨트롤러 
- 테이블뷰 내부 모든 셀 높이의 절반지점까지 스크롤하면, 검색된 다음 페이지를 로드합니다. 
- 인터랙터의 CurrentState 상태값에 따라 다음페이지를 로드하는 흐름으로 갈지, 해당 흐름을 진행하지 않을지 분기됩니다.

### 에러처리 
- 워커에서 발생하는 모든 에러들은 인터랙터의 handleError() 메서드를 통해 핸들링됩니다. 
- 현재는 핸들링 흐름이 구체화 되지 않아서, 에러가 catch되면 toast를 띄워주고 있습니다. 

### 실행화면 

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-07 at 03 33 14](https://github.com/user-attachments/assets/0dea376d-3783-467b-a12f-282f7ec9878f)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?