### PR TITLE
HTTPClient 확장 (미들웨어 갈아끼기) + 정적객체 추가

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPClientCustomable.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPClientCustomable.swift
@@ -1,0 +1,15 @@
+//
+//  HTTPClientCustomable.swift
+//  TDFoundation
+//
+//  Created by SONG on 2/1/25.
+//
+
+public protocol HTTPClientCustomable: HTTPClientAPI {
+  func sendWithCustomMiddlewares<Input: Sendable, Output: Sendable>(
+    middlewares: [any ClientMiddleware],
+    input: Input,
+    serializer: @Sendable (Input) throws -> HTTPRequest,
+    deserializer: @Sendable (HTTPResponse) throws -> Output
+  ) async throws -> Output
+}

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/HTTPClient+Extension/HTTPClient+Extension.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/HTTPClient+Extension/HTTPClient+Extension.swift
@@ -1,0 +1,72 @@
+//
+//  HTTPClient+Extension.swift
+//  TDFoundation
+//
+//  Created by SONG on 2/1/25.
+//
+
+import Foundation
+
+import HTTPClient
+import HTTPClientAPI
+
+extension HTTPClient: HTTPClientCustomable {
+  @TaskLocal
+  private static var current: HTTPClient = HTTPClient.live
+  
+  public func sendWithCustomMiddlewares<Input, Output>(
+    middlewares: [any ClientMiddleware],
+    input: Input,
+    serializer: @Sendable (Input) throws -> HTTPRequest,
+    deserializer: @Sendable (HTTPResponse) throws -> Output
+  ) async throws -> Output where Input: Sendable, Output: Sendable {
+    return try await self.replaceMiddlewares(middlewares) { @Sendable in
+      try await HTTPClient.current.send(
+        input: input,
+        serializer: serializer,
+        deserializer: deserializer
+      )
+    }
+  }
+  
+  private func replaceMiddlewares<Result>(
+    _ newMiddlewares: [any ClientMiddleware],
+    operation: () async throws -> Result
+  ) async rethrows -> Result {
+    try await HTTPClient.$current.withValue(
+      HTTPClient(
+        transport: HTTPClient.live.transport,
+        middlewares: newMiddlewares
+      )
+    ) {
+      try await operation()
+    }
+  }
+}
+
+extension HTTPClient {
+  public static let live = Self(
+    transport: URLSessionTransport(urlSession: URLSession.shared),
+    middlewares: [
+      AuthenticationMiddleWare(),
+      CommonHeaderMiddleware(),
+      RefreshMiddleware.live
+    ]
+  )
+}
+
+extension RefreshMiddleware {
+  public static let live = RefreshMiddleware(accessTokenManager: AccessTokenManager.live)
+}
+
+extension AccessTokenManager {
+  static let live = AccessTokenManager(
+    httpClient: HTTPClient(
+      transport: URLSessionTransport(urlSession: URLSession.shared),
+      middlewares: [
+        AuthenticationMiddleWare(),
+        CommonHeaderMiddleware()
+      ]
+    )
+  )
+}

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/HTTPClient+Extension/HTTPClientCustom.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/HTTPClient+Extension/HTTPClientCustom.swift
@@ -1,0 +1,13 @@
+//
+//  HTTPClientCustom.swift
+//  TDFoundation
+//
+//  Created by SONG on 2/1/25.
+//
+
+import HTTPClient
+import HTTPClientAPI
+
+public enum HTTPClientCustom {
+  public static let live: HTTPClientCustomable = HTTPClient.live
+}


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #798 
## 🎉 변경 사항
- HTTPClient.live 추가 
- HTTPClientCustomable 인터페이스 추가 
- extension으로 HTTPClient에 미들웨어 갈아끼우는 기능 추가 
## 📌 PR Point

### 사용법 
#### 기존 HTTPClient와 사용법은 거의 동일합니다. `sendWithCustomMiddlewares` 메서드에 갈아끼울 미들웨어를 넣어주면 됩니다.
```swift
import HTTPClientAPI
import TDFoundation

    try await HTTPClientCustom.live.sendWithCustomMiddlewares(
      middlewares: [
         // 여기에 미들웨어 추가 
         // 빈 배열로 두면 미들웨어없이 돌아감 
      ],
      input: HTTPRequest(method: .get, endPoint: someURL),
      serializer: { $0 },
      deserializer: { response in
        guard let body = response.body else { return }
        // ...
      }
    )
```

#### 미들웨어 변경 없이 기존의 `send`메서드도 그대로 사용가능합니다. 
#### TDFoundation에 미들웨어들이 존재하기 때문에 바로 가져올 수 있습니다. 

### 시뮬레이션

#### 미들웨어가 잘 갈아끼워지는지를 확인해보았습니다. 
- SearchGardenScene을 이용했습니다. HTTPClientCustom.live를 사용합니다. 
   - 리스트 불러오기 : 기존의 `send()`를 사용하여 3개의 미들웨어 장착되어있음
   - 사진 불러오기 : `sendWithCustomMiddlewares()`로 아무런 미들웨어를 장착하지 않았음 
   - 기대 동작 : 리스트는 성공적으로 불러와지되, 사진은 실패해야함. 
                       두 동작이 번갈아가며 실행되어도 서로의 미들웨어에 영향미치지 않아야함.
   
#### 실제 동작 
- 기대와 일치함. 
![Simulator Screen Recording - iPhone 15 Pro - 2025-02-02 at 21 42 10](https://github.com/user-attachments/assets/bf5fad06-4d2c-4d47-ba9c-91dc7d95396a)

@noah0316 @wood0203 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?