### PR TITLE
Refactor cache

### DIFF
--- a/ToDo-Garden/TDFoundation/Package.swift
+++ b/ToDo-Garden/TDFoundation/Package.swift
@@ -47,6 +47,10 @@ let package = Package(
         "HTTPClientAPI",
         "HTTPClient"
       ]
+    ),
+    Target.testTarget(
+      name: "CacheTests",
+      dependencies: ["TDFoundation"]
     )
   ]
 )

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Cache.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Cache.swift
@@ -1,156 +1,145 @@
 import Foundation
 import UIKit.UIApplication
 
-import TDUtility
-
 // swiftlint:disable function_body_length
-public final class Cache<Request: Requestable>: Sendable {
+public final actor Cache<Request: Requestable>: Sendable {
   let request: Request
   let configuration: Configuration
-  
-  let storage: LockIsolated<Storage>
-  
-  private let memoryWarningTask = LockIsolated<Task<Void, Never>?>(nil)
-  private let expireTask = LockIsolated<Task<Void, Never>?>(nil)
+  let storage: Storage
+  private var memoryWarningTask: Task<Void, Never>?
+  private var cleanupTask: Task<Void, Never>?
   
   public init(
     request: Request,
-    configuration: Configuration = Configuration()
+    configuration: Configuration = Configuration(),
+    dependency: Dependecny = Dependecny.liveValue
   ) {
     self.request = request
     self.configuration = configuration
-    self.storage = LockIsolated(Storage(totalCostLimit: configuration.limit.cost))
-    self.memoryWarningTask.setValue(self.buildMemoryWarningTask())
-    self.expireTask.setValue(self.buildExpireTask())
+    self.storage = Storage(totalCostLimit: configuration.limit.cost)
+    
+    Task {
+      await self.prepare(dependency: dependency)
+    }
   }
   
-  private func buildMemoryWarningTask() -> Task<Void, Never> {
-    Task {
-      let stream = NotificationCenter.default
-        .publisher(for: UIApplication.didReceiveMemoryWarningNotification)
+  private func prepare(dependency: Dependecny) {
+    self.memoryWarningTask = Task { [weak self] in
+      let stream = dependency
+        .memoryWarningStream()
         .values
       for await _ in stream {
-        storage.withValue { cache in
-          cache.removeAllObjects()
+        guard let self, !Task.isCancelled else {
+          break
         }
+        await self.removeAllObjects()
       }
     }
-  }
-  
-  private func buildExpireTask() -> Task<Void, Never> {
-    Task {
-      let stream = Timer
-        .publish(
-          every: self.configuration.cleanupInterval,
-          on: .main,
-          in: .common
-        )
-        .autoconnect()
+    
+    let cleanupInterval = self.configuration.cleanupInterval
+    self.cleanupTask = Task { [weak self] in
+      let stream = dependency
+        .cleanupTimerStream(cleanupInterval)
         .values
       for await _ in stream {
-        self.removeExpired()
+        guard let self, !Task.isCancelled else {
+          break
+        }
+        await self.removeExpiredCacheItem()
       }
     }
   }
   
-  private func removeExpired() {
-    self.storage.withValue { cache in
-      for (key, item) in cache where item.isExpired {
-        item.loadingState?.task.cancel()
-        cache.removeObject(forKey: key)
+  private func removeAllObjects() {
+    self.storage.removeAllObjects()
+  }
+  
+  private func removeExpiredCacheItem() {
+    for (key, item) in self.storage where item.isExpired {
+      if let loadingState = item.loadingState {
+        loadingState.task.cancel()
+      } else {
+        self.storage.removeObject(forKey: key)
       }
     }
+  }
+  
+  deinit {
+    self.memoryWarningTask?.cancel()
+    self.cleanupTask?.cancel()
   }
   
   public func execute(
-    _ id: Request.ID,
+    id: Request.ID,
     expiration: StorageExpiration? = nil
   ) async throws -> Request.Response {
-    try await withTaskCancellationHandler {
+    let task = self.storage.object(forKey: id.description)?.loadingState?.task
+    guard !Task.isCancelled else {
+      task?.cancel()
+      throw CancellationError()
+    }
+    
+    return try await withTaskCancellationHandler {
       try await withCheckedThrowingContinuation { continuation in
-        self.storage.withValue { cache in
-          let expiration = expiration ?? self.configuration.expiration
-          Expiration.$value.withValue(expiration) {
-            let key = id.description
-            let item = cache.object(forKey: key)
-            
-            switch item?.value {
-            case RequestState.response(let response)?:
-              continuation.resume(returning: response)
-              
-            case RequestState.loading(var state)?:
-              if Task.isCancelled {
-                continuation.resume(throwing: CancellationError())
-                state.task.cancel()
-                return
-              }
-              state.continuations.append(continuation)
-              item?.value.loadingState = state
-              
-            case .none:
-              if Task.isCancelled {
-                continuation.resume(throwing: CancellationError())
-                return
-              }
-              let task = self.buildTask(id)
-              cache.setRequestState(
-                RequestState.loading(
-                  RequestState.LoadingState(task: task, continuations: [continuation])
-                ),
-                forKey: key
-              )
-            }
-            
-            if let item, !item.isExpired {
-              item.extendExpiration()
-            }
+        let item = self.storage.object(forKey: id.description)
+        switch item?.boxedValue {
+        case RequestState.response(let response)?:
+          continuation.resume(returning: response)
+          
+        case RequestState.loading?:
+          item?.loadingState?.continuations.append(continuation)
+          
+        case nil:
+          ExpirationLocals.$value.withValue(expiration ?? configuration.expiration) {
+            self.storage.setRequestState(
+              .loading(.init(task: initialTask(id), continuations: [continuation])),
+              forKey: id.description
+            )
           }
         }
         
+        if let item, !item.isExpired {
+          item.extendExpiration()
+        }
       }
     } onCancel: {
-      let task = self.storage.withValue { cache in
-        cache.object(forKey: id.description)?.loadingState?.task
-      }
       task?.cancel()
     }
   }
   
-  private func buildTask(_ id: Request.ID) -> Task<Void, Never> {
+  private func initialTask(_ id: Request.ID) -> Task<Void, Never> {
     Task {
       do {
         let response = try await self.request.execute(id: id)
-        let continuations: [Continuation] = try self.storage.withValue { cache  in
-          let key = id.description
-          let continuations = cache.continuations(forKey: key)
-          cache.removeObject(forKey: key)
-          cache.setRequestState(
-            RequestState.response(response),
-            forKey: key,
-            cost: try response.estimatedMemory.cost
-          )
-          
-          return continuations
-        }
-        
         try Task.checkCancellation()
+        let key = id.description
+        let continuations = self.storage.continuations(forKey: key)
+        self.storage.removeObject(forKey: key)
+        self.storage.setRequestState(
+          RequestState.response(response),
+          forKey: key,
+          cost: try response.estimatedMemory.cost
+        )
+        
         for continuation in continuations {
           continuation.resume(returning: response)
           await Task.yield()
         }
       } catch {
-        self.cancel(for: id, error: error)
+        self._cancel(for: id, error: error)
       }
     }
   }
   
-  public func cancel(for id: Request.ID, error: any Error) {
-    let continuations: [Continuation] = self.storage.withValue { cache in
-      let continuations = cache.continuations(forKey: id.description)
-      cache.removeObject(forKey: id.description)
-      return continuations
+  public nonisolated func cancel(id: Request.ID) {
+    Task {
+      await self._cancel(for: id)
     }
-    
+  }
+  
+  private func _cancel(for id: Request.ID, error: any Error = CancellationError()) {
+    let continuations = self.storage.continuations(forKey: id.description)
+    self.storage.removeObject(forKey: id.description)
     Task {
       for continuation in continuations {
         continuation.resume(throwing: error)
@@ -158,7 +147,13 @@ public final class Cache<Request: Requestable>: Sendable {
       }
     }
   }
+  
+  public func isCached(id: Request.ID) -> Bool {
+    self.storage.contains(forKey: id.description)
+  }
 }
+
+import Combine
 
 extension Cache {
   public struct Configuration: Sendable {
@@ -178,7 +173,7 @@ extension Cache {
   }
   
   typealias Continuation = CheckedContinuation<Request.Response, any Error>
-  enum RequestState: Sendable {
+  enum RequestState {
     case response(Request.Response)
     
     struct LoadingState: Sendable {
@@ -187,15 +182,52 @@ extension Cache {
     }
     var loadingState: LoadingState? {
       get {
-        guard case RequestState.loading(let state) = self else { return nil }
+        guard case Self.loading(let state) = self else {
+          return nil
+        }
         return state
       }
       set {
-        guard let newValue else { return }
-        self = RequestState.loading(newValue)
+        guard let newValue else {
+          return
+        }
+        self = Self.loading(newValue)
       }
     }
     case loading(LoadingState)
+  }
+  
+  public struct Dependecny: Sendable {
+    public var memoryWarningStream: @Sendable () -> AnyPublisher<Void, Never>
+    public var cleanupTimerStream: @Sendable (Double) -> AnyPublisher<Void, Never>
+    
+    public init(
+      memoryWarningStream: @Sendable @escaping () -> AnyPublisher<Void, Never>,
+      cleanupTimerStream: @Sendable @escaping (Double) -> AnyPublisher<Void, Never>
+    ) {
+      self.memoryWarningStream = memoryWarningStream
+      self.cleanupTimerStream = cleanupTimerStream
+    }
+  }
+}
+
+extension Cache.Dependecny {
+  public static var liveValue: Self {
+    Self(
+      memoryWarningStream: {
+        NotificationCenter.default
+          .publisher(for: UIApplication.didReceiveMemoryWarningNotification)
+          .map { _ in () }
+          .eraseToAnyPublisher()
+      },
+      cleanupTimerStream: {
+        Timer
+          .publish(every: $0, on: .main, in: .common)
+          .autoconnect()
+          .map { _ in () }
+          .eraseToAnyPublisher()
+      }
+    )
   }
 }
 
@@ -211,6 +243,12 @@ extension Cache.RequestState: MemorySizeProvider {
         return Measurement(value: 0, unit: .bytes)
       }
     }
+  }
+}
+
+extension Measurement where UnitType == UnitInformationStorage {
+  var cost: Int {
+    Int(converted(to: .bytes).value)
   }
 }
 // swiftlint:enable function_body_length

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/CachePolicies.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/CachePolicies.swift
@@ -1,4 +1,5 @@
-import Foundation
+import struct Foundation.TimeInterval
+import struct Foundation.Date
 
 public enum StorageExpiration: Sendable {
   var estimatedExpirationSinceNow: Date {

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Storage.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Storage.swift
@@ -1,12 +1,8 @@
 import Foundation
 
-enum Expiration {
-  @TaskLocal static var value: StorageExpiration = .expired
-}
-
 extension Cache {
-  class Storage: IterableCache<String, CacheItem<RequestState>>, NSCacheDelegate {
-    private(set) var removedContinuations: [String: [Continuation]] = [:]
+  final class Storage: IterableCache<String, CacheItem<RequestState>>, NSCacheDelegate {
+    var removedContinuations: [String: [Continuation]] = [:]
     
     override init(totalCostLimit: Int) {
       super.init(totalCostLimit: totalCostLimit)
@@ -15,7 +11,21 @@ extension Cache {
     
     override func removeObject(forKey key: String) {
       super.removeObject(forKey: key)
-      self.removedContinuations[key] = nil
+      self.lock.withLock {
+        self.removedContinuations[key] = nil
+      }
+    }
+    
+    override func removeAllObjects() {
+      for key in keys {
+        self.object(forKey: key)?.loadingState?.task.cancel()
+      }
+      for continuations in self.removedContinuations {
+        for continutaion in continuations.value {
+          continutaion.resume(throwing: CancellationError())
+        }
+      }
+      super.removeAllObjects()
     }
     
     func setRequestState(
@@ -26,43 +36,54 @@ extension Cache {
       let cacheItem = CacheItem<RequestState>(
         key: key,
         value: value,
-        expiration: Expiration.value
+        expiration: ExpirationLocals.value
       )
       super.setObject(cacheItem, forKey: key, cost: cost)
     }
     
     func continuations(forKey key: String) -> [Continuation] {
-      self.lock.lock()
-      defer { self.lock.unlock() }
-      return self.object(forKey: key)?.value.loadingState?.continuations
-      ?? self.removedContinuations[key]
-      ?? []
+      self.lock.withLock {
+        self.object(forKey: key)?.loadingState?.continuations
+        ?? removedContinuations[key]
+        ?? []
+      }
     }
     
-    // MARK: - NSCacheDelegate Protocol
+    // MARK: - NSCacheDelegate
     /// loading 상태에서 캐시 정책에 의해서 제거될 경우, 값을 저장해서 전파하기 위해서.
     func cache(
       _ cache: NSCache<AnyObject, AnyObject>,
       willEvictObject obj: Any
     ) {
-      guard let item = obj as? CacheItem<RequestState> else { return }
+      guard let item = obj as? CacheItem<RequestState> else {
+        return
+      }
       let key = item.key
-      switch item.value {
-      case .response:
+      switch item.boxedValue {
+      case RequestState.response:
         self.removedContinuations[key] = nil
         self.keys.remove(key)
-      case .loading(let state):
-        self.removedContinuations[item.key] = state.continuations
+      case RequestState.loading(let state):
+        self.removedContinuations[key] = state.continuations
       }
     }
   }
 }
 
+enum ExpirationLocals {
+  @TaskLocal static var value: StorageExpiration = .expired
+}
+
 @dynamicMemberLookup
 final class CacheItem<Value> {
   let key: String
-  var value: Value
+  private var value: Value
   let expiration: StorageExpiration
+  
+  var boxedValue: Value {
+    _read { yield self.value }
+    _modify { yield &self.value }
+  }
   
   var isExpired: Bool {
     Date().timeIntervalSince(self.estimatedExpiration) <= 0
@@ -82,15 +103,16 @@ final class CacheItem<Value> {
   
   func extendExpiration(_ extendingExpiration: ExpirationExtending = .cacheTime) {
     switch extendingExpiration {
-    case .none: break
-    case .cacheTime:
-      self.estimatedExpiration = self.expiration.estimatedExpirationSinceNow
-    case .expirationTime(let expiration):
-      self.estimatedExpiration = expiration.estimatedExpirationSinceNow
+    case ExpirationExtending.none: break
+    case ExpirationExtending.cacheTime:
+      estimatedExpiration = expiration.estimatedExpirationSinceNow
+    case ExpirationExtending.expirationTime(let expiration):
+      estimatedExpiration = expiration.estimatedExpirationSinceNow
     }
   }
   
-  public subscript<Member>(dynamicMember keyPath: KeyPath<Value, Member>) -> Member {
-    self.value[keyPath: keyPath]
+  public subscript<Member>(dynamicMember keyPath: WritableKeyPath<Value, Member>) -> Member {
+    get { self.boxedValue[keyPath: keyPath] }
+    set { self.boxedValue[keyPath: keyPath] = newValue }
   }
 }

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/IterableCache.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/IterableCache.swift
@@ -1,54 +1,44 @@
 import Foundation
 
 // swiftlint:disable identifier_name
-public class IterableCache<Key: Hashable, Value: AnyObject>: NSObject {
+class IterableCache<Key: Hashable, Value: AnyObject>: NSObject {
   let cache = NSCache<Ref<Key>, Value>()
   var keys = Set<Key>()
   let lock = NSLock()
   
-  public init(totalCostLimit: Int) {
-    self.cache.totalCostLimit = totalCostLimit
+  init(totalCostLimit: Int) {
+    cache.totalCostLimit = totalCostLimit
   }
   
-  public func setObject(_ obj: Value, forKey key: Key, cost g: Int = 0) {
-    let ref = Ref(key)
-    self.lock.work {
-      self.cache.setObject(obj, forKey: ref, cost: g)
-      self.keys.insert(key)
+  func setObject(_ obj: Value, forKey key: Key, cost g: Int = 0) {
+    lock.withLock {
+      cache.setObject(obj, forKey: Ref(key), cost: g)
+      keys.insert(key)
     }
   }
   
-  public func object(forKey key: Key) -> Value? {
-    self.cache.object(forKey: Ref(key))
+  func object(forKey key: Key) -> Value? {
+    cache.object(forKey: Ref(key))
   }
   
-  public func removeObject(forKey key: Key) {
-    self.lock.work {
-      self.cache.removeObject(forKey: Ref(key))
-      self.keys.remove(key)
+  func removeObject(forKey key: Key) {
+    lock.withLock {
+      cache.removeObject(forKey: Ref(key))
+      keys.remove(key)
     }
   }
   
-  public func removeAllObjects() {
-    self.lock.work {
-      self.cache.removeAllObjects()
-      self.keys.removeAll()
+  func removeAllObjects() {
+    lock.withLock {
+      cache.removeAllObjects()
+      keys.removeAll()
     }
   }
-}
-
-// MARK: - Sequence Protocol
-extension IterableCache: Sequence {
-  public func makeIterator() -> AnyIterator<(Key, Value)> {
-    var iterator = self.keys.makeIterator()
-    return AnyIterator {
-      while let key = iterator.next() {
-        if let value = self.cache.object(forKey: Ref(key)) {
-          return (key, value)
-        }
-      }
-      
-      return nil
+  
+  func contains(forKey key: Key) -> Bool {
+    lock.withLock {
+      cache.object(forKey: Ref(key)) != nil
+      || keys.contains(key)
     }
   }
 }
@@ -56,7 +46,7 @@ extension IterableCache: Sequence {
 extension IterableCache {
   final class Ref<T: Hashable>: NSObject {
     override var hash: Int {
-      self.key.hashValue
+      key.hashValue
     }
     let key: T
     
@@ -68,16 +58,23 @@ extension IterableCache {
       guard let other = object as? Ref<T> else {
         return false
       }
-      return self.key == other.key
+      return key == other.key
     }
   }
 }
 
-private extension NSLock {
-  func work(_ work: () -> Void) {
-    self.lock()
-    defer { self.unlock() }
-    work()
+extension IterableCache: Sequence {
+  func makeIterator() -> AnyIterator<(Key, Value)> {
+    var iterator = keys.makeIterator()
+    return AnyIterator {
+      while let key = iterator.next() {
+        if let value = self.cache.object(forKey: Ref(key)) {
+          return (key, value)
+        }
+      }
+      
+      return nil
+    }
   }
 }
 // swiftlint:enable identifier_name

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/MemorySizeProvider.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/MemorySizeProvider.swift
@@ -4,12 +4,6 @@ public protocol MemorySizeProvider: Sendable {
   var estimatedMemory: Measurement<UnitInformationStorage> { get throws }
 }
 
-extension Measurement where UnitType == UnitInformationStorage {
-  var cost: Int {
-    Int(converted(to: .bytes).value)
-  }
-}
-
 extension Measurement<UnitInformationStorage> {
   @usableFromInline
   static let memoryLimit: Self = {

--- a/ToDo-Garden/TDFoundation/Tests/CacheTests/CacheTest.swift
+++ b/ToDo-Garden/TDFoundation/Tests/CacheTests/CacheTest.swift
@@ -1,0 +1,157 @@
+@preconcurrency import Combine
+import Foundation
+import Testing
+import UIKit
+
+import TDFoundation
+
+// swiftlint:disable identifier_name
+@MainActor
+struct CacheTest {
+  @Test func immediateCancellation() async throws {
+    let cache = Cache(request: TestNetworkClient())
+    await confirmation(expectedCount: 10) { confirmation in
+      var tasks: [Task<Void, Never>] = []
+      for i in 1...10 {
+        let task = Task {
+          do {
+            _ = try await cache.execute(id: 3)
+          } catch {
+            confirmation()
+          }
+        }
+        if i == 5 {
+          task.cancel()
+        }
+        tasks.append(task)
+      }
+      
+      for task in tasks {
+        _ = await task.value
+      }
+    }
+  }
+  
+  @Test func delayedCancellation() async throws {
+    let cache = Cache(request: TestNetworkClient())
+    await confirmation(expectedCount: 10) { confirmation in
+      var tasks: [Task<Void, Never>] = []
+      for _ in 1...10 {
+        let task = Task {
+          do {
+            _ = try await cache.execute(id: 3)
+          } catch {
+            confirmation()
+          }
+        }
+        tasks.append(task)
+      }
+      Task {
+        try await Task.sleep(nanoseconds: 100)
+        cache.cancel(id: 3)
+      }
+      
+      for task in tasks {
+        _ = await task.value
+      }
+    }
+  }
+  
+  @Test func singleCancellation() async throws {
+    let cache = Cache(request: TestNetworkClient())
+    await confirmation(expectedCount: 1) { confirmation in
+      let task = Task {
+        do {
+          _ = try await cache.execute(id: 3)
+        } catch {
+          confirmation()
+        }
+      }
+      
+      Task {
+        try await Task.sleep(nanoseconds: 100)
+        cache.cancel(id: 3)
+      }
+      
+      _ = await task.value
+    }
+  }
+  
+  @Test func memoryWarning() async throws {
+    let subject = PassthroughSubject<Void, Never>()
+    let cache = Cache(
+      request: TestNetworkClient(),
+      dependency: .overrideMemoryWarning(subject)
+    )
+    _ = try await cache.execute(id: 3)
+    #expect(await cache.isCached(id: 3))
+    subject.send(())
+    await superYield()
+    #expect(await !cache.isCached(id: 3))
+  }
+  
+  // 테스트코드 환경에서 타이머의 경우 오동작하는 경우가 있음. 이를 테스트하기 위해선, 다른 조치가 필요함.
+  // CombineSchedulers를 사용하면 좋음.
+  //  @Test func expiredCachedItem() async throws {
+  //    let temp = Cache(
+  //      request: TestNetworkClient(),
+  //      configuration: .init(expiration: .seconds(0.2), cleanupInterval: 0.3)
+  //    )
+  //    _ = try await temp.execute(id: 3)
+  //    #expect(await temp.isCached(id: 3))
+  //    try await Task.sleep(for: .seconds(0.3))
+  //    #expect(await !temp.isCached(id: 3))
+  //  }
+  
+  func superYield() async {
+    for _ in 1...100 {
+      await Task.yield()
+    }
+  }
+  
+  @Test func memoryCostOver() async throws {
+    let cache = Cache(
+      request: TestNetworkClient(),
+      configuration: .init(limit: .init(value: 50, unit: .bytes))
+    )
+    for i in 1...3 {
+      do {
+        _ = try await cache.execute(id: i)
+      } catch {
+        print(error)
+      }
+    }
+    await confirmation(expectedCount: 2) { confirmation in
+      for i in 1...3 where await cache.isCached(id: i) {
+        confirmation()
+      }
+    }
+  }
+}
+
+struct TestNetworkClient: Requestable {
+  func execute(id: Int) async throws -> String {
+    try await Task.sleep(nanoseconds: 50_000_000)
+    return "id \(id)"
+  }
+}
+
+extension String: MemorySizeProvider {
+  public var estimatedMemory: Measurement<UnitInformationStorage> {
+    .init(value: 20, unit: .bytes)
+  }
+}
+
+extension Cache.Dependecny {
+  static func overrideMemoryWarning(
+    _ subject: PassthroughSubject<Void, Never>
+  ) -> Self {
+    var live = Self.liveValue
+    live.memoryWarningStream = {
+      subject
+        .eraseToAnyPublisher()
+    }
+    return live
+  }
+}
+// swiftlint:enable identifier_name


### PR DESCRIPTION
## 💡 관련 이슈
#758 

## 🎉 변경 사항
- class 기반 cache를 actor 기반으로 수정
- 메모리 누수 제거(cache 객체가 deinit되지 않던 문제 수정)
- test code 추가

## 📌 PR Point
기존의 class 기반의 캐시의 경우, LockIsolated의 경우 Transaction(withValue)안에서 상태 값을 관리했었지만 
actor로 변경하고나서 부턴 지역 경계를 활용한 보다 직관적인 코드로 수정했습니다.

## 📝 셀프체크리스트
- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?