### PR TITLE
타이머 완료시 푸시 알림 기능 추가

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/NotificationManager.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/NotificationManager.swift
@@ -8,8 +8,10 @@
 import Foundation
 import UserNotifications
 
-public final class NotificationManager {
-  public init() {}
+public final class NotificationManager: NSObject, Sendable, UNUserNotificationCenterDelegate {
+  public static let shared = NotificationManager()
+
+  private override init() {}
 
   /// 현재 사용자가 설정한 알림 설정 권한을 가져오는 메서드입니다.
   /// 권한이 허용되어있으면 true, 거부되어 있으면 false를 반환합니다.
@@ -39,6 +41,15 @@ public final class NotificationManager {
 
   public func clearPendingNotifications() {
     UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+  }
+}
+
+extension NotificationManager {
+  public func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification
+  ) async -> UNNotificationPresentationOptions {
+    return [.badge, .banner, .sound]
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
@@ -15,7 +15,8 @@ extension TimerSceneSceneBuilder.Dependency {
   @MainActor
   public static let live = TimerSceneSceneBuilder.Dependency(
     timerWorker: TimerSceneWorker.live,
-    storageWorker: TimerStorageWorker.live
+    storageWorker: TimerStorageWorker.live,
+    notificationManager: NotificationManager()
   )
 }
 

--- a/ToDo-Garden/ToDo-Garden/Sources/Application/AppDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/Sources/Application/AppDelegate.swift
@@ -16,6 +16,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     registerCustomFonts()
+    UNUserNotificationCenter.current().delegate = self
     return true
   }
 }
@@ -24,5 +25,14 @@ extension AppDelegate {
   private func registerCustomFonts() {
     PretendardFont.register()
     GmarkSansFont.register()
+  }
+}
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+  func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification
+  ) async -> UNNotificationPresentationOptions {
+    return [.badge, .banner, .sound]
   }
 }

--- a/ToDo-Garden/ToDo-Garden/Sources/Application/AppDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/Sources/Application/AppDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import TDFoundation
 import ToDoGardenUIResource
 
 @main
@@ -16,7 +17,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     registerCustomFonts()
-    UNUserNotificationCenter.current().delegate = self
+    UNUserNotificationCenter.current().delegate = NotificationManager.shared
     return true
   }
 }
@@ -25,14 +26,5 @@ extension AppDelegate {
   private func registerCustomFonts() {
     PretendardFont.register()
     GmarkSansFont.register()
-  }
-}
-
-extension AppDelegate: UNUserNotificationCenterDelegate {
-  func userNotificationCenter(
-    _ center: UNUserNotificationCenter,
-    willPresent notification: UNNotification
-  ) async -> UNNotificationPresentationOptions {
-    return [.badge, .banner, .sound]
   }
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneInteractor.swift
@@ -89,6 +89,7 @@ extension TimerSceneInteractor: TimerSceneBusinessLogic {
       try Task.checkCancellation()
       self.presenter?.clearPresentState()
       self.updateAndPresentAlertStatus(self.bottomSheetStatus.completionAlertStatus)
+      self.makeNotification()
     }
   }
   
@@ -165,7 +166,18 @@ extension TimerSceneInteractor {
       debugPrint(error)
     }
   }
-  
+
+  private func makeNotification() {
+    switch alertStatus {
+    case .welldone:
+      self.notificationManager.makeFocusNotification(after: 0.1)
+    case .fullyCharged:
+      self.notificationManager.makeRestNotification(after: 0.1)
+    default:
+      break
+    }
+  }
+
   func setCurrentGroup(_ payload: TimerScenePayloadable) {
     self.currentGroup = TimerScene.CurrentGroup(
       groupId: payload.groupId,

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneInteractor.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+import TDFoundation
 import TimerSceneAPI
 import TimerSceneEntity
 
@@ -22,15 +23,18 @@ final class TimerSceneInteractor {
   var presenter: TimerScenePresentationLogic?
   private let timerWorker: TimerSceneWorkable
   private let storageWorker: TimerStorageWorkable
-  
+  private let notificationManager: NotificationManager
+
   public var tasks: [AnyHashable: Task<Void, Never>] = [:]
   
   init(
     timerWorker: TimerSceneWorkable,
-    storageWorker: TimerStorageWorkable
+    storageWorker: TimerStorageWorkable,
+    notificationManager: NotificationManager
   ) {
     self.timerWorker = timerWorker
     self.storageWorker = storageWorker
+    self.notificationManager = notificationManager
     self.currentGroup = TimerScene.CurrentGroup(groupId: "", groupName: "")
     // MARK: currentGroup은 Payload로 이전화면에서 전달받아 의미있는 값으로 대체됨
   }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneInteractor.swift
@@ -107,6 +107,7 @@ extension TimerSceneInteractor: TimerSceneBusinessLogic {
       self.keepConcentrationAction()
     
     case .goHome:
+      self.notificationManager.clearPendingNotifications()
       self.presenter?.dismiss()
     
     case .cancel:

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneSceneBuilder.swift
@@ -47,7 +47,8 @@ extension TimerSceneSceneBuilder {
   private func configureVIPCycle(for viewController: TimerSceneViewController) -> TimerSceneViewController {
     let interactor = TimerSceneInteractor(
       timerWorker: self.dependency.timerWorker,
-      storageWorker: self.dependency.storageWorker
+      storageWorker: self.dependency.storageWorker,
+      notificationManager: self.dependency.notificationManager
     )
     let presenter = TimerScenePresenter()
     viewController.interactor = interactor

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneSceneBuilder.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+import TDFoundation
 import TimerSceneAPI
 
 @MainActor
@@ -8,13 +9,16 @@ public struct TimerSceneSceneBuilder {
   public struct Dependency {
     let timerWorker: TimerSceneWorkable
     let storageWorker: TimerStorageWorkable
-    
+    let notificationManager: NotificationManager
+
     public init(
       timerWorker: any TimerSceneWorkable,
-      storageWorker: any TimerStorageWorkable
+      storageWorker: any TimerStorageWorkable,
+      notificationManager: NotificationManager
     ) {
       self.timerWorker = timerWorker
       self.storageWorker = storageWorker
+      self.notificationManager = notificationManager
     }
   }
   

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+import TDFoundation
 import TDUtility
 import TimerSceneAPI
 import TimerSceneEntity
@@ -351,7 +352,8 @@ import HTTPClient
   let viewController = TimerSceneSceneBuilder(
     dependency: .init(
       timerWorker: timerWorker,
-      storageWorker: storageWorker
+      storageWorker: storageWorker,
+      notificationManager: NotificationManager()
     )
   ).build(with: nil)
   


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #820 

## 🎉 변경 사항
- TimerScene에 타이머 완료시 푸시알림 기능을 추가하였습니다.

## 📌 PR Point
### NotificationManager 의존성 추가
- TimerScene에 #816 의존성을 추가하였습니다.
- AppDelegate에 알림 생성을 위한 UNUserNotificationDelegate 프로토콜을 채택하였습니다.

### 동작 GIF
- 집중 / 휴식 타이머 완료시 디자인에 맞게 푸시 알림을 생성합니다.
- 실기기에서도 정상 작동하였습니다.
- GIF에서는 테스트를 위해 5초 타이머를 가능하도록 잠깐 설정하였습니다.

|집중 완료|휴식 완료|
|--|--|
|<img width="250" src="https://github.com/user-attachments/assets/bc898040-230c-4aaa-9635-3bc455523fbf">|<img width="250" src="https://github.com/user-attachments/assets/604a9702-5ac2-4961-ab84-065e2f9d81fe">|

### 추가 논의사항
타이머 화면 진입시 알림 권한이 없으면, 사용자에게 요청하는 알럿을 띄우면 어떨까요?
⬇️ 아래는 구현되지 않았으며, 예시입니다.

<img width="250" src="https://github.com/user-attachments/assets/26c32e12-8e47-4f22-a127-6641257a219a">

- 장점: 사용자가 최초에 알림 권한을 거부했을 때, 권한 허용을 유도할 수 있음.
- 단점: 타이머 화면에 진입할 때 마다 권한 알럿을 띄우면, 사용자가 불편할 수 있음.


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?