### PR TITLE
CalendarView 다크모드 UI 대응 + 요일 / 월 한글 설정

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/Calendar+localeUpdated.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/Calendar+localeUpdated.swift
@@ -10,12 +10,7 @@ import Foundation
 extension Calendar {
   static var localeUpdated: Self {
     var calendar = Self(identifier: Identifier.gregorian)
-    if let localeIdentifier = Locale.preferredLanguages.first {
-      calendar.locale = Locale(identifier: localeIdentifier)
-    } else {
-      calendar.locale = Locale.autoupdatingCurrent
-    }
-
+    calendar.locale = Locale.korea
     return calendar
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarView.swift
@@ -179,6 +179,7 @@ extension CalendarView {
   }
 
   private func setupDateCollectionView() {
+    self.dateCollectionView.backgroundColor = UIColor.toDoGardenWhite
     self.configureCollectionView(self.dateCollectionView)
     self.dateCollectionView.collectionViewLayout = self.makeCollectionViewLayout(with: self.model.collectionViewLayout)
     self.dateCollectionView.delegate = self.calendarViewDelegate

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
@@ -343,3 +343,7 @@ enum CalendarScrollDirection: Int {
 enum CalendarViewDelegateError: Error {
   case snapshotIsNotLoaded
 }
+
+extension Locale {
+  static let korea = Locale(identifier: "ko_KR")
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CalendarView/CalendarViewSingleSelectionDelegate.swift
@@ -102,13 +102,7 @@ extension CalendarViewSingleSelectionDelegate {
   }
   
   private func setupDateFormatter() {
-    if let userPreferredIdentifier = Locale.preferredLanguages.first {
-      let userLocale = Locale(identifier: userPreferredIdentifier)
-      self.dateFormatter.locale = userLocale
-    } else {
-      self.dateFormatter.locale = Locale.autoupdatingCurrent
-    }
-    
+    self.dateFormatter.locale = Locale.korea
     self.dateFormatter.dateFormat = Constant.CalendarView.StringLiteral.dateFormat
   }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #800 

## 🎉 변경 사항
- CalendarView가 다크모드에서도 ToDoGardenWhite 배경색이 보이도록 수정하였습니다.
- 날짜가 한국 기준으로 되도록 포맷팅 되도록 Locale을 설정하였습니다.

## 📌 PR Point

### 다크모드 적용 Before / After GIF
- Locale 설정하여 정상적으로 한글이 보여지고 있습니다.

|수정 전|수정 후|
|--|--|
|<img width ="250" src="https://github.com/user-attachments/assets/4f72366f-b19a-49f9-84a0-6d06cf0aee94">|<img width="250" src="https://github.com/user-attachments/assets/d098ad68-0e65-452b-afe6-1ed3b69ec17c">|

### 테스트용 SceneDelegate 코드

``` swift
//
//  SceneDelegate.swift
//  ToDo-Garden
//
//  Created by Noah on 1/10/24.
//

import UIKit

import AppCore
import ToDoGardenUIComponent
import ToDoGardenUIResource

final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
  var window: UIWindow?
  var appCore = AppCore(
    dependency: AppCore.Dependency.live
  )
  
  func scene(
    _ scene: UIScene,
    willConnectTo session: UISceneSession,
    options connectionOptions: UIScene.ConnectionOptions
  ) {
    self.setupWindow(with: scene)
    self.prepare()
//    self.appCore.getStarted()
  }
}

extension SceneDelegate {
  private func setupWindow(with scene: UIScene) {
    guard let windowScene = (scene as? UIWindowScene) else { return }
    self.window = UIWindow(windowScene: windowScene)
    window?.rootViewController = self.appCore.dependency.router.navigationController
    self.window?.rootViewController = HomeVC()
    window?.makeKeyAndVisible()
  }
  
  private func prepare() {
    self.registerCustomFonts()
    NavigationBarUIUpdator.update()
  }
  
  private func registerCustomFonts() {
    PretendardFont.register()
    GmarkSansFont.register()
  }
}

class HomeVC: UIViewController {
  let calendarView = CalendarView(model: CalendarView.Model.primary)

  override func viewDidAppear(_ animated: Bool) {
    super.viewDidAppear(animated)
    self.view.backgroundColor = UIColor.white
    self.setupCalendarViewLayout()
  }

  private func setupCalendarViewLayout() {
    self.view.addSubview(calendarView)
    calendarView.usingAutolayout()
    NSLayoutConstraint.activate(
      [
        calendarView.topAnchor.constraint(equalTo: self.view.topAnchor, constant: 30),
        calendarView.widthAnchor.constraint(equalToConstant: 323),
        calendarView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
      ]
    )
  }
}

```

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?