### PR TITLE
Feature/#905 imple image down sampling

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Cache+ImageClient.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Cache+ImageClient.swift
@@ -11,12 +11,31 @@ extension Cache where Request == ImageClient {
 public struct ImageClient: Requestable {
   var request: @Sendable (URL) async throws -> Data
   
-  public func execute(id: URL) async throws -> UIImage {
-    let data = try await self.request(id)
-    guard let image = UIImage(data: data) else {
-      throw CocoaError(.coderInvalidValue)
-    }
-    return image
+  public func execute(id: URL, isDownsample: Bool = false) async throws -> UIImage {
+    let data = try await request(id)
+    
+    return isDownsample
+    ? downsample(imageData: data, for: CGSize(width: 72, height: 72), scale: 1.0)
+    : try UIImage(data: data) ?? { throw CocoaError(.coderInvalidValue) }()
+  }
+  
+  private func downsample(imageData: Data, for size: CGSize, scale: CGFloat) -> UIImage {
+    let imageSourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+    guard let imageSource = CGImageSourceCreateWithData(imageData as CFData, imageSourceOptions)
+      else { return UIImage() }
+    
+    let maxDimensionInPixels = max(size.width, size.height) * scale
+    let downsampleOptions = [
+      kCGImageSourceCreateThumbnailFromImageAlways: true,
+      kCGImageSourceShouldCacheImmediately: true,
+      kCGImageSourceCreateThumbnailWithTransform: true,
+      kCGImageSourceThumbnailMaxPixelSize: maxDimensionInPixels
+    ] as CFDictionary
+    
+    guard let downsampledImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, downsampleOptions)
+      else { return UIImage() }
+    
+    return UIImage(cgImage: downsampledImage)
   }
 }
 

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Cache.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Cache.swift
@@ -110,7 +110,7 @@ public final actor Cache<Request: Requestable>: Sendable {
   private func initialTask(_ id: Request.ID) -> Task<Void, Never> {
     Task {
       do {
-        let response = try await self.request.execute(id: id)
+        let response = try await self.request.execute(id: id, isDownsample: false)
         try Task.checkCancellation()
         let key = id.description
         let continuations = self.storage.continuations(forKey: key)

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Requestable.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Requestable.swift
@@ -4,6 +4,6 @@ import Foundation
 public protocol Requestable: Sendable {
   associatedtype ID: Hashable, Sendable, CustomStringConvertible
   associatedtype Response: MemorySizeProvider
-  func execute(id: ID) async throws -> Response
+  func execute(id: ID, isDownsample: Bool) async throws -> Response
 }
 // swiftlint:enable type_name

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -234,7 +234,7 @@ extension SearchGardenViewController: SearchGardenDisplayLogic {
       guard let imageURL = user.userImageURL else { continue }
       Task {
         do {
-          let image = try await ImageClient.live.execute(id: imageURL)
+          let image = try await ImageClient.live.execute(id: imageURL, isDownsample: true)
           let updatedUser = user
           
           updatedUser.userImage = image

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -90,7 +90,7 @@ extension SettingViewController: SettingDisplayLogic {
 
     Task {
       do {
-        let image = try await ImageClient.live.execute(id: imageUrl)
+        let image = try await ImageClient.live.execute(id: imageUrl, isDownsample: true)
         self.profileRow.iconImage = image
       } catch {
         debugPrint("SettingScene: Image Download failed")

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -194,7 +194,7 @@ extension ShareGardenSceneViewController.MyGardenView {
     Task {
       guard let imageURL = imageURL else { return }
       
-      let image = try await Cache.shared.execute(id: imageURL)
+      let image = try await ImageClient.live.execute(id: imageURL, isDownsample: true)
       self.profileInfoView.iconImage = image
     }
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #905 
## 🎉 변경 사항
- 72x72로 스케일을 조절하고 해상도에 맞게 다운샘플링합니다. 

## 📌 PR Point

### ImageClient.live.execute() 메서드에 Bool파라미터로 다운샘플링 여부를 결정합니다. 
### 이미지 로드시, 런타임 메모리 사용량 120MB 이상 -> 50MB 로 안정화 되었습니다. 
### 해당 브랜치에 패키지 의존성 관련 빌드에러가 나는 상태입니다. 머지되면 해결됩니다. 
(지금 앱코어 모듈 Package에 `SearchGardenScene` 의존성 없음, develop엔 적용되어있는 상태)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?