### PR TITLE
Imple home features - 버튼에 대한 동작 정의 

### DIFF
--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
@@ -21,6 +21,7 @@ import TimerScene
 extension HomeSceneBuilder.Dependency {
   @MainActor
   public static let live = HomeSceneBuilder.Dependency.init(
+    homeSceneWorker: HomeSceneWorker(httpClient: HTTPClient.live),
     manageGroupSceneBuilder: ManageGroupSceneBuilder.init(dependency: .live),
     editToDoSceneBuilder: EditToDoSceneBuilder(dependency: .live),
     timerSceneBuilder: TimerSceneBuilder(dependency: .live)

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneBuilder.swift
@@ -16,15 +16,18 @@ import TimerSceneAPI
 public struct HomeSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
+    let homeSceneWorker: HomeSceneWorkable
     let manageGroupSceneBuilder: ManageGroupSceneBuildable
     let editToDoSceneBuilder: EditToDoSceneBuildable
     let timerSceneBuilder: TimerSceneBuildable
     
     public init(
+      homeSceneWorker: HomeSceneWorkable,
       manageGroupSceneBuilder: ManageGroupSceneBuildable,
       editToDoSceneBuilder: EditToDoSceneBuildable,
       timerSceneBuilder: TimerSceneBuildable
     ) {
+      self.homeSceneWorker = homeSceneWorker
       self.manageGroupSceneBuilder = manageGroupSceneBuilder
       self.editToDoSceneBuilder = editToDoSceneBuilder
       self.timerSceneBuilder = timerSceneBuilder
@@ -56,7 +59,7 @@ extension HomeSceneBuilder {
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
   @MainActor
   private func configureVIPCycle(for viewController: HomeSceneViewController) -> HomeSceneViewController {
-    let interactor = HomeSceneInteractor()
+    let interactor = HomeSceneInteractor(homeSceneWorker: self.dependency.homeSceneWorker)
     let presenter = HomeScenePresenter()
     let router = HomeSceneRouter(
       manageGroupSceneBuilder: self.dependency.manageGroupSceneBuilder,

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -7,20 +7,65 @@
 
 import Foundation
 
+import HomeSceneAPI
+
 protocol HomeSceneDataStore {
 }
 
+@MainActor
 protocol HomeSceneBusinessLogic {
+  func fetchToDoList() async
+  func createToDo() async
+  func deleteToDo() async
 }
 
+@MainActor
 final class HomeSceneInteractor: HomeSceneDataStore {
   var presenter: (any HomeScenePresentationLogic)?
+  private var homeSceneWorker: HomeSceneWorkable
   
-  init() {
+  init(homeSceneWorker: HomeSceneWorkable) {
+    self.homeSceneWorker = homeSceneWorker
   }
 }
 
 // MARK: - Request to worker
-
 extension HomeSceneInteractor: HomeSceneBusinessLogic {
+  func fetchToDoList() async {
+    do {
+      let fetchedToDoList = try await self.homeSceneWorker.fetchToDoList()
+      self.presenter?.presentFetchedToDoList(response: fetchedToDoList)
+    } catch let error {
+      self.handleErrors(error)
+    }
+  }
+  
+  func createToDo() async {
+    do {
+      try await self.homeSceneWorker.createToDo()
+      self.presenter?.presentCreateToDo()
+    } catch let error {
+      self.handleErrors(error)
+    }
+  }
+  
+  func deleteToDo() async {
+    do {
+      try await self.homeSceneWorker.deleteToDo()
+      self.presenter?.presentDeleteToDo()
+    } catch let error {
+      self.handleErrors(error)
+    }
+  }
+}
+
+// MARK: - HandleErrors
+
+extension HomeSceneInteractor {
+  private func handleErrors(_ error: Error) {
+    switch error {
+    default:
+      break
+    }
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeScenePresenter.swift
@@ -5,11 +5,19 @@
 //  Created by Noah on 1/9/25.
 //  Copyright (c) 2025 ToDoGarden. All rights reserved.
 
-import Foundation
+import UIKit
 
+import HomeSceneEntity
+import ToDoGardenUIComponent
+
+@MainActor
 protocol HomeScenePresentationLogic {
+  func presentFetchedToDoList(response: HomeScene.FetchToDoList.Response)
+  func presentCreateToDo()
+  func presentDeleteToDo()
 }
 
+@MainActor
 final class HomeScenePresenter {
   weak var viewController: (any HomeSceneDisplayLogic)?
 }
@@ -17,4 +25,62 @@ final class HomeScenePresenter {
 // MARK: - Request to ViewController
 
 extension HomeScenePresenter: HomeScenePresentationLogic {
+  func presentFetchedToDoList(response: HomeScene.FetchToDoList.Response) {
+    let snapshot = self.makeNewSnapshotSections(response: response)
+    self.viewController?.displayFetchedToDoList(snapshot: snapshot)
+  }
+  
+  func presentCreateToDo() {
+    self.viewController?.displayCreateToDo()
+  }
+  
+  func presentDeleteToDo() {
+    self.viewController?.displayDeleteToDo()
+  }
+}
+
+extension HomeScenePresenter {
+  private func makeNewSnapshotSections(response: HomeScene.FetchToDoList.Response) -> ToDoListView.Snapshot {
+    var snapshot = ToDoListView.Snapshot()
+    
+    // 요청한 날짜의 DailyToDoList만 generateSections으로 넘기도록 수정해야함.
+    if let firstDailyTodoList = response.list?.first {
+      snapshot.appendSections(self.generateSections(from: firstDailyTodoList))
+      snapshot.sectionIdentifiers.forEach { section in
+        snapshot.appendItems(section.toDoItems, toSection: section)
+      }
+    }
+    
+    return snapshot
+  }
+  
+  func generateSections(from dailyTodoList: HomeScene.DailyTodoList) -> [ToDoListView.ToDoSection] {
+    let sections = dailyTodoList.list.map { group in
+      let toDoItems = (group.todoList ?? []).map { todo in
+        ToDoListView.ToDoItem(
+          toDoUIModel: .init(text: todo.name, foregroundColor: self.getColor(for: group.color))
+        )
+      }
+
+      return ToDoListView.ToDoSection(
+        headerUIModel: .init(
+          progressColor: self.getColor(for: group.color),
+          progressRate: Double(group.progressRate),
+          groupTitle: group.name
+        ),
+        toDoItems: toDoItems
+      )
+    }
+
+    return sections
+  }
+  
+  private func getColor(for hex: String) -> UIColor {
+    do {
+      let color = try UIColor().fromHex(hex)
+      return color
+    } catch {
+      return UIColor.toDoGardenGray
+    }
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -11,10 +11,16 @@ import TDUtility
 import ToDoGardenUIComponent
 
 import HomeSceneAPI
+import HomeSceneEntity
 
+@MainActor
 protocol HomeSceneDisplayLogic: AnyObject {
+  func displayFetchedToDoList(snapshot: ToDoListView.Snapshot)
+  func displayCreateToDo()
+  func displayDeleteToDo() 
 }
 
+@MainActor
 open class HomeSceneViewController: UIViewController, HomeSceneViewControllable {
   
   // MARK: - View Properties
@@ -47,6 +53,7 @@ open class HomeSceneViewController: UIViewController, HomeSceneViewControllable 
   open override func viewDidLoad() {
     super.viewDidLoad()
     self.setupViews()
+    self.fetchToDoList()
   }
   
   open override func viewIsAppearing(_ animated: Bool) {
@@ -57,6 +64,7 @@ open class HomeSceneViewController: UIViewController, HomeSceneViewControllable 
   open func setBottomSheet() {
     let toDoListViewContainer = ToDoListViewContainer()
     self.todoListView = toDoListViewContainer.toDoListView
+    self.todoListView?.buttonActionDelegate = self
     let bottomSheet = BottomSheet()
     bottomSheet.usingAutolayout()
     self.view.addSubview(bottomSheet)
@@ -126,14 +134,63 @@ extension HomeSceneViewController {
   }
 }
 
+extension HomeSceneViewController {
+  private func fetchToDoList() {
+    Task {
+      await self.interactor?.fetchToDoList()
+    }
+  }
+}
+
 // MARK: - Confirm display logic protocol
 
 extension HomeSceneViewController: HomeSceneDisplayLogic {
+  func displayFetchedToDoList(snapshot: ToDoListView.Snapshot) {
+    self.todoListView?.apply(snapshot)
+  }
+  
+  func displayCreateToDo() {
+    debugPrint("CREATE TODO")
+  }
+  
+  func displayDeleteToDo() {
+    debugPrint("DELETE TODO")
+  }
 }
 
 // MARK: - Request to interactor
 
 extension HomeSceneViewController {
+}
+
+// MARK: - ToDoList Button Actions
+
+extension HomeSceneViewController: ToDoListButtonActionDelegate {
+  public func didEditButtonTapped(
+    group: ToDoListView.ToDoSection,
+    todo: ToDoListView.ToDoItem
+  ) {
+    self.router?.routeToEditToDoScene(toDoId: todo.id)
+  }
+  
+  public func didDeleteButtonTapped(
+    group: ToDoListView.ToDoSection,
+    todo: ToDoListView.ToDoItem
+  ) {
+    Task {
+      await self.interactor?.deleteToDo()
+    }
+  }
+  
+  public func didCreateToDoButtonTapped(group: ToDoListView.ToDoSection) {
+    Task {
+      await self.interactor?.createToDo()
+    }
+  }
+  
+  public func didTimerButtonTapped(group: ToDoListView.ToDoSection) {
+    self.router?.routeToTimerScene(groupId: group.id.uuidString, groupName: group.getGroupTitle())
+  }
 }
 
 #if DEBUG

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
@@ -7,5 +7,96 @@
 
 import Foundation
 
-struct HomeSceneWorker {
+import HomeSceneAPI
+import HomeSceneEntity
+import HTTPClientAPI
+
+public struct HomeSceneWorker: HomeSceneWorkable, Sendable {
+  private let httpClient: HTTPClientAPI
+  
+  public init(httpClient: HTTPClientAPI) {
+    self.httpClient = httpClient
+  }
+  
+  public func fetchToDoList() async throws -> HomeScene.FetchToDoList.Response {
+    
+    return self.makeMockList()
+  }
+  
+  public func createToDo() async throws {
+    
+  }
+  
+  public func deleteToDo() async throws {
+    
+  }
 }
+
+// swiftlint:disable all
+extension HomeSceneWorker {
+  private func makeMockList() -> HomeScene.FetchToDoList.Response {
+    let mockData = HomeScene.FetchToDoList.Response(
+      groups: [
+        HomeScene.Group(id: "6e75050a-1859-4781-88ef-b1ce3c2c3158", name: "그룹 1", color: "#FFC83C", todoList: nil, progressRate: 0),
+        HomeScene.Group(id: "c5e18427-2928-42ab-8cd0-f8695c63f173", name: "iOS", color: "#4563FF", todoList: nil, progressRate: 0),
+        HomeScene.Group(id: "e89850f8-315f-46bd-96f4-713b38691d93", name: "그룹 2", color: "#FF6464", todoList: nil, progressRate: 0)
+      ],
+      list: [
+        HomeScene.DailyTodoList(
+          date: Date.now.toStringDateFormat(),
+          list: [
+            HomeScene.Group(
+              id: "6e75050a-1859-4781-88ef-b1ce3c2c3158",
+              name: "그룹 1",
+              color: "#FFC83C",
+              todoList: nil,
+              progressRate: 0
+            ),
+            HomeScene.Group(
+              id: "c5e18427-2928-42ab-8cd0-f8695c63f173",
+              name: "iOS",
+              color: "#4563FF",
+              todoList: [
+                HomeScene.Todo(id: "a523d5ae-b6ff-481e-98c9-11deb10eb7fb", name: "background Task 학습", isDone: false, orderIdx: 0, isAlarmOn: true),
+                HomeScene.Todo(id: "fdabd569-f835-4756-b3c2-46ab253ec69c", name: "UIApplication 학습", isDone: false, orderIdx: 1, isAlarmOn: true),
+                HomeScene.Todo(id: "a2fcec4d-50d5-4152-ac6a-e710bce4d47f", name: "SceneDelegate 학습", isDone: false, orderIdx: 2, isAlarmOn: true),
+                HomeScene.Todo(id: "f80cdcfb-273f-4320-bbf3-b9faec859eab", name: "Structured Concurrency WWDC 학습", isDone: true, orderIdx: 3, isAlarmOn: true),
+                HomeScene.Todo(id: "de119513-b415-451c-825e-9ab94a03d10f", name: "Diffable DataSource WWDC 학습", isDone: true, orderIdx: 4, isAlarmOn: true)
+              ],
+              progressRate: 0.4
+            ),
+            HomeScene.Group(
+              id: "e89850f8-315f-46bd-96f4-713b38691d93",
+              name: "그룹 2",
+              color: "#FF6464",
+              todoList: [
+                HomeScene.Todo(id: "e29e8791-0683-418c-8658-78ed2fdc981c", name: "View LifeCycle 학습", isDone: false, orderIdx: 0, isAlarmOn: true),
+                HomeScene.Todo(id: "01a19311-5727-49fe-af20-89bd0a5af848", name: "Swift Testing 공부하기", isDone: true, orderIdx: 1, isAlarmOn: true)
+              ],
+              progressRate: 0.5
+            ),
+            HomeScene.Group(
+              id: "d7591884-f6be-454a-9372-fd157bb091ab",
+              name: "수학",
+              color: "#946E26",
+              todoList: nil,
+              progressRate: 0
+            )
+          ]
+        )
+      ]
+    )
+    
+    return mockData
+  }
+}
+
+extension Date {
+  func toStringDateFormat() -> String {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+    dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+    return dateFormatter.string(from: self)
+  }
+}
+// swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneAPI/HomeSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneAPI/HomeSceneWorkable.swift
@@ -7,5 +7,10 @@
 
 import Foundation
 
-public protocol HomeSceneWorkable {
+import HomeSceneEntity
+
+public protocol HomeSceneWorkable: Sendable {
+  func fetchToDoList() async throws -> HomeScene.FetchToDoList.Response
+  func createToDo() async throws
+  func deleteToDo() async throws
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneEntity/HomeSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneEntity/HomeSceneModels.swift
@@ -9,4 +9,75 @@ import Foundation
 
 public enum HomeScene {
   // MARK: Use cases
+  public enum FetchToDoList {
+    public struct Request {
+      
+      public init() {
+      }
+    }
+    
+    public struct Response: Codable, Sendable {
+      public let groups: [Group]?
+      public let list: [DailyTodoList]?
+      
+      public init(groups: [Group]?, list: [DailyTodoList]?) {
+        self.groups = groups
+        self.list = list
+      }
+    }
+    
+    public struct ViewModel {
+      
+      public init() {
+      }
+    }
+  }
+  
+}
+
+// MARK: DTO
+extension HomeScene {
+  public struct Todo: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let isDone: Bool
+    public let orderIdx: Int
+    public let isAlarmOn: Bool
+    
+    public init(id: String, name: String, isDone: Bool, orderIdx: Int, isAlarmOn: Bool) {
+      self.id = id
+      self.name = name
+      self.isDone = isDone
+      self.orderIdx = orderIdx
+      self.isAlarmOn = isAlarmOn
+    }
+  }
+
+  // 그룹
+  public struct Group: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let color: String
+    public let todoList: [Todo]?
+    public let progressRate: Float
+    
+    public init(id: String, name: String, color: String, todoList: [Todo]?, progressRate: Float) {
+      self.id = id
+      self.name = name
+      self.color = color
+      self.todoList = todoList
+      self.progressRate = progressRate
+    }
+  }
+
+  // 특정 날짜에 해당하는 일정 목록
+  public struct DailyTodoList: Codable, Sendable {
+    public let date: String
+    public let list: [Group]
+    
+    public init(date: String, list: [Group]) {
+      self.date = date
+      self.list = list
+    }
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/TimerScene/Sources/TimerScene/TimerSceneViewController.swift
@@ -56,6 +56,11 @@ public final class TimerSceneViewController: UIViewController, TimerSceneViewCon
     self.layoutStack()
   }
   
+  public override func viewIsAppearing(_ animated: Bool) {
+    super.viewIsAppearing(animated)
+    self.navigationController?.navigationBar.isHidden = false
+  }
+  
   public override func viewWillDisappear(_ animated: Bool) {
     super.viewDidDisappear(animated)
     self.interactor?.requestPOST()

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoGroupSectionHeaderView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoGroupSectionHeaderView.swift
@@ -40,20 +40,24 @@ public final class ToDoGroupSectionHeaderView: UICollectionReusableView {
     model: CreateToDoButton.Model.primary
   )
   
-  private let timerImageView: UIImageView = {
-    let timerImageView = UIImageView(image: UIImage.timerButtonImage)
-    timerImageView.usingAutolayout()
+  private let timerButton: UIButton = {
+    let timerButton = UIButton()
+    timerButton.setImage(UIImage.timerButtonImage, for: UIControl.State.normal)
+    timerButton.usingAutolayout()
     
     let timerImageViewSize = LayoutConstant.timerImageViewSize
     NSLayoutConstraint.activate([
-      timerImageView.widthAnchor.constraint(equalToConstant: timerImageViewSize.width),
-      timerImageView.heightAnchor.constraint(equalToConstant: timerImageViewSize.height)
+      timerButton.widthAnchor.constraint(equalToConstant: timerImageViewSize.width),
+      timerButton.heightAnchor.constraint(equalToConstant: timerImageViewSize.height)
     ])
     
-    return timerImageView
+    return timerButton
   }()
   
-  public override init(frame: CGRect) {
+  weak var delegate: ToDoGroupSectionHeaderViewDelegate?
+  var section: Int = Int.zero
+  
+  override init(frame: CGRect) {
     super.init(frame: frame)
     self.setup()
   }
@@ -77,6 +81,7 @@ public final class ToDoGroupSectionHeaderView: UICollectionReusableView {
 extension ToDoGroupSectionHeaderView {
   private func setup() {
     self.setupLayout()
+    self.setupButtonAction()
   }
   
   private func setupLayout() {
@@ -92,7 +97,7 @@ extension ToDoGroupSectionHeaderView {
         self.progressView,
         self.createToDoButton,
         spacer,
-        self.timerImageView
+        self.timerButton
       ]
     )
     self.contentView.addSubview(hStack)
@@ -101,6 +106,20 @@ extension ToDoGroupSectionHeaderView {
     
     hStack.layoutMargins = LayoutConstant.hStackLayoutMargins
     hStack.isLayoutMarginsRelativeArrangement = true
+  }
+  
+  private func setupButtonAction() {
+    self.createToDoButton.addAction(UIAction { [weak self] _ in
+      guard let self = self else { return }
+
+      self.delegate?.createToDo(in: self.section)
+    }, for: UIControl.Event.touchUpInside)
+    
+    self.timerButton.addAction(UIAction { [weak self] _ in
+      guard let self = self else { return }
+      
+      self.delegate?.goTimer(in: self.section)
+    }, for: UIControl.Event.touchUpInside)
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListButtonActionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListButtonActionDelegate.swift
@@ -1,0 +1,23 @@
+//
+//  ToDoListButtonActionDelegate.swift
+//  ToDoGardenUI
+//
+//  Created by SONG on 3/18/25.
+//
+
+import Foundation
+
+// MARK: ToDoListView -> 외부 ViewController에게 라우팅,통신 작업 위임용 파라미터는 변동가능성 있음
+@MainActor
+public protocol ToDoListButtonActionDelegate: AnyObject {
+  func didEditButtonTapped(group: ToDoListView.ToDoSection, todo: ToDoListView.ToDoItem)
+  func didDeleteButtonTapped(group: ToDoListView.ToDoSection, todo: ToDoListView.ToDoItem)
+  func didCreateToDoButtonTapped(group: ToDoListView.ToDoSection)
+  func didTimerButtonTapped(group: ToDoListView.ToDoSection)
+}
+
+// MARK: Header -> ToDoListView에게 위임
+protocol ToDoGroupSectionHeaderViewDelegate: AnyObject {
+  func createToDo(in section: Int)
+  func goTimer(in section: Int)
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView+UIModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView+UIModel.swift
@@ -22,6 +22,10 @@ extension ToDoListView {
       self.headerUIModel = headerUIModel
       self.toDoItems = toDoItems
     }
+    
+    public func getGroupTitle() -> String {
+      return self.headerUIModel.groupTitle
+    }
   }
   
   public struct ToDoItem: Hashable, Sendable {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView.swift
@@ -38,6 +38,8 @@ public final class ToDoListView: UIView {
   
   private lazy var dataSource: DataSource = self.makeDataSource()
   
+  public weak var buttonActionDelegate: ToDoListButtonActionDelegate?
+  
   public override init(frame: CGRect) {
     super.init(frame: frame)
     self.setup()
@@ -77,6 +79,8 @@ extension ToDoListView {
       let section = snapshot.sectionIdentifiers[indexPath.section]
       
       supplementaryView.update(with: section.headerUIModel)
+      supplementaryView.section = indexPath.section
+      supplementaryView.delegate = self
     }
     
     let dataSource = DataSource(collectionView: self.contentView) { collectionView, indexPath, item in
@@ -118,12 +122,16 @@ extension ToDoListView {
     return UICollectionViewCompositionalLayout.list(using: listConfiguration)
   }
   
-  private func makeSwipeAction(for indexPath: IndexPath?) -> UISwipeActionsConfiguration? {
+  private func makeSwipeAction(for indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+    guard let todo = self.getItemForIndexPath(indexPath),
+      let group = self.getGroupForIndexPath(indexPath)
+    else { return nil }
+    
     let deleteAction = UIContextualAction(
       style: UIContextualAction.Style.destructive,
       title: nil
     ) { _, _, _ in
-      // TODO: - add delete action
+      self.buttonActionDelegate?.didDeleteButtonTapped(group: group, todo: todo)
     }
     deleteAction.accessibilityLabel = "Delete"
     deleteAction.image = UIImage.deleteIconImage
@@ -133,12 +141,46 @@ extension ToDoListView {
       style: UIContextualAction.Style.normal,
       title: nil
     ) { _, _, _ in
-      // TODO: - add edit action
+      self.buttonActionDelegate?.didEditButtonTapped(group: group, todo: todo)
     }
     editAction.accessibilityLabel = "Edit"
     editAction.image = UIImage.editIconImage.withRenderingMode(UIImage.RenderingMode.alwaysTemplate)
     editAction.backgroundColor = UIColor.toDoGardenEditButtonOrange
     return UISwipeActionsConfiguration(actions: [deleteAction, editAction])
+  }
+}
+
+extension ToDoListView {
+  private func getItemForIndexPath(_ indexPath: IndexPath) -> ToDoItem? {
+    let snapshot = self.dataSource.snapshot()
+    guard indexPath.section < snapshot.sectionIdentifiers.count else {
+      return nil
+    }
+    
+    return snapshot.sectionIdentifiers[indexPath.section].toDoItems[indexPath.item]
+  }
+  
+  private func getGroupForIndexPath(_ indexPath: IndexPath) -> ToDoSection? {
+    let snapshot = self.dataSource.snapshot()
+    guard indexPath.section < snapshot.sectionIdentifiers.count else {
+      return nil
+    }
+    
+    return snapshot.sectionIdentifiers[indexPath.section]
+  }
+}
+
+extension ToDoListView: ToDoGroupSectionHeaderViewDelegate {
+  func createToDo(in section: Int) {
+    guard let group = self.getGroupForIndexPath(IndexPath(item: 0, section: section)) else { return }
+
+    self.buttonActionDelegate?.didCreateToDoButtonTapped(group: group)
+  }
+  
+  func goTimer(in section: Int) {
+    guard let group = self.getGroupForIndexPath(IndexPath(item: 0, section: section)) else { return }
+
+    self.buttonActionDelegate?.didTimerButtonTapped(group: group)
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #874 
## 🎉 변경 사항
- 홈 탭의 버튼에 대한 동작을 정의했습니다. 
## 📌 PR Point
<img width="390" alt="스크린샷 2025-03-18 오후 3 04 04" src="https://github.com/user-attachments/assets/4724eb1b-e8b7-485c-9511-161b7afe241c" />

- ToDoList는 가짜데이터입니다. 
- delegate 패턴을 이용해서 각 셀에 포함된 버튼들에 대해 동작을 외부에서 정의할 수 있습니다. 
- 각각의 셀의 버튼을 누르면 해당 셀의 group or todo 정보가 vc 로 전달되고, 전달된 정보로 지지고 볶고 할 수 있습니다. 
- 투두 생성 , 삭제의 경우 API 연동은 하지 않았으나 , V - I - W - P - V 의 사이클을 비동기로 뚫어놨습니다. 

![Simulator Screen Recording - iPhone 16 - 2025-03-18 at 15 10 41](https://github.com/user-attachments/assets/ac0b7f83-c09a-4529-870e-43e82ff1f9b2)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?