### PR TITLE
apply on rest api mystats scene

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/CommonHeaderMiddleWare.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/CommonHeaderMiddleWare.swift
@@ -22,13 +22,13 @@ public struct CommonHeaderMiddleware: ClientMiddleware {
     }
 
     var updatedRequest = request
-    updatedRequest.header["Content-Type"] = "application/json"
     updatedRequest.header["Authorization"] = "Bearer \(accessTokenString)"
 
     switch updatedRequest.method {
     case .get:
       updatedRequest.header["Accept-Profile"] = "todogarden"
     default:
+      updatedRequest.header["Content-Type"] = "application/json"
       updatedRequest.header["Content-Profile"] = "todogarden"
     }
 

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/CommonHeaderMiddleWare.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/CommonHeaderMiddleWare.swift
@@ -1,0 +1,37 @@
+//
+//  CommonHeaderMiddleWare.swift
+//  TDFoundation
+//
+//  Created by SONG on 1/7/25.
+//
+
+import Foundation
+
+import HTTPClientAPI
+
+public struct CommonHeaderMiddleware: ClientMiddleware {
+  public init() {}
+
+  public func intercept(
+    request: HTTPRequest,
+    next: @Sendable (HTTPRequest) async throws -> HTTPResponse
+  ) async throws -> HTTPResponse {
+    guard let accessTokenData = try? KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken),
+      let accessTokenString = String(data: accessTokenData, encoding: .utf8) else {
+      throw KeychainError.nonExistentKey
+    }
+
+    var updatedRequest = request
+    updatedRequest.header["Content-Type"] = "application/json"
+    updatedRequest.header["Authorization"] = "Bearer \(accessTokenString)"
+
+    switch updatedRequest.method {
+    case .get:
+      updatedRequest.header["Accept-Profile"] = "todogarden"
+    default:
+      updatedRequest.header["Content-Profile"] = "todogarden"
+    }
+
+    return try await next(updatedRequest)
+  }
+}

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
@@ -14,6 +14,7 @@ public enum URLConstants {
   public enum Garden { }
   public enum Profile { }
   public enum Timer { }
+  public enum Stats { }
 }
 
 // swiftlint:disable all
@@ -33,5 +34,11 @@ extension URLConstants.Garden {
   public static let searchGarden = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/search_garden")!
   public static let loadUserGarden = URL(string:"https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/friend")!
   public static let addGarden = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/add_friend")!
+}
+
+extension URLConstants.Stats {
+  public static let getCurrentContinuousDays = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/get_current_consecutive_days")!
+  public static let getMaxRecords = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/get_max_records")!
+  public static let getSummary = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/get_summary")!
 }
 // swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Package.swift
@@ -49,7 +49,8 @@ let package = Package(
         .product(name: "HTTPClientAPI", package: "TDFoundation"),
         .product(name: "TDUtility", package: "TDUtility"),
         .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI"),
-        .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI")
+        .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI"),
+        .product(name: "TDFoundation", package: "TDFoundation")
       ]
     ),
     .testTarget(

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsInteractor.swift
@@ -13,8 +13,8 @@ import MyStatsSceneEntity
 import ToDoGardenUIComponent // PomodoroRecordCollection 이관 예정
 
 protocol MyStatsDataStore {
-  var myName: String { get set }
-  var myImage: UIImage { get set }
+//  var myName: String { get set }
+//  var myImage: UIImage { get set }
   var myGarden: PomodoroRecordCollection { get set }
 }
 
@@ -24,17 +24,18 @@ protocol MyStatsBusinessLogic {
 }
 
 class MyStatsInteractor: MyStatsDataStore {
-  var myName: String
-  var myImage: UIImage
   var myGarden: ToDoGardenUIComponent.PomodoroRecordCollection
   
   var presenter: MyStatsPresentationLogic?
   private let myStatsWorker: MyStatsWorkable
   private var loadMyStatsViewDataTask: Task<Void, Never>?
+  private var periodicState = PeriodicState.init(
+    daily: (focusTime: Int.zero, pomodoroCount: Int.zero),
+    weekly: (focusTime: Int.zero, pomodoroCount: Int.zero),
+    monthly: (focusTime: Int.zero, pomodoroCount: Int.zero)
+  )
   
   init(myStatsWorker: MyStatsWorkable) {
-    self.myName = "이인우"
-    self.myImage = UIImage.defaultProfileImage
     self.myGarden = ToDoGardenUIComponent.PomodoroRecordCollection.init(pomodoroRecords: [])
     // TODO: ↑ 세 라인 페이로드로 세팅될 예정 지금은 임시로 이니셜라이저에서 할당
     self.myStatsWorker = myStatsWorker
@@ -50,25 +51,17 @@ extension MyStatsInteractor: MyStatsBusinessLogic {
         try Task.checkCancellation()
         let payload = self.createPayload()
         let response = try await self.fetchViewData()
+        self.savePeriodicState(with: response)
         try Task.checkCancellation()
         self.presenter?.presentMyStatsViewData(response: response, with: payload)
-      } catch is CancellationError {
-        // 취소된 경우의 처리
-      } catch let error as HTTPClientError {
-        // HTTPClientError case 별 처리
-        switch error {
-        default: break
-        }
-      } catch {
-        // 기타 예상치 못한 에러 처리
+      } catch let error {
+        debugPrint(error)
       }
     }
   }
   
   private func createPayload() -> MyStats.Payload {
     return MyStats.Payload(
-      myName: self.myName,
-      myImage: self.myImage,
       myGarden: self.myGarden
     )
   }
@@ -91,32 +84,38 @@ extension MyStatsInteractor: MyStatsBusinessLogic {
   }
 }
 
-// swiftlint:disable all
-// TODO: ↓ 제거예정
 extension MyStatsInteractor {
-  private func makeRandomPomodoroRecords() -> [PomodoroRecord] {
-    var pomodoroRecords = [PomodoroRecord]()
+  private struct PeriodicState {
+    let daily: (focusTime: Int, pomodoroCount: Int)
+    let weekly: (focusTime: Int, pomodoroCount: Int)
+    let monthly: (focusTime: Int, pomodoroCount: Int)
     
-    let calendar = Calendar.current
-    
-    let startDateComponents = DateComponents(year: 2024, month: 6, day: 14)
-    let date = calendar.date(from: startDateComponents)!
-    
-    for i in 0..<140 {
-      let currentDate = calendar.date(byAdding: .day, value: i, to: date)!
-      let pomodoroCount = Int.random(in: 0...10) // Random pomodoro count between 0 and 10
-      let formattedDate = calendar.date(
-        from: DateComponents(
-          year: calendar.component(.year, from: currentDate),
-          month: calendar.component(.month, from: currentDate),
-          day: calendar.component(.day, from: currentDate)
-        )
-      )!
-      let pomodoroRecord = PomodoroRecord(date: formattedDate, pomodoroCount: pomodoroCount)
-      pomodoroRecords.append(pomodoroRecord)
+    init(
+      daily: (focusTime: Int, pomodoroCount: Int),
+      weekly: (focusTime: Int, pomodoroCount: Int),
+      monthly: (focusTime: Int, pomodoroCount: Int)
+    ) {
+      self.daily = daily
+      self.weekly = weekly
+      self.monthly = monthly
     }
-    
-    return pomodoroRecords
+  }
+  
+  private func savePeriodicState(with response: MyStats.LoadMyStatsViewData.Response) {
+    let dataSet = response.summaryViewData
+    self.periodicState = PeriodicState(
+      daily: (
+        focusTime: dataSet.dailyAverageFocusTime,
+        pomodoroCount: dataSet.dailyAveragePomodoroCount
+      ),
+      weekly: (
+        focusTime: dataSet.weeklyAverageFocusTime,
+        pomodoroCount: dataSet.weeklyAveragePomodoroCount
+      ),
+      monthly: (
+        focusTime: dataSet.monthlyAverageFocusTime,
+        pomodoroCount: dataSet.monthlyAveragePomodoroCount
+      )
+    )
   }
 }
-// swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsInteractor.swift
@@ -52,8 +52,8 @@ extension MyStatsInteractor: MyStatsBusinessLogic {
         try Task.checkCancellation()
         let payload = self.createPayload()
         let response = try await self.fetchViewData()
-        self.savePeriodicState(with: response)
         try Task.checkCancellation()
+        self.savePeriodicState(with: response)
         self.presenter?.presentMyStatsViewData(response: response, with: payload)
       } catch let error {
         debugPrint(error)

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsInteractor.swift
@@ -47,6 +47,7 @@ class MyStatsInteractor: MyStatsDataStore {
 extension MyStatsInteractor: MyStatsBusinessLogic {
   func loadMyStatsViewData(request: MyStats.LoadMyStatsViewData.Request) {
     self.loadMyStatsViewDataTask = Task {
+      defer { self.loadMyStatsViewDataTask = nil }
       do {
         try Task.checkCancellation()
         let payload = self.createPayload()

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsInteractor.swift
@@ -61,6 +61,7 @@ extension MyStatsInteractor: MyStatsBusinessLogic {
   }
   
   private func createPayload() -> MyStats.Payload {
+    // TODO: 화면 연결완료되면 제거 될 예정
     return MyStats.Payload(
       myGarden: self.myGarden
     )

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsPresenter.swift
@@ -40,9 +40,7 @@ extension MyStatsPresenter {
   private func makeViewModel(response: MyStats.LoadMyStatsViewData.Response, with payload: MyStats.Payload)
   -> MyStats.LoadMyStatsViewData.ViewModel {
     let profileViewModel = self.makeProfileViewModel(
-      fetchedData: response.profileViewData,
-      myName: payload.myName,
-      myImage: payload.myImage
+      fetchedData: response.profileViewData
     )
     let gardenViewModel = self.makeGardenViewModel(myGarden: payload.myGarden)
     let longestRecordViewModel = self.makeLongestRecordViewModel(fetchedData: response.longestRecordViewData)
@@ -58,16 +56,23 @@ extension MyStatsPresenter {
   }
   
   private func makeProfileViewModel(
-    fetchedData: MyStats.FetchedProfileViewData,
-    myName: String,
-    myImage: UIImage
+    fetchedData: MyStats.FetchedProfileViewData
   ) -> MyStats.ProfileViewModel {
+    var image: UIImage
+    if let imageData = fetchedData.profileImage, let profielImage = UIImage(data: imageData) {
+      image = profielImage
+    } else {
+      image = UIImage.defaultProfileImage
+    }
+    
     let viewModel = MyStats.ProfileViewModel(
-      myName: myName,
-      myImage: myImage,
+      myName: fetchedData.nickname,
+      myImage: image,
       continuousRecordCount: fetchedData.continuousRecordCount,
-      continuousRecordStartDate: fetchedData.continuousRecordStartDate.toStringDefaultFormat(),
-      continuousRecordEndDate: fetchedData.continuousRecordEndDate.toStringDefaultFormat()
+      continuousRecordStartDate:
+        fetchedData.continuousRecordStartDate.replacingOccurrences(of: "-", with: "."),
+      continuousRecordEndDate:
+        fetchedData.continuousRecordEndDate.replacingOccurrences(of: "-", with: ".")
     )
     return viewModel
   }
@@ -80,47 +85,23 @@ extension MyStatsPresenter {
   private func makeLongestRecordViewModel(
     fetchedData: MyStats.FetchedLongestRecordViewData
   ) -> MyStats.LongestRecordViewModel {
+    let convertedDate = fetchedData.maxPomodoroRecord.recordDate.toDateISO8601Format().toStringDefaultFormat()
     let viewModel = MyStats.LongestRecordViewModel(
-      concentratedRecordGroupName: fetchedData.concentratedRecordGroupName,
-      concentratedRecordCount: fetchedData.concentratedRecordCount,
-      concentratedRecordDate: fetchedData.concentratedRecordDate.toStringDefaultFormat(),
-      longestContinuousRecordCount: fetchedData.longestContinuousRecordCount,
-      longestContinuousRecordStartDate: fetchedData.longestContinuousRecordStartDate.toStringDefaultFormat(),
-      longestContinuousRecordEndDate: fetchedData.longestContinuousRecordEndDate.toStringDefaultFormat()
+      concentratedRecordGroupName: fetchedData.maxPomodoroRecord.groupName,
+      concentratedRecordCount: fetchedData.maxPomodoroRecord.maxPomodoroCount,
+      concentratedRecordDate: convertedDate,
+      longestContinuousRecordCount: fetchedData.maxContinuousDays?.maxCount ?? 0,
+      longestContinuousRecordStartDate: fetchedData.maxContinuousDays?.startDate ?? "",
+      longestContinuousRecordEndDate: fetchedData.maxContinuousDays?.endDate ?? ""
     )
     return viewModel
   }
   
   private func makeSummaryViewModel(fetchedData: MyStats.FetchedSummaryViewData) -> MyStats.SummaryViewModel {
     let viewModel = MyStats.SummaryViewModel(
-      concentratedTime: fetchedData.concentratedTime.toTimeString(),
-      completedCount: fetchedData.completedCount.toStringWithOneDecimal()
+      concentratedTime: "\(fetchedData.weeklyAverageFocusTime) 단위몰라",
+      completedCount: "\(fetchedData.weeklyAveragePomodoroCount) 개 목표"
     )
     return viewModel
-  }
-}
-
-// MARK: - 아래 코드는 API명세 / supaBase에서 어떤 데이터를 제공해 줄지에 따라 사용여부가 결정되므로, 일단 임시로 사용하고 있는 메서드입니다.
-
-extension Double {
-  func toStringWithOneDecimal() -> String {
-    return String(format: "%.1f개 목표", self)
-  }
-}
-
-extension Int {
-  func toTimeString() -> String {
-    let hours = self / 3600
-    let minutes = (self % 3600) / 60
-    var timeString = ""
-    
-    if hours > 0 {
-      timeString += "\(hours)시간"
-    }
-    if minutes > 0 {
-      timeString += " \(minutes)분"
-    }
-    
-    return timeString.trimmingCharacters(in: CharacterSet.whitespaces)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsWorker.swift
@@ -3,49 +3,130 @@ import Foundation
 import HTTPClientAPI
 import MyStatsSceneAPI
 import MyStatsSceneEntity
+import TDFoundation
 
 public struct MyStatsWorker: MyStatsWorkable {
-  public init() {}
+  private let httpClient: HTTPClientAPI
+  
+  public init(httpClient: HTTPClientAPI) {
+    self.httpClient = httpClient
+  }
   
   public func fetchProfileViewData() async throws -> MyStats.FetchedProfileViewData {
-    do {
-      // TODO: RESTAPI 연동
-      
-      return MyStats.FetchedProfileViewData(
-        continuousRecordCount: 99,
-        continuousRecordStartDate: Date.distantPast,
-        continuousRecordEndDate: Date.distantFuture
-      )
-    } catch let error as HTTPClientError {
-      throw error
+    let result = try await self.downloadProfileData()
+    
+    var imageData: Data?
+    if let imageUrlString = result.imageUrl {
+      imageData = try await self.downloadImage(urlString: imageUrlString)
+    } else {
+      imageData = nil
     }
+    
+    return MyStats.FetchedProfileViewData(
+      nickname: result.nickname,
+      profileImage: imageData,
+      continuousRecordCount: result.continuousRecordCount,
+      continuousRecordStartDate: result.continuousRecordStartDate,
+      continuousRecordEndDate: result.continuousRecordEndDate
+    )
   }
   
   public func fetchLongestRecordsViewData() async throws -> MyStats.FetchedLongestRecordViewData {
-    do {
-      // TODO: RESTAPI 연동
-      return MyStats.FetchedLongestRecordViewData(
-        concentratedRecordGroupName: "킹왕짱그룹",
-        concentratedRecordCount: 99,
-        concentratedRecordDate: Date.now,
-        longestContinuousRecordCount: 10,
-        longestContinuousRecordStartDate: Date.distantPast,
-        longestContinuousRecordEndDate: Date.distantFuture
-      )
-    } catch let error as HTTPClientError {
-      throw error
-    }
+    let result = try await self.downloadLongestRecordsViewData()
+    return result
   }
   
   public func fetchSummaryViewData() async throws -> MyStats.FetchedSummaryViewData {
-    do {
-      // TODO: RESTAPI 연동
-      return MyStats.FetchedSummaryViewData(
-        concentratedTime: 3660,
-        completedCount: 3.5
-      )
-    } catch let error as HTTPClientError {
-      throw error
+    let result = try await self.downloadSummaryData()
+    return result
+  }
+}
+
+extension MyStatsWorker {
+  private func downloadProfileData() async throws -> MyStats.ProfileViewDataDTO {
+    let request = HTTPRequest(
+      method: .get,
+      endPoint: URLConstants.Stats.getCurrentContinuousDays
+    )
+    
+    let result = try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        guard response.statusCode >= 200 && response.statusCode < 400 else {
+          throw HTTPClientError.badStatusCode(response.statusCode)
+        }
+        
+        guard let data = response.body else {
+          throw HTTPClientError.deserializationError
+        }
+        
+        return try JSONDecoder().decode(MyStats.ProfileViewDataDTO.self, from: data)
+      }
+    )
+    return result
+  }
+  
+  private func downloadLongestRecordsViewData() async throws -> MyStats.FetchedLongestRecordViewData {
+    let request = HTTPRequest(method: .get, endPoint: URLConstants.Stats.getMaxRecords)
+    let result = try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        guard response.statusCode >= 200 && response.statusCode < 400 else {
+          throw HTTPClientError.badStatusCode(response.statusCode)
+        }
+        
+        guard let data = response.body else {
+          throw HTTPClientError.deserializationError
+        }
+        
+        return try JSONDecoder().decode(MyStats.FetchedLongestRecordViewData.self, from: data)
+      }
+    )
+    return result
+  }
+  
+  private func downloadSummaryData() async throws -> MyStats.FetchedSummaryViewData {
+    let request = HTTPRequest(method: .get, endPoint: URLConstants.Stats.getSummary)
+    let result = try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        guard response.statusCode >= 200 && response.statusCode < 400 else {
+          throw HTTPClientError.badStatusCode(response.statusCode)
+        }
+        
+        guard let data = response.body else {
+          throw HTTPClientError.deserializationError
+        }
+        
+        return try JSONDecoder().decode(MyStats.FetchedSummaryViewData.self, from: data)
+      }
+    )
+    return result
+  }
+  
+  private func downloadImage(urlString: String) async throws -> Data {
+    guard let url = URL(string: urlString) else {
+      throw NSError(domain: "Failed to create URL from \(urlString)", code: 0)
     }
+    
+    let request = HTTPRequest(method: .get, endPoint: url)
+    let result = try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        guard response.statusCode >= 200 && response.statusCode < 400 else {
+          throw HTTPClientError.badStatusCode(response.statusCode)
+        }
+        
+        guard let data = response.body else {
+          throw HTTPClientError.deserializationError
+        }
+        return data
+      }
+    )
+    return result
   }
 }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsWorker.swift
@@ -17,7 +17,7 @@ public struct MyStatsWorker: MyStatsWorkable {
     
     var imageData: Data?
     if let imageUrlString = result.imageUrl {
-      imageData = try await self.downloadImage(urlString: imageUrlString)
+      imageData = try await self.downloadImageData(urlString: imageUrlString)
     } else {
       imageData = nil
     }
@@ -107,7 +107,7 @@ extension MyStatsWorker {
     return result
   }
   
-  private func downloadImage(urlString: String) async throws -> Data {
+  private func downloadImageData(urlString: String) async throws -> Data {
     guard let url = URL(string: urlString) else {
       throw NSError(domain: "Failed to create URL from \(urlString)", code: 0)
     }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsWorker.swift
@@ -109,7 +109,7 @@ extension MyStatsWorker {
   
   private func downloadImageData(urlString: String) async throws -> Data {
     guard let url = URL(string: urlString) else {
-      throw NSError(domain: "Failed to create URL from \(urlString)", code: 0)
+      throw URLError(.badURL)
     }
     
     let request = HTTPRequest(method: .get, endPoint: url)

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
@@ -146,10 +146,11 @@ extension MyStatsView {
     
     var dateRangeString: String
     
-    if startDate == nil || endDate == nil || startDate == endDate {
+    if startDate == nil || endDate == nil {
       dateRangeString = ""
     } else {
-      dateRangeString = "\(startDate ?? "") ~ \(endDate ?? "")"
+      dateRangeString =
+      "\(startDate ?? "") ~ \(endDate ?? "")"
     }
     
     self.profileView.configuration = .profile(

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
@@ -22,8 +22,8 @@ final class MyStatsView: UIView {
     self.profileView = Styled.Row(configuration: .profile(
       .init(
         style: .myStats,
-        title: "asdasd\nasdasdasd",
-        description: "asdasd"
+        title: "Nickname님,\n0000일 연속으로 기록 유지중이에요",
+        description: "0000.00.00 ~ 0000.00.00"
         )
       )
     )

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneAPI/MyStatsSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneAPI/MyStatsSceneBuildable.swift
@@ -7,9 +7,11 @@
 
 import Foundation
 
+import ToDoGardenUIComponent
+
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
 public protocol MyStatsScenePayloadable {
-  // var name: String { get }
+  var myGarden: PomodoroRecordCollection { get }
 }
 
 public protocol MyStatsSceneBuildable {

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneEntity/MyStatsModels.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneEntity/MyStatsModels.swift
@@ -126,13 +126,9 @@ extension MyStats {
   }
   
   public struct Payload {
-    public let myName: String
-    public let myImage: UIImage
     public let myGarden: PomodoroRecordCollection
     
-    public init(myName: String, myImage: UIImage, myGarden: PomodoroRecordCollection) {
-      self.myName = myName
-      self.myImage = myImage
+    public init(myGarden: PomodoroRecordCollection) {
       self.myGarden = myGarden
     }
   }
@@ -142,58 +138,40 @@ extension MyStats {
 
 extension MyStats {
   public struct FetchedProfileViewData: Sendable {
+    public let nickname: String
+    public let profileImage: Data? // TODO: 이미지 캐싱이 Data를 뱉는지, UIImage를 뱉는지에 따라 달라짐
     public let continuousRecordCount: Int
-    public let continuousRecordStartDate: Date
-    public let continuousRecordEndDate: Date
+    public let continuousRecordStartDate: String
+    public let continuousRecordEndDate: String
     
     public init(
+      nickname: String,
+      profileImage: Data?,
       continuousRecordCount: Int,
-      continuousRecordStartDate: Date,
-      continuousRecordEndDate: Date
+      continuousRecordStartDate: String,
+      continuousRecordEndDate: String
     ) {
+      self.nickname = nickname
+      self.profileImage = profileImage
       self.continuousRecordCount = continuousRecordCount
       self.continuousRecordStartDate = continuousRecordStartDate
       self.continuousRecordEndDate = continuousRecordEndDate
     }
   }
   
-  public struct FetchedLongestRecordViewData: Sendable {
-    public let concentratedRecordGroupName: String
-    public let concentratedRecordCount: Int
-    public let concentratedRecordDate: Date
-    
-    public let longestContinuousRecordCount: Int
-    public let longestContinuousRecordStartDate: Date
-    public let longestContinuousRecordEndDate: Date
-    
-    public init(
-      concentratedRecordGroupName: String,
-      concentratedRecordCount: Int,
-      concentratedRecordDate: Date,
-      longestContinuousRecordCount: Int,
-      longestContinuousRecordStartDate: Date,
-      longestContinuousRecordEndDate: Date
-    ) {
-      self.concentratedRecordGroupName = concentratedRecordGroupName
-      self.concentratedRecordCount = concentratedRecordCount
-      self.concentratedRecordDate = concentratedRecordDate
-      self.longestContinuousRecordCount = longestContinuousRecordCount
-      self.longestContinuousRecordStartDate = longestContinuousRecordStartDate
-      self.longestContinuousRecordEndDate = longestContinuousRecordEndDate
-    }
+  public struct FetchedLongestRecordViewData: Sendable, Codable {
+    public let maxPomodoroRecord: MaxPomodoroRecordDTO
+    public let maxContinuousDays: MaxContinuousDaysDTO?
   }
   
-  public struct FetchedSummaryViewData: Sendable {
-    public let concentratedTime: Int
-    public let completedCount: Double
+  public struct FetchedSummaryViewData: Sendable, Codable {
+    public let dailyAverageFocusTime: Int
+    public let weeklyAverageFocusTime: Int
+    public let monthlyAverageFocusTime: Int
     
-    public init(
-      concentratedTime: Int,
-      completedCount: Double
-    ) {
-      self.concentratedTime = concentratedTime
-      self.completedCount = completedCount
-    }
+    public let dailyAveragePomodoroCount: Int
+    public let weeklyAveragePomodoroCount: Int
+    public let monthlyAveragePomodoroCount: Int
   }
 }
 
@@ -202,5 +180,39 @@ extension MyStats {
     case fetchProfileDataFailed
     case fetchLongestRecordDataFailed
     case fetchSummaryDataFailed
+  }
+  
+  public struct ProfileViewDataDTO: Sendable, Codable {
+    public let nickname: String
+    public let imageUrl: String?
+    public let continuousRecordStartDate: String
+    public let continuousRecordEndDate: String
+    public let continuousRecordCount: Int
+    
+    public init(
+      nickname: String,
+      imageUrl: String?,
+      continuousRecordStartDate: String,
+      continuousRecordEndDate: String,
+      continuousRecordCount: Int
+    ) {
+      self.nickname = nickname
+      self.imageUrl = imageUrl
+      self.continuousRecordStartDate = continuousRecordStartDate
+      self.continuousRecordEndDate = continuousRecordEndDate
+      self.continuousRecordCount = continuousRecordCount
+    }
+  }
+  
+  public struct MaxPomodoroRecordDTO: Sendable, Codable {
+    public let groupName: String
+    public let recordDate: String
+    public let maxPomodoroCount: Int
+  }
+  
+  public struct MaxContinuousDaysDTO: Sendable, Codable {
+    public let startDate: String
+    public let endDate: String
+    public let maxCount: Int
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #766 

## 🎉 변경 사항
- 통계보기씬 api 연동을 위한 작업을 진행합니다. 

## 📌 PR Point

### 모델 수정 및 DTO 추가 
- api명세에 맞게 모델을 수정하고, DTO객체를 추가합니다. 
- 엔터티 객체를 공통으로 쓸 수 있는 친구들은 공통으로 사용하고 있지만, 공통으로 사용하기 까다로운 녀석들은 냅뒀습니다. 
(ImageURL 을 포함하고 있다던가... 내부에서 한번더 래핑된 구조를 가지고 있다던가...) 
- 프로퍼티명이 변경된 엔터티가 일부 존재합니다. 

### 인터랙터에 상태값 추가
- 일, 주, 월에 대한 데이터를 저장하고 있는 객체를 추가합니다. 
- 다음 PR에서 사용될 예정입니다. 

### 워커에서 통신 수행 
<img width="342" alt="스크린샷 2025-01-08 오후 7 52 25" src="https://github.com/user-attachments/assets/0517c143-483d-4794-a1c6-a7dbf7f35e37" />

- 워커에서 HTTPClient를 이용하여 통신합니다. 
- 총 3개의 섹션에 대한 통신을 수행하는데, 각각의 통신이 워커내부에서 비동기적으로 동작하는 반면, UI업데이트는 3개의 섹션이 동시에 보여지는 구조가 눈에 밟힙니다. 수정을 할까 생각도 했지만, 여러 이미지를 받아오는 것도 아니고, 수정해도 체감되는 차이점은 없겠다 싶은 생각에 우선순위가 낮다고 판단했습니다. 
- 다음 PR에서 일,주,월에 대한 UI표시를 하는 VIP를 구현할때 함께 고려해보도록 하겠습니다. 
- 집중시간으로 Int를 받고있는데, 단위를 몰라서 스크럼때 물어보고 수정할겁니다. 

### 페이로드 수정 
- 기존 페이로드 : 이전화면에서 프로필사진 , 닉네임, 가든을 전달받음
- 변경된 페이로드 : 가든만 전달받음 

### 실행화면 
![Simulator Screen Recording - iPhone 16 Pro - 2025-01-08 at 19 30 33](https://github.com/user-attachments/assets/47e83559-156c-4cdb-b99c-42e612daa602)

++ ⬇️ 위 GIF에서 쉬머링 영역이 좀 이상한데, 아래처럼 변경했습니다. 
<img width="365" alt="스크린샷 2025-01-08 오후 7 47 23" src="https://github.com/user-attachments/assets/76a4b1c4-0757-4784-80df-63e97b7abe0c" />

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?