### PR TITLE
set UI on home vc

### DIFF
--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -18,7 +18,8 @@ protocol HomeSceneDisplayLogic: AnyObject {
 final class HomeSceneViewController: UIViewController, HomeSceneViewControllable {
   
   // MARK: - View Properties
-  
+  private let homeHeaderView: HomeSceneHeaderView
+  private let calendarView: CalendarView
   private var todoListView: ToDoListView?
   
   // MARK: - VIP Properties
@@ -33,7 +34,10 @@ final class HomeSceneViewController: UIViewController, HomeSceneViewControllable
   // MARK: - Object lifecycle
   
   init() {
+    self.homeHeaderView = HomeSceneHeaderView()
+    self.calendarView = CalendarView(model: CalendarView.Model.primary)
     super.init(nibName: nil, bundle: nil)
+    self.view.backgroundColor = UIColor.white
   }
   
   @available(*, unavailable)
@@ -42,6 +46,10 @@ final class HomeSceneViewController: UIViewController, HomeSceneViewControllable
   }
   
   // MARK: - View lifecycle
+  public override func viewDidLoad() {
+    super.viewDidLoad()
+    self.setupViews()
+  }
   
   public override func viewIsAppearing(_ animated: Bool) {
     super.viewIsAppearing(animated)
@@ -67,6 +75,54 @@ extension HomeSceneViewController {
     toDoListViewContainer.isModalInPresentation = true
     
     self.present(toDoListViewContainer, animated: true)
+  }
+  
+  private func setupViews() {
+    self.setHomeHeaderView()
+    self.setCalendarView()
+  }
+  
+  private func setHomeHeaderView() {
+    self.view.addSubview(self.homeHeaderView)
+    
+    self.homeHeaderView.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        self.homeHeaderView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+        self.homeHeaderView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+        self.homeHeaderView.leadingAnchor.constraint(
+          equalTo: self.view.leadingAnchor,
+          constant: Constant.HeaderView.leadingMargin
+        ),
+        self.homeHeaderView.trailingAnchor.constraint(
+          equalTo: self.view.trailingAnchor,
+          constant: -Constant.HeaderView.trailingMargin
+        )
+      ]
+    )
+  }
+  
+  private func setCalendarView() {
+    self.view.addSubview(self.calendarView)
+    
+    self.calendarView.usingAutolayout()
+    NSLayoutConstraint.activate(
+      [
+        self.calendarView.topAnchor.constraint(
+          equalTo: self.homeHeaderView.bottomAnchor,
+          constant: Constant.CalendarView.topMargin
+        ),
+        self.calendarView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+        self.calendarView.leadingAnchor.constraint(
+          equalTo: self.view.leadingAnchor,
+          constant: Constant.CalendarView.commonHorizontalMargin
+        ),
+        self.calendarView.trailingAnchor.constraint(
+          equalTo: self.view.trailingAnchor,
+          constant: -Constant.CalendarView.commonHorizontalMargin
+        )
+      ]
+    )
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/View/HomeSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/View/HomeSceneConstants.swift
@@ -1,0 +1,20 @@
+//
+//  HomeSceneConstants.swift
+//  HomeScene
+//
+//  Created by SONG on 3/8/25.
+//
+
+import Foundation
+
+enum Constant {
+  enum HeaderView {
+    static let leadingMargin: CGFloat = 21.0
+    static let trailingMargin: CGFloat = 30.0
+  }
+  
+  enum CalendarView {
+    static let commonHorizontalMargin: CGFloat = 26.0
+    static let topMargin: CGFloat = 22.0
+  }
+}


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #837 
## 🎉 변경 사항
- 헤더뷰 배치 
- 캘린더뷰 배치 

## 📌 PR Point
- 피그마와 똑같이 배치했습니다. 
- 바텀시트는 아예 건들지 않았습니다. 지금은 midium이라 달력이 길면 가려지네요. 

![Simulator Screen Recording - iPhone 15 Pro - 2025-03-08 at 22 51 27](https://github.com/user-attachments/assets/10eeb548-7066-4195-948f-87a3f18a8916)

++ 그리고 온보딩 마무리 플랜 아래 사항 다시 알립니다.

<img width="901" alt="스크린샷 2025-03-08 오후 10 58 44" src="https://github.com/user-attachments/assets/5f2e8bb7-f8df-42bb-8756-0da08aa806ce" />


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?