### PR TITLE
UserInfoScene api 적용 

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/CommonHeaderMiddleWare.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/CommonHeaderMiddleWare.swift
@@ -27,6 +27,9 @@ public struct CommonHeaderMiddleware: ClientMiddleware {
     switch updatedRequest.method {
     case .get:
       updatedRequest.header["Accept-Profile"] = "todogarden"
+    case .put:
+      updatedRequest.header["Content-Type"] = "image/jpeg"
+      updatedRequest.header["Content-Profile"] = "todogarden"
     default:
       updatedRequest.header["Content-Type"] = "application/json"
       updatedRequest.header["Content-Profile"] = "todogarden"

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
@@ -24,6 +24,8 @@ extension URLConstants.Auth {
   public static let validateUserURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/validate_user")!
   // ↑ 기존유저/신규유저 체크 URL
   public static let refreshTokenURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/auth/v1/token?grant_type=refresh_token")!
+  public static let withDrawURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/cancel_membership")!
+  public static let logoutURL = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/auth/v1/logout?scope=global")!
 }
 
 extension URLConstants.Group {
@@ -42,5 +44,13 @@ extension URLConstants.Stats {
   public static let getCurrentContinuousDays = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/get_current_consecutive_days")!
   public static let getMaxRecords = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/get_max_records")!
   public static let getSummary = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/get_summary")!
+}
+
+extension URLConstants.Profile {
+  public static let getUserProfile = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/get_my_info")!
+  public static let getProfileImage = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/storage/v1/object/authenticated/profileImages/")!
+  public static let changeProfileImage = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/storage/v1/object/profileImages/")!
+  public static let changeIntroduction = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/edit_introduction")!
+  public static let changeNickname = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/edit_nickname")!
 }
 // swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Package.swift
@@ -21,7 +21,8 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(name: "ToDoGardenUI", path: "../ToDoGardenUI")
+    .package(name: "ToDoGardenUI", path: "../ToDoGardenUI"),
+    .package(name: "TDFoundation", path: "../TDFoundation")
   ],
   targets: [
     .target(
@@ -40,7 +41,8 @@ let package = Package(
         "EditUserIntroductionSceneEntity",
         .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI"),
         .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
-        .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI")
+        .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI"),
+        .product(name: "TDFoundation", package: "TDFoundation")
       ]
     )
   ]

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneBuilder.swift
@@ -72,21 +72,3 @@ extension EditUserIntroductionSceneBuilder {
     viewController.router?.delegate = payload.delegate
   }
 }
-
-// MARK: - Preview Builder
-
-#if DEBUG
-extension EditUserIntroductionSceneBuilder {
-  private struct PreviewPayload: EditUserIntroductionScenePayloadable {
-    var delegate: EditUserIntroductionDelegate?
-    var userIntroduction: String?
-  }
-
-  /// Preview에서 VIP 동작을 확인하기 위한 Builder입니다.
-  static let previewScene = Self(
-    dependency: Dependency(
-      someWorker: EditUserIntroductionSceneWorker()
-    )
-  ).build(with: PreviewPayload())
-}
-#endif

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionScenePresenter.swift
@@ -1,6 +1,6 @@
 //
 //  EditUserIntroductionScenePresenter.swift
-//  
+//
 //
 //  Created by Wood on 10/7/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
@@ -8,6 +8,7 @@
 import Foundation
 
 import EditUserIntroductionSceneEntity
+import HTTPClientAPI
 
 // swiftlint:disable type_name
 @MainActor
@@ -31,25 +32,24 @@ extension EditUserIntroductionScenePresenter: EditUserIntroductionScenePresentat
   func presentUserIntroduction(_ introduction: String) {
     self.viewController?.displayUserIntroduction(introduction)
   }
-
+  
   func presentEmptyUserIntroduction() {
     self.viewController?.displayEmptyUserIntroduction()
   }
-
+  
   func presentIntroductionIsValid() {
     self.viewController?.displayUserIntroductionValid()
   }
-
+  
   func presentIntroductionIsInvalid() {
     self.viewController?.displayUserIntroductionInvalid()
   }
-
+  
   func presentEditUserIntroductionSuccess() {
     self.viewController?.displayEditUserIntroductionSuccess()
   }
-
+  
   func presentEditUserIntroductionError(_ error: Error) {
-    // TODO: ToDoGardenAlertController에 Model 추가 후 구현 예정입니다. 에러 발생시 알럿에 표시할 문자열을 Display 로직으로 전달합니다.
-//    self.viewController?.displayEditUserIntroductionFailure(error.localizedDescription)
+    self.viewController?.displayEditUserIntroductionFailure(error.localizedDescription)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneViewController.swift
@@ -100,7 +100,7 @@ extension EditUserIntroductionSceneViewController: EditUserIntroductionSceneDisp
   }
 
   func displayEditUserIntroductionFailure(_ errorMessage: String) {
-    // TODO: - 알럿을 띄울 예정이며, 알럿 디자인을 추가한 이후에 구현할 예정입니다.
+    self.showToast(message: errorMessage)
   }
 }
 
@@ -190,10 +190,3 @@ extension EditUserIntroductionSceneViewController {
     )
   }
 }
-
-#if DEBUG
-@available(iOS 17.0, *)
-#Preview {
-  return UINavigationController(rootViewController: EditUserIntroductionSceneBuilder.previewScene)
-}
-#endif

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionScene/EditUserIntroductionSceneWorker.swift
@@ -8,9 +8,34 @@
 import Foundation
 
 import EditUserIntroductionSceneAPI
+import EditUserIntroductionSceneEntity
+import HTTPClientAPI
+import TDFoundation
 
-struct EditUserIntroductionSceneWorker: EditUserIntroductionSceneWorkable {
-  func editUserIntroduction(_ introduction: String) async throws {
-    // TODO: 서버 구현이 완료되면 구현할 예정입니다.
+public struct EditUserIntroductionSceneWorker: EditUserIntroductionSceneWorkable {
+  private let httpClient: HTTPClientAPI
+  
+  public init(httpClient: HTTPClientAPI) {
+    self.httpClient = httpClient
+  }
+  public func editUserIntroduction(_ introduction: String) async throws {
+    let body = try JSONEncoder().encode(
+      EditUserIntroductionScene.ChangeIntroduction.RequestDTO(introduction: introduction)
+    )
+    let request = HTTPRequest(
+      method: HTTPMethod.post,
+      endPoint: URLConstants.Profile.changeIntroduction,
+      body: body
+    )
+    
+    try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        guard response.statusCode >= 200 && response.statusCode < 400 else {
+          throw HTTPClientError.badStatusCode(response.statusCode)
+        }
+      }
+    )
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneEntity/EditUserIntroductionSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserIntroductionScene/Sources/EditUserIntroductionSceneEntity/EditUserIntroductionSceneModels.swift
@@ -23,3 +23,18 @@ public enum EditUserIntroductionScene {
     }
   }
 }
+
+extension EditUserIntroductionScene {
+  public enum ChangeIntroduction {
+    public struct RequestDTO: Sendable, Codable {
+      public let introduction: String
+      public init(introduction: String) {
+        self.introduction = introduction
+      }
+      
+      enum CodingKeys: String, CodingKey {
+        case introduction = "new_introduction"
+      }
+    }
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
   ],
   dependencies: [
     .package(name: "ToDoGardenUI", path: "../ToDoGardenUI"),
-    .package(path: "../TDUtility")
+    .package(path: "../TDUtility"),
+    .package(name: "TDFoundation", path: "../TDFoundation")
   ],
   targets: [
     .target(
@@ -42,7 +43,8 @@ let package = Package(
         .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI"),
         .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
         .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI"),
-        .product(name: "TDUtility", package: "TDUtility")
+        .product(name: "TDUtility", package: "TDUtility"),
+        .product(name: "TDFoundation", package: "TDFoundation")
       ]
     )
   ]

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneBuilder.swift
@@ -26,19 +26,6 @@ public struct EditUserNameSceneBuilder {
   }
 }
 
-extension EditUserNameSceneBuilder {
-  private struct PreviewScenePayload: EditUserNameScenePayloadable {
-    var userName: String = "나야울버린"
-    var delegate: EditUserNameDelegate?
-  }
-
-  public static let previewScene = Self(
-    dependency: Dependency(
-      editUserNameWorker: EditUserNameSceneWorker()
-    )
-  ).build(with: PreviewScenePayload())
-}
-
 extension EditUserNameSceneBuilder: EditUserNameSceneSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneViewController.swift
@@ -189,10 +189,3 @@ extension EditUserNameSceneViewController {
     )
   }
 }
-
-#if DEBUG
-@available(iOS 17.0, *)
-#Preview {
-  return UINavigationController(rootViewController: EditUserNameSceneBuilder.previewScene)
-}
-#endif

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameScene/EditUserNameSceneWorker.swift
@@ -8,8 +8,35 @@
 import Foundation
 
 import EditUserNameSceneAPI
+import EditUserNameSceneEntity
+import HTTPClientAPI
+import TDFoundation
 
-struct EditUserNameSceneWorker: EditUserNameSceneWorkable {
-  // TODO: 서버에 닉네임 수정 요청을 하는 메서드로, 서버가 완성되면 구현할 예정입니다.
-  func requestEditUserName(_ userName: String) async throws {}
+public struct EditUserNameSceneWorker: EditUserNameSceneWorkable {
+  private let httpClient: HTTPClientAPI
+  
+  public init(httpClient: HTTPClientAPI) {
+    self.httpClient = httpClient
+  }
+
+  public func requestEditUserName(_ userName: String) async throws {
+    let body = try JSONEncoder().encode(
+      EditUserNameScene.ChangeNickname.RequestDTO(nickname: userName)
+    )
+    let request = HTTPRequest(
+      method: HTTPMethod.post,
+      endPoint: URLConstants.Profile.changeNickname,
+      body: body
+    )
+    
+    try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        guard response.statusCode >= 200 && response.statusCode < 400 else {
+          throw HTTPClientError.badStatusCode(response.statusCode)
+        }
+      }
+    )
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameSceneEntity/EditUserNameSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/EditUserNameScene/Sources/EditUserNameSceneEntity/EditUserNameSceneModels.swift
@@ -23,3 +23,18 @@ public enum EditUserNameScene {
     }
   }
 }
+
+extension EditUserNameScene {
+  public enum ChangeNickname {
+    public struct RequestDTO: Sendable, Codable {
+      public let nickname: String
+      public init(nickname: String) {
+        self.nickname = nickname
+      }
+      
+      enum CodingKeys: String, CodingKey {
+        case nickname = "new_nickname"
+      }
+    }
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -213,7 +213,7 @@ extension SearchGardenViewController: SearchGardenDisplayLogic {
   func displaySearchedGarden(viewModel: SearchGarden.LoadSearchedGarden.ViewModel) {
     self.loadingIndicator.isHidden = true
     self.loadingIndicator.pauseAnimation()
-    self.searchGardenView.tableView.updateData(with: viewModel.fetchedData.searchedGardens)
+    self.searchGardenView.tableView.updateData(of: viewModel.fetchedData.searchedGardens)
   }
   
   func displayErrorInfoToast(error: any Error) {

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenWorker.swift
@@ -43,20 +43,20 @@ public struct SearchGardenWorker: SearchGardenWorkable {
         throw HTTPClientError.deserializationError
       }
       
-      //      var userImage: UIImage?
-      //      if let urlString = user.imageurl, let url = URL(string: urlString) {
-      //        let imageData = try await self.downloadImage(imageURL: url)
-      //        userImage = UIImage(data: imageData)
-      //      } else {
-      //        userImage = nil
-      //      }
+      var userImageURL: URL?
+      if let urlString = user.imageurl, let url = URL(string: urlString) {
+        userImageURL = url
+      } else {
+        userImageURL = nil
+      }
       
       result.append(
         SearchGardenUser(
           id: id,
           nickname: user.nickname,
           customId: user.customId,
-          userImage: nil
+          userImage: nil,
+          userImageURL: userImageURL
         )
       )
     }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
   dependencies: [
     .package(name: "ToDoGardenUI", path: "../ToDoGardenUI"),
     .package(name: "EditUserIntroductionScene", path: "EditUserIntroductionScene"),
-    .package(name: "EditUserNameScene", path: "EditUserNameScene")
+    .package(name: "EditUserNameScene", path: "EditUserNameScene"),
+    .package(name: "TDFoundation", path: "../TDFoundation")
   ],
   targets: [
     .target(
@@ -44,7 +45,8 @@ let package = Package(
         .product(name: "EditUserNameSceneAPI", package: "EditUserNameScene"),
         .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI"),
         .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
-        .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI")
+        .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI"),
+        .product(name: "TDFoundation", package: "TDFoundation")
       ]
     )
   ]

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -25,6 +25,7 @@ protocol UserInfoSceneBusinessLogic {
   func signOut()
   func reloadUserIntroduction(_ introduction: String?)
   func reloadUserName(_ userName: String)
+  func fetchProfileImage()
 }
 
 final class UserInfoSceneInteractor: UserInfoSceneDataStore {
@@ -73,8 +74,8 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
     self.requestUserPhotoTask = Task {
       do {
         let profileImageToChange = try await self.userPhotoWorker.requestPhoto()
-        if let imageData = profileImageToChange.pngData() {
-          try self.userInfoWorker.requestChangeProfileImage(with: imageData)
+        if let imageData = profileImageToChange.jpegData(compressionQuality: 0.7) {
+          try await self.userInfoWorker.requestChangeProfileImage(with: imageData)
           let response = UserInfoScene.ChangeProfileImage.Response(
             changeResult: Result.success(profileImageToChange)
           )
@@ -137,12 +138,25 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
     self.userName = userName
     self.presenter?.presentChangedUserName(userName)
   }
+  
+  func fetchProfileImage() {
+    Task {
+      let image = try await self.userInfoWorker.requestProfileImage()
+      let response = UserInfoScene.FetchProfileImage.Response(image: image)
+      self.presenter?.presentFetchedProfileImage(response: response)
+    }
+  }
 }
 
 extension UserInfoSceneInteractor: UserInfoLoadable {
   func requestDescription(for userInfo: UserInfoScene.UserInfo) async -> String {
-    let value = await self.userInfoWorker.requestUserProfile(urlString: userInfo.rawValue)
-    self.storeUserInfoData(of: userInfo, value: value)
+    var value: String = ""
+    do {
+      value = try await self.userInfoWorker.requestUserProfile(urlString: userInfo.rawValue)
+      self.storeUserInfoData(of: userInfo, value: value)
+    } catch let error {
+      debugPrint(error)
+    }
     return value
   }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoScenePresenter.swift
@@ -5,8 +5,9 @@
 //  Created by Wood on 8/28/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit.UIImage
 
+import ToDoGardenUIResource
 import UserInfoSceneEntity
 
 @MainActor
@@ -20,6 +21,7 @@ protocol UserInfoScenePresentationLogic {
   func presentChangedUserIntroduction(_ userIntroduction: String)
   func presentEmptyUserIntroduction()
   func presentChangedUserName(_ userName: String)
+  func presentFetchedProfileImage(response: UserInfoScene.FetchProfileImage.Response)
 }
 
 final class UserInfoScenePresenter {
@@ -77,6 +79,11 @@ extension UserInfoScenePresenter: UserInfoScenePresentationLogic {
 
   func presentChangedUserName(_ userName: String) {
     self.viewController?.displayChangedUserName(userName)
+  }
+  
+  func presentFetchedProfileImage(response: UserInfoScene.FetchProfileImage.Response) {
+    let viewModel = UserInfoScene.FetchProfileImage.ViewModel(image: response.image ?? UIImage.defaultProfileImage)
+    self.viewController?.displayFetchedUserImage(viewModel: viewModel)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneRouter.swift
@@ -40,7 +40,7 @@ class UserInfoSceneRouter: UserInfoSceneDataPassing {
 
 extension UserInfoSceneRouter: UserInfoSceneRoutingLogic {
   func routeToLoginScene() {
-    // TODO: LoginSceneBuilder가 구현되면 해당 화면으로 라우팅할 예정입니다.
+    // TODO: AppRouter -> switchTo(login) 으로 가는 흐름
   }
 
   func routeToEditUserNameScene() {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
@@ -51,14 +51,12 @@ extension UserInfoSceneSceneBuilder: UserInfoSceneSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
-  public func build(with payload: UserInfoSceneScenePayloadable) -> UserInfoSceneViewControllable {
+  public func build() -> UserInfoSceneViewControllable {
     self.dependency.photoPicker.delegate = self.dependency.userPhotoWorker
     let userInfoSceneViewController = UserInfoSceneViewController(
       photoPicker: self.dependency.photoPicker
     )
     let configuredVIPCycleViewController = self.configureVIPCycle(for: userInfoSceneViewController)
-    self.setPayload(for: configuredVIPCycleViewController, with: payload)
-
     return configuredVIPCycleViewController
   }
 }
@@ -86,16 +84,5 @@ extension UserInfoSceneSceneBuilder {
     router.dataStore = interactor
     
     return viewController
-  }
-  
-  /// ViewController에 런타임 파라미터 `payload`를 설정합니다.
-  /// - Parameters:
-  ///   - viewController: 런타임 의존성을 설정할 ViewController 객체입니다.
-  ///   - payload: 런타임에 전달할 의존성입니다.
-  private func setPayload(
-    for viewController: UserInfoSceneViewController,
-    with payload: UserInfoSceneScenePayloadable
-  ) {
-    // viewController.router?.dataStore?.name = payload.name
   }
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -27,6 +27,7 @@ protocol UserInfoSceneDisplayLogic: AnyObject {
   func displayChangedUserIntroduction(_ introduction: String)
   func displayEmptyUserIntroduction(_ placeholderText: String)
   func displayChangedUserName(_ userName: String)
+  func displayFetchedUserImage(viewModel: UserInfoScene.FetchProfileImage.ViewModel)
 }
 
 final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewControllable {
@@ -65,6 +66,11 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
     super.viewDidLoad()
     self.setup()
     self.interactor?.configureCollectionView()
+    self.interactor?.fetchProfileImage()
+  }
+  
+  override func viewIsAppearing(_ animated: Bool) {
+    super.viewIsAppearing(animated)
   }
 }
 
@@ -136,6 +142,10 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
   func displayChangedUserName(_ userName: String) {
     self.updateReloadedUserInfo(userName, isUserName: true)
   }
+  
+  func displayFetchedUserImage(viewModel: UserInfoScene.FetchProfileImage.ViewModel) {
+    self.profileInfoView.updateImage(viewModel.image)
+  }
 
   private func updateReloadedUserInfo(_ value: String, isUserName: Bool) {
     let row = isUserName ? 0 : 1
@@ -161,6 +171,10 @@ extension UserInfoSceneViewController: EditUserIntroductionDelegate, EditUserNam
 
   func didSelectEditProfileButton() {
     self.interactor?.fetchUserPhotoAccess()
+  }
+  
+  func fetchProfileImage() {
+    self.interactor?.fetchProfileImage()
   }
 }
 
@@ -247,6 +261,7 @@ extension UserInfoSceneViewController {
   }
 
   private func setupMainUI() {
+    self.navigationController?.navigationBar.isHidden = false
     self.title = UserInfoSceneTheme.StringLiteral.title
     self.view.backgroundColor = UIColor.toDoGardenWhite
   }
@@ -346,20 +361,3 @@ extension UserInfoSceneViewController {
 }
 
 struct SomePayload: UserInfoSceneScenePayloadable {}
-
-#if DEBUG
-@available(iOS 17.0, *)
-#Preview {
-  let userInfoScene = UserInfoSceneSceneBuilder(
-    dependency: UserInfoSceneSceneBuilder.Dependency(
-      photoPicker: PHPickerViewController(configuration: PHPickerConfiguration()),
-      appServiceWorker: AppServiceWorker(),
-      userPhotoWorker: UserPhotoWorker(),
-      userInfoWorker: UserInfoSceneWorker(),
-      editUserIntroductionSceneBuilder: nil,
-      editUserNameSceneBuilder: nil
-    )
-  ).build(with: SomePayload())
-  return userInfoScene
-}
-#endif

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -68,10 +68,6 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
     self.interactor?.configureCollectionView()
     self.interactor?.fetchProfileImage()
   }
-  
-  override func viewIsAppearing(_ animated: Bool) {
-    super.viewIsAppearing(animated)
-  }
 }
 
 // MARK: - Confirm display logic protocol

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneWorker.swift
@@ -5,38 +5,160 @@
 //  Created by Wood on 8/28/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit.UIImage
 
+import HTTPClientAPI
+import TDFoundation
+import ToDoGardenUIResource
 import UserInfoSceneAPI
 import UserInfoSceneEntity
 
 public struct UserInfoSceneWorker: UserInfoSceneWorkable {
-  public init() {}
-
-  public func requestChangeProfileImage(with data: Data) throws {
-    return
+  private let httpClient: HTTPClientAPI
+  
+  public init(httpClient: HTTPClientAPI) {
+    self.httpClient = httpClient
   }
 
-  public func requestUserProfile(urlString: String) async -> String {
+  public func requestChangeProfileImage(with data: Data) async throws {
+    let userIDString = try self.getUserID()
+    let imageURLString = URLConstants.Profile.changeProfileImage.absoluteString + userIDString + "/image.jpeg"
+    
+    guard let url = URL(string: imageURLString) else {
+      throw NSError(domain: "URL decoding error", code: 0)
+    }
+    
+    let request = HTTPRequest(
+      method: .put,
+      endPoint: url,
+      header: [
+        "Content-Type": "image/jpeg"
+      ],
+      body: data
+    )
+    
+    try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        guard response.statusCode >= 200 && response.statusCode < 400 else {
+          throw HTTPClientError.badStatusCode(response.statusCode)
+        }
+      }
+    )
+  }
+
+  // swiftlint: disable function_body_length
+  public func requestUserProfile(urlString: String) async throws -> String {
+    let request = HTTPRequest(
+      method: HTTPMethod.get,
+      endPoint: URLConstants.Profile.getUserProfile
+    )
+    
+    let result = try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        guard response.statusCode >= 200 && response.statusCode < 400 else {
+          throw HTTPClientError.badStatusCode(response.statusCode)
+        }
+        
+        guard let body = response.body else {
+          throw HTTPClientError.deserializationError
+        }
+        
+        let result = try JSONDecoder().decode(UserInfoScene.GetProfileResponseDTO.self, from: body)
+        return result
+      }
+    )
+    
     let data = UserInfoScene.UserInfo.self
     if urlString == data.nickName.rawValue {
-      try? await Task.sleep(nanoseconds: 1_000_000_000)
-      return MockData.nickName
+      return result.nickname
     } else if urlString == data.introduction.rawValue {
-      try? await Task.sleep(nanoseconds: 1_000_000_000)
-      return MockData.introduction
+      return result.introduction
     } else if urlString == data.id.rawValue {
-      try? await Task.sleep(nanoseconds: 2_000_000_000)
-      return MockData.id
+      return result.customId
     } else {
-      try? await Task.sleep(nanoseconds: 3_000_000_000)
-      return MockData.email
+      return result.email
     }
   }
+  // swiftlint: enable function_body_length
 
-  public func requestWithdraw() async throws {}
+  public func requestWithdraw() async throws {
+    let request = HTTPRequest(
+      method: HTTPMethod.post,
+      endPoint: URLConstants.Auth.withDrawURL
+    )
+    
+    try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        guard response.statusCode >= 200 && response.statusCode < 300 else {
+          throw HTTPClientError.badStatusCode(response.statusCode)
+        }
+      }
+    )
+  }
 
-  public func requestSignOut() async throws {}
+  public func requestSignOut() async throws {
+    let request = HTTPRequest(
+      method: HTTPMethod.post,
+      endPoint: URLConstants.Auth.logoutURL
+    )
+    
+    try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        guard response.statusCode >= 200 && response.statusCode < 300 else {
+          throw HTTPClientError.badStatusCode(response.statusCode)
+        }
+      }
+    )
+  }
+  
+  public func requestProfileImage() async throws -> UIImage? {
+    let userIDString = try self.getUserID()
+    let imageURLString = URLConstants.Profile.changeProfileImage.absoluteString + userIDString + "/image.jpeg"
+    
+    guard let url = URL(string: imageURLString) else {
+      throw NSError(domain: "URL decoding error", code: 0)
+    }
+    
+    // TODO: 이미지 캐시 객체로 대체예정
+    
+    let request = HTTPRequest(
+      method: HTTPMethod.get,
+      endPoint: url
+    )
+    
+    let imageData = try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        return response.body
+      }
+    )
+    
+    guard let result = imageData,
+      let image = UIImage(data: result) else {
+      return nil
+    }
+    
+    return image
+  }
+}
+
+extension UserInfoSceneWorker {
+  private func getUserID() throws -> String {
+    guard let userID = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.userIdentifier),
+      let userIDString = String(data: userID, encoding: .utf8) else {
+      throw KeychainError.unknownKeyChainError
+    }
+    return userIDString
+  }
 }
 
 extension UserInfoSceneWorker {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserPhotoWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserPhotoWorker.swift
@@ -33,8 +33,8 @@ public final class UserPhotoWorker: PHPickerViewControllerDelegate {
   }
 
   func requestPhoto() async throws -> UIImage {
-    try await withCheckedThrowingContinuation { continuation in
-      self.selectedImagesHandler = { image, error in
+    try await withCheckedThrowingContinuation { [weak self] continuation in
+      self?.selectedImagesHandler = { image, error in
         if let image {
           continuation.resume(returning: image)
         } else {

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/UserInfoSceneSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/UserInfoSceneSceneBuildable.swift
@@ -16,5 +16,5 @@ public protocol UserInfoSceneSceneBuildable {
   ///  VIP Cycle, 런타임 파라미터가 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 파라미터입니다.
   /// - Returns: 런타임 파라미터, VIP Cycle이 설정된 ViewController가 반환되도록 구현합니다.
-  func build(with payload: UserInfoSceneScenePayloadable) -> UserInfoSceneViewControllable
+  func build() -> UserInfoSceneViewControllable
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/UserInfoSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneAPI/UserInfoSceneWorkable.swift
@@ -5,11 +5,12 @@
 //  Created by Wood on 8/28/24.
 //  Copyright (c) 2024 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit.UIImage
 
 public protocol UserInfoSceneWorkable {
-  func requestChangeProfileImage(with data: Data) throws
-  func requestUserProfile(urlString: String) async -> String
+  func requestChangeProfileImage(with data: Data) async throws
+  func requestUserProfile(urlString: String) async throws -> String
   func requestWithdraw() async throws
   func requestSignOut() async throws
+  func requestProfileImage() async throws -> UIImage?
 }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoSceneEntity/UserInfoSceneModels.swift
@@ -114,6 +114,26 @@ public enum UserInfoScene {
       }
     }
   }
+  
+  public enum FetchProfileImage {
+    public struct Response {
+      public let image: UIImage?
+
+      public init(image: UIImage?) {
+        self.image = image
+      }
+    }
+
+    public struct ViewModel {
+      public let image: UIImage
+
+      public init(image: UIImage) {
+        self.image = image
+      }
+
+    }
+
+  }
 }
 
 // MARK: - Data Objects
@@ -149,6 +169,24 @@ public extension UserInfoScene {
       self.userInfo = userInfo
       self.title = title
       self.isRightImageExisted = isRightImageExisted
+    }
+  }
+}
+
+extension UserInfoScene {
+  public struct GetProfileResponseDTO: Decodable {
+    public let id: String
+    public let customId: String
+    public let introduction: String
+    public let nickname: String
+    public let email: String
+    
+    private enum CodingKeys: String, CodingKey {
+      case id
+      case customId = "custom_id"
+      case introduction
+      case nickname
+      case email
     }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
@@ -42,8 +42,8 @@ final public class SearchGardenTableView: UITableView {
     return self.diffableDataSource.itemIdentifier(for: indexPath)
   }
   
-  public func updateData(of user: SearchGardenUser) {
-    self.snapshot.reconfigureItems([user])
+  public func updateData(of user: [SearchGardenUser]) {
+    self.snapshot.reconfigureItems(user)
     self.diffableDataSource.apply(self.snapshot, animatingDifferences: false)
   }
   


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #783 
## 🎉 변경 사항
- UserInfoScene api 적용 
## 📌 PR Point

미리 말씀드린대로 fileChanges가 좀 많습니다 ^^;;

### 아래 내용을 구현하였습니다. 
<img width="361" alt="스크린샷 2025-01-19 오후 6 37 52" src="https://github.com/user-attachments/assets/f754edaf-b008-4b0d-9877-944cb9135df0" />

- 모든 요청 200번대 확인하였습니다. 
- 기존 코드에서 빠진 내용은 거의 없고, 살을 더 붙이는 형태로 구현하였습니다. 여전히 해당 씬은 우드가 설계한 방식대로 돌아갑니다. 
   ( 기존 코드 틀에 아구를 맞추는 식으로 진행하였음 )
- 다만, preview관련 코드는 제거하였습니다.
    ( 각 worker에 httpClient를 주입시켜주는 과정, 더이상 쓰지 않는 mock객체 등.. 여러모로 빌드에러 유발 ) 

### 사실상 코드 양만 많지 정리하자면 아래내용에서 벗어나지 않습니다. 
- URL추가 
- httpClient로 통신 
- JSON 인코딩 / 디코딩

### 결과화면 

| 요청  | 요청 후 재 로그인 |
|----------|----------|
|  ![Simulator Screen Recording - iPhone 16 Pro - 2025-01-19 at 17 59 31](https://github.com/user-attachments/assets/d8e803a8-e88d-46ed-ab29-70226ab5af7c) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-01-19 at 18 00 08](https://github.com/user-attachments/assets/83b8bcf3-d0da-4660-82f9-8880d35063e2) |

- 요청 후 재 로그인 했을때, 변경사항이 정상적으로 불러와지는 것을 볼 수 있습니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?