### PR TITLE
홈화면 커스텀 바텀 시트 적용

### DIFF
--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -51,26 +51,19 @@ final class HomeSceneViewController: UIViewController, HomeSceneViewControllable
 }
 
 extension HomeSceneViewController {
-  private func presentSheet() {
+  private func setBottomSheet() {
     let toDoListViewContainer = ToDoListViewContainer()
     self.todoListView = toDoListViewContainer.toDoListView
-    if let sheet = toDoListViewContainer.sheetPresentationController {
-      sheet.detents = [
-        UISheetPresentationController.Detent.medium(),
-        UISheetPresentationController.Detent.large()
-      ]
-      sheet.prefersGrabberVisible = true
-      sheet.prefersScrollingExpandsWhenScrolledToEdge = false
-      sheet.largestUndimmedDetentIdentifier = UISheetPresentationController.Detent.Identifier.medium
-    }
-    toDoListViewContainer.isModalInPresentation = true
-    
-    self.present(toDoListViewContainer, animated: true)
+    let bottomSheet = BottomSheet()
+    bottomSheet.usingAutolayout()
+    self.view.addSubview(bottomSheet)
+    bottomSheet.contentView = self.todoListView
   }
   
   private func setupViews() {
     self.setHomeHeaderView()
     self.setCalendarView()
+    self.setBottomSheet()
   }
   
   private func setHomeHeaderView() {

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -89,7 +89,6 @@ extension HomeSceneViewController {
     NSLayoutConstraint.activate(
       [
         self.homeHeaderView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
-        self.homeHeaderView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
         self.homeHeaderView.leadingAnchor.constraint(
           equalTo: self.view.leadingAnchor,
           constant: Constant.HeaderView.leadingMargin

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -29,8 +29,6 @@ final class HomeSceneViewController: UIViewController, HomeSceneViewControllable
   
   // MARK: - Properties
   
-  @ExecuteOnce private var presentSheetIfNeeded: (() -> Void)?
-  
   // MARK: - Object lifecycle
   
   init() {
@@ -49,13 +47,6 @@ final class HomeSceneViewController: UIViewController, HomeSceneViewControllable
   public override func viewDidLoad() {
     super.viewDidLoad()
     self.setupViews()
-  }
-  
-  public override func viewIsAppearing(_ animated: Bool) {
-    super.viewIsAppearing(animated)
-    self.presentSheetIfNeeded = {
-      self.presentSheet()
-    }
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
@@ -86,7 +86,7 @@ extension Styled.Row.Configuration {
     }
   }
   
-  public struct TodoListModel: Equatable, Hashable {
+  public struct TodoListModel: Equatable, Hashable, Sendable {
     public static let empty = Self()
     public var text: String?
     public var foregroundColor: UIColor

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView+UIModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView+UIModel.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension ToDoListView {
-  public struct ToDoSection: Hashable {
+  public struct ToDoSection: Hashable, Sendable {
     public var id: UUID
     let headerUIModel: ToDoGroupUIModel
     public let toDoItems: [ToDoItem]
@@ -24,7 +24,7 @@ extension ToDoListView {
     }
   }
   
-  public struct ToDoItem: Hashable {
+  public struct ToDoItem: Hashable, Sendable {
     public var id: UUID
     let toDoUIModel: ToDoUIModel
     
@@ -37,7 +37,7 @@ extension ToDoListView {
     }
   }
   
-  public struct ToDoGroupUIModel: Hashable {
+  public struct ToDoGroupUIModel: Hashable, Sendable {
     let progressColor: UIColor
     let progressRate: Double
     let groupTitle: String


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #840 
## 🎉 변경 사항
- [x] 홈화면 UI 충돌 제약조건 제거
- [x] BottomSheet 적용

## 📌 PR Point
홈화면에 커스텀 바텀 시트를 적용하였습니다.
캘린더 사이즈가 가장 크기가 큰 3월로 데모를 촬영하였습니다!

|사이즈별 크기 확인|
|---|
|<img src="https://github.com/user-attachments/assets/a8d76d4d-a818-44b7-be20-75c13caef056" />|

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?