### PR TITLE
timerScene에 StorageWorker 연결

### DIFF
--- a/ToDo-Garden/TDUtility/Sources/TDUtility/Protocol/TransitionHandlable.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/Protocol/TransitionHandlable.swift
@@ -21,7 +21,9 @@ extension TransitionHandlable {
     )
   }
   
+  // swiftlint:disable notification_center_detachment
   public func unregisterBackgroundTransition() {
     NotificationCenter.default.removeObserver(self)
   }
+  // swiftlint:enable notification_center_detachment
 }

--- a/ToDo-Garden/TDUtility/Sources/TDUtility/Protocol/TransitionHandlable.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/Protocol/TransitionHandlable.swift
@@ -1,0 +1,27 @@
+//
+//  TransitionHandlable.swift
+//  TDUtility
+//
+//  Created by SONG on 2/6/25.
+//
+
+import UIKit
+
+@objc public protocol TransitionHandlable: AnyObject {
+  @objc func handleBackgroundTransition()
+}
+
+extension TransitionHandlable {
+  public func registerBackgroundTransitionObserver() {
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(self.handleBackgroundTransition),
+      name: UIScene.didEnterBackgroundNotification,
+      object: nil
+    )
+  }
+  
+  public func unregisterBackgroundTransition() {
+    NotificationCenter.default.removeObserver(self)
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Package.swift
@@ -12,7 +12,8 @@ let package = Package(
   ],
   dependencies: [
     .package(path: "../ToDoGardenUI"),
-    .package(path: "../TDFoundation")
+    .package(path: "../TDFoundation"),
+    .package(path: "../TDUtility")
   ],
   targets: [
     .target(
@@ -21,7 +22,8 @@ let package = Package(
         "TimerSceneEntity",
         "TimerSceneAPI",
         .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
-        .product(name: "TDFoundation", package: "TDFoundation")
+        .product(name: "TDFoundation", package: "TDFoundation"),
+        .product(name: "TDUtility", package: "TDUtility")
       ],
       swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
     ),

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneInteractor.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+import TimerSceneAPI
 import TimerSceneEntity
 
 @MainActor
@@ -7,6 +8,8 @@ protocol TimerSceneBusinessLogic {
   func controlButtonTapped()
   func setTimer(for seconds: Double)
   func sendAlertAction(_ action: TimerScene.AlertAction)
+  func setCurrentGroup(_ payload: TimerScenePayloadable)
+  func requestPOST()
 }
 
 @MainActor
@@ -14,6 +17,7 @@ final class TimerSceneInteractor {
   public var isCountingDown: Bool = false
   public var alertStatus: TimerScene.TimerAlertStatus?
   public var bottomSheetStatus: TimerScene.BottomSheetStatus = .focus
+  public var currentGroup: TimerScene.CurrentGroup
   
   var presenter: TimerScenePresentationLogic?
   private let timerWorker: TimerSceneWorkable
@@ -27,6 +31,8 @@ final class TimerSceneInteractor {
   ) {
     self.timerWorker = timerWorker
     self.storageWorker = storageWorker
+    self.currentGroup = TimerScene.CurrentGroup(groupId: "", groupName: "")
+    // MARK: currentGroup은 Payload로 이전화면에서 전달받아 의미있는 값으로 대체됨
   }
   
   private func run(
@@ -48,6 +54,7 @@ final class TimerSceneInteractor {
   
   enum CancelTaskID: Hashable {
     case countdown
+    case postItems
   }
   private func cancel(_ id: AnyHashable) {
     self.tasks[id]?.cancel()
@@ -74,6 +81,7 @@ extension TimerSceneInteractor: TimerSceneBusinessLogic {
         let range = TimerScene.CircularProgressRange(1 - (time / seconds))
         self.presenter?.updateTimeState(time, range: range)
       }
+      self.didCompleteTimer(seconds: Int(seconds))
       try Task.checkCancellation()
       self.presenter?.clearPresentState()
       self.updateAndPresentAlertStatus(self.bottomSheetStatus.completionAlertStatus)
@@ -138,4 +146,38 @@ extension TimerScene.BottomSheetStatus {
       return .fullyCharged
     }
   }
+}
+
+extension TimerSceneInteractor {
+  func didCompleteTimer(seconds: Int) {
+    self.currentGroup.update(seconds: seconds)
+    
+    do {
+      try self.storageWorker.recordCompletedItemInLocal(
+        groupId: self.currentGroup.groupId,
+        seconds: self.currentGroup.seconds
+      )
+    } catch let error {
+      debugPrint(error)
+    }
+  }
+  
+  func setCurrentGroup(_ payload: TimerScenePayloadable) {
+    self.currentGroup = TimerScene.CurrentGroup(
+      groupId: payload.groupId,
+      groupName: payload.groupName
+    )
+  }
+}
+
+extension TimerSceneInteractor {
+  func requestPOST() {
+    self.run(id: CancelTaskID.postItems) {
+      try await self.storageWorker.postCompletedItem()
+      try Task.checkCancellation()
+    } errorHandler: { error in
+      debugPrint(error)
+    }
+  }
+    
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneSceneBuilder.swift
@@ -29,8 +29,10 @@ extension TimerSceneSceneBuilder: TimerSceneSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
-  public func build() -> TimerSceneViewControllable {
-    return self.configureVIPCycle(for: TimerSceneViewController())
+  public func build(with payload: TimerScenePayloadable?) -> TimerSceneViewControllable {
+    let timerSceneViewController = self.configureVIPCycle(for: TimerSceneViewController())
+    self.setPayload(for: timerSceneViewController, with: payload)
+    return timerSceneViewController
   }
 }
 
@@ -47,7 +49,12 @@ extension TimerSceneSceneBuilder {
     viewController.interactor = interactor
     interactor.presenter = presenter
     presenter.viewController = viewController
-    
     return viewController
+  }
+  
+  // TODO: 조립할 때 TimerScenePayloadable? 에 걸린 옵셔널 풀어서 조립할 것. 지금은 홈화면이 없어서 옵셔널.
+  private func setPayload(for viewController: TimerSceneViewController, with payload: TimerScenePayloadable?) {
+    guard let payload = payload else { return }
+    viewController.setPayload(payload)
   }
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+import TDUtility
 import TimerSceneAPI
 import TimerSceneEntity
 import ToDoGardenUIAPI
@@ -35,6 +36,11 @@ public final class TimerSceneViewController: UIViewController, TimerSceneViewCon
   // MARK: - Object lifecycle
   public init() {
     super.init(nibName: nil, bundle: nil)
+    self.registerBackgroundTransitionObserver()
+  }
+  
+  deinit {
+    self.unregisterBackgroundTransition()
   }
   
   @available(*, unavailable)
@@ -49,6 +55,11 @@ public final class TimerSceneViewController: UIViewController, TimerSceneViewCon
     self.layoutStack()
   }
   
+  public override func viewWillDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    self.interactor?.requestPOST()
+  }
+
   private func build() {
     self.view.backgroundColor = UIColor.toDoGardenWhite
     self.timerProgressView = TimerProgressView(
@@ -313,6 +324,12 @@ extension TimerSceneViewController {
     guard let payload = payload else { return }
     
     self.interactor?.setCurrentGroup(payload)
+  }
+}
+
+extension TimerSceneViewController: @preconcurrency TransitionHandlable {
+  public func handleBackgroundTransition() {
+    self.interactor?.requestPOST()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
@@ -308,6 +308,14 @@ extension TimerSceneViewController {
   }
 }
 
+extension TimerSceneViewController {
+  func setPayload(_ payload: TimerScenePayloadable?) {
+    guard let payload = payload else { return }
+    
+    self.interactor?.setCurrentGroup(payload)
+  }
+}
+
 #if DEBUG
 import HTTPClient
 @available(iOS 17.0, *)
@@ -328,7 +336,7 @@ import HTTPClient
       timerWorker: timerWorker,
       storageWorker: storageWorker
     )
-  ).build()
+  ).build(with: nil)
   
   let navigation = UINavigationController(rootViewController: viewController)
   navigation

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneWorkable.swift
@@ -9,7 +9,7 @@ public protocol TimerSceneWorkable: Sendable {
 
 public protocol TimerStorageWorkable: Sendable {
   func postCompletedItem() async throws
-  func recordCompletedItemInLocal(groupId: String, duration: Int) throws
+  func recordCompletedItemInLocal(groupId: String, seconds: Int) throws
   func deleteAllTimerItems() throws
   func getTimerItemsAsDTO() throws -> TimerScene.FocusTimeRequestDTO
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorage.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorage.swift
@@ -26,7 +26,7 @@ public final class TimerStorage: TimerStorable, @unchecked Sendable {
       in: .userDomainMask).first else {
       fatalError("Can not access documents directory.")
     }
-    
+
     self.documentsURL = documentsURL
   }
   
@@ -100,4 +100,8 @@ extension TimerStorage {
 
 public extension TimerStorage {
   static let live = TimerStorage()
+}
+
+public enum TimerStorageError: Error {
+  case emptyData // "pomodoros.json"가 비어있을때 (POST요청 필요 없을 때)
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorageWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorageWorker.swift
@@ -36,6 +36,7 @@ public struct TimerStorageWorker: TimerStorageWorkable {
       input: request,
       serializer: { $0 },
       deserializer: { response in
+        // MARK: 현재 홈화면의 부재로 payload를 통해 들어오는 GroupID가 없어서, 실패 응답 옴
         guard response.statusCode == 204 else {
           throw HTTPClientError.badStatusCode(response.statusCode)
         }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorageWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerStorageWorker.swift
@@ -48,8 +48,8 @@ public struct TimerStorageWorker: TimerStorageWorkable {
 
 // MARK: - Local Methods
 extension TimerStorageWorker {
-  public func recordCompletedItemInLocal(groupId: String, duration: Int) throws {
-    try self.timerStorage.saveCompletedTimer(groupId: groupId, duration: duration)
+  public func recordCompletedItemInLocal(groupId: String, seconds: Int) throws {
+    try self.timerStorage.saveCompletedTimer(groupId: groupId, duration: seconds)
   }
   
   public func deleteAllTimerItems() throws {

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerSceneAPI/TimerSceneSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerSceneAPI/TimerSceneSceneBuildable.swift
@@ -1,8 +1,11 @@
 import Foundation
 
+import TimerSceneEntity
+
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
-public protocol TimerSceneScenePayloadable {
-	// var name: String { get }
+public protocol TimerScenePayloadable {
+  var groupId: String { get }
+  var groupName: String { get }
 }
 
 @MainActor
@@ -10,5 +13,5 @@ public protocol TimerSceneSceneBuildable {
 	///  VIP Cycle, 런타임 파라미터가 설정된 ViewController 인스턴스를 반환하는 함수입니다.
 	/// - Parameter payload: 런타임에 전달받아야 하는 파라미터입니다.
 	/// - Returns: 런타임 파라미터, VIP Cycle이 설정된 ViewController가 반환되도록 구현합니다.
-  func build() -> TimerSceneViewControllable
+  func build(with payload: TimerScenePayloadable?) -> TimerSceneViewControllable
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerSceneEntity/TimerSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerSceneEntity/TimerSceneModels.swift
@@ -36,6 +36,21 @@ public enum TimerScene {
     case focus
     case rest
   }
+  
+  public struct CurrentGroup: Sendable {
+    public let groupId: String
+    public let groupName: String
+    public var seconds: Int = Int.zero
+    
+    public init(groupId: String, groupName: String) {
+      self.groupId = groupId
+      self.groupName = groupName
+    }
+    
+    public mutating func update(seconds: Int) {
+      self.seconds = seconds
+    }
+  }
 }
 
 extension TimerScene {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #807 
## 🎉 변경 사항
- StorageWorker를 연결합니다. 
## 📌 PR Point
### 로컬DB관련 네트워킹 관련 로직은 이미 구현이 되어있는 상태고, TimerScene에 연결시키는 PR입니다. 

### 로컬DB는 GRDB가 대체할 가능성이 농후합니다. 현재는 FileManager를 사용하고 있습니다. 

### Payload 세팅 
- TimerSceneBuilder를 통해 이전화면에서 선택된 Group에 대한 정보를 전달받아, CurrentGroup에 세팅합니다. 

### 타이머 완료시 로컬DB에 저장 
- 타이머가 완료되면, 로컬DB에 데이터를 저장합니다. 
- 아래 경로에 `pomodoro.json` 파일이 생성되며, 바로 POST요청을 쏠 수 있는 형태로 저장됩니다. (시뮬레이터 / 디바이스 경로임. 프로젝트에 포함되지않음.)

> file:///Users/song/Library/Developer/CoreSimulator/Devices/B29DC4A1-EDFF-4F06-AF20-3A973AEA8BD9/data/Containers/Data/Application/9BF3F4D4-06B1-47B7-8A0D-B44B5D558D4A/Documents/

- 아래는 최소시간 제한을 잠깐 없애고 테스트한 결과입니다. 잘 저장됩니다.
( 홈화면이 생기면 페이로드로 groupID를 전달받습니다 )
<img width="791" alt="스크린샷 2025-02-06 오후 4 19 59" src="https://github.com/user-attachments/assets/233aaf79-38e7-4643-8c07-01ac9ce74360" />

- file i/o 과정이라 비용이 비싼 작업입니다. 타이머 완료시 마다 하는 것이 아닌, 다른 적절한 시점에서 해당 과정을 실행시키려고 했으나, 누락되는 데이터없이 정확하게 저장하기 위해서는 완료시마다 저장하는게 가장 깔끔하다고 생각됩니다. 
- 타이머 최소시간이 10분인 점을 고려한다면, 무리없이 비용을 치를 수 있을 것으로 생각됩니다. 누락되는 데이터가 없어야 한다는 장점을 가져가기 위해서 어쩔 수 없는 trade-off인 것 같습니다. 

### 화면이탈시 로컬DB에 쌓인 애들 POST요청 
#### 1) 앱 내에서 다른화면으로 이동시 `ViewWillDisappear`에서 POST요청을 합니다.
#### 2) 앱 자체가 백그라운드로 이동시 POST요청
- `TransitionHandlable` 인터페이스를 만들었습니다. 
- `TransitionHandlable` 를 채택한 모든 객체는 `didEnterBackgroundNotification`을 감지하면, `handleBackgroundTransition`를 호출합니다. 
- VC에서 `TransitionHandlable` 를 채택시키고, 노티를 감지하면, POST요청을 트리거합니다. 
- 다른 화면 어디서든 사용가능합니다. 

```swift
class SomeClass: TransitionHandlable {
   init() {
      self.registerBackgroundTransitionObserver // 1. 옵저버 등록메서드 호출
   }
   
   func handleBackgroundTransition() {
      // 백그라운드로 갔을 때 실행할 내용 작성
   }
}
```

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?