### PR TITLE
ScrollPrefetcher 적용 (1) : 사전준비

### DIFF
--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenWorker.swift
@@ -137,11 +137,6 @@ extension SearchGardenWorker {
 // - MARK: Make HTTPRequest
 extension SearchGardenWorker {
   private func makeHTTPRequestForFetchingGarden(inputText: String, page: Int) throws -> HTTPRequest {
-    guard let accessToken = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken),
-      let accessTokenString = String(data: accessToken, encoding: .utf8) else {
-      throw KeychainError.nonExistentKey
-    }
-    
     return HTTPRequest(
       method: .get,
       endPoint: URLConstants.Garden.searchGarden,
@@ -153,11 +148,6 @@ extension SearchGardenWorker {
   }
   
   private func makeHTTPRequestForLoadingImage(url: URL) throws -> HTTPRequest {
-    guard let accessToken = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken),
-      let accessTokenString = String(data: accessToken, encoding: .utf8) else {
-      throw KeychainError.nonExistentKey
-    }
-    
     return HTTPRequest(
       method: .get,
       endPoint: url
@@ -165,11 +155,6 @@ extension SearchGardenWorker {
   }
   
   private func makeHTTPRequestForLoadingFriendGarden(userID: UUID) throws -> HTTPRequest {
-    guard let accessToken = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken),
-      let accessTokenString = String(data: accessToken, encoding: .utf8) else {
-      throw KeychainError.nonExistentKey
-    }
-    
     return HTTPRequest(
       method: .get,
       endPoint: URLConstants.Garden.loadUserGarden,
@@ -178,11 +163,6 @@ extension SearchGardenWorker {
   }
   
   private func makeHTTPRequestForAddingGarden(userID: UUID) throws -> HTTPRequest {
-    guard let accessToken = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken),
-      let accessTokenString = String(data: accessToken, encoding: .utf8) else {
-      throw KeychainError.nonExistentKey
-    }
-    
     let body = try JSONEncoder().encode(SearchGarden.AddGardenDTO.Response(gardenId: userID.uuidString))
     
     return HTTPRequest(

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenWorker.swift
@@ -19,7 +19,7 @@ public struct SearchGardenWorker: SearchGardenWorkable {
   public init(httpclient: HTTPClientAPI) {
     self.httpclient = httpclient
   }
-
+  
   // swiftlint:disable function_body_length
   public func loadSearchedGardenList(
     inputText: String,
@@ -95,7 +95,7 @@ extension SearchGardenWorker {
       }
     )
   }
-
+  
   private func fetchSearchedGarden(
     inputText: String,
     page: Int
@@ -135,7 +135,6 @@ extension SearchGardenWorker {
 // swiftlint:enable function_body_length
 
 // - MARK: Make HTTPRequest
-// - TODO: apiKey 이외의 공통헤더 관련 작업하는 MiddleWare 도입예정
 extension SearchGardenWorker {
   private func makeHTTPRequestForFetchingGarden(inputText: String, page: Int) throws -> HTTPRequest {
     guard let accessToken = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken),
@@ -146,11 +145,6 @@ extension SearchGardenWorker {
     return HTTPRequest(
       method: .get,
       endPoint: URLConstants.Garden.searchGarden,
-      header: [
-        "Content-Type": "application/json",
-        "Accept-Profile": "todogarden",
-        "Authorization": "Bearer \(accessTokenString)"
-      ],
       queryItems: [
         "pageindex": "\(page)",
         "search_id": inputText
@@ -166,12 +160,7 @@ extension SearchGardenWorker {
     
     return HTTPRequest(
       method: .get,
-      endPoint: url,
-      header: [
-        "Content-Type": "application/json",
-        "Accept-Profile": "todogarden",
-        "Authorization": "Bearer \(accessTokenString)"
-      ]
+      endPoint: url
     )
   }
   
@@ -184,11 +173,6 @@ extension SearchGardenWorker {
     return HTTPRequest(
       method: .get,
       endPoint: URLConstants.Garden.loadUserGarden,
-      header: [
-        "Content-Type": "application/json",
-        "Accept-Profile": "todogarden",
-        "Authorization": "Bearer \(accessTokenString)"
-      ],
       queryItems: ["garden_id": userID.uuidString]
     )
   }
@@ -204,12 +188,6 @@ extension SearchGardenWorker {
     return HTTPRequest(
       method: .post,
       endPoint: URLConstants.Garden.addGarden,
-      header: [
-        "Content-Type": "application/json",
-        "Accept-Profile": "todogarden",
-        "Content-Profile": "todogarden",
-        "Authorization": "Bearer \(accessTokenString)"
-      ],
       body: body
     )
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenSection+User.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenSection+User.swift
@@ -11,17 +11,28 @@ enum SearchGardenSection {
   case main
 }
 
-public struct SearchGardenUser: Sendable {
+public final class SearchGardenUser {
   public let id: UUID
   public let nickname: String
   public let customId: String
-  public let userImage: UIImage?
+  public var userImage: UIImage?
+  public var userImageURL: URL?
+  public let isDummyData: Bool
 
-  public init(id: UUID, nickname: String, customId: String, userImage: UIImage?) {
+  public init(
+    id: UUID,
+    nickname: String,
+    customId: String,
+    userImage: UIImage?,
+    userImageURL: URL?,
+    isDummyData: Bool = false
+  ) {
     self.id = id
     self.nickname = nickname
     self.customId = customId
     self.userImage = userImage
+    self.userImageURL = userImageURL
+    self.isDummyData = isDummyData
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenSection+User.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenSection+User.swift
@@ -44,4 +44,13 @@ extension SearchGardenUser: Hashable {
   public static func == (lhs: SearchGardenUser, rhs: SearchGardenUser) -> Bool {
     return lhs.id == rhs.id
   }
+  
+  public static let placeholderData = SearchGardenUser(
+    id: UUID(),
+    nickname: "Dummy",
+    customId: "@DummyID",
+    userImage: nil,
+    userImageURL: nil,
+    isDummyData: true
+  )
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
@@ -9,10 +9,21 @@ import UIKit
 
 final public class SearchGardenTableView: UITableView {
   private var diffableDataSource: UITableViewDiffableDataSource<SearchGardenSection, SearchGardenUser>!
-  
+  private var snapshot: NSDiffableDataSourceSnapshot<SearchGardenSection, SearchGardenUser>!
+  private let dummyCellData = SearchGardenUser(
+    id: UUID(),
+    nickname: "Dummy",
+    customId: "@DummyID",
+    userImage: nil,
+    userImageURL: nil,
+    isDummyData: true
+  )
+
   public override init(frame: CGRect, style: UITableView.Style) {
     super.init(frame: frame, style: style)
     self.configureDataSource()
+    self.snapshot = NSDiffableDataSourceSnapshot<SearchGardenSection, SearchGardenUser>()
+    self.snapshot.appendSections([SearchGardenSection.main])
     self.backgroundColor = UIColor.white
     self.register(TableRow.self, forCellReuseIdentifier: TableRow.identifier)
     self.separatorStyle = UITableViewCell.SeparatorStyle.none
@@ -23,15 +34,39 @@ final public class SearchGardenTableView: UITableView {
     fatalError("init(coder:) has not been implemented")
   }
   
-  public func updateData(with users: [SearchGardenUser]) {
-    var snapshot = NSDiffableDataSourceSnapshot<SearchGardenSection, SearchGardenUser>()
-    snapshot.appendSections([SearchGardenSection.main])
-    snapshot.appendItems(users)
-    self.diffableDataSource.apply(snapshot, animatingDifferences: true)
+  public func appendData(with users: [SearchGardenUser]) {
+    if !self.snapshot.sectionIdentifiers.contains(SearchGardenSection.main) {
+      self.snapshot.appendSections([SearchGardenSection.main])
+    }
+    self.snapshot.appendItems(users)
+    self.diffableDataSource.apply(self.snapshot, animatingDifferences: true)
+  }
+    public func clearData() {
+    self.snapshot.deleteItems(snapshot.itemIdentifiers(inSection: SearchGardenSection.main))
+    self.diffableDataSource.apply(self.snapshot, animatingDifferences: false)
   }
   
   public func userForCell(at indexPath: IndexPath) -> SearchGardenUser? {
     return self.diffableDataSource.itemIdentifier(for: indexPath)
+  }
+  
+  public func updateData(of user: SearchGardenUser) {
+    self.snapshot.reconfigureItems([user])
+    self.diffableDataSource.apply(self.snapshot, animatingDifferences: false)
+  }
+  
+  public func appendDummyCell() {
+    self.snapshot.appendItems([self.dummyCellData])
+    self.diffableDataSource.apply(self.snapshot, animatingDifferences: false)
+  }
+  
+  public func deleteDummyCell() {
+    guard self.snapshot.itemIdentifiers.contains(self.dummyCellData) else {
+      return
+    }
+    
+    self.snapshot.deleteItems([self.dummyCellData])
+    self.diffableDataSource.apply(self.snapshot, animatingDifferences: false)
   }
   
   private func configureDataSource() {
@@ -45,20 +80,34 @@ final public class SearchGardenTableView: UITableView {
       ) as? TableRow else {
         return nil
       }
-      
       self.diffableDataSource.defaultRowAnimation = UITableView.RowAnimation.fade
-      tableRow.update(
-        configuration: Styled.Row.Configuration.profile(
-          .init(
-            style: .searchRow,
-            title: userData.nickname,
-            description: "@" + userData.customId,
-            image: userData.userImage
-          )
+      self.updateTableRow(userData: userData, tableRow: tableRow)
+      self.setDummyOrNot(userData: userData, tableRow: tableRow)
+      return tableRow
+    }
+  }
+  
+  private func updateTableRow(userData: SearchGardenUser, tableRow: TableRow) {
+    tableRow.update(
+      configuration: Styled.Row.Configuration.profile(
+        .init(
+          style: .searchRow,
+          title: userData.nickname,
+          description: "@" + userData.customId,
+          image: userData.userImage
         )
       )
-
-      return tableRow
+    )
+  }
+  
+  private func setDummyOrNot(userData: SearchGardenUser, tableRow: TableRow) {
+    if userData.isDummyData {
+      tableRow.contentView.subviews.forEach { $0.isShimmering = true }
+      tableRow.contentView.startShimmering()
+      tableRow.isUserInteractionEnabled = false
+    } else {
+      tableRow.contentView.stopShimmering()
+      tableRow.isUserInteractionEnabled = true
     }
   }
 }
@@ -73,13 +122,14 @@ final public class SearchGardenTableView: UITableView {
     view.heightAnchor.constraint(equalToConstant: 700)
   ])
   
-  view.updateData(
+  view.appendData(
     with: [
       SearchGardenUser(
         id: UUID(),
         nickname: "흥민갓",
         customId: "hmzzang123",
-        userImage: nil
+        userImage: nil,
+        userImageURL: nil
       )
     ]
   )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
@@ -41,7 +41,7 @@ final public class SearchGardenTableView: UITableView {
     self.snapshot.appendItems(users)
     self.diffableDataSource.apply(self.snapshot, animatingDifferences: true)
   }
-    public func clearData() {
+  public func clearItemsInMainSection() {
     self.snapshot.deleteItems(snapshot.itemIdentifiers(inSection: SearchGardenSection.main))
     self.diffableDataSource.apply(self.snapshot, animatingDifferences: false)
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
@@ -10,14 +10,6 @@ import UIKit
 final public class SearchGardenTableView: UITableView {
   private var diffableDataSource: UITableViewDiffableDataSource<SearchGardenSection, SearchGardenUser>!
   private var snapshot: NSDiffableDataSourceSnapshot<SearchGardenSection, SearchGardenUser>!
-  private let dummyCellData = SearchGardenUser(
-    id: UUID(),
-    nickname: "Dummy",
-    customId: "@DummyID",
-    userImage: nil,
-    userImageURL: nil,
-    isDummyData: true
-  )
 
   public override init(frame: CGRect, style: UITableView.Style) {
     super.init(frame: frame, style: style)
@@ -55,17 +47,17 @@ final public class SearchGardenTableView: UITableView {
     self.diffableDataSource.apply(self.snapshot, animatingDifferences: false)
   }
   
-  public func appendDummyCell() {
-    self.snapshot.appendItems([self.dummyCellData])
+  public func appendPlaceholderCell() {
+    self.snapshot.appendItems([SearchGardenUser.placeholderData])
     self.diffableDataSource.apply(self.snapshot, animatingDifferences: false)
   }
   
-  public func deleteDummyCell() {
-    guard self.snapshot.itemIdentifiers.contains(self.dummyCellData) else {
+  public func deletePlaceholderCell() {
+    guard self.snapshot.itemIdentifiers.contains(SearchGardenUser.placeholderData) else {
       return
     }
     
-    self.snapshot.deleteItems([self.dummyCellData])
+    self.snapshot.deleteItems([SearchGardenUser.placeholderData])
     self.diffableDataSource.apply(self.snapshot, animatingDifferences: false)
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
@@ -13,7 +13,8 @@ extension Styled.Row {
     stack.addInnerPadding(model[style: \.innerPadding])
     
     if model.style == Configuration.ProfileModel.Style.shareProfile ||
-      model.style == Configuration.ProfileModel.Style.myStats {
+      model.style == Configuration.ProfileModel.Style.myStats ||
+      model.style == Configuration.ProfileModel.Style.searchRow {
       stack.isShimmering = true
     }
     
@@ -111,7 +112,8 @@ extension Styled.Row {
     }
     
     if model.style == Configuration.ProfileModel.Style.shareProfile ||
-      model.style == Configuration.ProfileModel.Style.myStats {
+      model.style == Configuration.ProfileModel.Style.myStats ||
+      model.style == Configuration.ProfileModel.Style.searchRow {
       self.setupShimmeringInnerStack(titleLabel, descriptionLabel, stack)
     }
     
@@ -129,7 +131,8 @@ extension Styled.Row {
     }
     
     if style == Configuration.ProfileModel.Style.shareProfile ||
-      style == Configuration.ProfileModel.Style.myStats {
+      style == Configuration.ProfileModel.Style.myStats ||
+      style == Configuration.ProfileModel.Style.searchRow {
       self.setupShimmeringProfileImageView(profileImageView)
     }
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #775 
## 🎉 변경 사항
### 프리페치를 적용시키기 전에 필요한 사전작업을 PR합니다. 
- 미들웨어 추가 전 코드 제거 
- 쉬머링 이펙트를 위한 코드 추가 
- DiffableDataSource의 모델( Hashable , ItemIdentifier) 를 Class로 수정
## 📌 PR Point

### 미들웨어 추가 전 코드 제거 
- 쌩으로 직접 넣어주던 헤더관련 코드를 제거합니다. 
- 미들웨어에서 다 처리합니다. 

### 쉬머링 이펙트를 위한 코드 추가 
- 쉬머링 이펙트를 위해 필요한 서브뷰에 대해 isShimmering 을 true로 지정합니다. 

### DiffableDataSource의 모델( Hashable , ItemIdentifier) 를 Class로 수정
- 현재 PR에는 포함되어있지 않지만, 변경될 가든검색은 아래와 같은 흐름으로 동작합니다.  
![스크린샷 2025-01-15 오전 2 58 10](https://github.com/user-attachments/assets/90049553-0dd5-4ed1-b52c-76490d2c6729)

- 아래 코드와 같이 이미지 데이터를 바꿔서 snapshot에 적용시켜주고있습니다. 
```swift
  public func updateData(of user: SearchGardenUser) {
    self.snapshot.reconfigureItems([user]) // or reloadItems()
    self.diffableDataSource.apply(self.snapshot, animatingDifferences: false)
  }
```
- `reloadItems()` / `reconfigureItems()` 은 value타입에 먹히지 않습니다. 호출 후, apply를 해도 변경사항이 반영되지 않습니다. 
- 기존 Struct였던 `SearchGardenUser` (DiffableDataSource의 cell 모델)을 사용하려면 
   - 1. deleteItem() -> insertItem() 을 하거나, 
   - 2. 스냅샷 자체를 통째로 갈아 끼우는 방식
   - 3. prefetch에 가장 권장되는 방식인 NSDiffableDataSourceSnapshot<Section, Item>() 의 Item자리에 `SearchGardenUser`를 대신해서 `ID`만 넣어주는 방법. (하.. 이걸 미리 알았다면...)
   등이 있긴 할 것 같은데, 그 중 가장 간단하게 문제를 해결할 수 있는 방법인 `class로 선언하기` 를 택했습니다. 
++ 3번방법으로 개선을 하려면 SearchGardenTableView의 구조를 바꾸는 작업이 필요하여 다른 PR에서 진행할 예정 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?