### PR TITLE
Feature/#894 imple batch processing at home

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/URLConstants.swift
@@ -35,7 +35,7 @@ extension URLConstants.ToDo {
   public static let editToDo = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/todos")!
   public static let deleteToDo = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/delete_todo")!
   public static let fetchToDoList = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/todo_list")!
-  public static let todoBatch = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/edit_todos")!
+  public static let todoBatch = URL(string: "https://dupsiwbkfitzegzlrwgv.supabase.co/rest/v1/rpc/edit_todos")!
 }
 
 extension URLConstants.Group {

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -24,6 +24,8 @@ protocol HomeSceneBusinessLogic {
   func loadDailyToDoList(targetDate: String) async
   func updateText(text: String, indexPath: IndexPath, date: Date)
   func updateSelection(isSelected: Bool, indexPath: IndexPath, date: Date)
+  func writeJSONFile() async
+  func requestBatchUpdateToServer() async
 }
 
 @MainActor
@@ -32,10 +34,10 @@ final class HomeSceneInteractor: HomeSceneDataStore {
   private var homeSceneWorker: HomeSceneWorkable
   private var monthlyData: [String: [HomeScene.TodoListGroup]]
   // ⬆️ 서버에서 받아오는 1달짜리 데이터입니다. ex) key = "20250302"
-  private var itemsForBatch: [String: HomeScene.TodoBatchItem]
+  private var itemsForBatch: [String: HomeScene.TodoBatchItem] 
   // ⬆️ JSONStorage가 매번 fileWrite를 하기엔 부담스러워서 모아놨다가 적절한 순간에 fileWrite를 진행하기 위한 데이터입니다.
   // 즉, 서버에게 배치처리를 요청하기 위한 배치처리 과정이라고 볼 수 있습니다.
-  // ex) key = "20250302"
+  // ex) key = ToDo의 UUIDString
   
   init(homeSceneWorker: HomeSceneWorkable) {
     self.homeSceneWorker = homeSceneWorker
@@ -111,6 +113,8 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
     guard let targetGroup = self.monthlyData[targetDate]?[indexPath.section],
       let targetToDo = targetGroup.todoList?[indexPath.item] else { return }
     
+    if targetToDo.name == text { return } // 텍스트에 변경사항이 없으면 그냥 리턴
+    
     targetToDo.name = text
     if let batchItem = self.itemsForBatch[targetToDo.localID] {
       batchItem.setName(text)
@@ -125,11 +129,34 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
     }
   }
   
+  func writeJSONFile() async {
+    guard !self.itemsForBatch.values.isEmpty else { return }
+    
+    do {
+      let data = Array(self.itemsForBatch.values)
+      try await self.homeSceneWorker.writeJSONFile(data: data)
+      self.itemsForBatch.removeAll()
+    } catch let error {
+      self.handleErrors(error)
+    }
+  }
+  
+  func requestBatchUpdateToServer() async {
+    do {
+      try await self.homeSceneWorker.requestBatchUpdateToServer()
+      self.itemsForBatch.removeAll()
+    } catch let error {
+      print(error)
+      self.handleErrors(error)
+    }
+  }
+  
   func updateSelection(isSelected: Bool, indexPath: IndexPath, date: Date) {
     let targetDate = date.description.toYYYYMMDDStringFromISO8601Space()
     guard let targetGroup = self.monthlyData[targetDate]?[indexPath.section],
       let targetToDo = targetGroup.todoList?[indexPath.item] else { return }
     
+    if isSelected == targetToDo.isDone { return }
     targetToDo.isDone = isSelected
     if let batchItem = self.itemsForBatch[targetToDo.localID] {
       batchItem.setDone(isSelected)
@@ -154,7 +181,7 @@ extension HomeSceneInteractor {
     if self.itemsForBatch[deletedToDo.localId] == nil {
       self.itemsForBatch[deletedToDo.localId] = deletedToDo
     } else {
-      self.itemsForBatch[deletedToDo.localId] = nil
+      self.itemsForBatch[deletedToDo.localId]?.isDelete = true
     }
   }
   

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -67,7 +67,7 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
   
   func createToDo(group: ToDoListView.ToDoSection, date: Date) async {
     let dateString = date.description.toYYYYMMDDStringFromISO8601Space()
-    let newToDo = self.makeItemForCreateToDo(group: group)
+    let newToDo = self.makeItemForCreateToDo(group: group, date: date)
     self.addBatchItem(newToDo: newToDo)
     
     if let targetGroupIndex = self.monthlyData[dateString]?.firstIndex(
@@ -98,7 +98,7 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
     }
     
     if deletedToDo != nil {
-      let batchItem = self.makeItemForDeleteToDo(group: group, todo: deletedToDo!)
+      let batchItem = self.makeItemForDeleteToDo(group: group, todo: deletedToDo!, date: date)
       self.removeBatchItem(deletedToDo: batchItem)
     }
     self.presenter?.presentDeleteToDo(groupID: group.id, deletedToDo: todo)
@@ -122,7 +122,7 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
       let alarmTime = Double(targetToDo.alarmTime ?? 0)
       self.itemsForBatch[targetToDo.localID] = HomeScene.TodoBatchItem(
         localId: targetToDo.localID, name: text, isDone: targetToDo.isDone,
-        createdAt: Date.now.toISOString(), isAlarmOn: targetToDo.isAlarmOn, alarmTime: alarmTime,
+        createdAt: date.toISOString(), isAlarmOn: targetToDo.isAlarmOn, alarmTime: alarmTime,
         isOnlyToday: targetToDo.isOnlyToday, startDay: targetToDo.startDay, endDay: targetToDo.endDay,
         groupId: targetGroup.localId, isDelete: false
       )
@@ -146,7 +146,6 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
       try await self.homeSceneWorker.requestBatchUpdateToServer()
       self.itemsForBatch.removeAll()
     } catch let error {
-      print(error)
       self.handleErrors(error)
     }
   }
@@ -164,7 +163,7 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
       let alarmTime = Double(targetToDo.alarmTime ?? 0)
       self.itemsForBatch[targetToDo.localID] = HomeScene.TodoBatchItem(
         localId: targetToDo.localID, name: targetToDo.name, isDone: isSelected,
-        createdAt: Date.now.toISOString(), isAlarmOn: targetToDo.isAlarmOn, alarmTime: alarmTime,
+        createdAt: date.toISOString(), isAlarmOn: targetToDo.isAlarmOn, alarmTime: alarmTime,
         isOnlyToday: targetToDo.isOnlyToday, startDay: targetToDo.startDay, endDay: targetToDo.endDay,
         groupId: targetGroup.localId, isDelete: false
       )
@@ -185,14 +184,14 @@ extension HomeSceneInteractor {
     }
   }
   
-  private func makeItemForCreateToDo(group: ToDoListView.ToDoSection) -> HomeScene.TodoBatchItem {
+  private func makeItemForCreateToDo(group: ToDoListView.ToDoSection, date: Date) -> HomeScene.TodoBatchItem {
     let newToDoID = UUID()
     let groupID = group.id.uuidString
     let newItem = HomeScene.TodoBatchItem(
       localId: newToDoID.uuidString,
       name: "New ToDo",
       isDone: false,
-      createdAt: Date.now.toISOString(),
+      createdAt: date.toISOString(),
       isAlarmOn: false,
       alarmTime: 0, // 기본값 뭐임?
       isOnlyToday: true,
@@ -204,7 +203,7 @@ extension HomeSceneInteractor {
     return newItem
   }
   
-  private func makeItemForDeleteToDo(group: ToDoListView.ToDoSection, todo: HomeScene.TodoListItem) -> HomeScene.TodoBatchItem {
+  private func makeItemForDeleteToDo(group: ToDoListView.ToDoSection, todo: HomeScene.TodoListItem, date: Date) -> HomeScene.TodoBatchItem {
     
     let groupID = group.id.uuidString
     let alarmTime = Double(todo.alarmTime ?? 0)
@@ -213,7 +212,7 @@ extension HomeSceneInteractor {
       localId: todo.localID,
       name: todo.name,
       isDone: todo.isDone,
-      createdAt: Date.now.toISOString(),
+      createdAt: date.toISOString(),
       isAlarmOn: todo.isAlarmOn,
       alarmTime: alarmTime,
       isOnlyToday: todo.isOnlyToday,

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeScenePresenter.swift
@@ -82,16 +82,18 @@ extension HomeScenePresenter {
   }
 
   func generateSections(from group: HomeScene.TodoListGroup) -> [ToDoListView.ToDoSection] {
-    guard let id = UUID(uuidString: group.localId) else { return [] }
+    guard let groupID = UUID(uuidString: group.localId) else { return [] }
     
-    let toDoItems = group.todoList?.map { todo in
-      ToDoListView.ToDoItem(
-        toDoUIModel: .init(text: todo.name, foregroundColor: self.getColor(for: group.color), isSelected: todo.isDone, hasAlert: todo.isAlarmOn)
-      )
-    } ?? []
+    let toDoItems: [ToDoListView.ToDoItem] = group.todoList?.map { todo in
+      let todoID = UUID(uuidString: todo.localID)
+        return ToDoListView.ToDoItem(
+          id: todoID ?? UUID(),
+          toDoUIModel: .init(text: todo.name, foregroundColor: self.getColor(for: group.color), isSelected: todo.isDone, hasAlert: todo.isAlarmOn)
+        )
+    } ?? [] 
     
     let section = ToDoListView.ToDoSection(
-      id: id,
+      id: groupID,
       headerUIModel: .init(
         progressColor: self.getColor(for: group.color),
         progressRate: group.progressRate,

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeScenePresenter.swift
@@ -74,7 +74,7 @@ extension HomeScenePresenter {
       
       sections.forEach { section in
         snapshot.appendSections([section])
-        snapshot.appendItems(section.toDoItems, toSection: section)
+        snapshot.appendItems(section.getToDoItems(), toSection: section)
       }
     }
     

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -59,6 +59,14 @@ open class HomeSceneViewController: UIViewController, HomeSceneViewControllable 
     self.setupViews()
   }
   
+  open override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    Task {
+      await self.interactor?.writeJSONFile()
+      await self.interactor?.requestBatchUpdateToServer()
+    }
+  }
+  
   open override func viewIsAppearing(_ animated: Bool) {
     super.viewWillAppear(animated)
     self.navigationController?.navigationBar.isHidden = true

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -75,6 +75,20 @@ open class HomeSceneViewController: UIViewController, HomeSceneViewControllable 
     self.bottomSheet.contentView = self.todoListView
   }
   
+  open func setLoadingIndicator() {
+    self.loadingIndicator.isHidden = true
+    self.loadingIndicator.pauseAnimation()
+    self.view.addSubview(self.loadingIndicator)
+    self.loadingIndicator.usingAutolayout()
+    
+    NSLayoutConstraint.activate(
+      [
+        self.loadingIndicator.centerXAnchor.constraint(equalTo: self.bottomSheet.centerXAnchor),
+        self.loadingIndicator.centerYAnchor.constraint(equalTo: self.bottomSheet.centerYAnchor, constant: -20)
+      ]
+    )
+  }
+  
   open func setUserInteractionDisable() {
     self.calendarView.isUserInteractionEnabled = false
     self.homeHeaderView.isUserInteractionEnabled = false
@@ -137,20 +151,6 @@ extension HomeSceneViewController {
     self.homeHeaderView.manageGroupButtonTapped = UIAction(handler: { [weak self] _ in
       self?.router?.routeToManageGroupScene()
     })
-  }
-  
-  private func setLoadingIndicator() {
-    self.loadingIndicator.isHidden = true
-    self.loadingIndicator.pauseAnimation()
-    self.view.addSubview(self.loadingIndicator)
-    self.loadingIndicator.usingAutolayout()
-    
-    NSLayoutConstraint.activate(
-      [
-        self.loadingIndicator.centerXAnchor.constraint(equalTo: self.bottomSheet.centerXAnchor),
-        self.loadingIndicator.centerYAnchor.constraint(equalTo: self.bottomSheet.centerYAnchor, constant: -20)
-      ]
-    )
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -181,8 +181,15 @@ extension HomeSceneViewController: HomeSceneDisplayLogic {
   func displayDailyToDoList(snapshot: ToDoListView.Snapshot) {
     self.loadingIndicator.isHidden = true
     self.loadingIndicator.pauseAnimation()
-    self.showToDoList()
-    self.todoListView?.apply(snapshot)
+    for section in snapshot.sectionIdentifiers {
+      self.todoListView?.updateHeaderUIAfterUpdatingToDo(section: section)
+    }
+    self.todoListView?.apply(
+      snapshot,
+      completion: { [weak self] in
+        self?.showToDoList()
+      }
+    )
   }
   
   func displayCreateToDo(newToDo: HomeScene.TodoBatchItem) {

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -196,7 +196,7 @@ extension HomeSceneViewController: HomeSceneDisplayLogic {
     guard var snapshot = self.todoListView?.getSnapShot(),
       let newToDoUUID = UUID(uuidString: newToDo.localId),
       let newToDoGroupUUID = UUID(uuidString: newToDo.groupId),
-      let section = snapshot.sectionIdentifiers.first(
+      var section = snapshot.sectionIdentifiers.first(
         where: { $0.id == newToDoGroupUUID }
       ) else { return }
  
@@ -211,20 +211,20 @@ extension HomeSceneViewController: HomeSceneDisplayLogic {
     )
     
     snapshot.appendItems([item], toSection: section)
-    section.toDoItems.append(item)
+    section.appendToDoItems(item)
     self.todoListView?.apply(snapshot)
   }
   
   func displayDeleteToDo(groupID: UUID, deletedToDo: ToDoListView.ToDoItem) {
     guard var snapshot = self.todoListView?.getSnapShot(),
-      let section = snapshot.sectionIdentifiers.first(
+      var section = snapshot.sectionIdentifiers.first(
         where: { $0.id == groupID }
       ) else { return }
 
-    if let deletedIndex = section.toDoItems.firstIndex(
+    if let deletedIndex = section.getToDoItems().firstIndex(
       where: { $0.id == deletedToDo.id }
     ) {
-      section.toDoItems.remove(at: deletedIndex)
+      section.removeToDoItems(at: deletedIndex)
     }
 
     snapshot.deleteItems([deletedToDo])
@@ -346,7 +346,7 @@ extension HomeSceneViewController {
     } else {
       snapshotForGuide.appendSections([groupForGuide])
       snapshotForGuide.sectionIdentifiers.forEach { section in
-        snapshotForGuide.appendItems(section.toDoItems, toSection: section)
+        snapshotForGuide.appendItems(section.getToDoItems(), toSection: section)
       }
     }
     self.todoListView?.apply(snapshotForGuide)

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -13,6 +13,8 @@ import TDFoundationExtension
 import TDUtility
 import ToDoGardenUIComponent
 
+// swiftlint: disable file_length
+
 @MainActor
 protocol HomeSceneDisplayLogic: AnyObject {
   func displayFetchedToDoList(fetchedData: [String: [HomeScene.TodoListGroup]])
@@ -165,12 +167,14 @@ extension HomeSceneViewController {
 // MARK: - Request to interactor
 extension HomeSceneViewController {
   private func fetchToDoList() {
+    guard let interactor = self.interactor else { return }
+    
     let targetMonth = self.calendarView.getCurrentMonth().toYYYYMMDDStringFromYYYYMM()
     self.hideToDoList()
     self.loadingIndicator.isHidden = false
     self.loadingIndicator.startAnimation()
     Task {
-      await self.interactor?.fetchToDoList(request: HomeScene.FetchToDoList.Request(dateString: targetMonth))
+      await interactor.fetchToDoList(request: HomeScene.FetchToDoList.Request(dateString: targetMonth))
     }
   }
 }
@@ -401,3 +405,4 @@ extension HomeSceneViewController {
   return homeSceneViewController
 }
 #endif
+// swiftlint: enable file_length

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -158,6 +158,7 @@ extension HomeSceneViewController {
 extension HomeSceneViewController {
   private func fetchToDoList() {
     let targetMonth = self.calendarView.getCurrentMonth().toYYYYMMDDStringFromYYYYMM()
+    self.hideToDoList()
     self.loadingIndicator.isHidden = false
     self.loadingIndicator.startAnimation()
     Task {
@@ -170,10 +171,9 @@ extension HomeSceneViewController {
 
 extension HomeSceneViewController: HomeSceneDisplayLogic {
   func displayFetchedToDoList(fetchedData: [String: [HomeScene.TodoListGroup]]) {
-    self.hideToDoList()
     Task {
       let date = self.calendarView.getSelectedDate() ?? Date.now
-      await self.interactor?.setMonthlyData(fetchedData) // 지금은 연동 안되어서 화면 이동하면 추가한 투두 안보임
+      await self.interactor?.setMonthlyData(fetchedData)
       await self.interactor?.loadDailyToDoList(targetDate: date.description)
     }
   }
@@ -229,7 +229,7 @@ extension HomeSceneViewController: HomeSceneDisplayLogic {
 
     snapshot.deleteItems([deletedToDo])
     self.todoListView?.apply(snapshot)
-    self.todoListView?.updateHeaderUIAfterDeleteTodo(section: section)
+    self.todoListView?.updateHeaderUIAfterUpdatingToDo(section: section)
   }
   
   func displayErrorToast(error: any Error) {
@@ -275,6 +275,7 @@ extension HomeSceneViewController: ToDoListViewCellUpdatingDelegate {
   }
 }
 
+// MARK: - Calendar Actions
 extension HomeSceneViewController: CalendarViewDateSelectionDelegate {
   public func didSelectDate(_ date: Date) {
     self.hideToDoList()
@@ -282,9 +283,46 @@ extension HomeSceneViewController: CalendarViewDateSelectionDelegate {
       await self.interactor?.loadDailyToDoList(targetDate: date.description)
     }
   }
-  
+
   public func didChangeMonth() {
-    self.fetchToDoList()
+    Task {
+      await self.interactor?.writeJSONFile()
+      await self.interactor?.requestBatchUpdateToServer()
+      self.fetchToDoList()
+    }
+  }
+}
+
+// MARK: - ToDoList Button Actions
+extension HomeSceneViewController: ToDoListButtonActionDelegate {
+  public func didEditButtonTapped(
+    group: ToDoListView.ToDoSection,
+    todo: ToDoListView.ToDoItem
+  ) {
+    self.router?.routeToEditToDoScene(toDoId: todo.id)
+  }
+  
+  public func didDeleteButtonTapped(
+    group: ToDoListView.ToDoSection,
+    todo: ToDoListView.ToDoItem
+  ) {
+    Task {
+      guard let selectedDate = self.calendarView.getSelectedDate() else { return }
+      
+      await self.interactor?.deleteToDo(group: group, todo: todo, date: selectedDate)
+    }
+  }
+  
+  public func didCreateToDoButtonTapped(group: ToDoListView.ToDoSection) {
+    Task {
+      guard let selectedDate = self.calendarView.getSelectedDate() else { return }
+  
+      await self.interactor?.createToDo(group: group, date: selectedDate)
+    }
+  }
+  
+  public func didTimerButtonTapped(group: ToDoListView.ToDoSection) {
+    self.router?.routeToTimerScene(groupId: group.id.uuidString, groupName: group.getGroupTitle())
   }
 }
 
@@ -345,39 +383,6 @@ extension HomeSceneViewController {
   
   public func getSwipedCell() -> UIView {
     return self.bottomSheet.contentView?.subviews.last ?? UIView()
-  }
-}
-// MARK: - ToDoList Button Actions
-
-extension HomeSceneViewController: ToDoListButtonActionDelegate {
-  public func didEditButtonTapped(
-    group: ToDoListView.ToDoSection,
-    todo: ToDoListView.ToDoItem
-  ) {
-    self.router?.routeToEditToDoScene(toDoId: todo.id)
-  }
-  
-  public func didDeleteButtonTapped(
-    group: ToDoListView.ToDoSection,
-    todo: ToDoListView.ToDoItem
-  ) {
-    Task {
-      guard let selectedDate = self.calendarView.getSelectedDate() else { return }
-      
-      await self.interactor?.deleteToDo(group: group, todo: todo, date: selectedDate)
-    }
-  }
-  
-  public func didCreateToDoButtonTapped(group: ToDoListView.ToDoSection) {
-    Task {
-      guard let selectedDate = self.calendarView.getSelectedDate() else { return }
-  
-      await self.interactor?.createToDo(group: group, date: selectedDate)
-    }
-  }
-  
-  public func didTimerButtonTapped(group: ToDoListView.ToDoSection) {
-    self.router?.routeToTimerScene(groupId: group.id.uuidString, groupName: group.getGroupTitle())
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
@@ -43,8 +43,40 @@ public struct HomeSceneWorker: HomeSceneWorkable, Sendable {
     return fetchedToDoList
   }
   
-  public func createToDo() async throws {
+  public func writeJSONFile(data: [HomeScene.TodoBatchItem]) async throws {
+    var storedItems = (try? self.homeStorage.getItems()) ?? []
     
+    for item in data {
+      if let index = storedItems.firstIndex(where: { $0.localId == item.localId }) {
+        storedItems[index] = item
+      } else {
+        storedItems.append(item)
+      }
+    }
+    
+    try self.homeStorage.saveItems(storedItems)
+  }
+  
+  public func requestBatchUpdateToServer() async throws {
+    let storedItems = (try? self.homeStorage.getItems()) ?? []
+    if storedItems.count == .zero { return }
+    
+    let body = try JSONEncoder().encode(HomeScene.BatchUpdate.TodoBatchRequest(data: storedItems))
+    let request = HTTPRequest(
+      method: HTTPMethod.post,
+      endPoint: URLConstants.ToDo.todoBatch,
+      body: body
+    )
+    
+    try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        try response.validateStatusCode()
+      }
+    )
+    
+    try self.homeStorage.deleteAllItems()
   }
   
   public func deleteToDo() async throws {

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneAPI/HomeSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneAPI/HomeSceneWorkable.swift
@@ -11,6 +11,7 @@ import HomeSceneEntity
 
 public protocol HomeSceneWorkable: Sendable {
   func fetchToDoList(dateString: String) async throws -> [HomeScene.FetchToDoList.Response]
-  func createToDo() async throws
+  func writeJSONFile(data: [HomeScene.TodoBatchItem]) async throws
   func deleteToDo() async throws
+  func requestBatchUpdateToServer() async throws
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneEntity/HomeSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneEntity/HomeSceneModels.swift
@@ -32,8 +32,11 @@ public enum HomeScene {
   public enum BatchUpdate {
     public struct TodoBatchRequest: Codable, Sendable {
       public let data: [TodoBatchItem]
+      
+      public init(data: [TodoBatchItem]) {
+        self.data = data
+      }
     }
-    
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/OnBoardingScene/Sources/OnBoardingScene/TutorialOnBoardingViewController.swift
@@ -66,6 +66,8 @@ public final class TutorialOnBoardingViewController: HomeSceneViewController {
     self.view.addSubview(self.bottomSheet)
     self.bottomSheet.isUserInteractionEnabled = false
   }
+  
+  override public func setLoadingIndicator() {}
 }
 
 extension TutorialOnBoardingViewController {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView+UIModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView+UIModel.swift
@@ -8,24 +8,10 @@
 import UIKit
 
 extension ToDoListView {
-  public final class ToDoSection: Hashable, @unchecked Sendable {
+  public struct ToDoSection: Hashable, Sendable {
     public let id: UUID
     let headerUIModel: ToDoGroupUIModel
-    private var _toDoItems: [ToDoItem]
-    private let lock = NSLock()
-    
-    public var toDoItems: [ToDoItem] {
-      get {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        return self._toDoItems
-      }
-      set {
-        self.lock.lock()
-        self._toDoItems = newValue
-        self.lock.unlock()
-      }
-    }
+    private(set) var toDoItems: [ToDoItem]
     
     public init(
       id: UUID = UUID(),
@@ -34,7 +20,7 @@ extension ToDoListView {
     ) {
       self.id = id
       self.headerUIModel = headerUIModel
-      self._toDoItems = toDoItems
+      self.toDoItems = toDoItems
     }
     
     public func getGroupTitle() -> String {
@@ -43,6 +29,22 @@ extension ToDoListView {
     
     public func getColor() -> UIColor {
       return self.headerUIModel.progressColor
+    }
+    
+    public func getToDoItems() -> [ToDoItem] {
+      return self.toDoItems
+    }
+    
+    public mutating func updateToDoItems(_ newToDoItems: [ToDoItem]) {
+      self.toDoItems = newToDoItems
+    }
+    
+    public mutating func appendToDoItems(_ newToDoItem: ToDoItem) {
+      self.toDoItems.append(newToDoItem)
+    }
+    
+    public mutating func removeToDoItems(at index: Int) {
+      self.toDoItems.remove(at: index)
     }
     
     public static func == (lhs: ToDoSection, rhs: ToDoSection) -> Bool {
@@ -54,7 +56,7 @@ extension ToDoListView {
     }
   }
   
-  public class ToDoItem: Hashable, @unchecked Sendable {
+  public struct ToDoItem: Hashable, Sendable {
     public let id: UUID
     public let toDoUIModel: ToDoUIModel
     
@@ -75,24 +77,10 @@ extension ToDoListView {
     }
   }
   
-  public final class ToDoGroupUIModel: Hashable, @unchecked Sendable {
+  public struct ToDoGroupUIModel: Hashable, Sendable {
     let progressColor: UIColor
-    private var _progressRate: Double
-    private let lock = NSLock()
+    private(set) var progressRate: Double
     let groupTitle: String
-    
-    public var progressRate: Double {
-      get {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        return self._progressRate
-      }
-      set {
-        self.lock.lock()
-        self._progressRate = newValue
-        self.lock.unlock()
-      }
-    }
     
     public init(
       progressColor: UIColor,
@@ -100,8 +88,12 @@ extension ToDoListView {
       groupTitle: String
     ) {
       self.progressColor = progressColor
-      self._progressRate = progressRate
+      self.progressRate = progressRate
       self.groupTitle = groupTitle
+    }
+    
+    public mutating func updateProgressRate(_ newRate: Double) {
+      self.progressRate = newRate
     }
     
     public static func == (lhs: ToDoGroupUIModel, rhs: ToDoGroupUIModel) -> Bool {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView.swift
@@ -59,15 +59,13 @@ public final class ToDoListView: UIView {
     return self.dataSource.snapshot()
   }
   
-  public func updateHeaderUIAfterDeleteTodo(section: ToDoSection) {
+  public func updateHeaderUIAfterUpdatingToDo(section: ToDoSection) {
     let newProgressRate = self.calculateProgressRate(for: section)
     
     guard let headerView = self.contentView.supplementaryView(
       forElementKind: UICollectionView.elementKindSectionHeader,
       at: IndexPath(item: 0, section: self.getSectionIndex(for: section))
-    ) as? ToDoGroupSectionHeaderView else {
-      return
-    }
+    ) as? ToDoGroupSectionHeaderView else { return }
     
     let updatedModel = section.headerUIModel
     updatedModel.progressRate = newProgressRate

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView.swift
@@ -67,8 +67,8 @@ public final class ToDoListView: UIView {
       at: IndexPath(item: 0, section: self.getSectionIndex(for: section))
     ) as? ToDoGroupSectionHeaderView else { return }
     
-    let updatedModel = section.headerUIModel
-    updatedModel.progressRate = newProgressRate
+    var updatedModel = section.headerUIModel
+    updatedModel.updateProgressRate(newProgressRate)
     headerView.update(with: updatedModel)
   }
 }
@@ -241,8 +241,8 @@ extension ToDoListView: ToDoGroupSectionHeaderViewDelegate {
       return
     }
 
-    let updatedModel = section.headerUIModel
-    updatedModel.progressRate = newProgressRate
+    var updatedModel = section.headerUIModel
+    updatedModel.updateProgressRate(newProgressRate)
     headerView.update(with: updatedModel)
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView.swift
@@ -51,8 +51,8 @@ public final class ToDoListView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
   
-  public func apply(_ snapshot: Snapshot) {
-    self.dataSource.apply(snapshot)
+  public func apply(_ snapshot: Snapshot, completion: (() -> Void)? = nil) {
+    self.dataSource.apply(snapshot, completion: completion)
   }
   
   public func getSnapShot() -> Snapshot {


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #894 
## 🎉 변경 사항
- 스냅샷 모델을 구조체로 변경합니다. 
- 파일매니저 기반으로 배치처리를 진행합니다. 
- rest api 연동완료

## 📌 PR Point

### 흐름 정리 
<img width="728" alt="스크린샷 2025-03-27 오후 3 51 10" src="https://github.com/user-attachments/assets/da3729e7-fffd-4e87-b38a-18846edb4f4d" />

### 해야할 일 
1) GRDB 적용 
2) 메모리 사용량 관리 
투두리스트를 보여줌에 있어서 스냅샷을 날짜마다, 월마다 apply하고 있습니다. 
이 과정에서 메모리에서 해제되지 않는 무언가가 있어 보입니다. 

#### 먼저, 앱 실행하고 아무것도 하지 않으면 평균적으로 33MB 정도의 메모리 사용량을 유지합니다. 
<img width="353" alt="스크린샷 2025-03-27 오후 3 56 34" src="https://github.com/user-attachments/assets/8af094d3-4101-40aa-a21c-17dd7df70d60" />

그리고, 날짜를 바꾸거나 월을 바꾸는 행위를 할 때마다 , 메모리사용량이 0.3~0.8MB 가 증가하고, 시간이 지나도 안정화 되지 않는 현상을 발견했습니다. 데이터를 받아오고, 표시하는 과정에서 무엇인가 메모리에서 해제되고 있지 않는 것 같습니다. 

아래는 Instrument를 키고, 1분간 날짜, 월 와리가리를 치면서 확인한 결과입니다. leak은 감지되지 않았고, 앱 실행후, 약 27만번의 Call이 있었는데, 그중 17만번의 Call이 apply에서 일어났고, 실제로도 apply 전후로 메모리사용량이 증가하는 것을 확인했습니다. call count가 많다고 해서 원인이라고 확정하긴 어렵습니만... apply 이후 cell 업데이트 과정에서 원인이 있을 것으로 추정됩니다. 일단 유력한 후보입니다. 

<img width="942" alt="스크린샷 2025-03-27 오후 4 14 41" src="https://github.com/user-attachments/assets/f9dc587c-7f06-4175-9095-298989bc7633" />

<img width="491" alt="스크린샷 2025-03-27 오후 4 06 29" src="https://github.com/user-attachments/assets/4d9e1f94-308c-4295-beef-1012412fc8e1" />
<img width="832" alt="스크린샷 2025-03-27 오후 4 07 23" src="https://github.com/user-attachments/assets/b9d46a2e-2555-4f5b-b287-604650165781" />

## Styled.Row의 resetState 미적용으로 인한 문제로 확인되었습니다. 노아가 머지해준 내용이 들어가면 문제 해결 됩니다.  

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?