### PR TITLE
Add CommonHeaderMiddleware

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/CommonHeaderMiddleWare.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/CommonHeaderMiddleWare.swift
@@ -22,13 +22,13 @@ public struct CommonHeaderMiddleware: ClientMiddleware {
     }
 
     var updatedRequest = request
-    updatedRequest.header["Content-Type"] = "application/json"
     updatedRequest.header["Authorization"] = "Bearer \(accessTokenString)"
 
     switch updatedRequest.method {
     case .get:
       updatedRequest.header["Accept-Profile"] = "todogarden"
     default:
+      updatedRequest.header["Content-Type"] = "application/json"
       updatedRequest.header["Content-Profile"] = "todogarden"
     }
 

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/CommonHeaderMiddleWare.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/CommonHeaderMiddleWare.swift
@@ -1,0 +1,37 @@
+//
+//  CommonHeaderMiddleWare.swift
+//  TDFoundation
+//
+//  Created by SONG on 1/7/25.
+//
+
+import Foundation
+
+import HTTPClientAPI
+
+public struct CommonHeaderMiddleware: ClientMiddleware {
+  public init() {}
+
+  public func intercept(
+    request: HTTPRequest,
+    next: @Sendable (HTTPRequest) async throws -> HTTPResponse
+  ) async throws -> HTTPResponse {
+    guard let accessTokenData = try? KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken),
+      let accessTokenString = String(data: accessTokenData, encoding: .utf8) else {
+      throw KeychainError.nonExistentKey
+    }
+
+    var updatedRequest = request
+    updatedRequest.header["Content-Type"] = "application/json"
+    updatedRequest.header["Authorization"] = "Bearer \(accessTokenString)"
+
+    switch updatedRequest.method {
+    case .get:
+      updatedRequest.header["Accept-Profile"] = "todogarden"
+    default:
+      updatedRequest.header["Content-Profile"] = "todogarden"
+    }
+
+    return try await next(updatedRequest)
+  }
+}


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #762 
## 🎉 변경 사항
- CommonHeaderMiddleware를 추가합니다.
## 📌 PR Point
### 공통 헤더 추가 
- "Content-Type": "application/json"
- "Authorization": "Bearer ~~~"

### HTTP Method별 헤더 추가 
- GET -> "Accept-Profile": "todogarden"
- 그 외 -> "Content-Profile": "todogarden"

```swift
let httpClient = HTTPClient(
  transport: URLSessionTransport(),
  middlewares: [
    AuthenticationMiddleWare(),
    CommonHeaderMiddleWare(),
    RefreshMiddleWare()
  ]
)
// 미들웨어 순서는 상관없습니다. 그냥 넣어서 사용하면 될 것 같습니다. 
```

### 어프루브 되면 머지시키기 전에 이미 머지된 httpClient 구현부내용을 수정할 생각입니다. 


```swift
  private func makeHTTPRequestForLoadingFriendGarden(userID: UUID) throws -> HTTPRequest {
    guard let accessToken = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken),
      let accessTokenString = String(data: accessToken, encoding: .utf8) else {
      throw KeychainError.nonExistentKey
    }

    return HTTPRequest(
      method: .get,
      endPoint: URLConstants.Garden.loadUserGarden,
      header: [
        "Content-Type": "application/json",
        "Accept-Profile": "todogarden",
        "Authorization": "Bearer \(accessTokenString)"
      ], // ← 이런놈들이 필요 없어지므로, 제거할 예정
      queryItems: ["garden_id": userID.uuidString]
    )
  }
```



## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?