### PR TITLE
#841: 로그인 여부 체크에 따른 라우팅 목적지 결정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
@@ -37,7 +37,15 @@ public final class AppCore {
       }
     } else {
       Task {
-        let isLoggedIn = false
+        var isLoggedIn: Bool
+        do {
+          _ = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken)
+          _ = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.refreshToken)
+          isLoggedIn = true
+        } catch {
+          isLoggedIn = false
+        }
+        
         self.destination = isLoggedIn
         ? Destination.home
         : Destination.login

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
@@ -37,7 +37,7 @@ public final class AppCore {
       }
     } else {
       Task {
-        var isLoggedIn: Bool
+        let isLoggedIn: Bool
         do {
           _ = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.accessToken)
           _ = try KeychainManager.shared.load(forKey: KeychainManager.KeychainKey.refreshToken)


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #841 
## 🎉 변경 사항
- 로그인 여부를 확인합니다. 
- 어디로 갈지 결정합니다. 
## 📌 PR Point
### 동작 흐름
1) 키체인에 저장된 엑세스토큰 / 리프레시 토큰을 확인
2) 없으면 Error를 던짐 -> 로그인 여부 False로 판단 -> 로그인화면 
3) 있으면 Error 안던짐 -> 로그인 여부 True로 판단 -> 홈화면

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?