### PR TITLE
체크박스 알럿뷰 UI 추가 

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CheckBoxAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CheckBoxAlertView.swift
@@ -1,0 +1,189 @@
+//
+//  CheckBoxAlertView.swift
+//  ToDoGardenUI
+//
+//  Created by SONG on 3/10/25.
+//
+
+import UIKit
+
+import ToDoGardenUIConstant
+import ToDoGardenUIResource
+
+// swiftlint:disable function_body_length
+final public class CheckBoxAlertView: UIView {
+  public var leftTapped: ((Bool) -> Void)?
+  public var rightTapped: ((Bool) -> Void)?
+  
+  private let containerView: UIView
+  private let messageLabel: UILabel
+  private let checkBoxRow: TermsAgreementViewRow
+  private let verticalStackView: UIStackView
+  private let horizontalStackView: UIStackView
+  private let leftButton: UIButton
+  private let rightButton: UIButton
+  
+  private let leftButtonText: String
+  private let rightButtonText: String
+  
+  typealias StringLiteral = Constant.CheckBoxAlertView.StringLiteral
+  typealias Layout = Constant.CheckBoxAlertView.Layout
+  
+  init(
+    mainMessage: String = StringLiteral.mainMessage,
+    checkBoxMessage: String = StringLiteral.checkBoxMessage,
+    leftButtonText: String = StringLiteral.cancelButtonTitle,
+    rightButtonText: String = StringLiteral.settingButtonTitle
+  ) {
+    self.leftButtonText = leftButtonText
+    self.rightButtonText = rightButtonText
+    self.checkBoxRow = TermsAgreementViewRow(
+      title: checkBoxMessage,
+      font: UIFont.pretendardDetailRegular12,
+      chevronIsHidden: true
+    )
+    self.containerView = UIView()
+    self.messageLabel = UILabel()
+    self.verticalStackView = UIStackView()
+    self.horizontalStackView = UIStackView()
+    self.leftButton = UIButton(type: .system)
+    self.rightButton = UIButton(type: .system)
+    
+    super.init(frame: UIScreen.main.bounds)
+    
+    self.setupView(message: mainMessage)
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupView(message: String) {
+    self.backgroundColor = UIColor.black.withAlphaComponent(Layout.backgroundAlpha)
+    self.setupContainerView()
+    self.setupMessageLabel(with: message)
+    self.setupButtons()
+    self.setupStackViews()
+    self.setupCheckBoxView()
+  }
+  
+  private func setupContainerView() {
+    self.containerView.backgroundColor = .white
+    self.containerView.layer.cornerRadius = Layout.containerCornerRadius
+    self.containerView.layer.masksToBounds = true
+    
+    self.addSubview(self.containerView)
+    self.containerView.usingAutolayout()
+    NSLayoutConstraint.activate([
+      self.containerView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+      self.containerView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+      self.containerView.widthAnchor.constraint(equalToConstant: Layout.containerWidth),
+      self.containerView.heightAnchor.constraint(greaterThanOrEqualToConstant: Layout.containerMinHeight)
+    ])
+  }
+  
+  private func setupMessageLabel(with text: String) {
+    self.messageLabel.text = text
+    self.messageLabel.textAlignment = .center
+    self.messageLabel.numberOfLines = Int.zero
+    self.messageLabel.font = UIFont.pretendardBodySemiBold15
+    self.messageLabel.textColor = UIColor.toDoGardenGreenDark
+  }
+  
+  private func setupButtons() {
+    self.leftButton.setTitle(self.leftButtonText, for: .normal)
+    self.leftButton.setTitleColor(.gray, for: .normal)
+    self.leftButton.addAction(UIAction { [weak self] _ in
+      guard let self = self else { return }
+      self.leftTapped?(self.checkBoxRow.isSelected)
+    }, for: .touchUpInside)
+    
+    self.rightButton.setTitle(self.rightButtonText, for: .normal)
+    self.rightButton.setTitleColor(.toDoGardenGreenDark, for: .normal)
+    self.rightButton.addAction(UIAction { [weak self] _ in
+      guard let self = self else { return }
+      self.rightTapped?(self.checkBoxRow.isSelected)
+    }, for: .touchUpInside)
+  }
+  
+  private func setupStackViews() {
+    self.verticalStackView.axis = .vertical
+    self.verticalStackView.spacing = Layout.verticalSpacing
+    self.verticalStackView.addArrangedSubview(self.messageLabel)
+    self.verticalStackView.alignment = .center
+    self.verticalStackView.backgroundColor = .white
+    
+    self.horizontalStackView.axis = .horizontal
+    self.horizontalStackView.distribution = .fillEqually
+    self.horizontalStackView.spacing = Layout.horizontalSpacing
+    self.horizontalStackView.addArrangedSubview(self.leftButton)
+    self.horizontalStackView.addArrangedSubview(self.rightButton)
+    
+    self.containerView.addSubview(self.verticalStackView)
+    self.containerView.addSubview(self.horizontalStackView)
+    
+    self.verticalStackView.usingAutolayout()
+    self.horizontalStackView.usingAutolayout()
+    
+    NSLayoutConstraint.activate([
+      self.verticalStackView.topAnchor.constraint(
+        equalTo: self.containerView.topAnchor,
+        constant: Layout.verticalStackTopPadding
+      ),
+      self.verticalStackView.leadingAnchor.constraint(
+        equalTo: self.containerView.leadingAnchor,
+        constant: Layout.horizontalPadding
+      ),
+      self.verticalStackView.trailingAnchor.constraint(
+        equalTo: self.containerView.trailingAnchor,
+        constant: -Layout.horizontalPadding
+      ),
+      
+      self.horizontalStackView.topAnchor.constraint(
+        equalTo: self.verticalStackView.bottomAnchor,
+        constant: Layout.buttonTopPadding
+      ),
+      self.horizontalStackView.leadingAnchor.constraint(
+        equalTo: self.containerView.leadingAnchor,
+        constant: Layout.horizontalPadding
+      ),
+      self.horizontalStackView.trailingAnchor.constraint(
+        equalTo: self.containerView.trailingAnchor,
+        constant: -Layout.horizontalPadding
+      ),
+      self.horizontalStackView.bottomAnchor.constraint(
+        equalTo: self.containerView.bottomAnchor,
+        constant: -Layout.buttonBottomPadding
+      ),
+      self.horizontalStackView.heightAnchor.constraint(equalToConstant: Layout.buttonHeight)
+    ])
+  }
+  
+  private func setupCheckBoxView() {
+    self.addSubview(self.checkBoxRow)
+    self.checkBoxRow.usingAutolayout()
+    
+    NSLayoutConstraint.activate([
+      self.checkBoxRow.heightAnchor.constraint(equalToConstant: Layout.checkBoxHeight),
+      self.checkBoxRow.widthAnchor.constraint(equalToConstant: Layout.checkBoxWidth),
+      self.checkBoxRow.topAnchor.constraint(equalTo: self.verticalStackView.bottomAnchor),
+      self.checkBoxRow.leadingAnchor.constraint(
+        equalTo: self.verticalStackView.leadingAnchor,
+        constant: Layout.checkBoxLeadingPadding
+      )
+    ])
+  }
+}
+// swiftlint:enable function_body_length
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+  let view = CheckBoxAlertView()
+  view.leftTapped = { isChecked in
+    print("Left tapped")
+  }
+  return view
+}
+#endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CheckBoxAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CheckBoxAlertView.swift
@@ -11,6 +11,7 @@ import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
 // swiftlint:disable function_body_length
+// MARK: dimmed 효과가 함께 적용되어 있습니다. 콜러측에서 addSubview하고 화면 전체로 레이아웃 맞춰주세요.
 final public class CheckBoxAlertView: UIView {
   public var leftTapped: ((Bool) -> Void)?
   public var rightTapped: ((Bool) -> Void)?
@@ -166,7 +167,7 @@ final public class CheckBoxAlertView: UIView {
     
     NSLayoutConstraint.activate([
       self.checkBoxRow.heightAnchor.constraint(equalToConstant: Layout.checkBoxHeight),
-      self.checkBoxRow.widthAnchor.constraint(equalToConstant: Layout.checkBoxWidth),
+      self.checkBoxRow.widthAnchor.constraint(greaterThanOrEqualToConstant: Layout.checkBoxWidth),
       self.checkBoxRow.topAnchor.constraint(equalTo: self.verticalStackView.bottomAnchor),
       self.checkBoxRow.leadingAnchor.constraint(
         equalTo: self.verticalStackView.leadingAnchor,

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CheckBoxAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CheckBoxAlertView.swift
@@ -182,9 +182,6 @@ final public class CheckBoxAlertView: UIView {
 @available(iOS 17.0, *)
 #Preview {
   let view = CheckBoxAlertView()
-  view.leftTapped = { isChecked in
-    print("Left tapped")
-  }
   return view
 }
 #endif

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+CheckBoxAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant+CheckBoxAlertView.swift
@@ -1,0 +1,37 @@
+//
+//  Constant+CheckBoxAlertView.swift
+//  ToDoGardenUI
+//
+//  Created by SONG on 3/11/25.
+//
+
+import Foundation
+
+extension Constant.CheckBoxAlertView {
+  public enum Layout { }
+  public enum StringLiteral { }
+}
+
+extension Constant.CheckBoxAlertView.Layout {
+  public static let backgroundAlpha: CGFloat = 0.5
+  public static let containerCornerRadius: CGFloat = 16
+  public static let containerWidth: CGFloat = 300
+  public static let containerMinHeight: CGFloat = 120
+  public static let verticalSpacing: CGFloat = 12
+  public static let horizontalSpacing: CGFloat = 8
+  public static let verticalStackTopPadding: CGFloat = 20
+  public static let horizontalPadding: CGFloat = 16
+  public static let buttonTopPadding: CGFloat = 40
+  public static let buttonBottomPadding: CGFloat = 16
+  public static let buttonHeight: CGFloat = 30
+  public static let checkBoxHeight: CGFloat = 40
+  public static let checkBoxWidth: CGFloat = 120
+  public static let checkBoxLeadingPadding: CGFloat = 87.5
+}
+
+extension Constant.CheckBoxAlertView.StringLiteral {
+  public static let mainMessage: String = "타이머 완료시 알림을 받기 위해서는\n권한 허용이 필요합니다."
+  public static let checkBoxMessage: String = "다시 묻지 않음"
+  public static let settingButtonTitle: String = "설정으로 이동"
+  public static let cancelButtonTitle: String = "취소"
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIConstant/Constant.swift
@@ -50,4 +50,5 @@ public enum Constant {
   public enum AddGardenView { }
   public enum DefaultModalNavigationBar { }
   public enum ToDoGroupSectionHeaderView { }
+  public enum CheckBoxAlertView { }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #845 
## 🎉 변경 사항
- 체크박스 알럿 뷰를 만들었습니다.

## 📌 PR Point
### 구현상세 
- 이미 딤드뷰를 배경으로 깔고 있습니다. 사용시 화면전체로 오토레이아웃 설정하시고 isHidden만 토글하여 쓰면 될 것 같습니다. 
- 아래 텍스트가 기본값입니다만, init()을 통해 텍스트를 바꿀 수 있습니다.
![스크린샷 2025-03-11 오후 12 48 50](https://github.com/user-attachments/assets/cff6e4e2-0b29-487e-9fe5-6bbe21667ff9)
- 사용하는 쪽에서 왼쪽 오른쪽 버튼에 대한 액션을 클로저로 정의할 수 있습니다. 해당 클로저에는 체크박스 체크여부가 Bool값으로 전달됩니다. 
- 메인메세지 텍스트 길이에 따라 동적으로 레이아웃이 변합니다. 

### 실행화면 
![체크박스 알럿뷰 체크](https://github.com/user-attachments/assets/7b9d4e5d-4896-4b92-81fa-e9d727dff6af)
![체크박스알럿뷰 동적](https://github.com/user-attachments/assets/2980565d-4197-4f4b-b6fb-a1df77ec3ba4)


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?