### PR TITLE
Feature/#856 connect to otherscene from home

### DIFF
--- a/ToDo-Garden/ToDo-Garden/AppCore/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Package.swift
@@ -42,6 +42,10 @@ let package = Package(
     Package.Dependency.package(
       name: "SettingScene",
       path: "../SettingScene"
+    ),
+    Package.Dependency.package(
+      name: "PostGroupScene",
+      path: "../PostGroupScene"
     )
   ],
   targets: [
@@ -83,6 +87,10 @@ let package = Package(
         Target.Dependency.product(
           name: "SettingScene",
           package: "SettingScene"
+        ),
+        Target.Dependency.product(
+          name: "PostGroupScene",
+          package: "PostGroupScene"
         )
       ]
     ),

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
@@ -72,7 +72,7 @@ extension AppCore {
         router: AppRouter(
           httpClient: httpClient,
           sceneBuilder: AppRouter.SceneBuilder(
-            home: HomeSceneBuilder(),
+            home: HomeSceneBuilder(dependency: .live),
             signup: SignUpSceneBuilder(
               dependency: SignUpSceneBuilder.Dependency(
                 signUpWorker: SignUpWorker(httpClient: httpClient)

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppRouter.swift
@@ -89,7 +89,7 @@ public final class AppRouter {
     login.afterLoginAction = { [weak self] isExistingUser in
       self?.switchTo(
         isExistingUser
-        ? Destination.home(HomeSceneBuilder().build())
+        ? Destination.home(HomeSceneBuilder(dependency: .live).build())
         : Destination.signUp
       )
     }
@@ -109,7 +109,7 @@ public final class AppRouter {
     )
     signUp.modalPresentationStyle = .overFullScreen
     signUp.afterSignUpAction = { [weak self] in
-      self?.switchTo(Destination.home(HomeSceneBuilder().build()))
+      self?.switchTo(Destination.home(HomeSceneBuilder(dependency: .live).build()))
     }
     return signUp
   }

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
@@ -7,14 +7,30 @@
 
 import Foundation
 
+import EditToDoScene
+import HomeScene
 import HTTPClient
+import ManageGroupScene
+import PostGroupScene
 import ShareGardenScene
+import SignUpScene
 import TDFoundation
 import TimerScene
 
-extension TimerSceneSceneBuilder.Dependency {
+// MARK: HOME SCENE
+extension HomeSceneBuilder.Dependency {
   @MainActor
-  public static let live = TimerSceneSceneBuilder.Dependency(
+  public static let live = HomeSceneBuilder.Dependency.init(
+    manageGroupSceneBuilder: ManageGroupSceneBuilder.init(dependency: .live),
+    editToDoSceneBuilder: EditToDoSceneBuilder(dependency: .live),
+    timerSceneBuilder: TimerSceneBuilder(dependency: .live)
+  )
+}
+
+// MARK: TIMER SCENE
+extension TimerSceneBuilder.Dependency {
+  @MainActor
+  public static let live = TimerSceneBuilder.Dependency(
     timerWorker: TimerSceneWorker.live,
     storageWorker: TimerStorageWorker.live,
     notificationManager: NotificationManager.shared,
@@ -29,12 +45,32 @@ extension TimerStorageWorker {
   )
 }
 
+// MARK: SHARE GARDEN SCENE
 extension ShareGardenSceneBuilder.Dependency {
   public static let live = ShareGardenSceneBuilder.Dependency.init(
-    shareGardenSceneWorker: ShareGardenSceneWorker.live
+    shareGardenSceneWorker: ShareGardenSceneWorker(httpClient: HTTPClient.live)
   )
 }
 
-extension ShareGardenSceneWorker {
-  static let live = ShareGardenSceneWorker.init(httpClient: HTTPClient.live)
+// MARK: MANAGE GROUP SCENE
+extension ManageGroupSceneBuilder.Dependency {
+  static let live = ManageGroupSceneBuilder.Dependency.init(
+    manageGroupWorker: ManageGroupWorker(httpClient: HTTPClient.live),
+    postGroupSceneBuilder: PostGroupSceneBuilder.init(dependency: .live)
+  )
+}
+
+// MARK: POST GROUP SCENE
+extension PostGroupSceneBuilder.Dependency {
+  static let live = PostGroupSceneBuilder.Dependency.init(postGroupWorker: PostGroupWorker())
+}
+
+// MARK: EDIT TODO SCENE
+extension EditToDoSceneBuilder.Dependency {
+  static let live = EditToDoSceneBuilder.Dependency.init(editToDoWorker: EditToDoWorker(httpClient: HTTPClient.live))
+}
+
+// MARK: SIGN UP SCENE
+extension SignUpSceneBuilder.Dependency {
+  static let live = SignUpSceneBuilder.Dependency.init(signUpWorker: SignUpWorker(httpClient: HTTPClient.live))
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Package.swift
@@ -19,7 +19,10 @@ let package = Package(
   ],
   dependencies: [
     Package.Dependency.package(path: "../ToDoGardenUI"),
-    Package.Dependency.package(path: "../TDUtility")
+    Package.Dependency.package(path: "../TDUtility"),
+    Package.Dependency.package(path: "../ManageGroupScene"),
+    Package.Dependency.package(path: "../EditToDoScene"),
+    Package.Dependency.package(path: "../TimerScene")
   ],
   targets: [
     Target.target(
@@ -54,6 +57,18 @@ let package = Package(
         Target.Dependency.product(
           name: "ToDoGardenUIResource",
           package: "ToDoGardenUI"
+        ),
+        Target.Dependency.product(
+          name: "ManageGroupScene",
+          package: "ManageGroupScene"
+        ),
+        Target.Dependency.product(
+          name: "EditToDoScene",
+          package: "EditToDoScene"
+        ),
+        Target.Dependency.product(
+          name: "TimerScene",
+          package: "TimerScene"
         )
       ]
     )

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneBuilder.swift
@@ -7,19 +7,33 @@
 
 import Foundation
 
+import EditToDoSceneAPI
 import HomeSceneAPI
+import ManageGroupSceneAPI
+import TimerSceneAPI
 
 @MainActor
 public struct HomeSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
-    public init() {
+    let manageGroupSceneBuilder: ManageGroupSceneBuildable
+    let editToDoSceneBuilder: EditToDoSceneBuildable
+    let timerSceneBuilder: TimerSceneBuildable
+    
+    public init(
+      manageGroupSceneBuilder: ManageGroupSceneBuildable,
+      editToDoSceneBuilder: EditToDoSceneBuildable,
+      timerSceneBuilder: TimerSceneBuildable
+    ) {
+      self.manageGroupSceneBuilder = manageGroupSceneBuilder
+      self.editToDoSceneBuilder = editToDoSceneBuilder
+      self.timerSceneBuilder = timerSceneBuilder
     }
   }
   
   private let dependency: Dependency
   
-  public init(dependency: Dependency = Dependency()) {
+  public init(dependency: Dependency) {
     self.dependency = dependency
   }
 }
@@ -44,7 +58,11 @@ extension HomeSceneBuilder {
   private func configureVIPCycle(for viewController: HomeSceneViewController) -> HomeSceneViewController {
     let interactor = HomeSceneInteractor()
     let presenter = HomeScenePresenter()
-    let router = HomeSceneRouter()
+    let router = HomeSceneRouter(
+      manageGroupSceneBuilder: self.dependency.manageGroupSceneBuilder,
+      editToDoSceneBuilder: self.dependency.editToDoSceneBuilder,
+      timerSceneBuilder: self.dependency.timerSceneBuilder
+    )
     viewController.interactor = interactor
     viewController.router = router
     interactor.presenter = presenter

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneRouter.swift
@@ -66,18 +66,9 @@ extension HomeSceneRouter: HomeSceneRoutingLogic {
 // MARK: - Declare Payload for scene
 struct EditToDoScenePayload: EditToDoScenePayloadable {
   var toDoId: UUID
-  
-  init(toDoId: UUID) {
-    self.toDoId = toDoId
-  }
 }
 
 struct TimerScenePayload: TimerScenePayloadable {
   var groupId: String
   var groupName: String
-  
-  init(groupId: String, groupName: String) {
-    self.groupId = groupId
-    self.groupName = groupName
-  }
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneRouter.swift
@@ -7,7 +7,14 @@
 
 import Foundation
 
+import EditToDoSceneAPI
+import ManageGroupSceneAPI
+import TimerSceneAPI
+
 protocol HomeSceneRoutingLogic {
+  @MainActor func routeToManageGroupScene()
+  @MainActor func routeToEditToDoScene(toDoId: UUID)
+  @MainActor func routeToTimerScene(groupId: String, groupName: String)
 }
 
 protocol HomeSceneDataPassing {
@@ -17,14 +24,60 @@ protocol HomeSceneDataPassing {
 final class HomeSceneRouter: HomeSceneDataPassing {
   weak var viewController: HomeSceneViewController?
   var dataStore: (any HomeSceneDataStore)?
+  private let manageGroupSceneBuilder: ManageGroupSceneBuildable
+  private let editToDoSceneBuilder: EditToDoSceneBuildable
+  private let timerSceneBuilder: TimerSceneBuildable
   
-  init() {
+  init(
+    manageGroupSceneBuilder: ManageGroupSceneBuildable,
+    editToDoSceneBuilder: EditToDoSceneBuildable,
+    timerSceneBuilder: TimerSceneBuildable
+  ) {
+    self.manageGroupSceneBuilder = manageGroupSceneBuilder
+    self.editToDoSceneBuilder = editToDoSceneBuilder
+    self.timerSceneBuilder = timerSceneBuilder
   }
 }
 
 // MARK: - Routing
 
 extension HomeSceneRouter: HomeSceneRoutingLogic {
+  func routeToManageGroupScene() {
+    let destinationViewController = self.manageGroupSceneBuilder.build()
+    
+    self.viewController?.navigationController?.pushViewController(destinationViewController, animated: true)
+  }
+  
+  func routeToEditToDoScene(toDoId: UUID) {
+    let payload = EditToDoScenePayload(toDoId: toDoId)
+    let destinationViewController = self.editToDoSceneBuilder.build(with: payload)
+    
+    self.viewController?.navigationController?.pushViewController(destinationViewController, animated: true)
+  }
+  
+  func routeToTimerScene(groupId: String, groupName: String) {
+    let payload = TimerScenePayload(groupId: groupId, groupName: groupName)
+    let destinationViewController = self.timerSceneBuilder.build(with: payload)
+    
+    self.viewController?.navigationController?.pushViewController(destinationViewController, animated: true)
+  }
 }
 
 // MARK: - Declare Payload for scene
+struct EditToDoScenePayload: EditToDoScenePayloadable {
+  var toDoId: UUID
+  
+  init(toDoId: UUID) {
+    self.toDoId = toDoId
+  }
+}
+
+struct TimerScenePayload: TimerScenePayloadable {
+  var groupId: String
+  var groupName: String
+  
+  init(groupId: String, groupName: String) {
+    self.groupId = groupId
+    self.groupName = groupName
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -49,14 +49,12 @@ open class HomeSceneViewController: UIViewController, HomeSceneViewControllable 
     self.setupViews()
   }
   
-  override func viewIsAppearing(_ animated: Bool) {
+  open override func viewIsAppearing(_ animated: Bool) {
     super.viewWillAppear(animated)
     self.navigationController?.navigationBar.isHidden = true
   }
-}
-
-extension HomeSceneViewController {
-  private func setBottomSheet() {
+  
+  open func setBottomSheet() {
     let toDoListViewContainer = ToDoListViewContainer()
     self.todoListView = toDoListViewContainer.toDoListView
     let bottomSheet = BottomSheet()

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -49,7 +49,14 @@ open class HomeSceneViewController: UIViewController, HomeSceneViewControllable 
     self.setupViews()
   }
   
-  open func setBottomSheet() {
+  override func viewIsAppearing(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    self.navigationController?.navigationBar.isHidden = true
+  }
+}
+
+extension HomeSceneViewController {
+  private func setBottomSheet() {
     let toDoListViewContainer = ToDoListViewContainer()
     self.todoListView = toDoListViewContainer.toDoListView
     let bottomSheet = BottomSheet()
@@ -69,6 +76,7 @@ extension HomeSceneViewController {
     self.setHomeHeaderView()
     self.setCalendarView()
     self.setBottomSheet()
+    self.setManageGroupButtonTapped()
   }
   
   private func setHomeHeaderView() {
@@ -111,6 +119,12 @@ extension HomeSceneViewController {
         )
       ]
     )
+  }
+  
+  private func setManageGroupButtonTapped() {
+    self.homeHeaderView.manageGroupButtonTapped = UIAction(handler: { [weak self] _ in
+      self?.router?.routeToManageGroupScene()
+    })
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneBuilder.swift
@@ -37,11 +37,10 @@ extension ManageGroupSceneBuilder: ManageGroupSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
-  public func build(with payload: ManageGroupScenePayloadable?) -> ManageGroupViewControllable {
+  public func build() -> ManageGroupViewControllable {
     let manageGroupSceneViewController = self.configureVIPCycle(
       for: ManageGroupViewController()
     )
-    self.setPayload(for: manageGroupSceneViewController, with: payload ?? nil )
     
     return manageGroupSceneViewController
   }
@@ -66,13 +65,5 @@ extension ManageGroupSceneBuilder {
     router.dataStore = interactor
     
     return viewController
-  }
-  
-  /// ViewController에 런타임 파라미터 `payload`를 설정합니다.
-  /// - Parameters:
-  ///   - viewController: 런타임 의존성을 설정할 ViewController 객체입니다.
-  ///   - payload: 런타임에 전달할 의존성입니다.
-  private func setPayload(for viewController: ManageGroupViewController, with payload: ManageGroupScenePayloadable?) {
-    // viewController.router?.dataStore?.name = payload.name
   }
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneAPI/ManageGroupSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneAPI/ManageGroupSceneBuildable.swift
@@ -16,5 +16,5 @@ public protocol ManageGroupSceneBuildable {
   ///  VIP Cycle, 런타임 파라미터가 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 파라미터입니다.
   /// - Returns: 런타임 파라미터, VIP Cycle이 설정된 ViewController가 반환되도록 구현합니다.
-  func build(with payload: ManageGroupScenePayloadable?) -> ManageGroupViewControllable
+  func build() -> ManageGroupViewControllable
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneBuilder.swift
@@ -4,7 +4,7 @@ import TDFoundation
 import TimerSceneAPI
 
 @MainActor
-public struct TimerSceneSceneBuilder {
+public struct TimerSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
     let timerWorker: TimerSceneWorkable
@@ -32,7 +32,7 @@ public struct TimerSceneSceneBuilder {
   }
 }
 
-extension TimerSceneSceneBuilder: TimerSceneSceneBuildable {
+extension TimerSceneBuilder: TimerSceneBuildable {
   ///  VIP Cycle, 런타임 의존성이 설정된 ViewController 인스턴스를 반환하는 함수입니다.
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
@@ -43,7 +43,7 @@ extension TimerSceneSceneBuilder: TimerSceneSceneBuildable {
   }
 }
 
-extension TimerSceneSceneBuilder {
+extension TimerSceneBuilder {
   /// VIP Cycle을 설정합니다.
   /// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
@@ -350,7 +350,7 @@ import HTTPClient
     ),
     timerStorage: TimerStorage.live
   )
-  let viewController = TimerSceneSceneBuilder(
+  let viewController = TimerSceneBuilder(
     dependency: .init(
       timerWorker: timerWorker,
       storageWorker: storageWorker,

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerSceneAPI/TimerSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerSceneAPI/TimerSceneBuildable.swift
@@ -9,7 +9,7 @@ public protocol TimerScenePayloadable {
 }
 
 @MainActor
-public protocol TimerSceneSceneBuildable {
+public protocol TimerSceneBuildable {
 	///  VIP Cycle, 런타임 파라미터가 설정된 ViewController 인스턴스를 반환하는 함수입니다.
 	/// - Parameter payload: 런타임에 전달받아야 하는 파라미터입니다.
 	/// - Returns: 런타임 파라미터, VIP Cycle이 설정된 ViewController가 반환되도록 구현합니다.


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #856 
## 🎉 변경 사항
- 그룹관리. 투두편집, 타이머 씬을 홈씬에 연결합니다. 
- 앱코어에서 디펜던시 주입시 가독성확보를 위한 live객체 선언 
- 파일명 수정 / 불필요한 코드 제거 등이 있었습니다. 
## 📌 PR Point
### UI가 표시되면 바로 연결할 수 있도록 해놨습니다. 현재 그룹 관리에 대한 UI는 준비되어 있어서 그룹관리 -> 그룹편집 및 생성 만 시뮬레이터로 확인가능합니다.
### 연동된 API 잘 동작합니다. 
![Simulator Screen Recording - iPhone 16 - 2025-03-13 at 12 53 35](https://github.com/user-attachments/assets/7bb26da2-88e4-4fc2-a62f-2762cc7fce45)


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?