### PR TITLE
가이드씬 : 홈화면을 제외한 모든 화면 추가 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/CommonViews/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/CommonViews/Package.swift
@@ -12,14 +12,18 @@ let package = Package(
   ],
   dependencies: [
     .package(path: "../ToDoGardenUI"),
-    .package(name: "ManageGroupScene", path: "./ManageGroupScene")
+    .package(name: "ManageGroupScene", path: "./ManageGroupScene"),
+    .package(name: "ShareGardenScene", path: "./ShareGardenScene"),
+    .package(name: "EditToDoScene", path: "./EditToDoScene")
   ],
   targets: [
     .target(
       name: "CommonViews",
       dependencies: [
         .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
-        .product(name: "ManageGroupScene", package: "ManageGroupScene")
+        .product(name: "ManageGroupScene", package: "ManageGroupScene"),
+        .product(name: "ShareGardenScene", package: "ShareGardenScene"),
+        .product(name: "EditToDoScene", package: "EditToDoScene")
       ]
     )
   ]

--- a/ToDo-Garden/ToDo-Garden/CommonViews/Sources/CommonViews/BaseContentsBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/CommonViews/Sources/CommonViews/BaseContentsBuilder.swift
@@ -1,5 +1,10 @@
 import UIKit
 
+import EditToDoScene
+import ShareGardenScene
+import ShareGardenSceneAPI
+
+// swiftlint:disable all
 public struct BaseContent {
   public var viewController: UIViewController
   public var transparentRegionsTask: [() -> DimmingView.TransparentRegion]
@@ -21,49 +26,221 @@ extension BaseContentsBuilder {
       []
     },
     groupManagement: {
-      let viewControllers = [
-        ManageGroupViewControllerForGuide(),
-        ManageGroupViewControllerForGuide(),
-        ManageGroupViewControllerForGuide(isEditMode: true)
-      ]
-      
-      let navigationControllers = viewControllers.map { viewController in
-        let naviController = UINavigationController(rootViewController: viewController)
-        naviController.view.preservesSuperviewLayoutMargins = true
-        naviController.additionalSafeAreaInsets = UIEdgeInsets(
-          top: Constants.safeAreaTopInset,
-          left: 0,
-          bottom: 0,
-          right: 0
-        )
-        
-        return naviController
-      }
-      return [
-        BaseContent(
-          viewController: navigationControllers[0], 
-          transparentRegionsTask: [viewControllers[0].getTableViewTransparentRegion]
-        ),
-        BaseContent(
-          viewController: navigationControllers[1], 
-          transparentRegionsTask: [viewControllers[1].getFooterViewTransparentRegion]
-        ),
-        BaseContent(
-          viewController: navigationControllers[2], 
-          transparentRegionsTask: [
-            viewControllers[2].getTableViewTransparentRegion,
-            viewControllers[1].getRightBarButtonTransparentRegion
-          ]
-        )
-      ]
+      return createGroupManagementContents()
     },
     todoEdit: {
-      []
+      return createTodoEditContents()
     },
     shareTab: {
-      []
+      return createShareTabContents()
     }
   )
+}
+
+// MARK: - Group Management
+private func createGroupManagementContents() -> [BaseContent] {
+  let viewControllers = createGroupManagementViewControllers()
+  let navigationControllers = createNavigationControllers(from: viewControllers)
+  
+  let normalTableViewRegionTask = createNormalTableViewRegionTask(for: viewControllers[0])
+  let footerRegionTask = createFooterRegionTask(for: viewControllers[0])
+  let rightButtonRegionTask = createRightButtonRegionTask(for: viewControllers[1])
+  let editTableViewRegionTask = createEditTableViewRegionTask(for: viewControllers[2])
+  
+  return [
+    BaseContent(viewController: navigationControllers[0], transparentRegionsTask: [normalTableViewRegionTask]),
+    BaseContent(viewController: navigationControllers[1], transparentRegionsTask: [footerRegionTask]),
+    BaseContent(viewController: navigationControllers[2], transparentRegionsTask: [rightButtonRegionTask, editTableViewRegionTask])
+  ]
+}
+
+private func createGroupManagementViewControllers() -> [ManageGroupViewControllerForGuide] {
+  return [
+    ManageGroupViewControllerForGuide(),
+    ManageGroupViewControllerForGuide(),
+    ManageGroupViewControllerForGuide(isEditMode: true)
+  ]
+}
+
+private func createNormalTableViewRegionTask(for viewController: ManageGroupViewControllerForGuide) -> () -> DimmingView.TransparentRegion {
+  return {
+    let cellRect = viewController.getTableViewCell().frame(in: viewController.view)
+    let rect = CGRect(
+      x: Int(cellRect.minX),
+      y: Int(cellRect.minY),
+      width: Int(cellRect.width),
+      height: Int(cellRect.height) * 3
+    ).offsetBy(dx: 0.0, dy: Constants.safeAreaTopInset + calculateYOffset(vc: viewController))
+    
+    
+    return DimmingView.TransparentRegion(rect: rect, cornerRadius: 18.0)
+  }
+}
+
+private func createFooterRegionTask(for viewController: ManageGroupViewControllerForGuide) -> () -> DimmingView.TransparentRegion {
+  return {
+    let cellRect = viewController.footerView.frame(in: viewController.view)
+    let rect = CGRect(x: Int(cellRect.minX), y: Int(cellRect.midY), width: Int(cellRect.width), height: Int(cellRect.height))
+    
+    return DimmingView.TransparentRegion(rect: rect, cornerRadius: 14.0)
+  }
+}
+
+private func createRightButtonRegionTask(for viewController: ManageGroupViewControllerForGuide) -> () -> DimmingView.TransparentRegion {
+  return {
+    let buttonRect = viewController.getRightBarButton().frame(in: viewController.view)
+    let rect = CGRect(x: Int(buttonRect.minX), y: Int(buttonRect.minY), width: Int(buttonRect.width), height: Int(buttonRect.height)).insetBy(dx: -5.0, dy: -5.0)
+    
+    return DimmingView.TransparentRegion(rect: rect.offsetBy(dx: -(buttonRect.width / 2) - 1, dy: Constants.safeAreaTopInset1Minus), cornerRadius: 8.0)
+  }
+}
+
+private func createEditTableViewRegionTask(for viewController: ManageGroupViewControllerForGuide) -> () -> DimmingView.TransparentRegion {
+  return {
+    let cellRect = viewController.getTableViewCell().frame(in: viewController.view)
+    let rect = CGRect(
+      x: Int(cellRect.minX),
+      y: Int(cellRect.minY),
+      width: Int(cellRect.width),
+      height: Int(cellRect.height) * 3
+    ).offsetBy(dx: 0.0, dy: Constants.safeAreaTopInset + calculateYOffset(vc: viewController))
+    
+    return DimmingView.TransparentRegion(rect: rect, cornerRadius: 18.0)
+  }
+}
+
+// MARK: - Todo Edit
+private func createTodoEditContents() -> [BaseContent] {
+  let viewControllers = [
+    UINavigationController(rootViewController: UIViewController(nibName: nil, bundle: nil)),
+    UINavigationController(rootViewController: EditToDoViewController()),
+    UINavigationController(rootViewController: EditToDoViewController())
+  ]
+  
+  var transparentRegionsTasks: [[() -> DimmingView.TransparentRegion]] = []
+  
+  viewControllers.enumerated().forEach { (index, viewController) in
+    let task = createTransparentRegionsTask(for: viewController, index: index)
+    transparentRegionsTasks.append(task)
+  }
+  
+  return [
+    BaseContent(viewController: viewControllers[0], transparentRegionsTask: transparentRegionsTasks[0]),
+    BaseContent(viewController: viewControllers[1], transparentRegionsTask: transparentRegionsTasks[1]),
+    BaseContent(viewController: viewControllers[2], transparentRegionsTask: transparentRegionsTasks[2])
+  ]
+}
+
+// MARK: - Share Tab
+@MainActor
+private func createShareTabContents() -> [BaseContent] {
+  let mockDependency = MockFriendsGardenStore()
+  let viewControllers = [
+    ShareGardenSceneViewController(friendsGardenStore: mockDependency),
+    ShareGardenSceneViewController(friendsGardenStore: mockDependency)
+  ]
+  
+  let getProfileViewRegionTask = createProfileViewRegionTask(for: viewControllers[0], verticalOffset: Constants.safeAreaTopInset3)
+  let getShareButtonRegionTask = createShareButtonRegionTask(for: viewControllers[1], verticalOffset: Constants.safeAreaTopInset2)
+  
+  viewControllers.forEach { $0.setForGuide() }
+  
+  let navigationControllers = createNavigationControllers(from: viewControllers)
+  
+  return [
+    BaseContent(viewController: navigationControllers[0], transparentRegionsTask: [getProfileViewRegionTask]),
+    BaseContent(viewController: navigationControllers[1], transparentRegionsTask: [getShareButtonRegionTask])
+  ]
+}
+
+// MARK: - Helper Methods
+
+private func calculateYOffset(vc: UIViewController?) -> CGFloat {
+  guard let vc = vc, let navi = vc.navigationController else {
+    return 0.0
+  }
+  
+  let navigationBarHeight = navi.navigationBar.frame(in: vc.view).height
+  return navigationBarHeight
+}
+
+private func createNavigationControllers(from viewControllers: [UIViewController]) -> [UINavigationController] {
+  return viewControllers.map { viewController in
+    let naviController = UINavigationController(rootViewController: viewController)
+    naviController.view.preservesSuperviewLayoutMargins = true
+    naviController.navigationBar.isHidden = true
+    return naviController
+  }
+}
+
+private func createTransparentRegionsTask(for viewController: UIViewController, index: Int) -> [() -> DimmingView.TransparentRegion] {
+  guard let topVC = (viewController as? UINavigationController)?.topViewController else {
+    return []
+  }
+  
+  switch index {
+  case 0:
+    return [] // TODO: 홈화면 빵꾸영역 클로저 삽입
+  case 1:
+    guard let editToDoVC = topVC as? EditToDoViewController else { return [] }
+    editToDoVC.setForGuide(index: index)
+    return [
+      createTodoNameInputViewRegionTask(for: editToDoVC, in: topVC),
+      createGroupSelectionViewRegionTask(for: editToDoVC, in: topVC)
+    ]
+  case 2:
+    guard let editToDoVC = topVC as? EditToDoViewController else { return [] }
+    editToDoVC.setForGuide(index: index)
+    return [
+      createSegmentedControlRegionTask(for: editToDoVC, in: topVC),
+      createAlarmTimeViewRegionTask(for: editToDoVC, in: topVC)
+    ]
+  default:
+    return []
+  }
+}
+private func createTodoNameInputViewRegionTask(for editToDoVC: EditToDoViewController, in viewController: UIViewController) -> () -> DimmingView.TransparentRegion {
+  return {
+    let rect = editToDoVC.getToDoNameInputView().frame(in: viewController.view).offsetBy(dx: 0.0, dy: Constants.safeAreaTopInset2Minus + calculateYOffset(vc: viewController)).insetBy(dx: -9.0, dy: -6)
+    return DimmingView.TransparentRegion(rect: rect, cornerRadius: 10.0)
+  }
+}
+
+private func createGroupSelectionViewRegionTask(for editToDoVC: EditToDoViewController, in viewController: UIViewController) -> () -> DimmingView.TransparentRegion {
+  return {
+    let rect = editToDoVC.getGroupSelectionView().frame(in: viewController.view).offsetBy(dx: 0.0, dy: Constants.safeAreaTopInset2Minus + calculateYOffset(vc: viewController)).insetBy(dx: 5.0, dy: -5)
+    return DimmingView.TransparentRegion(rect: rect, cornerRadius: 10.0)
+  }
+}
+
+private func createSegmentedControlRegionTask(for editToDoVC: EditToDoViewController, in viewController: UIViewController) -> () -> DimmingView.TransparentRegion {
+  return {
+    let rect = editToDoVC.getSegmentedControl().frame(in: viewController.view).offsetBy(dx: 0.0, dy: Constants.safeAreaTopInset1Minus + calculateYOffset(vc: viewController)).insetBy(dx: -5, dy: -5)
+    return DimmingView.TransparentRegion(rect: rect, cornerRadius: 8.0)
+  }
+}
+
+private func createAlarmTimeViewRegionTask(for editToDoVC: EditToDoViewController, in viewController: UIViewController) -> () -> DimmingView.TransparentRegion {
+  return {
+    let rect = editToDoVC.getAlarmTimeView().frame(in: viewController.view).offsetBy(dx: 0.0, dy: Constants.safeAreaTopInset1Minus + calculateYOffset(vc: viewController)).insetBy(dx: -5, dy: -5)
+    return DimmingView.TransparentRegion(rect: rect, cornerRadius: 15.0)
+  }
+}
+
+private func createProfileViewRegionTask(for viewController: ShareGardenSceneViewController, verticalOffset: CGFloat) -> () -> DimmingView.TransparentRegion {
+  return {
+    let frame = viewController.getMyProfileView().frame(in: viewController.view)
+    let rect = frame.offsetBy(dx: .zero, dy: verticalOffset).insetBy(dx: 10.0, dy: .zero)
+    return DimmingView.TransparentRegion(rect: rect, cornerRadius: 18.0)
+  }
+}
+
+private func createShareButtonRegionTask(for viewController: ShareGardenSceneViewController, verticalOffset: CGFloat) -> () -> DimmingView.TransparentRegion {
+  return {
+    let frame = viewController.getShareButton().frame(in: viewController.view)
+    let rect = frame.offsetBy(dx: .zero, dy: verticalOffset + 2).insetBy(dx: -2.5, dy: -2.5)
+    return DimmingView.TransparentRegion(rect: rect, cornerRadius: 7.5)
+  }
 }
 
 // MARK: - Backport: 필요하면 공용 파일로 옮기겠습니다.
@@ -76,3 +253,5 @@ extension UIView {
     }
   }
 }
+
+// swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/CommonViews/Sources/CommonViews/Constants.swift
+++ b/ToDo-Garden/ToDo-Garden/CommonViews/Sources/CommonViews/Constants.swift
@@ -12,6 +12,22 @@ enum Constants {
       let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) else {
       return 0
     }
-    return keyWindow.safeAreaInsets.top
+    return keyWindow.safeAreaInsets.top - 4.0
+  }
+  
+  static var safeAreaTopInset1: CGFloat {
+    return safeAreaTopInset + 1.0
+  }
+  static var safeAreaTopInset2: CGFloat {
+    return safeAreaTopInset + 2.0
+  }
+  static var safeAreaTopInset3: CGFloat {
+    return safeAreaTopInset + 3.0
+  }
+  static var safeAreaTopInset1Minus: CGFloat {
+    return safeAreaTopInset - 1.0
+  }
+  static var safeAreaTopInset2Minus: CGFloat {
+    return safeAreaTopInset - 2.0
   }
 }

--- a/ToDo-Garden/ToDo-Garden/CommonViews/Sources/CommonViews/ManageGroupViewControllerForGuide.swift
+++ b/ToDo-Garden/ToDo-Garden/CommonViews/Sources/CommonViews/ManageGroupViewControllerForGuide.swift
@@ -76,34 +76,15 @@ final class ManageGroupViewControllerForGuide: ManageGroupViewController {
 
 // MARK: - Regions with Offset
 extension ManageGroupViewControllerForGuide {
-  func getTableViewTransparentRegion() -> DimmingView.TransparentRegion {
-    let yOffset = self.calculateYOffset()
-    let rect = self.groupListTableView.rect(forSection: .zero)
-      .offsetBy(dx: 5.0, dy: yOffset)
-      .insetBy(dx: 0, dy: 25.0)
+  func getTableViewCell() -> UIView {
+    guard let cell = self.groupListTableView.cellForRow(at: IndexPath(row: 0, section: 0)) else { return UIView() }
     
-    return DimmingView.TransparentRegion(rect: rect, cornerRadius: 18.0)
+    return cell
   }
   
-  func getFooterViewTransparentRegion() -> DimmingView.TransparentRegion {
-    let yOffset = self.calculateYOffset()
-    let rect = self.footerView.frame(in: self.view).offsetBy(dx: 0.0, dy: yOffset)
-    return DimmingView.TransparentRegion(rect: rect, cornerRadius: 15.0)
-  }
-  
-  func getRightBarButtonTransparentRegion() -> DimmingView.TransparentRegion {
-    let navigationBarHeight = self.navigationController?.navigationBar.frame(in: self.view).height ?? 0
-    let yOffset = self.calculateYOffset() - navigationBarHeight
-    let rect = self.rightBarButton.customView?
-      .frame(in: self.view)
-      .offsetBy(dx: -16.5, dy: yOffset)
-      .insetBy(dx: -10, dy: -5)
+  func getRightBarButton() -> UIView {
+    guard let button = self.rightBarButton.customView else { return UIView() }
     
-    return DimmingView.TransparentRegion(rect: rect ?? CGRect.zero, cornerRadius: 10.0)
-  }
-  
-  private func calculateYOffset() -> CGFloat {
-    let navigationBarHeight = self.navigationController?.navigationBar.frame(in: self.view).height ?? 0
-    return Constants.safeAreaTopInset + navigationBarHeight
+    return button
   }
 }

--- a/ToDo-Garden/ToDo-Garden/CommonViews/Sources/CommonViews/MockFriendsGardenStore.swift
+++ b/ToDo-Garden/ToDo-Garden/CommonViews/Sources/CommonViews/MockFriendsGardenStore.swift
@@ -1,0 +1,26 @@
+//
+//  MockFriendsGardenStore.swift
+//  CommonViews
+//
+//  Created by SONG on 3/14/25.
+//
+import Foundation
+
+import ShareGardenScene
+import ShareGardenSceneEntity
+import ToDoGardenUIComponent
+
+class MockFriendsGardenStore: FriendsGardenStore {
+  func fetch(
+    by id: ShareGardenSceneEntity.ShareGardenScene.FriendsGarden.ID
+  ) -> ShareGardenSceneEntity.ShareGardenScene.FriendsGarden? {
+    ShareGardenSceneEntity.ShareGardenScene.FriendsGarden(
+      nickname: "김첨지",
+      focusStreakDays: Int.zero,
+      pomodoroRecords: PomodoroRecordCollection())
+  }
+  
+  func delete(by id: ShareGardenSceneEntity.ShareGardenScene.FriendsGarden.ID, completion: @escaping () -> Void) {
+    return
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -289,3 +289,26 @@ extension EditToDoView {
     )
   }
 }
+
+extension EditToDoView {
+  func setForGuide() {
+    let text = "영어독해"
+    self.toDoNameInputView.setBeginEditing(with: text)
+    self.toDoNameInputView.changeBottomLine(color: UIColor.toDoGardenYellow)
+    self.groupSelectionView.updateGroup(
+      current: GroupSelectionViewItem(
+        groupId: UUID(),
+        groupName: text,
+        groupColor: UIColor.toDoGardenYellow
+      )
+    )
+  }
+  
+  func getToDoNameInputView() -> UIView {
+    return self.toDoNameInputView
+  }
+  
+  func getGroupSelectionView() -> UIView {
+    return self.groupSelectionView
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -27,7 +27,7 @@ protocol EditToDoDisplayLogic: AnyObject {
   func displayChangedAlarmTime(viewModel: EditToDo.ChangeAlarmTime.ViewModel)
 }
 
-final class EditToDoViewController: UIViewController, EditToDoViewControllable {
+final public class EditToDoViewController: UIViewController, EditToDoViewControllable {
   private(set) var editToDoSegmentedControl: EditToDoSegmentedControl
   private(set) var editModeScrollView: UIScrollView
   private(set) var editToDoView: EditToDoView
@@ -43,7 +43,7 @@ final class EditToDoViewController: UIViewController, EditToDoViewControllable {
 
   // MARK: - Object lifecycle
 
-  init() {
+  public init() {
     self.editToDoSegmentedControl = EditToDoSegmentedControl()
     self.editModeScrollView = UIScrollView()
     self.editToDoView = EditToDoView()
@@ -56,23 +56,23 @@ final class EditToDoViewController: UIViewController, EditToDoViewControllable {
   }
 
   @available(*, unavailable)
-  required init?(coder: NSCoder) {
+  public required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
 
   // MARK: - View lifecycle
 
-  override func viewDidLoad() {
+  public override func viewDidLoad() {
     super.viewDidLoad()
     self.setup()
   }
 
-  override func viewIsAppearing(_ animated: Bool) {
+  public override func viewIsAppearing(_ animated: Bool) {
     super.viewIsAppearing(animated)
     self.interactor?.prepareSceneData()
   }
 
-  override func viewDidLayoutSubviews() {
+  public override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
     // MARK: 투두 수정화면 진입시 투두 수정 모드로 변경합니다.
     self.scrollToEditToDoMode = {
@@ -201,7 +201,7 @@ extension EditToDoViewController: EditToDoDisplayLogic {
 // MARK: ToDoGardenAlertController Delegate Functions
 
 extension EditToDoViewController: ToDoGardenAlertControllerDelegate {
-  func handleButtonAction(
+  public func handleButtonAction(
     _ buttonType: ToDoGardenUIConstant.Constant.ToDoGardenAlertView.Content.ButtonActionType
   ) {
     self.closeAlert()
@@ -256,7 +256,7 @@ extension EditToDoViewController: EditToDoView.EditToDoViewDelegate {
 // MARK: ScrollView Delegate Functions
 
 extension EditToDoViewController: UIScrollViewDelegate {
-  func scrollViewWillEndDragging(
+  public func scrollViewWillEndDragging(
     _ scrollView: UIScrollView,
     withVelocity velocity: CGPoint,
     targetContentOffset: UnsafeMutablePointer<CGPoint>
@@ -292,6 +292,37 @@ extension EditToDoViewController {
       ).build(with: EditToDoViewController.EditToDoScenePayload(toDoId: UUID()))
       self.navigationController?.pushViewController(editToDoViewController, animated: true)
     }
+  }
+}
+
+extension EditToDoViewController {
+  public func setForGuide(index: Int) {
+    switch index {
+    case 1:
+      self.editToDoSegmentedControl.selectedSegmentIndex = 1
+      self.editToDoView.setForGuide()
+    case 2:
+      self.editToDoSegmentedControl.selectedSegmentIndex = 0
+      self.editToDoScheduleView.setForGuide()
+    default:
+      break
+    }
+  }
+  
+  public func getToDoNameInputView() -> UIView {
+    return self.editToDoView.getToDoNameInputView()
+  }
+  
+  public func getGroupSelectionView() -> UIView {
+    return self.editToDoView.getGroupSelectionView()
+  }
+  
+  public func getSegmentedControl() -> UIView {
+    return self.editToDoSegmentedControl
+  }
+  
+  public func getAlarmTimeView() -> UIView {
+    return self.editToDoScheduleView.getAlarmTimeView()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoAlarmView.swift
@@ -170,6 +170,17 @@ extension EditToDoAlarmView {
   }
 }
 
+extension EditToDoAlarmView {
+  func setForGuide() {
+    self.enableAlarm()
+    self.alarmTimeSettingView.updateAlarmTime(with: "20:00")
+  }
+  
+  func getAlarmTimeView() -> UIView {
+    return self.alarmTimeSettingView
+  }
+}
+
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoRepetitionView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoRepetitionView.swift
@@ -163,3 +163,10 @@ extension EditToDoRepetitionView {
     )
   }
 }
+
+extension EditToDoRepetitionView {
+  func setForGuide() {
+    self.repeatOnlyTodayView.setDeSelected()
+    self.repeatOtherDaysView.updateDate(startDate: "2025.05.21", endDate: "2025.07.10")
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoScheduleView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoScheduleView.swift
@@ -140,6 +140,17 @@ extension EditToDoScheduleView {
   }
 }
 
+extension EditToDoScheduleView {
+  func setForGuide() {
+    self.editToDoAlarmView.setForGuide()
+    self.editToDoRepetitionView.setForGuide()
+  }
+  
+  func getAlarmTimeView() -> UIView {
+    return self.editToDoAlarmView.getAlarmTimeView()
+  }
+}
+
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
   ],
   dependencies: [
     .package(name: "TDFoundation", path: "../TDFoundation"),
-    .package(name: "ToDoGardenUI", path: "../ToDoGardenUI")
+    .package(name: "ToDoGardenUI", path: "../ToDoGardenUI"),
+    .package(name: "GuideScene", path: "../GuideScene")
   ],
   targets: [
     .target(
@@ -41,7 +42,8 @@ let package = Package(
         .product(name: "TDFoundation", package: "TDFoundation"),
         .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI"),
         .product(name: "ToDoGardenUIComponent", package: "ToDoGardenUI"),
-        .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI")
+        .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI"),
+        .product(name: "GuideScene", package: "GuideScene")
       ]
     ),
     .testTarget(

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingRouter.swift
@@ -7,9 +7,11 @@
 
 import Foundation
 
+import GuideScene
 import SettingSceneAPI
 
 protocol SettingRoutingLogic {
+  func routeToGuideScene()
 }
 
 protocol SettingDataPassing {
@@ -19,11 +21,18 @@ protocol SettingDataPassing {
 class SettingRouter: SettingDataPassing {
 	weak var viewController: SettingViewController?
 	var dataStore: SettingDataStore?
+  
 }
 
 // MARK: - Routing
 
 extension SettingRouter: SettingRoutingLogic {
+  func routeToGuideScene() {
+    // TODO: GuideDetailViewController는 임시로 연결해놓았고, GuideDetailViewController로 진입할 수 있는 VC로 연결되어야함
+    let guideSceneViewController = GuideDetailViewController(.todoEdit)
+    guideSceneViewController.modalPresentationStyle = .fullScreen
+    self.viewController?.present(guideSceneViewController, animated: true)
+  }
 }
 
 // MARK: - Declare Payload for scene

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingSceneBuilder.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+import GuideScene
 import SettingSceneAPI
 
 @MainActor

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -124,6 +124,7 @@ extension SettingViewController {
     self.setupSubviewDeleagte()
     self.setupSettingCollectionView()
     self.setupSubviewsLayout()
+    self.setupButtonActions()
   }
 
   private func setupSettingLabel() {
@@ -202,6 +203,12 @@ extension SettingViewController {
     )
 
     return [userSettingSection, appSupportSection]
+  }
+  
+  private func setupButtonActions() {
+    self.userGuideButton.touchAction = { [weak self] in
+      self?.router?.routeToGuideScene()
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserGuideButton.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/UserGuideButton.swift
@@ -10,6 +10,8 @@ import UIKit
 import ToDoGardenUIResource
 
 final class UserGuideButton: UIStackView {
+  var touchAction: (() -> Void)?
+  
   init() {
     super.init(frame: CGRect.zero)
     self.setupUI()
@@ -29,6 +31,7 @@ extension UserGuideButton {
     self.setupToDoGardenLogoImageView()
     self.setupUserGuideLabel()
     self.setupRightForwardImage()
+    self.setupGestureRecognizer()
   }
 
   private func setupStackViewUI() {
@@ -83,6 +86,17 @@ extension UserGuideButton {
       for: NSLayoutConstraint.Axis.horizontal
     )
     self.addArrangedSubview(rightForwardImageView)
+  }
+  
+  private func setupGestureRecognizer() {
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.handleTap))
+    self.addGestureRecognizer(tapGesture)
+  }
+}
+
+extension UserGuideButton {
+  @objc private func handleTap() {
+    self.touchAction?()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/FriendsGardenDataStore.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/FriendsGardenDataStore.swift
@@ -10,7 +10,7 @@ import Foundation
 import ShareGardenSceneEntity
 
 @MainActor
-final class FriendsGardenDataStore {
+final public class FriendsGardenDataStore {
   private var friendsGardens: [ShareGardenScene.FriendsGarden] {
     didSet {
       self.continuation.yield(self.friendsGardens)
@@ -22,7 +22,7 @@ final class FriendsGardenDataStore {
     bufferingPolicy: AsyncStream.Continuation.BufferingPolicy.bufferingNewest(1)
   )
 
-  nonisolated init() {
+  nonisolated public init() {
     self.friendsGardens = []
   }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/Protocol/FriendsGardenStore.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/Protocol/FriendsGardenStore.swift
@@ -10,7 +10,7 @@ import Foundation
 import ShareGardenSceneEntity
 
 @MainActor
-protocol FriendsGardenStore: AnyObject {
+public protocol FriendsGardenStore: AnyObject {
   func fetch(by id: ShareGardenScene.FriendsGarden.ID) -> ShareGardenScene.FriendsGarden?
   func delete(by id: ShareGardenScene.FriendsGarden.ID, completion: @escaping () -> Void)
 }

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController+Constant.swift
@@ -9,9 +9,9 @@ import Foundation
 import struct UIKit.NSDirectionalEdgeInsets
 
 extension ShareGardenSceneViewController {
-  enum Constant {
+  public enum Constant {
     enum StringLiteral { }
-    enum Layout { }
+    public enum Layout { }
   }
 }
 
@@ -36,7 +36,7 @@ extension ShareGardenSceneViewController.Constant.StringLiteral {
 // MARK: - Layout
 
 extension ShareGardenSceneViewController.Constant.Layout {
-  static let topInset: CGFloat = 21
+  public static let topInset: CGFloat = 21
   
   enum SectionHeaderView {
     static let spacingRatio: CGFloat = 100 / 323

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import ShareGardenSceneAPI
 import ShareGardenSceneEntity
+import ToDoGardenUIComponent
 
 @MainActor
 protocol ShareGardenSceneDisplayLogic: AnyObject {
@@ -19,7 +20,7 @@ protocol ShareGardenSceneDisplayLogic: AnyObject {
   func stopShimmeringFriendsGardenList()
 }
 
-final class ShareGardenSceneViewController: UIViewController, ShareGardenSceneViewControllable {
+final public class ShareGardenSceneViewController: UIViewController, ShareGardenSceneViewControllable {
   
   // MARK: - VIP Properties
   
@@ -33,25 +34,25 @@ final class ShareGardenSceneViewController: UIViewController, ShareGardenSceneVi
   
   // MARK: - Object lifecycle
   
-  init(friendsGardenStore: FriendsGardenStore) {
+  public init(friendsGardenStore: FriendsGardenStore) {
     self.myGardenView = MyGardenView()
     self.friendsGardenView = FriendsGardenView(friendsGardenStore: friendsGardenStore)
     super.init(nibName: nil, bundle: nil)
   }
   
   @available(*, unavailable)
-  required init?(coder: NSCoder) {
+  required public init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
  
   // MARK: - View life cycle
-  override func viewDidLoad() {
+  public override func viewDidLoad() {
     super.viewDidLoad()
     self.setup()
     self.updateViewContents()
   }
  
-  override func viewDidDisappear(_ animated: Bool) {
+  public override func viewDidDisappear(_ animated: Bool) {
     super.viewDidDisappear(animated)
     self.cleanUpViewResources()
   }
@@ -170,6 +171,30 @@ extension ShareGardenSceneViewController {
       self.friendsGardenView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
       self.friendsGardenView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
     ])
+  }
+}
+
+extension ShareGardenSceneViewController {
+  public func setForGuide() {
+    self.view.isShimmering = false
+    let myGardenView = ShareGardenScene.RequestMyGarden.ViewModel(
+      nickname: "홍길동",
+      description: "형을 형이라 부르지 못한다.",
+      pomodoroRecords: PomodoroRecordCollection.fixedGardenView,
+      imageURL: nil
+    )
+    
+    self.myGardenView.update(viewModel: myGardenView)
+    self.friendsGardenView.displayFriendsGardenList([UUID()])
+    self.myGardenView.stopShimmeringAnimation()
+  }
+  
+  public func getMyProfileView() -> UIView {
+    return self.myGardenView.getMyProfileViewView()
+  }
+  
+  public func getShareButton() -> UIView {
+    return self.myGardenView.getShareButton()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -185,16 +185,12 @@ extension ShareGardenSceneViewController.MyGardenView {
       guard let imageURL = imageURL else { return }
       
       let image = try await Cache.shared.execute(id: imageURL)
-      self.profileInfoView.iconImage = try await Cache.shared.execute(id: imageURL)
+      self.profileInfoView.iconImage = image
     }
   }
   
   private func updateGardenView(with pomodoroRecordCollection: PomodoroRecordCollection) {
     self.gardenView.configure(with: pomodoroRecordCollection)
-  }
-  
-  private func stopShimmeringAnimation() {
-    self.profileInfoView.stopShimmering()
   }
 }
 
@@ -232,6 +228,20 @@ extension ShareGardenSceneViewController.MyGardenView {
       self.profileInfoView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
       self.profileInfoView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
     ])
+  }
+}
+
+extension ShareGardenSceneViewController.MyGardenView {
+  func stopShimmeringAnimation() {
+    self.profileInfoView.stopShimmering()
+  }
+  
+  func getMyProfileViewView() -> UIView {
+    return self.profileInfoView
+  }
+  
+  func getShareButton() -> UIView {
+    return self.sectionHeaderView.getShareButton()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/ShareGardenSceneViewController+SectionHeaderView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/ShareGardenSceneViewController+SectionHeaderView.swift
@@ -110,3 +110,9 @@ extension ShareGardenSceneViewController.SectionHeaderView {
     self.spacing = self.bounds.width * spacingRatio
   }
 }
+
+extension ShareGardenSceneViewController.SectionHeaderView {
+  func getShareButton() -> UIView {
+    return self.rightActionButton
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneEntity/StaticDataForGuide.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneEntity/StaticDataForGuide.swift
@@ -1,0 +1,38 @@
+//
+//  StaticDataForGuide.swift
+//  ShareGardenScene
+//
+//  Created by SONG on 3/14/25.
+//
+
+import Foundation
+
+import ToDoGardenUIComponent
+
+extension PomodoroRecordCollection {
+  public static let fixedGardenView: PomodoroRecordCollection = {
+    let calendar = Calendar.current
+    let today = Date()
+    
+    let fixedCounts: [Int] = [
+      3, 5, 12, 7, 10, 8, 1, 0, 4, 6, 9, 11, 13, 2, 15, 14, 7, 3, 8, 10,
+      5, 9, 6, 12, 11, 4, 1, 0, 14, 15, 3, 8, 7, 10, 5, 9, 6, 12, 11, 4,
+      2, 13, 0, 1, 15, 14, 3, 7, 8, 10, 5, 9, 6, 12, 11, 4, 1, 0, 14, 15,
+      3, 8, 7, 10, 5, 9, 6, 12, 11, 4, 2, 13, 0, 1, 15, 14, 3, 7, 8, 10,
+      5, 9, 6, 12, 11, 4, 1, 0, 14, 15, 3, 8, 7, 10, 5, 9, 6, 12, 11, 4,
+      2, 13, 0, 1, 15, 14, 3, 7, 8, 10, 5, 9, 6, 12, 11, 4, 1, 0, 14, 15,
+      3, 8, 7, 10, 5, 9, 6, 12, 11, 4, 2, 13, 0, 1, 15, 14, 3, 7, 8, 10
+    ]
+    
+    let records: [PomodoroRecord] = (0..<140).map { dayOffset in
+      guard let date = calendar.date(byAdding: .day, value: -dayOffset, to: today) else {
+        return PomodoroRecord(date: Date(), pomodoroCount: Int.zero)
+      }
+      
+      let pomodoroCount = fixedCounts[dayOffset % fixedCounts.count]
+      return PomodoroRecord(date: date, pomodoroCount: pomodoroCount)
+    }
+    
+    return PomodoroRecordCollection(pomodoroRecords: records)
+  }()
+}


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #870 
## 🎉 변경 사항
- 투두편집 추가 
- 공유하기 추가 
- 레이아웃 재조정 
- 가짜객체 생성 
## 📌 PR Point

### 각 화면별, 각 컴포넌트별 레이아웃을 정밀 조정했습니다. 
- 1~2픽셀 차이로 미묘한 어색함을 해결했습니다. 
- CommonViews.Constants의 safeAreaTopInset에서 확인할 수 있습니다. 

### 홈화면을 제외한 모든 화면을 완성시켰습니다. 기본적인 흐름은 아래와 같습니다. 
- 각 화면의 VC만 떼어와서 표시합니다. 
- 가이드씬에 필요한 초기상태를 setForGuide() 를 이용해서 설정합니다. 통신이 필요한 부분을 떼어내고, 가짜 UI를 표시합니다. 
- 하이라이트될 영역을 얻기 위해, 하이라이트될 뷰가 필요한데, 이는 get~~View() 메서드를 호출하여 얻습니다. 
- BaseContentsBuilder에서 모든것을 조립하여 표시합니다. 

| 그룹관리 | 투두편집 (홈화면 제외) | 공유하기 |
|---------|--------------------|---------|
| ![그룹관리](https://github.com/user-attachments/assets/35ba9ae6-5fc3-44a7-9d87-0ff7f76fafbb) | ![투두편집](https://github.com/user-attachments/assets/051f1e7f-352a-4c96-b26e-9db1fe34fd01) | ![공유하기](https://github.com/user-attachments/assets/1a32f804-e66d-4745-bffd-e4ebe4364029) |


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?