### PR TITLE
NotificationManager 객체 추가

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/NotificationManager.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/NotificationManager.swift
@@ -33,3 +33,15 @@ public final class NotificationManager {
 public enum NotificationPermissionError: Error {
   case unknownError
 }
+
+// MARK: Constant
+
+extension NotificationManager {
+  enum Constant {
+    static let title = "ToDo Garden"
+    static let focusBody = "수고했어요! 오늘도 열심히 집중한 당신!"
+    static let restBody = "충전완료! 이제 다시 열심히 힘을 내볼까요?"
+    static let focusIdentifier = "focusComplete"
+    static let restIdentifier = "restComplete"
+  }
+}

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/NotificationManager.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/NotificationManager.swift
@@ -10,4 +10,26 @@ import UserNotifications
 
 public final class NotificationManager {
   public init() {}
+
+  /// 현재 사용자가 설정한 알림 설정 권한을 가져오는 메서드입니다.
+  /// 권한이 허용되어있으면 true, 거부되어 있으면 false를 반환합니다.
+  public func fetchPermission() async throws -> Bool {
+    let notificationCenter = UNUserNotificationCenter.current()
+    let settings = await notificationCenter.notificationSettings()
+    switch settings.authorizationStatus {
+    case .authorized:
+      return true
+    case .denied:
+      return false
+    case .notDetermined:
+      let options: UNAuthorizationOptions = [.alert, .badge, .sound]
+      return try await notificationCenter.requestAuthorization(options: options)
+    default:
+      throw NotificationPermissionError.unknownError
+    }
+  }
+}
+
+public enum NotificationPermissionError: Error {
+  case unknownError
 }

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/NotificationManager.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/NotificationManager.swift
@@ -36,6 +36,10 @@ public final class NotificationManager {
   public func makeRestNotification(after seconds: Double) {
     self.makeNotification(seconds: seconds, isFocus: false)
   }
+
+  public func clearPendingNotifications() {
+    UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+  }
 }
 
 // MARK: Private Functions

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/NotificationManager.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/NotificationManager.swift
@@ -1,0 +1,13 @@
+//
+//  NotificationManager.swift
+//
+//
+//  Created by Wood on 2/8/25.
+//
+
+import Foundation
+import UserNotifications
+
+public final class NotificationManager {
+  public init() {}
+}

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/NotificationManager.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/NotificationManager.swift
@@ -28,6 +28,31 @@ public final class NotificationManager {
       throw NotificationPermissionError.unknownError
     }
   }
+
+  public func makeFocusNotification(after seconds: Double) {
+    makeNotification(seconds: seconds, isFocus: true)
+  }
+
+  public func makeRestNotification(after seconds: Double) {
+    self.makeNotification(seconds: seconds, isFocus: false)
+  }
+}
+
+// MARK: Private Functions
+
+extension NotificationManager {
+  private func makeNotification(seconds: Double, isFocus: Bool) {
+    let notiContent = UNMutableNotificationContent()
+    let constant = NotificationManager.Constant.self
+    notiContent.title = constant.title
+    notiContent.body = isFocus ? constant.focusBody : constant.restBody
+
+    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: seconds, repeats: false)
+    let identifier = isFocus ? constant.focusIdentifier : constant.restIdentifier
+    let request = UNNotificationRequest(identifier: identifier, content: notiContent, trigger: trigger)
+
+    UNUserNotificationCenter.current().add(request)
+  }
 }
 
 public enum NotificationPermissionError: Error {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #811 

## 🎉 변경 사항
- 푸시 알림을 생성하고, 권한을 받아오는 객체를 추가하였습니다.

## 📌 PR Point
### 필요성
- `타이머`, `데일리 ToDo 알림`, `ToDo 수정` 화면에서 알림 기능 사용시 권한 수집을 위해 추가하였습니다.
- 여러 패키지서 사용해야하기에 TDFoundation 패키지에 추가하였습니다.

### 로컬 푸시 알림 기능
- Simulator에서 테스트하고 GIF로 추가하였습니다.
- 실기기에서도 정상작동 합니다.

|집중 완료|휴식 완료|
|---|---|
|<img width="250" src="https://github.com/user-attachments/assets/40f28ec5-6bbe-4f97-b163-083e72c86206">|<img width="250" src="https://github.com/user-attachments/assets/cba2541b-c229-463e-b0df-8ff81e563b3e">|


### 사용 방법
``` Swift
let notificationManager = NotificationManager()
Taks {
  let isAllowed = try notificationManager.fetchPermission() // 권한 허용 여부 조회
}

// 1분 30초 후에 집중 완료 Push Noti 알림 띄우기
notificationManager.makeFocusNotification(after: 100)
// 10 초 후에 집중 완료 Push Noti 알림 띄우기
notificationManager.makeRestNotification(after: 10)
```

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?