### PR TITLE
Timer API 연동관련 객체 추가 

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
@@ -53,4 +53,8 @@ extension URLConstants.Profile {
   public static let changeIntroduction = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/edit_introduction")!
   public static let changeNickname = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/edit_nickname")!
 }
+
+extension URLConstants.Timer {
+  public static let postCompletedTimerItems = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/complete_timer")!
+}
 // swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/AppCore/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Package.swift
@@ -22,6 +22,10 @@ let package = Package(
     Package.Dependency.package(
       name: "SignUpScene",
       path: "../SignUpScene"
+    ),
+    Package.Dependency.package(
+      name: "TimerScene",
+      path: "../TimerScene"
     )
   ],
   targets: [
@@ -43,6 +47,10 @@ let package = Package(
         Target.Dependency.product(
           name: "SignUpScene",
           package: "SignUpScene"
+        ),
+        Target.Dependency.product(
+          name: "TimerScene",
+          package: "TimerScene"
         )
       ]
     ),

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
@@ -9,6 +9,7 @@ import Foundation
 
 import HTTPClient
 import TDFoundation
+import TimerScene
 
 extension HTTPClient {
   static let live = HTTPClient(
@@ -31,4 +32,9 @@ extension AccessTokenManager {
       ]
     )
   )
+}
+
+extension TimerSceneSceneBuilder.Dependency {
+  @MainActor
+  public static let live = Self(worker: TimerSceneWorker.live)
 }

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
@@ -36,5 +36,15 @@ extension AccessTokenManager {
 
 extension TimerSceneSceneBuilder.Dependency {
   @MainActor
-  public static let live = Self(worker: TimerSceneWorker.live)
+  public static let live = TimerSceneSceneBuilder.Dependency(
+    timerWorker: TimerSceneWorker.live,
+    storageWorker: TimerStorageWorker.live
+  )
+}
+
+extension TimerStorageWorker {
+  static let live = TimerStorageWorker(
+    httpClient: HTTPClient.live,
+    timerStorage: TimerStorage.live
+  )
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Package.swift
@@ -11,7 +11,8 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(path: "../ToDoGardenUI")
+    .package(path: "../ToDoGardenUI"),
+    .package(path: "../TDFoundation")
   ],
   targets: [
     .target(
@@ -19,7 +20,8 @@ let package = Package(
       dependencies: [
         "TimerSceneEntity",
         "TimerSceneAPI",
-        .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI")
+        .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
+        .product(name: "TDFoundation", package: "TDFoundation")
       ],
       swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
     ),

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneSceneBuilder.swift
@@ -20,11 +20,6 @@ public struct TimerSceneSceneBuilder {
   }
 }
 
-extension TimerSceneSceneBuilder.Dependency {
-  @MainActor
-  public static let live = Self(worker: TimerSceneWorker.live)
-}
-
 extension TimerSceneSceneBuilder: TimerSceneSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneSceneBuilder.swift
@@ -6,10 +6,15 @@ import TimerSceneAPI
 public struct TimerSceneSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
-    let worker: TimerSceneWorkable
+    let timerWorker: TimerSceneWorkable
+    let storageWorker: TimerStorageWorkable
     
-    public init(worker: any TimerSceneWorkable) {
-      self.worker = worker
+    public init(
+      timerWorker: any TimerSceneWorkable,
+      storageWorker: any TimerStorageWorkable
+    ) {
+      self.timerWorker = timerWorker
+      self.storageWorker = storageWorker
     }
   }
   
@@ -34,7 +39,7 @@ extension TimerSceneSceneBuilder {
   /// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
   private func configureVIPCycle(for viewController: TimerSceneViewController) -> TimerSceneViewController {
-    let interactor = TimerSceneInteractor(worker: self.dependency.worker)
+    let interactor = TimerSceneInteractor(worker: self.dependency.timerWorker)
     let presenter = TimerScenePresenter()
     viewController.interactor = interactor
     interactor.presenter = presenter

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
@@ -312,7 +312,8 @@ extension TimerSceneViewController {
 @available(iOS 17.0, *)
 #Preview {
   /// Navigation Title Not Displaying Correctly
-  let viewController = TimerSceneSceneBuilder(dependency: .live).build()
+  let worker = TimerSceneWorker.live
+  let viewController = TimerSceneSceneBuilder(dependency: .init(worker: worker)).build()
   viewController.title = "영어 독해"
   let navigation = UINavigationController(rootViewController: viewController)
   return navigation

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
@@ -312,8 +312,14 @@ extension TimerSceneViewController {
 @available(iOS 17.0, *)
 #Preview {
   /// Navigation Title Not Displaying Correctly
-  let worker = TimerSceneWorker.live
-  let viewController = TimerSceneSceneBuilder(dependency: .init(worker: worker)).build()
+  let timerWorker = TimerSceneWorker.live
+  let storageWorker = TimerStorageWorker(timerStorage: TimerStorage.live)
+  let viewController = TimerSceneSceneBuilder(
+    dependency: .init(
+      timerWorker: timerWorker,
+      storageWorker: storageWorker
+    )
+  ).build()
   viewController.title = "영어 독해"
   let navigation = UINavigationController(rootViewController: viewController)
   return navigation

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorkable.swift
@@ -4,3 +4,7 @@ import Foundation
 public protocol TimerSceneWorkable: Sendable {
   var countDownStream: @Sendable (Double) -> AsyncStream<Double> { get set }
 }
+
+public protocol TimerStorageWorkable: Sendable {
+  
+}

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorkable.swift
@@ -1,10 +1,15 @@
 import Foundation
 
+import TimerSceneEntity
+
 @MainActor
 public protocol TimerSceneWorkable: Sendable {
   var countDownStream: @Sendable (Double) -> AsyncStream<Double> { get set }
 }
 
 public protocol TimerStorageWorkable: Sendable {
-  
+  func postCompletedItem() async throws
+  func recordCompletedItemInLocal(groupId: String, duration: Int) throws
+  func deleteAllTimerItems() throws
+  func getTimerItemsAsDTO() throws -> TimerScene.FocusTimeRequestDTO
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorker.swift
@@ -1,8 +1,6 @@
 import CombineExtension
 import Foundation
 
-import TimerSceneEntity
-
 public struct TimerSceneWorker: TimerSceneWorkable, Sendable {
   public var countDownStream: @Sendable (Double) -> AsyncStream<Double>
 

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorker.swift
@@ -1,8 +1,11 @@
 import CombineExtension
 import Foundation
 
+import TimerSceneEntity
+
 public struct TimerSceneWorker: TimerSceneWorkable, Sendable {
   public var countDownStream: @Sendable (Double) -> AsyncStream<Double>
+
   public init(
     countDownStream: @Sendable @escaping (Double) -> AsyncStream<Double>
   ) {

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorker.swift
@@ -11,7 +11,7 @@ public struct TimerSceneWorker: TimerSceneWorkable, Sendable {
   }
 }
 
-extension TimerSceneWorker {
+public extension TimerSceneWorker {
   static let live = Self { seconds in
     return Timer
       .publish(every: 1, on: RunLoop.main, in: RunLoop.Mode.common)

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorage.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorage.swift
@@ -1,0 +1,93 @@
+//
+//  TimerStorage.swift
+//  TimerScene
+//
+//  Created by SONG on 1/22/25.
+//
+
+import Foundation
+
+import TimerSceneEntity
+
+final class TimerStorage: @unchecked Sendable {
+  private let fileManager: FileManager
+  private let documentsURL: URL
+  private var storageURL: URL {
+    self.documentsURL.appendingPathComponent("pomodoros.json")
+  }
+  
+  init() throws {
+    self.fileManager = FileManager.default
+    self.documentsURL = try self.fileManager.url(
+      for: .documentDirectory,
+      in: .userDomainMask,
+      appropriateFor: nil,
+      create: true
+    )
+  }
+  
+  // MARK: - Load & Save Methods
+  private func loadPomodorosJSON() throws -> [TimerScene.PomodoroDTO] {
+    guard self.fileManager.fileExists(atPath: self.storageURL.path) else {
+      return []
+    }
+    
+    let data = try Data(contentsOf: self.storageURL)
+    return try JSONDecoder().decode([TimerScene.PomodoroDTO].self, from: data)
+  }
+  
+  private func savePomodorosAsJSON(_ pomodoros: [TimerScene.PomodoroDTO]) throws {
+    let data = try JSONEncoder().encode(pomodoros)
+    try data.write(to: self.storageURL)
+  }
+  
+  func saveCompletedTimer(groupId: String, duration: Int) throws {
+    let today = self.getCurrentDateString()
+    
+    var pomodoros = try self.loadPomodorosJSON()
+    
+    if let index = pomodoros.firstIndex(where: {
+      $0.focusGroupId == groupId && $0.focusDate == today
+    }) {
+      self.updateExistingPomodoro(&pomodoros[index], with: duration)
+    } else {
+      self.addNewPomodoro(&pomodoros, groupId: groupId, date: today, duration: duration)
+    }
+    
+    try self.savePomodorosAsJSON(pomodoros)
+  }
+  
+  func deleteAllPomodoros() throws {
+    try self.savePomodorosAsJSON([])
+  }
+  
+  func getAsDTO() throws -> TimerScene.FocusTimeRequestDTO {
+    let pomodoros = try self.loadPomodorosJSON()
+    return TimerScene.FocusTimeRequestDTO(pomodoros: pomodoros)
+  }
+  
+  private func getCurrentDateString() -> String {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+    return dateFormatter.string(from: Date())
+  }
+  
+  private func updateExistingPomodoro(_ pomodoro: inout TimerScene.PomodoroDTO, with duration: Int) {
+    pomodoro.focusTime.append(duration)
+    pomodoro.focusTime.sort()
+  }
+  
+  private func addNewPomodoro(
+    _ pomodoros: inout [TimerScene.PomodoroDTO],
+    groupId: String,
+    date: String,
+    duration: Int
+  ) {
+    let newPomodoro = TimerScene.PomodoroDTO(
+      focusGroupId: groupId,
+      focusDate: date,
+      focusTime: [duration]
+    )
+    pomodoros.append(newPomodoro)
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorage.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorage.swift
@@ -11,7 +11,7 @@ import TimerSceneAPI
 import TimerSceneEntity
 
 // TODO: GRDB로 대체될 예정입니다
-final class TimerStorage: TimerStorable, @unchecked Sendable {
+public final class TimerStorage: TimerStorable, @unchecked Sendable {
   private let fileManager: FileManager
   private let documentsURL: URL
   private var storageURL: URL {
@@ -30,7 +30,7 @@ final class TimerStorage: TimerStorable, @unchecked Sendable {
     self.documentsURL = documentsURL
   }
   
-  func saveCompletedTimer(groupId: String, duration: Int) throws {
+  public func saveCompletedTimer(groupId: String, duration: Int) throws {
     let today = self.getCurrentDateString()
     
     var pomodoros = try self.loadPomodorosJSON()
@@ -46,11 +46,11 @@ final class TimerStorage: TimerStorable, @unchecked Sendable {
     try self.savePomodorosAsJSON(pomodoros)
   }
   
-  func deleteAllPomodoros() throws {
+  public func deleteAllPomodoros() throws {
     try self.savePomodorosAsJSON([])
   }
   
-  func getAsDTO() throws -> TimerScene.FocusTimeRequestDTO {
+  public func getAsDTO() throws -> TimerScene.FocusTimeRequestDTO {
     let pomodoros = try self.loadPomodorosJSON()
     return TimerScene.FocusTimeRequestDTO(pomodoros: pomodoros)
   }
@@ -98,6 +98,6 @@ extension TimerStorage {
   }
 }
 
-extension TimerStorage {
+public extension TimerStorage {
   static let live = TimerStorage()
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorage.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorage.swift
@@ -7,38 +7,27 @@
 
 import Foundation
 
+import TimerSceneAPI
 import TimerSceneEntity
 
-final class TimerStorage: @unchecked Sendable {
+// TODO: GRDB로 대체될 예정입니다
+final class TimerStorage: TimerStorable, @unchecked Sendable {
   private let fileManager: FileManager
   private let documentsURL: URL
   private var storageURL: URL {
     self.documentsURL.appendingPathComponent("pomodoros.json")
   }
   
-  init() throws {
+  init() {
     self.fileManager = FileManager.default
-    self.documentsURL = try self.fileManager.url(
+    
+    guard let documentsURL = FileManager.default.urls(
       for: .documentDirectory,
-      in: .userDomainMask,
-      appropriateFor: nil,
-      create: true
-    )
-  }
-  
-  // MARK: - Load & Save Methods
-  private func loadPomodorosJSON() throws -> [TimerScene.PomodoroDTO] {
-    guard self.fileManager.fileExists(atPath: self.storageURL.path) else {
-      return []
+      in: .userDomainMask).first else {
+      fatalError("Can not access documents directory.")
     }
     
-    let data = try Data(contentsOf: self.storageURL)
-    return try JSONDecoder().decode([TimerScene.PomodoroDTO].self, from: data)
-  }
-  
-  private func savePomodorosAsJSON(_ pomodoros: [TimerScene.PomodoroDTO]) throws {
-    let data = try JSONEncoder().encode(pomodoros)
-    try data.write(to: self.storageURL)
+    self.documentsURL = documentsURL
   }
   
   func saveCompletedTimer(groupId: String, duration: Int) throws {
@@ -65,6 +54,23 @@ final class TimerStorage: @unchecked Sendable {
     let pomodoros = try self.loadPomodorosJSON()
     return TimerScene.FocusTimeRequestDTO(pomodoros: pomodoros)
   }
+}
+
+// MARK: - Private Methods
+extension TimerStorage {
+  private func loadPomodorosJSON() throws -> [TimerScene.PomodoroDTO] {
+    guard self.fileManager.fileExists(atPath: self.storageURL.path) else {
+      return []
+    }
+    
+    let data = try Data(contentsOf: self.storageURL)
+    return try JSONDecoder().decode([TimerScene.PomodoroDTO].self, from: data)
+  }
+  
+  private func savePomodorosAsJSON(_ pomodoros: [TimerScene.PomodoroDTO]) throws {
+    let data = try JSONEncoder().encode(pomodoros)
+    try data.write(to: self.storageURL)
+  }
   
   private func getCurrentDateString() -> String {
     let dateFormatter = DateFormatter()
@@ -90,4 +96,8 @@ final class TimerStorage: @unchecked Sendable {
     )
     pomodoros.append(newPomodoro)
   }
+}
+
+extension TimerStorage {
+  static let live = TimerStorage()
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorageWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorageWorker.swift
@@ -17,8 +17,10 @@ public struct TimerStorageWorker: TimerStorageWorkable {
   private let timerStorage: TimerStorable
   
   public init(
+    httpClient: HTTPClientAPI,
     timerStorage: TimerStorable
   ) {
+    self.httpClient = httpClient
     self.timerStorage = timerStorage
   }
   
@@ -56,8 +58,4 @@ extension TimerStorageWorker {
   public func getTimerItemsAsDTO() throws -> TimerScene.FocusTimeRequestDTO {
     return try self.timerStorage.getAsDTO()
   }
-}
-
-extension TimerStorageWorker {
-  static let live = TimerStorageWorker(timerStorage: TimerStorage.live)
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorageWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorageWorker.swift
@@ -9,18 +9,20 @@ import Foundation
 
 import HTTPClientAPI
 import TDFoundation
+import TimerSceneAPI
 import TimerSceneEntity
 
-public struct TimerStorageWorker: TimerStorageWorkable, Sendable {
-  public let httpClient: HTTPClientAPI
-  private let timerStorage: TimerStorage
+public struct TimerStorageWorker: TimerStorageWorkable {
+  private var httpClient: HTTPClientAPI?
+  private let timerStorage: TimerStorable
   
-  public init(httpClient: HTTPClientAPI) throws {
-    self.httpClient = httpClient
-    self.timerStorage = try TimerStorage()
+  public init(
+    timerStorage: TimerStorable
+  ) {
+    self.timerStorage = timerStorage
   }
   
-  func postCompletedItem() async throws {
+  public func postCompletedItem() async throws {
     let body = try JSONEncoder().encode(self.getTimerItemsAsDTO())
     let request = HTTPRequest(
       method: HTTPMethod.post,
@@ -28,7 +30,7 @@ public struct TimerStorageWorker: TimerStorageWorkable, Sendable {
       body: body
     )
     
-    try await self.httpClient.send(
+    try await self.httpClient?.send(
       input: request,
       serializer: { $0 },
       deserializer: { response in
@@ -43,15 +45,19 @@ public struct TimerStorageWorker: TimerStorageWorkable, Sendable {
 
 // MARK: - Local Methods
 extension TimerStorageWorker {
-  func recordCompletedItemInLocal(groupId: String, duration: Int) throws {
+  public func recordCompletedItemInLocal(groupId: String, duration: Int) throws {
     try self.timerStorage.saveCompletedTimer(groupId: groupId, duration: duration)
   }
   
-  func deleteAllTimerItems() throws {
+  public func deleteAllTimerItems() throws {
     try self.timerStorage.deleteAllPomodoros()
   }
   
-  func getTimerItemsAsDTO() throws -> TimerScene.FocusTimeRequestDTO {
+  public func getTimerItemsAsDTO() throws -> TimerScene.FocusTimeRequestDTO {
     return try self.timerStorage.getAsDTO()
   }
+}
+
+extension TimerStorageWorker {
+  static let live = TimerStorageWorker(timerStorage: TimerStorage.live)
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorageWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorageWorker.swift
@@ -1,0 +1,57 @@
+//
+//  TimerStorageWorker.swift
+//  TimerScene
+//
+//  Created by SONG on 1/23/25.
+//
+
+import Foundation
+
+import HTTPClientAPI
+import TDFoundation
+import TimerSceneEntity
+
+public struct TimerStorageWorker: TimerStorageWorkable, Sendable {
+  public let httpClient: HTTPClientAPI
+  private let timerStorage: TimerStorage
+  
+  public init(httpClient: HTTPClientAPI) throws {
+    self.httpClient = httpClient
+    self.timerStorage = try TimerStorage()
+  }
+  
+  func postCompletedItem() async throws {
+    let body = try JSONEncoder().encode(self.getTimerItemsAsDTO())
+    let request = HTTPRequest(
+      method: HTTPMethod.post,
+      endPoint: URLConstants.Timer.postCompletedTimerItems,
+      body: body
+    )
+    
+    try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        guard response.statusCode == 204 else {
+          throw HTTPClientError.badStatusCode(response.statusCode)
+        }
+        try self.deleteAllTimerItems()
+      }
+    )
+  }
+}
+
+// MARK: - Local Methods
+extension TimerStorageWorker {
+  func recordCompletedItemInLocal(groupId: String, duration: Int) throws {
+    try self.timerStorage.saveCompletedTimer(groupId: groupId, duration: duration)
+  }
+  
+  func deleteAllTimerItems() throws {
+    try self.timerStorage.deleteAllPomodoros()
+  }
+  
+  func getTimerItemsAsDTO() throws -> TimerScene.FocusTimeRequestDTO {
+    return try self.timerStorage.getAsDTO()
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerSceneAPI/TimerStorable.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerSceneAPI/TimerStorable.swift
@@ -1,0 +1,14 @@
+//
+//  TimerStorable.swift
+//  TimerScene
+//
+//  Created by SONG on 1/27/25.
+//
+
+import TimerSceneEntity
+
+public protocol TimerStorable: Sendable {
+  func saveCompletedTimer(groupId: String, duration: Int) throws
+  func deleteAllPomodoros() throws
+  func getAsDTO() throws -> TimerScene.FocusTimeRequestDTO
+}

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerSceneEntity/TimerSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerSceneEntity/TimerSceneModels.swift
@@ -37,3 +37,25 @@ public enum TimerScene {
     case rest
   }
 }
+
+extension TimerScene {
+  public struct FocusTimeRequestDTO: Codable, Sendable {
+    public let pomodoros: [PomodoroDTO]
+    
+    public init(pomodoros: [PomodoroDTO]) {
+      self.pomodoros = pomodoros
+    }
+  }
+
+  public struct PomodoroDTO: Codable, Sendable {
+    public let focusGroupId: String
+    public let focusDate: String
+    public var focusTime: [Int]
+    
+    public init(focusGroupId: String, focusDate: String, focusTime: [Int]) {
+      self.focusGroupId = focusGroupId
+      self.focusDate = focusDate
+      self.focusTime = focusTime
+    }
+  }
+}


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #786 
## 🎉 변경 사항
- TimerStorage / TimerStorageWorker 추가 
- 그 외 프로토콜, DTO 모델 및 URL추가 
## 📌 PR Point

### TimerStorage / TimerStorageWorker 를 추가하였습니다. 
- TimerStorage : FileManager를 이용하여 타이머완료 데이터와 관련된 JSON을 로컬에서 관리합니다. (저장,삭제,읽기)
   - GRDB 세팅이 완료되면 FileManager는 교체될 예정입니다.
- TimerStorageWorker : TimerStorage와 HTTPClient를 이용하여 서버와 통신하고, 응답에 따른 처리를 합니다. 

### Worker를 하나 더 만든 이유 
- 기존 워커가 static `live`로 사용되고 있는 점, 이니셜라이저에 무언가 덕지 덕지 추가되면 가독성이 저하될 것 같은 점 등등...TimerSceneWorker에 끼어들 틈이 안보였습니다. 
- 기존 워커에 뭔가를 붙이기 보다는 아예 카운트다운을 담당하는 워커 / 로컬디비,서버와 통신하는 워커를 따로 두는게 낫겠다는 판단을 했습니다. 

### 앞으로 구현할 전체적인 방향성은 아래 그림과 같습니다. 
<img width="667" alt="스크린샷 2025-01-27 오전 4 48 22" src="https://github.com/user-attachments/assets/266ca869-d751-489c-ba7b-4278063565e9" />

### `live` 객체 관련 
- 현재 구현상으로, TimerSceneSceneBuilder.Dependency 를 `live`로 받아서 TimerSceneSceneBuilder를 생성하고 있습니다.
- 기존의 구조를 유지하고자 아래와 같은 형식으로 사용할 수 있게 만들어보려고 했습니다. 
```swift
extension TimerSceneSceneBuilder.Dependency {
  @MainActor
  public static let live = Self(
    timerWorker: TimerSceneWorker.live,
    storageWorker: TimerStorageWorker.live
  )
}

```
- 다만 위와 같이 TimerStorageWorker를 `live`로 static화 했을때, HTTPClient는 어떻게 주입할 것인가... 방법이 몇가지가 떠오르긴 하지만 "이걸로 가야겠다" 싶은건 없네요. 혹시 강운이 생각하고 계신 방법이 있었을까요? 
- 일단 TimerStorageWorker 의 HTTPClient는 옵셔널 처리해놓았습니다. 이 PR에서 방향을 잡고 마저 구현할 예정입니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?