### PR TITLE
Feature/#886 imple progressbar UI update

### DIFF
--- a/ToDo-Garden/TDUtility/Sources/TDUtility/ObservingValue.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDUtility/ObservingValue.swift
@@ -1,0 +1,37 @@
+import Foundation.NSLock
+
+public final class ObservingValue<T: Equatable & Hashable>: @unchecked Sendable {
+  private var lock = NSLock()
+  private var listener: ((T) -> Void)?
+  
+  public var value: T {
+    didSet {
+      self.lock.lock()
+      defer { self.lock.unlock() }
+      self.listener?(value)
+    }
+  }
+  
+  public init(_ value: T) {
+    self.value = value
+  }
+  
+  public func bind(_ listener: @escaping (T) -> Void) {
+    self.lock.lock()
+    defer { self.lock.unlock() }
+    self.listener = listener
+    listener(self.value)
+  }
+}
+
+extension ObservingValue: Equatable {
+  public static func == (lhs: ObservingValue<T>, rhs: ObservingValue<T>) -> Bool {
+    return lhs.value == rhs.value
+  }
+}
+
+extension ObservingValue: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.value)
+  }
+}

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CircularProgressView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/CircularProgressView.swift
@@ -13,6 +13,7 @@ public final class CircularProgressView: UIView {
   public var isAnimating: Bool = false
   private let progressLayer: CAShapeLayer
   private let progressBackgroundLayer: CAShapeLayer
+  public var currentProgress: Float = 0
   
   public init(progressColor: UIColor, backgroundColor: UIColor, lineWidth: CGFloat) {
     self.progressLayer = CAShapeLayer()
@@ -78,6 +79,7 @@ extension CircularProgressView {
   }
   
   private func setProgress(duration: TimeInterval, from: Float, to value: Float) {
+    self.currentProgress = value
     let animationKeyPath = Constant.CircularProgressView.StringLiteral.Animation.keyPath
     let animation = CABasicAnimation(keyPath: animationKeyPath)
     animation.duration = duration

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManagerGroupListTableViewCellModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ManagerGroupListTableViewCellModel.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import TDUtility
 import ToDoGardenUIConstant
 
 extension ManageGroupTableViewCell {
@@ -92,8 +93,8 @@ extension ManageGroupTableViewCell {
     ) -> Model.ProgressCircle {
       let constants = Constant.ManageGroupListTableViewCell.self
       return Model.ProgressCircle(
-        progressColor: Observable(progressColor),
-        progressRate: Observable(progressRate),
+        progressColor: ObservingValue(progressColor),
+        progressRate: ObservingValue(progressRate),
         backgroundColor: UIColor.toDoGardenGray1,
         lineWidth: constants.ProgressCircle.lineWidth,
         size: constants.CommonSize.size,
@@ -107,7 +108,7 @@ extension ManageGroupTableViewCell {
     ) -> Model.GroupNameButton {
       let constants = Constant.ManageGroupListTableViewCell.self
       return Model.GroupNameButton(
-        groupName: Observable(groupName),
+        groupName: ObservingValue(groupName),
         cornerRadius: constants.GroupNameButton.cornerRadius,
         isCreateToDoButton: isCreateToDoButton,
         leading: constants.GroupNameButton.leading,
@@ -129,7 +130,7 @@ extension ManageGroupTableViewCell {
     ) -> Model.RightImageView {
       let constants = Constant.ManageGroupListTableViewCell.self
       return Model.RightImageView(
-        isHidden: Observable(isHidden),
+        isHidden: ObservingValue(isHidden),
         image: image,
         size: constants.CommonSize.size,
         trailing: trailing
@@ -170,8 +171,8 @@ extension ManageGroupTableViewCell {
 
 extension ManageGroupTableViewCell.Configuration.Model {
   struct ProgressCircle {
-    var progressColor: Observable<UIColor>
-    var progressRate: Observable<Float>
+    var progressColor: ObservingValue<UIColor>
+    var progressRate: ObservingValue<Float>
     let backgroundColor: UIColor
     let lineWidth: CGFloat
     let size: CGSize
@@ -179,7 +180,7 @@ extension ManageGroupTableViewCell.Configuration.Model {
   }
   
   struct GroupNameButton {
-    var groupName: Observable<String>
+    var groupName: ObservingValue<String>
     let cornerRadius: CGFloat
     let isCreateToDoButton: Bool
     let leading: CGFloat
@@ -189,7 +190,7 @@ extension ManageGroupTableViewCell.Configuration.Model {
   }
   
   struct RightImageView {
-    var isHidden: Observable<Bool>
+    var isHidden: ObservingValue<Bool>
     let image: UIImage
     let size: CGSize
     let trailing: CGFloat

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/RepeatOtherDaysViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+import TDUtility
 import ToDoGardenUIConstant
 
 final class RepeatOtherDaysViewModel {
@@ -15,8 +16,8 @@ final class RepeatOtherDaysViewModel {
   private(set) var innerStackView: InnerStackViewState
   private(set) var title: TitleState
   
-  private(set) var isSelected: Observable<Bool>
-  private(set) var height: Observable<CGFloat>
+  private(set) var isSelected: ObservingValue<Bool>
+  private(set) var height: ObservingValue<CGFloat>
   
   init(
     startDate: String?,
@@ -29,14 +30,16 @@ final class RepeatOtherDaysViewModel {
       today: today
     )
     
-    self.isSelected = Observable(false)
-    self.divider = DividerState(isHidden: Observable(true))
+    self.isSelected = ObservingValue(false)
+    self.divider = DividerState(isHidden: ObservingValue(true))
     self.innerStackView = InnerStackViewState(
-      isHidden: Observable(true),
-      height: Observable(Constant.RepeatOtherDaysView.Layout.InnerStackView.height)
+      isHidden: ObservingValue(true),
+      height: ObservingValue(Constant.RepeatOtherDaysView.Layout.InnerStackView.height)
     )
-    self.height = Observable(Constant.RepeatOtherDaysView.Layout.heightUnselected)
-    self.title = TitleState(topMargin: Observable(Constant.ToDoRepeatSelectionView.Layout.RepetitionLabel.topMargin))
+    self.height = ObservingValue(Constant.RepeatOtherDaysView.Layout.heightUnselected)
+    self.title = TitleState(
+      topMargin: ObservingValue(Constant.ToDoRepeatSelectionView.Layout.RepetitionLabel.topMargin)
+    )
   }
   
   func toggleSelection() {
@@ -84,53 +87,34 @@ extension RepeatOtherDaysViewModel {
   private static func initializeDateButton(startDate: String?, endDate: String?, today: String) -> DateButtonState {
     let isDateUndecided = (startDate == nil) || (endDate == nil)
     return DateButtonState(
-      startDate: Observable(startDate ?? today),
-      endDate: Observable(endDate ?? today),
-      isSelected: Observable(!isDateUndecided)
+      startDate: ObservingValue(startDate ?? today),
+      endDate: ObservingValue(endDate ?? today),
+      isSelected: ObservingValue(!isDateUndecided)
     )
   }
 }
 
 extension RepeatOtherDaysViewModel {
   struct DateButtonState {
-    var startDate: Observable<String>
-    var endDate: Observable<String>
-    var isSelected: Observable<Bool>
+    var startDate: ObservingValue<String>
+    var endDate: ObservingValue<String>
+    var isSelected: ObservingValue<Bool>
   }
   
   struct RingToggleButtonState {
-    var isSelected: Observable<Bool>
+    var isSelected: ObservingValue<Bool>
   }
   
   struct DividerState {
-    var isHidden: Observable<Bool>
+    var isHidden: ObservingValue<Bool>
   }
   
   struct InnerStackViewState {
-    var isHidden: Observable<Bool>
-    var height: Observable<CGFloat>
+    var isHidden: ObservingValue<Bool>
+    var height: ObservingValue<CGFloat>
   }
   
   struct TitleState {
-    var topMargin: Observable<CGFloat>
-  }
-}
-
-final class Observable<T> {
-  var value: T {
-    didSet {
-      self.listener?(value)
-    }
-  }
-  
-  private var listener: ((T) -> Void)?
-  
-  init(_ value: T) {
-    self.value = value
-  }
-  
-  func bind(_ listener: @escaping (T) -> Void) {
-    self.listener = listener
-    listener(value)
+    var topMargin: ObservingValue<CGFloat>
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+import TDUtility
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
@@ -90,7 +91,7 @@ extension Styled.Row.Configuration {
     public static let empty = Self()
     public var text: String?
     public var foregroundColor: UIColor
-    public var isSelected: Bool
+    public var isSelected: ObservingValue<Bool>
     public var hasAlert: Bool
     
     public init(
@@ -101,7 +102,7 @@ extension Styled.Row.Configuration {
     ) {
       self.text = text
       self.foregroundColor = foregroundColor
-      self.isSelected = isSelected
+      self.isSelected = ObservingValue(isSelected)
       self.hasAlert = hasAlert
     }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ToDoListStyle.swift
@@ -12,7 +12,7 @@ extension Styled.Row {
     let (zStack, checkBoxAction) = self.buildZStack(model: model)
     let checkBox = self.buildCheckBox(
       color: model.foregroundColor,
-      isSelected: model.isSelected,
+      isSelected: model.isSelected.value,
       checkBoxAction
     )
     stack.addArrangedSubview(checkBox)
@@ -27,7 +27,7 @@ extension Styled.Row {
     let textField = self.buildTextField(
       text: model.text,
       color: model.foregroundColor,
-      isSelected: model.isSelected
+      isSelected: model.isSelected.value
     )
     self.setupTextFieldConstraints(textField)
     let zStack = UIStackView(arrangedSubviews: [textField])
@@ -48,7 +48,7 @@ extension Styled.Row {
       textField?.isHidden = !textIsEmpty
       selectedView?.isHidden = textIsEmpty
       
-      let isSelected = self?.configuration.todoListModel?.isSelected ?? true
+      let isSelected = self?.configuration.todoListModel?.isSelected.value ?? true
       selecetdViewUpdateAction(text, isSelected)
     }
     
@@ -73,7 +73,7 @@ extension Styled.Row {
     let task = Task {
       for await text in textField.stream {
         guard !Task.isCancelled else { return }
-        let isSelected = self.configuration.todoListModel?.isSelected ?? false
+        let isSelected = self.configuration.todoListModel?.isSelected.value ?? false
         let isEmpty = text?.isEmpty ?? true
         if !isSelected || !isEmpty {
           self.configuration.todoListModel?.text = text
@@ -94,7 +94,7 @@ extension Styled.Row {
     let strikeThroughLabel = self.buildStrikethroughLabel(text: model.text)
     let imageView = self.buildAlarmImage(hasAlarm: model.hasAlert)
     let stack = UIHStackView(arrangedSubviews: [strikeThroughLabel, imageView])
-    stack.isHidden = !model.isSelected
+    stack.isHidden = !model.isSelected.value
     
     return (stack, { [weak strikeThroughLabel] in
       strikeThroughLabel?.update(text: $0, animated: $1)
@@ -132,14 +132,14 @@ extension Styled.Row {
         else { return }
         if self?.configuration.todoListModel?.text?.isEmpty ?? true {
           checkBox.isActionBlocked = false
-          let flag = (self?.configuration.todoListModel?.isSelected ?? true)
+          let flag = (self?.configuration.todoListModel?.isSelected.value ?? true)
           if flag {
             handler(false)
           }
         } else {
           checkBox.isActionBlocked = true
           handler(checkBox.isSelected)
-          self?.configuration.todoListModel?.isSelected = checkBox.isSelected
+          self?.configuration.todoListModel?.isSelected.value = checkBox.isSelected
         }
       }
     )

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoGroupSectionHeaderView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoGroupSectionHeaderView.swift
@@ -71,7 +71,7 @@ public final class ToDoGroupSectionHeaderView: UICollectionReusableView {
     self.progressView.setupProgressLayerStrokeColor(with: model.progressColor)
     self.progressView.startAnimation(
       duration: TimeInterval(0.5),
-      from: Float.zero,
+      from: self.progressView.currentProgress,
       to: Float(model.progressRate)
     )
     self.createToDoButton.updateTitle(with: model.groupTitle)

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView+UIModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView+UIModel.swift
@@ -43,7 +43,7 @@ extension ToDoListView {
   
   public struct ToDoGroupUIModel: Hashable, Sendable {
     let progressColor: UIColor
-    let progressRate: Double
+    var progressRate: Double
     let groupTitle: String
     
     public init(

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView.swift
@@ -64,10 +64,17 @@ extension ToDoListView {
 }
 
 // MARK: - DataSource
-
+// swiftlint: disable all
 extension ToDoListView {
   private func makeDataSource() -> DataSource {
     let toDoCellRegistration = ToDoCellRegistration { cell, _, toDoItem in
+      
+      toDoItem.toDoUIModel.isSelected.bind { [weak self] _ in
+        Task { @MainActor in
+          await self?.updateHeaderUI(for: toDoItem)
+        }
+      }
+      
       cell.contentConfiguration = ToDoContentViewContentConfiguration(model: toDoItem.toDoUIModel)
       cell.indentationLevel = Int.zero
     }
@@ -185,16 +192,62 @@ extension ToDoListView {
 extension ToDoListView: ToDoGroupSectionHeaderViewDelegate {
   func createToDo(in section: Int) {
     guard let group = self.getGroupForIndexPath(IndexPath(item: 0, section: section)) else { return }
-
+    
     self.buttonActionDelegate?.didCreateToDoButtonTapped(group: group)
   }
   
   func goTimer(in section: Int) {
     guard let group = self.getGroupForIndexPath(IndexPath(item: 0, section: section)) else { return }
-
+    
     self.buttonActionDelegate?.didTimerButtonTapped(group: group)
   }
+  
+  private func updateHeaderUI(for toDoItem: ToDoItem) async {
+    guard let section = self.getSection(for: toDoItem) else { return }
+    
+    let newProgressRate = self.calculateProgressRate(for: section)
+    
+    guard let headerView = self.contentView.supplementaryView(
+      forElementKind: UICollectionView.elementKindSectionHeader,
+      at: IndexPath(item: 0, section: self.getSectionIndex(for: section))
+    ) as? ToDoGroupSectionHeaderView else {
+      return
+    }
+    
+    var updatedModel = section.headerUIModel
+    updatedModel.progressRate = newProgressRate
+    headerView.update(with: updatedModel)
+  }
+  
+  // swiftlint: disable for_where
+  private func getSection(for toDoItem: ToDoItem) -> ToDoSection? {
+    let snapshot = self.dataSource.snapshot()
+    for section in snapshot.sectionIdentifiers {
+      if section.toDoItems.contains(where: { $0 == toDoItem }) {
+        return section
+      }
+    }
+    return nil
+  }
+  // swiftlint: enable for_where
+  
+  private func calculateProgressRate(for section: ToDoSection) -> CGFloat {
+    let selected = section.toDoItems.filter { item in
+      item.toDoUIModel.isSelected.value
+    }.count
+    return CGFloat(selected) / CGFloat(section.toDoItems.count)
+  }
+  
+  func getSectionIndex(for section: ToDoSection) -> Int {
+    let snapshot = dataSource.snapshot()
+    guard let sectionIndex = snapshot.sectionIdentifiers.firstIndex(of: section) else {
+      return 0
+    }
+    
+    return sectionIndex
+  }
 }
+// swiftlint: enable all
 
 @available(iOS 17.0, *)
 #Preview {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #886 
## 🎉 변경 사항
- 이전에 만들어놓은 Observable을 위치 이동 / 리네임 -> ObservingValue 했습니다. 
- 선택된 투두 개수 / 투두 전체 개수 값을 headerUI에 반영시킵니다. 
- 기존의 `0 -> 목적지 까지의 애니메이션` 에서 `이전상태 -> 목적지 까지의 애니메이션` 으로 변경하여 보다 자연스럽게 변경하였습니다. 
## 📌 PR Point

### 실행화면 
![Simulator Screen Recording - iPhone 15 Pro - 2025-03-24 at 12 43 45](https://github.com/user-attachments/assets/455f3b3a-2309-4e3d-9bca-86e64efefcd4)
#### 투두 추가 / 삭제에 따라 유동적으로 변화할 수 있도록 했습니다. (GIF가 좀 이상하네요 ^^ ; 실제론 문제없음)
#### 현재 PR에는 투두 추가/ 삭제가 없는 관계로 `ToDoListView.swfit` 파일의 프리뷰로 확인해주시면 되겠습니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?