### PR TITLE
가든뷰 가로세로 비율 맞춤 적용

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AddGardenView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/AddGardenView.swift
@@ -158,20 +158,17 @@ extension AddGardenView {
   
   private func setupGardenViewConstraints() {
     self.gardenView.usingAutolayout()
+    let intrinsicWidth = self.gardenView.intrinsicContentSize.width
+    let intrinsicHeight = self.gardenView.intrinsicContentSize.height
     NSLayoutConstraint.activate(
       [
-        self.gardenView.leadingAnchor.constraint(
-          equalTo: self.leadingAnchor,
-          constant: Constants.Layout.commonHorizontalMargin
-        ),
-        self.gardenView.trailingAnchor.constraint(
-          equalTo: self.trailingAnchor,
-          constant: -Constants.Layout.commonHorizontalMargin
-        ),
+        self.gardenView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
         self.gardenView.bottomAnchor.constraint(
           equalTo: self.addButton.topAnchor,
           constant: Constants.GardenView.Layout.verticalMargin
-        )
+        ),
+        self.gardenView.widthAnchor.constraint(equalToConstant: intrinsicWidth * 278 / 332 ),
+        self.gardenView.heightAnchor.constraint(equalToConstant: intrinsicHeight * 99.64 / 119 )
       ]
     )
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #779
## 🎉 변경 사항
- gardenView를 쓸 때, 가로세로 비율을 유지할 수 있도록 오토레이아웃을 조정합니다. 
## 📌 PR Point
<img width="701" alt="스크린샷 2025-01-17 오전 3 59 17" src="https://github.com/user-attachments/assets/b504983e-7779-4d4b-9a1f-24bad4347376" />

머쓱 ^^;; 죄송죄송 
단순히 나의 불찰이었던 것. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?