### PR TITLE
그룹편집 스냅샷 방식 api 연동 

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
@@ -29,6 +29,7 @@ extension URLConstants.Auth {
 extension URLConstants.Group {
   public static let fetchGroups = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/grouplist")!
   public static let addGroup = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/make_group")!
+  public static let saveEdittedGroup = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/edit_groups")!
 }
 
 extension URLConstants.Garden {

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -149,8 +149,13 @@ extension ManageGroupInteractor {
     case none
   }
   
+  @MainActor
   private func handleError(_ error: Error, about task: TaskKey) {
     debugPrint("Error: \(error)")
+    if task == .saveGroups {
+      self.presenter?.presentFailedToSaveGroupList()
+    }
+    
     if error is CancellationError {
       return
     } else if error is HTTPClientError {

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupPresenter.swift
@@ -16,6 +16,7 @@ protocol ManageGroupPresentationLogic {
   func presentDeletedGroup(response: ManageGroup.DeleteGroup.Response)
   func presentAddedGroup(response: ManageGroup.AddGroup.Response)
   func presentEditedGroup(response: ManageGroup.EditGroup.Response)
+  func presentFailedToSaveGroupList()
 }
 
 class ManageGroupPresenter {
@@ -51,5 +52,9 @@ extension ManageGroupPresenter: ManageGroupPresentationLogic {
   func presentEditedGroup(response: ManageGroup.EditGroup.Response) {
     let viewModel = ManageGroup.EditGroup.ViewModel(group: response.group, editedIndex: response.editedIndex)
     self.viewController?.displayEditedGroup(viewModel: viewModel)
+  }
+  
+  func presentFailedToSaveGroupList() {
+    self.viewController?.displayFailToSaveGroupList()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -21,6 +21,7 @@ protocol ManageGroupDisplayLogic: AnyObject {
   func displayDeletedGroup(viewModel: ManageGroup.DeleteGroup.ViewModel)
   func displayAddedGroup(viewModel: ManageGroup.AddGroup.ViewModel)
   func displayEditedGroup(viewModel: ManageGroup.EditGroup.ViewModel)
+  func displayFailToSaveGroupList()
 }
 
 open class ManageGroupViewController: UIViewController, ManageGroupViewControllable {
@@ -343,6 +344,11 @@ extension ManageGroupViewController: ManageGroupDisplayLogic {
     self.groupListTableView.reloadRows(
       at: [IndexPath(row: viewModel.editedIndex, section: Int.zero)],
       with: UITableView.RowAnimation.fade)
+  }
+  
+  func displayFailToSaveGroupList() {
+    self.showToast(message: "저장 실패")
+    self.cancelEditing()
   }
   
   private func updateTableViewWithAnimation(

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
@@ -111,7 +111,7 @@ public class ManageGroupWorker: ManageGroupWorkable {
       guard let groupID = UUID(uuidString: item.id) else {
         throw NSError(domain: "Invalid GroupID", code: 0)
       }
-      print(item.progressrate)
+      
       groups.append(
         ManageGroup.ToDoGroup(
           groupID: groupID,

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
@@ -85,22 +85,12 @@ public class ManageGroupWorker: ManageGroupWorkable {
   }
   // swiftlint: disable all
   private func fetchGroupsFromDatabase() async throws -> [ManageGroup.ToDoGroup] {
-    guard let accessToken = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken),
-          let accessTokenString = String(data: accessToken, encoding: .utf8) else {
-      throw KeychainError.nonExistentKey
-    }
-    
     let fetchedData = try await self.httpClient.send(
       input: ManageGroup.FetchGroupList.RequestDTO(),
       serializer: { data in
         return HTTPRequest(
           method: .get,
-          endPoint: URLConstants.Group.fetchGroups,
-          header: [
-            "Content-Type": "application/json",
-            "Authorization": "Bearer \(accessTokenString)",
-            "Accept-Profile": "todogarden"
-          ]
+          endPoint: URLConstants.Group.fetchGroups
         )
       },
       deserializer: { response in
@@ -121,7 +111,7 @@ public class ManageGroupWorker: ManageGroupWorkable {
       guard let groupID = UUID(uuidString: item.id) else {
         throw NSError(domain: "Invalid GroupID", code: 0)
       }
-      
+      print(item.progressrate)
       groups.append(
         ManageGroup.ToDoGroup(
           groupID: groupID,
@@ -136,11 +126,6 @@ public class ManageGroupWorker: ManageGroupWorkable {
   }
   
   private func addGroupDirectlyInDatabase(request: ManageGroup.AddGroup.Request) async throws -> UUID {
-    guard let accessToken = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken),
-          let accessTokenString = String(data: accessToken, encoding: .utf8) else {
-      throw KeychainError.nonExistentKey
-    }
-    
     guard let groupID = try await self.httpClient.send(
       input: ManageGroup.AddGroup.RequestDTO(
         name: request.groupName,
@@ -150,11 +135,6 @@ public class ManageGroupWorker: ManageGroupWorkable {
         return HTTPRequest(
           method: .post,
           endPoint: URLConstants.Group.addGroup,
-          header: [
-            "Content-Type": "application/json",
-            "Authorization": "Bearer \(accessTokenString)",
-            "Accept-Profile": "todogarden"
-          ],
           body: try JSONEncoder().encode(data)
         )
       },

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
@@ -71,6 +71,16 @@ public class ManageGroupWorker: ManageGroupWorkable {
   }
   
   private func saveGroupsInDatabase(groupList: [ManageGroup.ToDoGroup]) async throws -> [ManageGroup.ToDoGroup] {
+    let request = try self.makeSaveGroupHTTPResquest(groupList: groupList)
+    try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        guard response.statusCode >= 200 && response.statusCode < 400 else {
+          throw HTTPClientError.badStatusCode(response.statusCode)
+        }
+      }
+    )
     return groupList
   }
   // swiftlint: disable all
@@ -167,6 +177,28 @@ public class ManageGroupWorker: ManageGroupWorkable {
     ) else { throw NSError(domain: "Invalid GroupID", code: 0) }
     
     return groupID
+  }
+  
+  private func makeSaveGroupHTTPResquest(groupList: [ManageGroup.ToDoGroup]) throws -> HTTPRequest {
+    var edittedGroupList: [ManageGroup.SaveGroupList.EdittedGroupDTO] = []
+    for (index, item) in groupList.enumerated() {
+      let group = ManageGroup.SaveGroupList.EdittedGroupDTO(
+        localId: item.groupID.uuidString,
+        name: item.groupName,
+        color: item.progressColor.hexStringFromColor(),
+        orderIdx: index
+      )
+      edittedGroupList.append(group)
+    }
+    let body = try JSONEncoder().encode(ManageGroup.SaveGroupList.RequestDTO(
+      data: edittedGroupList)
+    )
+    let request = HTTPRequest(
+      method: .post,
+      endPoint: URLConstants.Group.saveEdittedGroup,
+      body: body
+    )
+    return request
   }
 }
 // swiftlint: enable all

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneEntity/ManageGroupModels.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneEntity/ManageGroupModels.swift
@@ -204,14 +204,25 @@ extension ManageGroup.AddGroup {
   }
 }
 
-extension ManageGroup.EditGroup {
+extension ManageGroup.SaveGroupList {
   public struct RequestDTO: Sendable, Codable {
+    public let data: [EdittedGroupDTO]
+    public init(data: [EdittedGroupDTO]) {
+      self.data = data
+    }
+  }
+  
+  public struct EdittedGroupDTO: Sendable, Codable {
+    public let localId: String
     public let name: String
     public let color: String
+    public let orderIdx: Int
     
-    public init(name: String, color: String) {
+    public init(localId: String, name: String, color: String, orderIdx: Int) {
+      self.localId = localId
       self.name = name
       self.color = color
+      self.orderIdx = orderIdx
     }
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #773

## 🎉 변경 사항
- 스냅샷방식으로 api연동 구현 

## 📌 PR Point

### 구현 상세 
- `저장` 버튼을 누르면, 현재 편집처리가 된 그룹리스트를 통으로 보냅니다. 
- 미들웨어 추가에 따라 공통헤더 추가해주는 코드를 제거하였습니다. 
- `저장 실패`의 경우 편집전으로 롤백되며 toast가 표시됩니다. 


### 목록 조회시, progressRate 0으로 도착하고 있습니다. 
### 현재 편집내용 저장 요청하면, 500번 응답을 받고 있습니다. 현재 PR에서 같이 고쳐나가면 될 것 같습니다. 
### 요청 헤더 : 
```
▿ 4 elements
  ▿ 0 : 2 elements
    - key : "apiKey"
    - value : "eyJh...GQ"
  ▿ 1 : 2 elements
    - key : "Authorization"
    - value : "Bearer eyJhbGciOiJ...TIDaK8Z7bE"
  ▿ 2 : 2 elements
    - key : "Content-Type"
    - value : "application/json"
  ▿ 3 : 2 elements
    - key : "Content-Profile"
    - value : "todogarden"
```

### 요청 바디 : 

```
{
  "data": [
    {
      "localId": "EF2F98EA-C438-4400-BA82-4F71D25BD019",
      "color": "#ffc83c",
      "name": "그룹 1",
      "orderIdx": 0
    },
    {
      "localId": "7AA0F334-807A-4A33-A431-688DD8BF4E96",
      "color": "#ff6464",
      "name": "그룹 2",
      "orderIdx": 1
    },
    ...
    ,
    {
      "localId": "FC171B1D-0C6F-4B7B-9452-1833CCAE5347",
      "color": "#252525",
      "name": "DirectAdd003",
      "orderIdx": 18
    }
  ]
}
```

### 응답 : 
```
statusCode : 500 
“{\“code\“:\“2D000\“,\“details\“:null,\“hint\“:null,\“message\“:\“invalid transaction termination\“}”
```

### 실행화면 
![Simulator Screen Recording - iPhone 16 Pro - 2025-01-10 at 18 54 24](https://github.com/user-attachments/assets/3c342dae-58d8-4ede-aeb9-eb898b943948)


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?