### PR TITLE
Feature/#851 finish onboarding scene

### DIFF
--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -15,7 +15,7 @@ import HomeSceneAPI
 protocol HomeSceneDisplayLogic: AnyObject {
 }
 
-final class HomeSceneViewController: UIViewController, HomeSceneViewControllable {
+open class HomeSceneViewController: UIViewController, HomeSceneViewControllable {
   
   // MARK: - View Properties
   private let homeHeaderView: HomeSceneHeaderView
@@ -31,7 +31,7 @@ final class HomeSceneViewController: UIViewController, HomeSceneViewControllable
   
   // MARK: - Object lifecycle
   
-  init() {
+  public init() {
     self.homeHeaderView = HomeSceneHeaderView()
     self.calendarView = CalendarView(model: CalendarView.Model.primary)
     super.init(nibName: nil, bundle: nil)
@@ -39,19 +39,17 @@ final class HomeSceneViewController: UIViewController, HomeSceneViewControllable
   }
   
   @available(*, unavailable)
-  required init?(coder: NSCoder) {
+  required public init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
   
   // MARK: - View lifecycle
-  public override func viewDidLoad() {
+  open override func viewDidLoad() {
     super.viewDidLoad()
     self.setupViews()
   }
-}
-
-extension HomeSceneViewController {
-  private func setBottomSheet() {
+  
+  open func setBottomSheet() {
     let toDoListViewContainer = ToDoListViewContainer()
     self.todoListView = toDoListViewContainer.toDoListView
     let bottomSheet = BottomSheet()

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -58,6 +58,13 @@ open class HomeSceneViewController: UIViewController, HomeSceneViewControllable 
     bottomSheet.contentView = self.todoListView
   }
   
+  open func setUserInteractionDisable() {
+    self.calendarView.isUserInteractionEnabled = false
+    self.homeHeaderView.isUserInteractionEnabled = false
+  }
+}
+
+extension HomeSceneViewController {
   private func setupViews() {
     self.setHomeHeaderView()
     self.setCalendarView()

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
@@ -7,18 +7,27 @@
 
 import UIKit
 
+import HomeScene
+import RootTabBar
 import ToDoGardenUIComponent
 import ToDoGardenUIResource
 
-public final class TutorialOnBoardingViewController: UIViewController {
-  private let cell: ManageGroupTableViewCell
+public final class TutorialOnBoardingViewController: HomeSceneViewController {
+  private let cell1: ManageGroupTableViewCell
+  private let cell2: ManageGroupTableViewCell
   private let leftBubbleLabel: BubbleLabel
   private let rightBubbleLabel: BubbleLabel
+  private let bottomSheet: BottomSheet
+  private let tabBar: RootTabBarController.RootTabBar
   
   public var endAction: (() -> Void)?
   
-  public init() {
-    self.cell = ManageGroupTableViewCell(
+  public override init() {
+    self.cell1 = ManageGroupTableViewCell(
+      style: UITableViewCell.CellStyle.default,
+      reuseIdentifier: ManageGroupTableViewCell.identifier
+    )
+    self.cell2 = ManageGroupTableViewCell(
       style: UITableViewCell.CellStyle.default,
       reuseIdentifier: ManageGroupTableViewCell.identifier
     )
@@ -32,7 +41,9 @@ public final class TutorialOnBoardingViewController: UIViewController {
       iconImage: UIImage.timerButtonImage,
       text: Constant.StringLiteral.rightBubbleTitle
     )
-    super.init(nibName: nil, bundle: nil)
+    self.bottomSheet = BottomSheet()
+    self.tabBar = RootTabBarController.RootTabBar()
+    super.init()
   }
   
   @available(*, unavailable)
@@ -46,30 +57,92 @@ public final class TutorialOnBoardingViewController: UIViewController {
     self.setupCell()
     self.setupBubbleLabels()
     self.setupGestureRecognizers()
+    self.setUserInteractionDisable()
+    self.setupTabBar()
+  }
+  
+  override public func setBottomSheet() {
+    self.bottomSheet.usingAutolayout()
+    self.view.addSubview(self.bottomSheet)
+    self.bottomSheet.isUserInteractionEnabled = false
   }
 }
 
 extension TutorialOnBoardingViewController {
+  private func setupTabBar() {
+    self.tabBar.items = self.makeTabBarItems()
+    self.tabBar.barTintColor = .white
+    self.tabBar.tintColor = .toDoGardenGreenDark
+    self.tabBar.selectedItem = self.tabBar.items?[0]
+    self.tabBar.isUserInteractionEnabled = false
+    self.view.addSubview(self.tabBar)
+    self.tabBar.usingAutolayout()
+    
+    NSLayoutConstraint.activate([
+      self.tabBar.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+      self.tabBar.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+      self.tabBar.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+      self.tabBar.heightAnchor.constraint(equalToConstant: Constant.Layout.tabBarHeight)
+    ])
+  }
+
+  private func makeTabBarItems() -> [UITabBarItem] {
+    return [
+      (Constant.StringLiteral.tabBarHome, UIImage.homeTabBarItemImage, 0),
+      (Constant.StringLiteral.tabBarShare, UIImage.shareTabBarItemImage, 1),
+      (Constant.StringLiteral.tabBarSettings, UIImage.settingsTabBarItemImage, 2)
+    ].map { UITabBarItem(title: $0.0, image: $0.1, tag: $0.2) }
+  }
+
+  // swiftlint:disable function_body_length
   private func setupCell() {
-    self.cell.isUserInteractionEnabled = false
-    self.cell.applyModelSecondary(
+    self.cell1.isUserInteractionEnabled = false
+    self.cell1.applyModelSecondary(
       id: UUID(),
-      groupName: Constant.StringLiteral.groupName,
-      progressColor: UIColor.red,
+      groupName: Constant.StringLiteral.groupName1,
+      progressColor: UIColor.toDoGardenYellow,
       progressRate: 0.5
     )
-    self.cell.usingAutolayout()
-    self.view.addSubview(self.cell)
+    self.cell1.usingAutolayout()
+    self.view.addSubview(self.cell1)
     
-    NSLayoutConstraint.activate(
-      [
-        self.cell.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-        self.cell.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
-        self.cell.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-        self.cell.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
-      ]
+    self.cell2.isUserInteractionEnabled = false
+    self.cell2.applyModelSecondary(
+      id: UUID(),
+      groupName: Constant.StringLiteral.groupName2,
+      progressColor: UIColor.red,
+      progressRate: 1.0
     )
+    self.cell2.usingAutolayout()
+    self.view.addSubview(self.cell2)
+    
+    NSLayoutConstraint.activate([
+      self.cell1.heightAnchor.constraint(equalToConstant: Constant.Layout.cellHeight),
+      self.cell1.centerXAnchor.constraint(equalTo: self.bottomSheet.centerXAnchor),
+      self.cell1.leadingAnchor.constraint(
+        equalTo: self.bottomSheet.leadingAnchor,
+        constant: Constant.Layout.cellLeading
+      ),
+      self.cell1.trailingAnchor.constraint(equalTo: self.bottomSheet.trailingAnchor),
+      self.cell1.topAnchor.constraint(
+        equalTo: self.bottomSheet.topAnchor,
+        constant: Constant.Layout.cellTopMargin1
+      ),
+
+      self.cell2.heightAnchor.constraint(equalToConstant: Constant.Layout.cellHeight),
+      self.cell2.centerXAnchor.constraint(equalTo: self.bottomSheet.centerXAnchor),
+      self.cell2.leadingAnchor.constraint(
+        equalTo: self.bottomSheet.leadingAnchor,
+        constant: Constant.Layout.cellLeading
+      ),
+      self.cell2.trailingAnchor.constraint(equalTo: self.bottomSheet.trailingAnchor),
+      self.cell2.topAnchor.constraint(
+        equalTo: self.cell1.bottomAnchor,
+        constant: Constant.Layout.cellTopMargin2
+      )
+    ])
   }
+  // swiftlint:enable function_body_length
   
   private func setupBubbleLabels() {
     self.leftBubbleLabel.delegate = self
@@ -88,8 +161,8 @@ extension TutorialOnBoardingViewController {
   }
   
   private func setBubbleConstraints() {
-    guard let groupNameButton = self.cell.groupNameButton,
-      let rightImageButton = self.cell.rightImageButton else {
+    guard let groupNameButton = self.cell2.groupNameButton,
+      let rightImageButton = self.cell2.rightImageButton else {
       return
     }
     

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/Views/OnBoardingSceneConstants.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/Views/OnBoardingSceneConstants.swift
@@ -16,6 +16,12 @@ enum Constant {
     static let bubbleLabelMargin: CGFloat = 5.0
     static let leftBubbleLabelLeading: CGFloat = -44.0
     static let rightBubbleLabelTrailing: CGFloat = 39.0
+    
+    static let tabBarHeight: CGFloat = 87.0
+    static let cellHeight: CGFloat = 30.0
+    static let cellLeading: CGFloat = 20.0
+    static let cellTopMargin1: CGFloat = 65.0
+    static let cellTopMargin2: CGFloat = 20.0
   }
   enum StringLiteral {
     static let buttonTitle: String = "시작하기"
@@ -32,6 +38,11 @@ enum Constant {
     static let leftBubbleTitle: String = "를 눌러 ToDo를 추가할 수 있어요"
     static let rightBubbleTitle: String = "뽀모도로 타이머를 이용하여\n집중력을 향상시킬 수 있어요"
     
-    static let groupName: String = "그룹 1"
+    static let groupName1: String = "그룹 1"
+    static let groupName2: String = "그룹 2"
+    
+    static let tabBarHome: String = "홈"
+    static let tabBarShare: String = "공유"
+    static let tabBarSettings: String = "설정"
   }
 }

--- a/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBar.swift
+++ b/ToDo-Garden/ToDo-Garden/RootTabBar/Sources/RootTabBar/RootTabBar.swift
@@ -10,23 +10,23 @@ import UIKit
 import ToDoGardenUIResource
 
 extension RootTabBarController {
-  final class RootTabBar: UITabBar {
+  final public class RootTabBar: UITabBar {
     private let topSeparatorLineLayer: CALayer = {
       let topSeparatorLineLayer = CALayer()
       topSeparatorLineLayer.backgroundColor = UIColor.toDoGardenGreenBackground.cgColor
       return topSeparatorLineLayer
     }()
     
-    override init(frame: CGRect) {
+    public override init(frame: CGRect) {
       super.init(frame: frame)
       self.setupTabBarAppearance()
     }
     
-    required init?(coder: NSCoder) {
+    public required init?(coder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
     }
     
-    override func layoutSubviews() {
+    public override func layoutSubviews() {
       super.layoutSubviews()
       self.topSeparatorLineLayer.frame.size = CGSize(width: self.bounds.width, height: 1)
       self.adjustTabBarItemImageInsets()


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #851 
## 🎉 변경 사항
- 온보딩씬 마무리 
## 📌 PR Point
### UI 배치를 위한 사전 작업 
- HomeScene에서 HomeSceneVC만 뽑아와서 쓰기 위해 접근제어자를 수정했습니다. 
- RootTabBar역시 같은 이유로 접근제어자를 수정했습니다. 

### 유저 인터랙션 OFF 
- HomeSceneVC의 캘린더, 헤더뷰의 인터랙션을 off해야하는데, private으로 선언되어 있었습니다. 접근제어를 풀고 OnboardingScene에서 extension으로 처리할까 하다가 HomeSceneVC내부에 `setUserInteractionDisable()`를 추가하고 외부에서 해당 메서드를 호출하여 처리하는 방식이 가장 관리하기 쉽겠다 생각했습니다.
- 탭바, 바텀시트 역시 OFF
- self.view, cell, 말풍선 ON

### 실행화면 
![Simulator Screen Recording - iPhone 16 - 2025-03-12 at 12 15 07](https://github.com/user-attachments/assets/42ce7432-6700-4b39-9528-cc9dd464f7ac)

#### ⬇️ SE에선 이렇게 보입니다.
<img width="300" alt="스크린샷 2025-03-12 오후 12 06 59" src="https://github.com/user-attachments/assets/1f580759-2364-4805-b166-6f125375ec2a" />

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?