### PR TITLE
#785: 슬라이드 액션 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
@@ -45,6 +45,7 @@ public final class TutorialOnBoardingViewController: UIViewController {
     self.view.backgroundColor = UIColor.white
     self.setupCell()
     self.setupBubbleLabels()
+    self.setupGestureRecognizers()
   }
 }
 
@@ -158,6 +159,70 @@ extension TutorialOnBoardingViewController: BubbleLabelDelegate {
         self?.rightBubbleLabel.isHidden = true
       }
     )
+  }
+  
+  private func animateRightBubbleLabelAndEndAction() {
+    UIView.animate(
+      withDuration: 0.5,
+      animations: { [weak self] in
+        self?.rightBubbleLabel.alpha = 0
+      },
+      completion: { [weak self] _ in
+        self?.rightBubbleLabel.isHidden = true
+        self?.endAction?()
+      }
+    )
+  }
+  
+  private func animateRightBubbleLabelToLeft() {
+    UIView.animate(
+      withDuration: 0.5,
+      animations: { [weak self] in
+        self?.rightBubbleLabel.alpha = 0
+      },
+      completion: { [weak self] _ in
+        self?.rightBubbleLabel.isHidden = true
+        self?.leftBubbleLabel.isHidden = false
+        self?.showLeftBubbleLabel()
+      }
+    )
+  }
+  
+  private func showLeftBubbleLabel() {
+    UIView.animate(
+      withDuration: 0.5,
+      animations: { [weak self] in
+        self?.leftBubbleLabel.alpha = 1
+      }
+    )
+  }
+}
+
+extension TutorialOnBoardingViewController {
+  private func setupGestureRecognizers() {
+    let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture))
+    self.view.addGestureRecognizer(panGesture)
+  }
+  
+  @objc private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
+    guard gesture.state == UIGestureRecognizer.State.ended else { return }
+    
+    let velocity = gesture.velocity(in: self.view)
+    let isHorizontal = abs(velocity.x) > abs(velocity.y)
+    
+    if isHorizontal {
+      if velocity.x > 0 {
+        if !self.rightBubbleLabel.isHidden {
+          self.animateRightBubbleLabelToLeft()
+        }
+      } else {
+        if !self.leftBubbleLabel.isHidden {
+          self.animateLeftBubbleLabel()
+        } else if !self.rightBubbleLabel.isHidden {
+          self.animateRightBubbleLabelAndEndAction()
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #785

## 🎉 변경 사항
- UIPanGestureRecognizer를 이용하여 구현합니다.
- 슬라이드 방향에 따라 다른 동작을 구현합니다.
- 말풍선 뷰 밖에서도 가능해야 합니다. 

## 📌 PR Point

### PanRecognizer를 이용하여 pan 동작에 대응할 수 있는 간단한 메서드 몇개 추가하였습니다. 

![슬라이드](https://github.com/user-attachments/assets/84389a33-380a-42ad-b0d8-9b92c98d6142)

### 페이지 느낌으로 좌우 왔다리갔다리 가능
### 기존 말풍선 터치 & x 버튼 터치도 동일하게 동작 
### 말풍선 위에서 슬라이드 & 말풍선 밖에서 슬라이드 둘 다 가능

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?