### PR TITLE
홈화면 -> 투두 수정 화면 라우팅 기능 추가

### DIFF
--- a/ToDo-Garden/TDFoundation/Package.swift
+++ b/ToDo-Garden/TDFoundation/Package.swift
@@ -16,6 +16,10 @@ let package = Package(
     Product.library(
       name: "HTTPClient",
       targets: ["HTTPClient"]
+    ),
+    Product.library(
+      name: "SharedEntity",
+      targets: ["SharedEntity"]
     )
   ],
   dependencies: [
@@ -43,6 +47,9 @@ let package = Package(
         ),
         "HTTPClientAPI"
       ]
+    ),
+    Target.target(
+      name: "SharedEntity"
     ),
     Target.testTarget(
       name: "HTTPClientTests",

--- a/ToDo-Garden/TDFoundation/Sources/SharedEntity/TodoBatchItem.swift
+++ b/ToDo-Garden/TDFoundation/Sources/SharedEntity/TodoBatchItem.swift
@@ -1,0 +1,59 @@
+//
+//  TodoBatchItem.swift
+//  TDFoundation
+//
+//  Created by Wood on 4/1/25.
+//
+
+// swiftlint:disable all
+public final class TodoBatchItem: Codable, @unchecked Sendable {
+  public let localId: String
+  public var name: String
+  public var isDone: Bool
+  public let createdAt: String
+  public var isAlarmOn: Bool
+  public var alarmTime: Double
+  public var isOnlyToday: Bool
+  public var startDay: String?
+  public var endDay: String?
+  public let groupId: String
+  public var isDelete: Bool
+
+  public init(localId: String, name: String, isDone: Bool, createdAt: String, isAlarmOn: Bool, alarmTime: Double, isOnlyToday: Bool, startDay: String?, endDay: String?, groupId: String, isDelete: Bool) {
+    self.localId = localId
+    self.name = name
+    self.isDone = isDone
+    self.createdAt = createdAt
+    self.isAlarmOn = isAlarmOn
+    self.alarmTime = alarmTime
+    self.isOnlyToday = isOnlyToday
+    self.startDay = startDay
+    self.endDay = endDay
+    self.groupId = groupId
+    self.isDelete = isDelete
+  }
+
+  public func setDelete(_ isDelete: Bool) {
+    self.isDelete = isDelete
+  }
+
+  public func setDone(_ isDone: Bool) {
+    self.isDone = isDone
+  }
+
+  public func setName(_ newName: String) {
+    self.name = newName
+  }
+
+  public func setAlarm(isOn: Bool, time: Double) {
+    self.isAlarmOn = isOn
+    self.alarmTime = time
+  }
+
+  public func setPeriod(start: String, end: String) {
+    self.isOnlyToday = false
+    self.startDay = start
+    self.endDay = end
+  }
+}
+// swiftlint:enable all

--- a/ToDo-Garden/TDFoundation/Sources/SharedEntity/TodoListGroup.swift
+++ b/ToDo-Garden/TDFoundation/Sources/SharedEntity/TodoListGroup.swift
@@ -1,0 +1,22 @@
+//
+//  TodoListGroup.swift
+//  TDFoundation
+//
+//  Created by Wood on 4/1/25.
+//
+
+public final class TodoListGroup: Codable, @unchecked Sendable {
+  public let localId: String
+  public let name: String
+  public let color: String
+  public var todoList: [TodoListItem]?
+  public let progressRate: Double
+
+  public init(localId: String, name: String, color: String, todoList: [TodoListItem]?, progressRate: Double) {
+    self.localId = localId
+    self.name = name
+    self.color = color
+    self.todoList = todoList
+    self.progressRate = progressRate
+  }
+}

--- a/ToDo-Garden/TDFoundation/Sources/SharedEntity/TodoListItem.swift
+++ b/ToDo-Garden/TDFoundation/Sources/SharedEntity/TodoListItem.swift
@@ -1,0 +1,37 @@
+//
+//  TodoListItem.swift
+//  TDFoundation
+//
+//  Created by Wood on 4/1/25.
+//
+
+// swiftlint:disable all
+public final class TodoListItem: Codable, @unchecked Sendable {
+  public var name: String
+  public let endDay: String?
+  public var isDone: Bool
+  public let localID: String
+  public let startDay: String?
+  public let alarmTime: Int?
+  public let isAlarmOn: Bool
+  public let isOnlyToday: Bool
+  public let repeatToDoId: String?
+
+  enum CodingKeys: String, CodingKey {
+    case name, endDay, isDone, startDay, alarmTime, isAlarmOn, isOnlyToday, repeatToDoId
+    case localID = "local_id"
+  }
+
+  public init(name: String, endDay: String?, isDone: Bool, localID: String, startDay: String?, alarmTime: Int?, isAlarmOn: Bool, isOnlyToday: Bool, repeatToDoId: String?) {
+    self.name = name
+    self.endDay = endDay
+    self.isDone = isDone
+    self.localID = localID
+    self.startDay = startDay
+    self.alarmTime = alarmTime
+    self.isAlarmOn = isAlarmOn
+    self.isOnlyToday = isOnlyToday
+    self.repeatToDoId = repeatToDoId
+  }
+}
+// swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
@@ -15,6 +15,7 @@ import ManageGroupScene
 import MyStatsScene
 import PostGroupScene
 import SearchGardenScene
+import SharedEntity
 import ShareGardenScene
 import SignUpScene
 import TDFoundation
@@ -27,7 +28,7 @@ extension HomeSceneBuilder.Dependency {
   public static let live = HomeSceneBuilder.Dependency.init(
     homeSceneWorker: HomeSceneWorker(
       httpClient: HTTPClient.live,
-      homeStorage: JSONStorage<HomeScene.TodoBatchItem>(fileName: "todolistBatch.json")
+      homeStorage: JSONStorage<SharedEntity.TodoBatchItem>(fileName: "todolistBatch.json")
     ),
     manageGroupSceneBuilder: ManageGroupSceneBuilder.init(dependency: .live),
     editToDoSceneBuilder: EditToDoSceneBuilder(dependency: .live),

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -9,10 +9,12 @@ import Foundation
 
 import EditToDoSceneAPI
 import EditToDoSceneEntity
+import SharedEntity
 
 @MainActor
 protocol EditToDoDataStore {
-  var toDoId: UUID? { get set }
+  var toDo: SharedEntity.TodoBatchItem? { get set }
+  var groups: [SharedEntity.TodoListGroup]? { get set }
 }
 
 @MainActor
@@ -30,8 +32,8 @@ protocol EditToDoBusinessLogic {
 
 @MainActor
 final class EditToDoInteractor: EditToDoDataStore {
-  var toDoId: UUID?
-  var toDo: EditToDo.ToDo?
+  var toDo: SharedEntity.TodoBatchItem?
+  var groups: [SharedEntity.TodoListGroup]?
 
   // MARK: VIP Objects
   var presenter: EditToDoPresentationLogic?
@@ -50,59 +52,55 @@ final class EditToDoInteractor: EditToDoDataStore {
 extension EditToDoInteractor: EditToDoBusinessLogic {
   /// 사용자가 투두 알림 스위치를 통해 활성화 여부를 변경했을 때 호출되는 메서드입니다.
   func changeAlarmActivation() {
-    guard let isAlarmOn = self.toDo?.alarm.isAlarmOn
-    else { return }
-
-    self.toDo?.alarm.isAlarmOn = !isAlarmOn
-    let response = EditToDo.ChangeAlarmActivation.Response(isAlarmOn: !isAlarmOn)
-    self.presenter?.presentAlarmActivation(response: response)
+//    self.toDo.isAlarmOn.toggle()
+//    let response = EditToDo.ChangeAlarmActivation.Response(isAlarmOn: self.toDo.isAlarmOn)
+//    self.presenter?.presentAlarmActivation(response: response)
   }
 
   /// 사용자가 투두 알림 시간 설정 버튼을 눌렀을 때, 기존에 설정했던 시간을 보여주기 위해 호출되는 메서드입니다.
   func fetchAlarmTime() {
-    let alarmTime = self.toDo?.alarm.alarmTime
-    let response = EditToDo.FetchAlarmTime.Response(alarmTime: alarmTime)
-    self.presenter?.presentFetchedAlarmTime(response: response)
+//    let alarmTime = self.toDo?.alarm.alarmTime
+//    let response = EditToDo.FetchAlarmTime.Response(alarmTime: alarmTime)
+//    self.presenter?.presentFetchedAlarmTime(response: response)
   }
 
   func changeAlarmTime(request: EditToDo.ChangeAlarmTime.Request) {
-    let alarmTime = request.alarmTime
-    self.toDo?.alarm.alarmTime = alarmTime
-    let response = EditToDo.ChangeAlarmTime.Response(alarmTime: alarmTime)
-    self.presenter?.presentChangedAlarmTime(response: response)
+//    let alarmTime = request.alarmTime
+//    self.toDo?.alarm.alarmTime = alarmTime
+//    let response = EditToDo.ChangeAlarmTime.Response(alarmTime: alarmTime)
+//    self.presenter?.presentChangedAlarmTime(response: response)
   }
 
   func changeRepetition(isOnlyToday: Bool) {
-    self.toDo?.repetition.isOnlyToday = isOnlyToday
-    if isOnlyToday {
-      self.presenter?.presentRepeatOnlyToday()
-    } else {
-      let currentDate = Date()
-      let tomorrowDate = currentDate.addingTimeInterval(60 * 60 * 24)
-      let repetition = self.toDo?.repetition
-      if repetition?.startDate == nil && repetition?.endDate == nil {
-        self.toDo?.repetition.startDate = currentDate
-        self.toDo?.repetition.endDate = tomorrowDate
-      }
-
-      let response = EditToDo.ChangeRepetitionRange.Response(
-        startDate: self.toDo?.repetition.startDate ?? currentDate,
-        endDate: self.toDo?.repetition.endDate ?? tomorrowDate
-      )
-      self.presenter?.presentChangedRepetitionRange(response: response)
-    }
+//    self.toDo?.repetition.isOnlyToday = isOnlyToday
+//    if isOnlyToday {
+//      self.presenter?.presentRepeatOnlyToday()
+//    } else {
+//      let currentDate = Date()
+//      let tomorrowDate = currentDate.addingTimeInterval(60 * 60 * 24)
+//      let repetition = self.toDo?.repetition
+//      if repetition?.startDate == nil && repetition?.endDate == nil {
+//        self.toDo?.repetition.startDate = currentDate
+//        self.toDo?.repetition.endDate = tomorrowDate
+//      }
+//
+//      let response = EditToDo.ChangeRepetitionRange.Response(
+//        startDate: self.toDo?.repetition.startDate ?? currentDate,
+//        endDate: self.toDo?.repetition.endDate ?? tomorrowDate
+//      )
+//      self.presenter?.presentChangedRepetitionRange(response: response)
   }
 
   /// 사용자가 투두 반복 설정 뷰를 선택했을 때 호출하는 메서드입니다.
   func changeReptitionRange(request: EditToDo.ChangeRepetitionRange.Request) {
-    self.toDo?.repetition.isOnlyToday = false
-    let startDate = request.startDate
-    let endDate = request.endDate
-    self.toDo?.repetition.startDate = startDate
-    self.toDo?.repetition.endDate = endDate
-
-    let response = EditToDo.ChangeRepetitionRange.Response(startDate: startDate, endDate: endDate)
-    self.presenter?.presentChangedRepetitionRange(response: response)
+//    self.toDo?.repetition.isOnlyToday = false
+//    let startDate = request.startDate
+//    let endDate = request.endDate
+//    self.toDo?.repetition.startDate = startDate
+//    self.toDo?.repetition.endDate = endDate
+//
+//    let response = EditToDo.ChangeRepetitionRange.Response(startDate: startDate, endDate: endDate)
+//    self.presenter?.presentChangedRepetitionRange(response: response)
   }
 }
 
@@ -118,26 +116,26 @@ extension EditToDoInteractor {
 
   /// 서버로부터 수정할 투두의 정보를 받아오는 메서드입니다.
   private func fetchToDo() {
-    guard let id = self.toDoId else {
-      self.presenter?.presentError(.network)
-      return
-    }
-
-    self.tasks[TaskKey.fetchToDo] = Task {
-      defer { self.tasks[TaskKey.fetchToDo] = nil }
-
-      do {
-        try Task.checkCancellation()
-        let toDo = try await self.editToDoWorker.fetchToDo(id: id)
-        try Task.checkCancellation()
-        self.toDo = toDo
-        let response = EditToDo.FetchToDo.Response(toDo: toDo)
-        self.presenter?.presentFetchedToDo(response: response)
-      } catch let error {
-        debugPrint(error.localizedDescription)
-        self.presenter?.presentError(.failToFetch)
-      }
-    }
+//    guard let id = self.toDoId else {
+//      self.presenter?.presentError(.network)
+//      return
+//    }
+//
+//    self.tasks[TaskKey.fetchToDo] = Task {
+//      defer { self.tasks[TaskKey.fetchToDo] = nil }
+//
+//      do {
+//        try Task.checkCancellation()
+//        let toDo = try await self.editToDoWorker.fetchToDo(id: id)
+//        try Task.checkCancellation()
+//        self.toDo = toDo
+//        let response = EditToDo.FetchToDo.Response(toDo: toDo)
+//        self.presenter?.presentFetchedToDo(response: response)
+//      } catch let error {
+//        debugPrint(error.localizedDescription)
+//        self.presenter?.presentError(.failToFetch)
+//      }
+//    }
   }
 
   private func fetchGroupList() {
@@ -157,54 +155,54 @@ extension EditToDoInteractor {
 
   /// 서버에 투두의 수정을 요청하는 메서드입니다.
   func editToDo(request: EditToDo.CompleteEditToDo.Request) {
-    guard let toDo else {
-      self.presenter?.presentError(.failToFetch)
-      return
-    }
-
-    self.toDo?.name = request.toDoName
-    self.toDo?.groupData = EditToDo.Group(
-      id: request.displayedGroup.id,
-      name: request.displayedGroup.name,
-      color: request.displayedGroup.color.hexStringFromColor(),
-      orderIdx: 0
-    )
-
-    self.tasks[TaskKey.editToDo] = Task {
-      defer { self.tasks[TaskKey.editToDo] = nil }
-
-      do {
-        try Task.checkCancellation()
-        try await self.editToDoWorker.editToDo(toDo)
-        try Task.checkCancellation()
-        self.presenter?.presentDismiss()
-      } catch let error {
-        debugPrint(error.localizedDescription)
-        self.presenter?.presentError(.network)
-      }
-    }
+//    guard let toDo else {
+//      self.presenter?.presentError(.failToFetch)
+//      return
+//    }
+//
+//    self.toDo?.name = request.toDoName
+//    self.toDo?.groupData = EditToDo.Group(
+//      id: request.displayedGroup.id,
+//      name: request.displayedGroup.name,
+//      color: request.displayedGroup.color.hexStringFromColor(),
+//      orderIdx: 0
+//    )
+//
+//    self.tasks[TaskKey.editToDo] = Task {
+//      defer { self.tasks[TaskKey.editToDo] = nil }
+//
+//      do {
+//        try Task.checkCancellation()
+//        try await self.editToDoWorker.editToDo(toDo)
+//        try Task.checkCancellation()
+//        self.presenter?.presentDismiss()
+//      } catch let error {
+//        debugPrint(error.localizedDescription)
+//        self.presenter?.presentError(.network)
+//      }
+//    }
   }
 
   /// 서버에 투두의 삭제를 요청하는 메서드입니다.
   func deleteToDo() {
-    guard let toDoId else {
-      self.presenter?.presentError(.failToFetch)
-      return
-    }
-
-    self.tasks[TaskKey.deleteToDo] = Task {
-      defer { self.tasks[TaskKey.deleteToDo] = nil }
-
-      do {
-        try Task.checkCancellation()
-        try await self.editToDoWorker.deleteToDo(id: toDoId)
-        try Task.checkCancellation()
-        self.presenter?.presentDismiss()
-      } catch let error {
-        debugPrint(error.localizedDescription)
-        self.presenter?.presentError(.network)
-      }
-    }
+//    guard let toDoId else {
+//      self.presenter?.presentError(.failToFetch)
+//      return
+//    }
+//
+//    self.tasks[TaskKey.deleteToDo] = Task {
+//      defer { self.tasks[TaskKey.deleteToDo] = nil }
+//
+//      do {
+//        try Task.checkCancellation()
+//        try await self.editToDoWorker.deleteToDo(id: toDoId)
+//        try Task.checkCancellation()
+//        self.presenter?.presentDismiss()
+//      } catch let error {
+//        debugPrint(error.localizedDescription)
+//        self.presenter?.presentError(.network)
+//      }
+//    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneBuilder.swift
@@ -62,6 +62,7 @@ extension EditToDoSceneBuilder {
   ///   - viewController: 런타임 의존성을 설정할 ViewController 객체입니다.
   ///   - payload: 런타임에 전달할 의존성입니다.
   private func setPayload(for viewController: EditToDoViewController, with payload: EditToDoScenePayloadable) {
-    viewController.router?.dataStore?.toDoId = payload.toDoId
+    viewController.router?.dataStore?.toDo = payload.toDo
+    viewController.router?.dataStore?.groups = payload.groups
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -64,6 +64,7 @@ final public class EditToDoViewController: UIViewController, EditToDoViewControl
 
   public override func viewDidLoad() {
     super.viewDidLoad()
+    print("i'm called")
     self.setup()
   }
 
@@ -89,7 +90,7 @@ extension EditToDoViewController: ToDoAlarmTimeSettingModalDelegate, ToDoRepetit
 extension EditToDoViewController: EditToDoScheduleViewDelegate {
   func editToDo() {
     if let toDoNameForEdit = self.editToDoView.getEditingText(),
-      let groupForEdit = self.editToDoView.getCurrentGroup() {
+    let groupForEdit = self.editToDoView.getCurrentGroup() {
       let request = EditToDo.CompleteEditToDo.Request(
         toDoName: toDoNameForEdit,
         displayedGroup: EditToDo.DisplayedGroup(
@@ -276,21 +277,23 @@ extension EditToDoViewController: UIScrollViewDelegate {
 }
 
 import HTTPClient
+import SharedEntity
 
 extension EditToDoViewController {
   struct EditToDoScenePayload: EditToDoScenePayloadable {
-    var toDoId: UUID
+    var toDo: SharedEntity.TodoBatchItem
+    var groups: [SharedEntity.TodoListGroup]
   }
 
   class SomeViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
-      super.viewDidAppear(animated)
-      let editToDoViewController = EditToDoSceneBuilder(
-        dependency: EditToDoSceneBuilder.Dependency(
-          editToDoWorker: EditToDoWorker(httpClient: HTTPClient.live)
-        )
-      ).build(with: EditToDoViewController.EditToDoScenePayload(toDoId: UUID()))
-      self.navigationController?.pushViewController(editToDoViewController, animated: true)
+      //      super.viewDidAppear(animated)
+      //      let editToDoViewController = EditToDoSceneBuilder(
+      //        dependency: EditToDoSceneBuilder.Dependency(
+      //          editToDoWorker: EditToDoWorker(httpClient: HTTPClient.live)
+      //        )
+      //      ).build(with: EditToDoViewController.EditToDoScenePayload(toDoId: UUID()))
+      //      self.navigationController?.pushViewController(editToDoViewController, animated: true)
     }
   }
 }
@@ -308,19 +311,19 @@ extension EditToDoViewController {
       break
     }
   }
-  
+
   public func getToDoNameInputView() -> UIView {
     return self.editToDoView.getToDoNameInputView()
   }
-  
+
   public func getGroupSelectionView() -> UIView {
     return self.editToDoView.getGroupSelectionView()
   }
-  
+
   public func getSegmentedControl() -> UIView {
     return self.editToDoSegmentedControl
   }
-  
+
   public func getAlarmTimeView() -> UIView {
     return self.editToDoScheduleView.getAlarmTimeView()
   }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneAPI/EditToDoSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneAPI/EditToDoSceneBuildable.swift
@@ -7,8 +7,12 @@
 
 import Foundation
 
+import SharedEntity
+
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
 public protocol EditToDoScenePayloadable {
+  var toDo: SharedEntity.TodoBatchItem { get set }
+  var groups: [SharedEntity.TodoListGroup] { get set }
 }
 
 @MainActor

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneAPI/EditToDoSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneAPI/EditToDoSceneBuildable.swift
@@ -9,7 +9,6 @@ import Foundation
 
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
 public protocol EditToDoScenePayloadable {
-  var toDoId: UUID { get }
 }
 
 @MainActor

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Package.swift
@@ -22,11 +22,18 @@ let package = Package(
     Package.Dependency.package(path: "../TDUtility"),
     Package.Dependency.package(path: "../ManageGroupScene"),
     Package.Dependency.package(path: "../EditToDoScene"),
-    Package.Dependency.package(path: "../TimerScene")
+    Package.Dependency.package(path: "../TimerScene"),
+    Package.Dependency.package(path: "../TDFoundation")
   ],
   targets: [
     Target.target(
-      name: "HomeSceneEntity"
+      name: "HomeSceneEntity",
+      dependencies: [
+        Target.Dependency.product(
+          name: "SharedEntity",
+          package: "TDFoundation"
+        )
+      ]
     ),
     Target.target(
       name: "HomeSceneAPI",
@@ -69,6 +76,10 @@ let package = Package(
         Target.Dependency.product(
           name: "TimerScene",
           package: "TimerScene"
+        ),
+        Target.Dependency.product(
+          name: "SharedEntity",
+          package: "TDFoundation"
         )
       ]
     )

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -30,6 +30,7 @@ protocol HomeSceneBusinessLogic {
   func updateSelection(isSelected: Bool, indexPath: IndexPath, date: Date)
   func writeJSONFile() async
   func requestBatchUpdateToServer() async
+  func prepareDataForEditTodoScene(todoId: UUID)
 }
 
 @MainActor
@@ -45,7 +46,12 @@ final class HomeSceneInteractor: HomeSceneDataStore {
   // ⬆️ JSONStorage가 매번 fileWrite를 하기엔 부담스러워서 모아놨다가 적절한 순간에 fileWrite를 진행하기 위한 데이터입니다.
   // 즉, 서버에게 배치처리를 요청하기 위한 배치처리 과정이라고 볼 수 있습니다.
   // ex) key = ToDo의 UUIDString
-  
+  // ex) key = "20250302"
+
+  var toDo: SharedEntity.TodoBatchItem?
+  var groups: [SharedEntity.TodoListGroup]?
+  // ⬆️ 투두 수정화면에서 필요한 데이터입니다.
+
   init(homeSceneWorker: HomeSceneWorkable) {
     self.homeSceneWorker = homeSceneWorker
     self.monthlyData = [:]
@@ -175,6 +181,16 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
         groupId: targetGroup.localId, isDelete: false
       )
     }
+  }
+
+  // EditToDoScene으로 넘겨주기 위한 데이터를 준비하는 작업입니다.
+  func prepareDataForEditTodoScene(todoId: UUID) {
+    let today = Date().description.toYYYYMMDDStringFromISO8601Space()
+    guard let groups = self.monthlyData[today]?.first
+    else { return }
+
+    self.toDo = itemsForBatch[todoId.uuidString]
+    self.presenter?.presentDataForEditToDoScene()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -30,7 +30,7 @@ protocol HomeSceneBusinessLogic {
   func updateSelection(isSelected: Bool, indexPath: IndexPath, date: Date)
   func writeJSONFile() async
   func requestBatchUpdateToServer() async
-  func prepareDataForEditTodoScene(todoId: UUID)
+  func prepareDataForEditTodoScene(request: HomeScene.PrepareDataForEditToDoScene.Request)
 }
 
 @MainActor
@@ -91,7 +91,6 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
     }
   
     self.presenter?.presentCreateToDo(newToDo: newToDo)
-
   }
   
   func deleteToDo(group:ToDoListView.ToDoSection, todo: ToDoListView.ToDoItem, date: Date) async {
@@ -184,13 +183,41 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
   }
 
   // EditToDoScene으로 넘겨주기 위한 데이터를 준비하는 작업입니다.
-  func prepareDataForEditTodoScene(todoId: UUID) {
-    let today = Date().description.toYYYYMMDDStringFromISO8601Space()
-    guard let groups = self.monthlyData[today]?.first
-    else { return }
+  func prepareDataForEditTodoScene(request: HomeScene.PrepareDataForEditToDoScene.Request) {
+    let dateString = request.selectedDate.description.toYYYYMMDDStringFromISO8601Space()
+    let groups = self.monthlyData[dateString]
+    print(request.groupId.uuidString.lowercased())
+    print(groups?[1].localId == request.groupId.uuidString.lowercased())
+    let group = groups?.first(where: { (group: SharedEntity.TodoListGroup) in
+      return group.localId.lowercased() == request.groupId.uuidString.lowercased()
+    })!
+    let todo = group?.todoList?.first(where: { (todo: SharedEntity.TodoListItem) in
+      return todo.localID.lowercased() == request.todoId.uuidString.lowercased()
+    })!
 
-    self.toDo = itemsForBatch[todoId.uuidString]
+    self.groups = groups
+    self.toDo = self.makeToDoBatchItem(from: todo!, groupId: group!.localId, dateString: dateString)
     self.presenter?.presentDataForEditToDoScene()
+  }
+
+  private func makeToDoBatchItem(
+    from todo: SharedEntity.TodoListItem,
+    groupId: String,
+    dateString: String
+  ) -> SharedEntity.TodoBatchItem {
+    return SharedEntity.TodoBatchItem(
+      localId: todo.localID,
+      name: todo.name,
+      isDone: todo.isDone,
+      createdAt: dateString,
+      isAlarmOn: todo.isAlarmOn,
+      alarmTime: Double(todo.alarmTime ?? 0),
+      isOnlyToday: todo.isOnlyToday,
+      startDay: todo.startDay,
+      endDay: todo.endDay,
+      groupId: groupId,
+      isDelete: false
+    )
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -35,9 +35,6 @@ protocol HomeSceneBusinessLogic {
 
 @MainActor
 final class HomeSceneInteractor: HomeSceneDataStore {
-  var toDo: SharedEntity.TodoBatchItem?
-  var groups: [SharedEntity.TodoListGroup]?
-
   var presenter: (any HomeScenePresentationLogic)?
   private var homeSceneWorker: HomeSceneWorkable
   private var monthlyData: [String: [SharedEntity.TodoListGroup]]

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -13,7 +13,10 @@ import HomeSceneEntity
 import SharedEntity
 import ToDoGardenUIComponent
 
+@MainActor
 protocol HomeSceneDataStore {
+  var toDo: SharedEntity.TodoBatchItem? { get set }
+  var groups: [SharedEntity.TodoListGroup]? { get set }
 }
 
 @MainActor
@@ -21,7 +24,7 @@ protocol HomeSceneBusinessLogic {
   func fetchToDoList(request: HomeScene.FetchToDoList.Request) async
   func createToDo(group: ToDoListView.ToDoSection, date: Date) async
   func deleteToDo(group: ToDoListView.ToDoSection, todo: ToDoListView.ToDoItem, date: Date) async
-  func setMonthlyData(_ monthlyData: [String: [HomeScene.TodoListGroup]]) async
+  func setMonthlyData(_ monthlyData: [String: [SharedEntity.TodoListGroup]]) async
   func loadDailyToDoList(targetDate: String) async
   func updateText(text: String, indexPath: IndexPath, date: Date)
   func updateSelection(isSelected: Bool, indexPath: IndexPath, date: Date)
@@ -31,9 +34,12 @@ protocol HomeSceneBusinessLogic {
 
 @MainActor
 final class HomeSceneInteractor: HomeSceneDataStore {
+  var toDo: SharedEntity.TodoBatchItem?
+  var groups: [SharedEntity.TodoListGroup]?
+
   var presenter: (any HomeScenePresentationLogic)?
   private var homeSceneWorker: HomeSceneWorkable
-  private var monthlyData: [String: [HomeScene.TodoListGroup]]
+  private var monthlyData: [String: [SharedEntity.TodoListGroup]]
   // ⬆️ 서버에서 받아오는 1달짜리 데이터입니다. ex) key = "20250302"
   private var itemsForBatch: [String: SharedEntity.TodoBatchItem]
   // ⬆️ JSONStorage가 매번 fileWrite를 하기엔 부담스러워서 모아놨다가 적절한 순간에 fileWrite를 진행하기 위한 데이터입니다.
@@ -61,7 +67,7 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
   
   func loadDailyToDoList(targetDate: String) async {
     let formattedDate = targetDate.toYYYYMMDDStringFromISO8601Space()
-    let dailyToDoList: [HomeScene.TodoListGroup] = self.monthlyData[formattedDate] ?? []
+    let dailyToDoList: [SharedEntity.TodoListGroup] = self.monthlyData[formattedDate] ?? []
     
     self.presenter?.presentDailyToDoList(dailyData: dailyToDoList)
   }
@@ -84,8 +90,8 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
   
   func deleteToDo(group:ToDoListView.ToDoSection, todo: ToDoListView.ToDoItem, date: Date) async {
     let dateString = date.description.toYYYYMMDDStringFromISO8601Space()
-    var deletedToDo: HomeScene.TodoListItem? = nil
-    
+    var deletedToDo: SharedEntity.TodoListItem? = nil
+
     if let targetGroupIndex = self.monthlyData[dateString]?.firstIndex(
       where: { UUID(uuidString: $0.localId) == group.id }
     ) {
@@ -105,7 +111,7 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
     self.presenter?.presentDeleteToDo(groupID: group.id, deletedToDo: todo)
   }
   
-  func setMonthlyData(_ monthlyData: [String: [HomeScene.TodoListGroup]]) async {
+  func setMonthlyData(_ monthlyData: [String: [SharedEntity.TodoListGroup]]) async {
     self.monthlyData = monthlyData
   }
   
@@ -204,7 +210,7 @@ extension HomeSceneInteractor {
     return newItem
   }
   
-    private func makeItemForDeleteToDo(group: ToDoListView.ToDoSection, todo: HomeScene.TodoListItem, date: Date) -> SharedEntity.TodoBatchItem {
+  private func makeItemForDeleteToDo(group: ToDoListView.ToDoSection, todo: SharedEntity.TodoListItem, date: Date) -> SharedEntity.TodoBatchItem {
     let groupID = group.id.uuidString
     let alarmTime = Double(todo.alarmTime ?? 0)
     
@@ -224,8 +230,8 @@ extension HomeSceneInteractor {
     return deletedItem
   }
   
-  private func makeToDoListItem(batchItem: SharedEntity.TodoBatchItem) -> HomeScene.TodoListItem {
-    let todoListItem = HomeScene.TodoListItem(
+  private func makeToDoListItem(batchItem: SharedEntity.TodoBatchItem) -> SharedEntity.TodoListItem {
+    let todoListItem = SharedEntity.TodoListItem(
       name: batchItem.name,
       endDay: nil,
       isDone: false,

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -10,6 +10,7 @@ import UIKit
 import FoundationExtension
 import HomeSceneAPI
 import HomeSceneEntity
+import SharedEntity
 import ToDoGardenUIComponent
 
 protocol HomeSceneDataStore {
@@ -34,7 +35,7 @@ final class HomeSceneInteractor: HomeSceneDataStore {
   private var homeSceneWorker: HomeSceneWorkable
   private var monthlyData: [String: [HomeScene.TodoListGroup]]
   // ⬆️ 서버에서 받아오는 1달짜리 데이터입니다. ex) key = "20250302"
-  private var itemsForBatch: [String: HomeScene.TodoBatchItem] 
+  private var itemsForBatch: [String: SharedEntity.TodoBatchItem]
   // ⬆️ JSONStorage가 매번 fileWrite를 하기엔 부담스러워서 모아놨다가 적절한 순간에 fileWrite를 진행하기 위한 데이터입니다.
   // 즉, 서버에게 배치처리를 요청하기 위한 배치처리 과정이라고 볼 수 있습니다.
   // ex) key = ToDo의 UUIDString
@@ -120,7 +121,7 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
       batchItem.setName(text)
     } else {
       let alarmTime = Double(targetToDo.alarmTime ?? 0)
-      self.itemsForBatch[targetToDo.localID] = HomeScene.TodoBatchItem(
+      self.itemsForBatch[targetToDo.localID] = SharedEntity.TodoBatchItem(
         localId: targetToDo.localID, name: text, isDone: targetToDo.isDone,
         createdAt: date.toISOString(), isAlarmOn: targetToDo.isAlarmOn, alarmTime: alarmTime,
         isOnlyToday: targetToDo.isOnlyToday, startDay: targetToDo.startDay, endDay: targetToDo.endDay,
@@ -161,7 +162,7 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
       batchItem.setDone(isSelected)
     } else {
       let alarmTime = Double(targetToDo.alarmTime ?? 0)
-      self.itemsForBatch[targetToDo.localID] = HomeScene.TodoBatchItem(
+      self.itemsForBatch[targetToDo.localID] = SharedEntity.TodoBatchItem(
         localId: targetToDo.localID, name: targetToDo.name, isDone: isSelected,
         createdAt: date.toISOString(), isAlarmOn: targetToDo.isAlarmOn, alarmTime: alarmTime,
         isOnlyToday: targetToDo.isOnlyToday, startDay: targetToDo.startDay, endDay: targetToDo.endDay,
@@ -172,11 +173,11 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
 }
 
 extension HomeSceneInteractor {
-  private func addBatchItem(newToDo: HomeScene.TodoBatchItem) {
+  private func addBatchItem(newToDo: SharedEntity.TodoBatchItem) {
     self.itemsForBatch[newToDo.localId] = newToDo
   }
   
-  private func removeBatchItem(deletedToDo: HomeScene.TodoBatchItem) {
+  private func removeBatchItem(deletedToDo: SharedEntity.TodoBatchItem) {
     if self.itemsForBatch[deletedToDo.localId] == nil {
       self.itemsForBatch[deletedToDo.localId] = deletedToDo
     } else {
@@ -184,10 +185,10 @@ extension HomeSceneInteractor {
     }
   }
   
-  private func makeItemForCreateToDo(group: ToDoListView.ToDoSection, date: Date) -> HomeScene.TodoBatchItem {
+  private func makeItemForCreateToDo(group: ToDoListView.ToDoSection, date: Date) -> SharedEntity.TodoBatchItem {
     let newToDoID = UUID()
     let groupID = group.id.uuidString
-    let newItem = HomeScene.TodoBatchItem(
+    let newItem = SharedEntity.TodoBatchItem(
       localId: newToDoID.uuidString,
       name: "New ToDo",
       isDone: false,
@@ -203,12 +204,11 @@ extension HomeSceneInteractor {
     return newItem
   }
   
-  private func makeItemForDeleteToDo(group: ToDoListView.ToDoSection, todo: HomeScene.TodoListItem, date: Date) -> HomeScene.TodoBatchItem {
-    
+    private func makeItemForDeleteToDo(group: ToDoListView.ToDoSection, todo: HomeScene.TodoListItem, date: Date) -> SharedEntity.TodoBatchItem {
     let groupID = group.id.uuidString
     let alarmTime = Double(todo.alarmTime ?? 0)
     
-    let deletedItem = HomeScene.TodoBatchItem(
+    let deletedItem = SharedEntity.TodoBatchItem(
       localId: todo.localID,
       name: todo.name,
       isDone: todo.isDone,
@@ -224,7 +224,7 @@ extension HomeSceneInteractor {
     return deletedItem
   }
   
-  private func makeToDoListItem(batchItem: HomeScene.TodoBatchItem) -> HomeScene.TodoListItem {
+  private func makeToDoListItem(batchItem: SharedEntity.TodoBatchItem) -> HomeScene.TodoListItem {
     let todoListItem = HomeScene.TodoListItem(
       name: batchItem.name,
       endDay: nil,

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeScenePresenter.swift
@@ -14,7 +14,7 @@ import ToDoGardenUIComponent
 @MainActor
 protocol HomeScenePresentationLogic {
   func presentFetchedToDoList(monthlyData: [HomeScene.FetchToDoList.Response])
-  func presentDailyToDoList(dailyData: [HomeScene.TodoListGroup])
+  func presentDailyToDoList(dailyData: [SharedEntity.TodoListGroup])
   func presentCreateToDo(newToDo: SharedEntity.TodoBatchItem)
   func presentDeleteToDo(groupID: UUID, deletedToDo: ToDoListView.ToDoItem)
   func presentErrorToast(error: Error)
@@ -33,7 +33,7 @@ extension HomeScenePresenter: HomeScenePresentationLogic {
     self.viewController?.displayFetchedToDoList(fetchedData: hashTable)
   }
   
-  func presentDailyToDoList(dailyData: [HomeScene.TodoListGroup]) {
+  func presentDailyToDoList(dailyData: [SharedEntity.TodoListGroup]) {
     let snapshot = self.makeNewSnapshotSections(dailyToDoList: dailyData)
     self.viewController?.displayDailyToDoList(snapshot: snapshot)
   }
@@ -53,9 +53,9 @@ extension HomeScenePresenter: HomeScenePresentationLogic {
 
 // swiftlint: disable all
 extension HomeScenePresenter {
-  private func makeHashTable(monthlyData: [HomeScene.FetchToDoList.Response]) -> [String: [HomeScene.TodoListGroup]] {
-    var hashTable: [String: [HomeScene.TodoListGroup]] = [:]
-    
+  private func makeHashTable(monthlyData: [HomeScene.FetchToDoList.Response]) -> [String: [SharedEntity.TodoListGroup]] {
+    var hashTable: [String: [SharedEntity.TodoListGroup]] = [:]
+
     for data in monthlyData {
       let date = data.date.toYYYYMMDDStringFromISO8601()
       if hashTable[date] == nil {
@@ -68,7 +68,7 @@ extension HomeScenePresenter {
     return hashTable
   }
   
-  private func makeNewSnapshotSections(dailyToDoList: [HomeScene.TodoListGroup]) -> ToDoListView.Snapshot {
+  private func makeNewSnapshotSections(dailyToDoList: [SharedEntity.TodoListGroup]) -> ToDoListView.Snapshot {
     var snapshot = ToDoListView.Snapshot()
     dailyToDoList.forEach { group in
       let sections = self.generateSections(from: group)
@@ -82,9 +82,9 @@ extension HomeScenePresenter {
     return snapshot
   }
 
-  func generateSections(from group: HomeScene.TodoListGroup) -> [ToDoListView.ToDoSection] {
+  func generateSections(from group: SharedEntity.TodoListGroup) -> [ToDoListView.ToDoSection] {
     guard let groupID = UUID(uuidString: group.localId) else { return [] }
-    
+
     let toDoItems: [ToDoListView.ToDoItem] = group.todoList?.map { todo in
       let todoID = UUID(uuidString: todo.localID)
         return ToDoListView.ToDoItem(

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeScenePresenter.swift
@@ -8,13 +8,14 @@
 import UIKit
 
 import HomeSceneEntity
+import SharedEntity
 import ToDoGardenUIComponent
 
 @MainActor
 protocol HomeScenePresentationLogic {
   func presentFetchedToDoList(monthlyData: [HomeScene.FetchToDoList.Response])
   func presentDailyToDoList(dailyData: [HomeScene.TodoListGroup])
-  func presentCreateToDo(newToDo: HomeScene.TodoBatchItem)
+  func presentCreateToDo(newToDo: SharedEntity.TodoBatchItem)
   func presentDeleteToDo(groupID: UUID, deletedToDo: ToDoListView.ToDoItem)
   func presentErrorToast(error: Error)
 }
@@ -37,7 +38,7 @@ extension HomeScenePresenter: HomeScenePresentationLogic {
     self.viewController?.displayDailyToDoList(snapshot: snapshot)
   }
   
-  func presentCreateToDo(newToDo: HomeScene.TodoBatchItem) {
+  func presentCreateToDo(newToDo: SharedEntity.TodoBatchItem) {
     self.viewController?.displayCreateToDo(newToDo: newToDo)
   }
   

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeScenePresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeScenePresenter.swift
@@ -18,6 +18,7 @@ protocol HomeScenePresentationLogic {
   func presentCreateToDo(newToDo: SharedEntity.TodoBatchItem)
   func presentDeleteToDo(groupID: UUID, deletedToDo: ToDoListView.ToDoItem)
   func presentErrorToast(error: Error)
+  func presentDataForEditToDoScene()
 }
 
 @MainActor
@@ -48,6 +49,10 @@ extension HomeScenePresenter: HomeScenePresentationLogic {
   
   func presentErrorToast(error: any Error) {
     self.viewController?.displayErrorToast(error: error)
+  }
+
+  func presentDataForEditToDoScene() {
+    self.viewController?.routeToEditToDoScene()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneRouter.swift
@@ -14,7 +14,7 @@ import TimerSceneAPI
 
 protocol HomeSceneRoutingLogic {
   @MainActor func routeToManageGroupScene()
-  @MainActor func routeToEditToDoScene(toDoId: UUID)
+  @MainActor func routeToEditToDoScene()
   @MainActor func routeToTimerScene(groupId: String, groupName: String)
 }
 
@@ -49,13 +49,11 @@ extension HomeSceneRouter: HomeSceneRoutingLogic {
     self.viewController?.navigationController?.pushViewController(destinationViewController, animated: true)
   }
   
-  func routeToEditToDoScene(toDoId: UUID) {
-    guard let todo = self.dataStore?.toDo, let groups = self.dataStore?.groups
+  func routeToEditToDoScene() {
+    guard let toDo = self.dataStore?.toDo, let groups = self.dataStore?.groups
     else { return }
-
-    let payload = EditToDoScenePayload(toDo: todo, groups: groups)
+    let payload = EditToDoScenePayload(toDo: toDo, groups: groups)
     let destinationViewController = self.editToDoSceneBuilder.build(with: payload)
-    
     self.viewController?.navigationController?.pushViewController(destinationViewController, animated: true)
   }
   

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneRouter.swift
@@ -9,6 +9,7 @@ import Foundation
 
 import EditToDoSceneAPI
 import ManageGroupSceneAPI
+import SharedEntity
 import TimerSceneAPI
 
 protocol HomeSceneRoutingLogic {
@@ -49,7 +50,10 @@ extension HomeSceneRouter: HomeSceneRoutingLogic {
   }
   
   func routeToEditToDoScene(toDoId: UUID) {
-    let payload = EditToDoScenePayload(toDoId: toDoId)
+    guard let todo = self.dataStore?.toDo, let groups = self.dataStore?.groups
+    else { return }
+
+    let payload = EditToDoScenePayload(toDo: todo, groups: groups)
     let destinationViewController = self.editToDoSceneBuilder.build(with: payload)
     
     self.viewController?.navigationController?.pushViewController(destinationViewController, animated: true)
@@ -65,7 +69,8 @@ extension HomeSceneRouter: HomeSceneRoutingLogic {
 
 // MARK: - Declare Payload for scene
 struct EditToDoScenePayload: EditToDoScenePayloadable {
-  var toDoId: UUID
+  var toDo: SharedEntity.TodoBatchItem
+  var groups: [SharedEntity.TodoListGroup]
 }
 
 struct TimerScenePayload: TimerScenePayloadable {

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -318,9 +318,18 @@ extension HomeSceneViewController: ToDoListButtonActionDelegate {
     group: ToDoListView.ToDoSection,
     todo: ToDoListView.ToDoItem
   ) {
-    self.router?.routeToEditToDoScene(toDoId: todo.id)
+    Task {
+      guard let selectedDate = self.calendarView.getSelectedDate() else { return }
+      let request = HomeScene.PrepareDataForEditToDoScene.Request(
+        todoId: todo.id,
+        selectedDate: selectedDate,
+        groupId: group.id
+      )
+
+      self.interactor?.prepareDataForEditTodoScene(request: request)
+    }
   }
-  
+
   public func didDeleteButtonTapped(
     group: ToDoListView.ToDoSection,
     todo: ToDoListView.ToDoItem

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -18,7 +18,7 @@ import ToDoGardenUIComponent
 
 @MainActor
 protocol HomeSceneDisplayLogic: AnyObject {
-  func displayFetchedToDoList(fetchedData: [String: [HomeScene.TodoListGroup]])
+  func displayFetchedToDoList(fetchedData: [String: [SharedEntity.TodoListGroup]])
   func displayDailyToDoList(snapshot: ToDoListView.Snapshot)
   func displayCreateToDo(newToDo: SharedEntity.TodoBatchItem)
   func displayDeleteToDo(groupID: UUID, deletedToDo: ToDoListView.ToDoItem)
@@ -183,7 +183,8 @@ extension HomeSceneViewController {
 // MARK: - Confirm display logic protocol
 
 extension HomeSceneViewController: HomeSceneDisplayLogic {
-  func displayFetchedToDoList(fetchedData: [String: [HomeScene.TodoListGroup]]) {
+  func displayFetchedToDoList(fetchedData: [String: [SharedEntity.TodoListGroup]]) {
+    self.hideToDoList()
     Task {
       let date = self.calendarView.getSelectedDate() ?? Date.now
       await self.interactor?.setMonthlyData(fetchedData)

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import HomeSceneAPI
 import HomeSceneEntity
+import SharedEntity
 import TDFoundationExtension
 import TDUtility
 import ToDoGardenUIComponent
@@ -19,7 +20,7 @@ import ToDoGardenUIComponent
 protocol HomeSceneDisplayLogic: AnyObject {
   func displayFetchedToDoList(fetchedData: [String: [HomeScene.TodoListGroup]])
   func displayDailyToDoList(snapshot: ToDoListView.Snapshot)
-  func displayCreateToDo(newToDo: HomeScene.TodoBatchItem)
+  func displayCreateToDo(newToDo: SharedEntity.TodoBatchItem)
   func displayDeleteToDo(groupID: UUID, deletedToDo: ToDoListView.ToDoItem)
   func displayErrorToast(error: Error)
 }
@@ -204,7 +205,7 @@ extension HomeSceneViewController: HomeSceneDisplayLogic {
     )
   }
   
-  func displayCreateToDo(newToDo: HomeScene.TodoBatchItem) {
+  func displayCreateToDo(newToDo: SharedEntity.TodoBatchItem) {
     guard var snapshot = self.todoListView?.getSnapShot(),
       let newToDoUUID = UUID(uuidString: newToDo.localId),
       let newToDoGroupUUID = UUID(uuidString: newToDo.groupId),

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -414,40 +414,6 @@ extension HomeSceneViewController {
   }
 }
 
-// MARK: - ToDoList Button Actions
-
-extension HomeSceneViewController: ToDoListButtonActionDelegate {
-  public func didEditButtonTapped(
-    group: ToDoListView.ToDoSection,
-    todo: ToDoListView.ToDoItem
-  ) {
-    self.interactor?.prepareDataForEditTodoScene(todoId: todo.id)
-  }
-  
-  public func didDeleteButtonTapped(
-    group: ToDoListView.ToDoSection,
-    todo: ToDoListView.ToDoItem
-  ) {
-    Task {
-      guard let selectedDate = self.calendarView.getSelectedDate() else { return }
-      
-      await self.interactor?.deleteToDo(group: group, todo: todo, date: selectedDate)
-    }
-  }
-  
-  public func didCreateToDoButtonTapped(group: ToDoListView.ToDoSection) {
-    Task {
-      guard let selectedDate = self.calendarView.getSelectedDate() else { return }
-  
-      await self.interactor?.createToDo(group: group, date: selectedDate)
-    }
-  }
-  
-  public func didTimerButtonTapped(group: ToDoListView.ToDoSection) {
-    self.router?.routeToTimerScene(groupId: group.id.uuidString, groupName: group.getGroupTitle())
-  }
-}
-
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -23,6 +23,7 @@ protocol HomeSceneDisplayLogic: AnyObject {
   func displayCreateToDo(newToDo: SharedEntity.TodoBatchItem)
   func displayDeleteToDo(groupID: UUID, deletedToDo: ToDoListView.ToDoItem)
   func displayErrorToast(error: Error)
+  func routeToEditToDoScene()
 }
 
 @MainActor
@@ -251,6 +252,10 @@ extension HomeSceneViewController: HomeSceneDisplayLogic {
     self.loadingIndicator.pauseAnimation()
     self.showToast(message: error.localizedDescription)
   }
+
+  func routeToEditToDoScene() {
+    self.router?.routeToEditToDoScene()
+  }
 }
 
 // MARK: - Animation
@@ -397,6 +402,40 @@ extension HomeSceneViewController {
   
   public func getSwipedCell() -> UIView {
     return self.bottomSheet.contentView?.subviews.last ?? UIView()
+  }
+}
+
+// MARK: - ToDoList Button Actions
+
+extension HomeSceneViewController: ToDoListButtonActionDelegate {
+  public func didEditButtonTapped(
+    group: ToDoListView.ToDoSection,
+    todo: ToDoListView.ToDoItem
+  ) {
+    self.interactor?.prepareDataForEditTodoScene(todoId: todo.id)
+  }
+  
+  public func didDeleteButtonTapped(
+    group: ToDoListView.ToDoSection,
+    todo: ToDoListView.ToDoItem
+  ) {
+    Task {
+      guard let selectedDate = self.calendarView.getSelectedDate() else { return }
+      
+      await self.interactor?.deleteToDo(group: group, todo: todo, date: selectedDate)
+    }
+  }
+  
+  public func didCreateToDoButtonTapped(group: ToDoListView.ToDoSection) {
+    Task {
+      guard let selectedDate = self.calendarView.getSelectedDate() else { return }
+  
+      await self.interactor?.createToDo(group: group, date: selectedDate)
+    }
+  }
+  
+  public func didTimerButtonTapped(group: ToDoListView.ToDoSection) {
+    self.router?.routeToTimerScene(groupId: group.id.uuidString, groupName: group.getGroupTitle())
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
@@ -44,7 +44,7 @@ public struct HomeSceneWorker: HomeSceneWorkable, Sendable {
     return fetchedToDoList
   }
   
-  public func writeJSONFile(data: [HomeScene.TodoBatchItem]) async throws {
+  public func writeJSONFile(data: [SharedEntity.TodoBatchItem]) async throws {
     var storedItems = (try? self.homeStorage.getItems()) ?? []
     
     for item in data {

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
@@ -10,16 +10,17 @@ import Foundation
 import HomeSceneAPI
 import HomeSceneEntity
 import HTTPClientAPI
+import SharedEntity
 import TDFoundation
 import TDFoundationExtension
 
 public struct HomeSceneWorker: HomeSceneWorkable, Sendable {
   private let httpClient: HTTPClientAPI
-  private let homeStorage: any JSONStorable<HomeScene.TodoBatchItem>
-  
+  private let homeStorage: any JSONStorable<SharedEntity.TodoBatchItem>
+
   public init(
     httpClient: HTTPClientAPI,
-    homeStorage: some JSONStorable<HomeScene.TodoBatchItem>
+    homeStorage: some JSONStorable<SharedEntity.TodoBatchItem>
   ) {
     self.httpClient = httpClient
     self.homeStorage = homeStorage

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneAPI/HomeSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneAPI/HomeSceneWorkable.swift
@@ -8,10 +8,11 @@
 import Foundation
 
 import HomeSceneEntity
+import SharedEntity
 
 public protocol HomeSceneWorkable: Sendable {
   func fetchToDoList(dateString: String) async throws -> [HomeScene.FetchToDoList.Response]
-  func writeJSONFile(data: [HomeScene.TodoBatchItem]) async throws
+  func writeJSONFile(data: [SharedEntity.TodoBatchItem]) async throws
   func deleteToDo() async throws
   func requestBatchUpdateToServer() async throws
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneEntity/HomeSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneEntity/HomeSceneModels.swift
@@ -40,5 +40,19 @@ public enum HomeScene {
       }
     }
   }
+
+  public enum PrepareDataForEditToDoScene {
+    public struct Request: Sendable {
+      public let todoId: UUID
+      public let selectedDate: Date
+      public let groupId: UUID
+
+      public init(todoId: UUID, selectedDate: Date, groupId: UUID) {
+        self.todoId = todoId
+        self.selectedDate = selectedDate
+        self.groupId = groupId
+      }
+    }
+  }
 }
 // swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneEntity/HomeSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneEntity/HomeSceneModels.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+import SharedEntity
+
 // swiftlint:disable all
 public enum HomeScene {
   // MARK: Use cases
@@ -31,8 +33,8 @@ public enum HomeScene {
   
   public enum BatchUpdate {
     public struct TodoBatchRequest: Codable, Sendable {
-      public let data: [TodoBatchItem]
-      
+      public let data: [SharedEntity.TodoBatchItem]
+
       public init(data: [TodoBatchItem]) {
         self.data = data
       }
@@ -84,57 +86,6 @@ extension HomeScene {
       self.isAlarmOn = isAlarmOn
       self.isOnlyToday = isOnlyToday
       self.repeatToDoId = repeatToDoId
-    }
-  }
-  
-  public final class TodoBatchItem: Codable, @unchecked Sendable {
-    public let localId: String
-    public var name: String
-    public var isDone: Bool
-    public let createdAt: String
-    public var isAlarmOn: Bool
-    public var alarmTime: Double
-    public var isOnlyToday: Bool
-    public var startDay: String?
-    public var endDay: String?
-    public let groupId: String
-    public var isDelete: Bool
-    
-    public init(localId: String, name: String, isDone: Bool, createdAt: String, isAlarmOn: Bool, alarmTime: Double, isOnlyToday: Bool, startDay: String?, endDay: String?, groupId: String, isDelete: Bool) {
-      self.localId = localId
-      self.name = name
-      self.isDone = isDone
-      self.createdAt = createdAt
-      self.isAlarmOn = isAlarmOn
-      self.alarmTime = alarmTime
-      self.isOnlyToday = isOnlyToday
-      self.startDay = startDay
-      self.endDay = endDay
-      self.groupId = groupId
-      self.isDelete = isDelete
-    }
-
-    public func setDelete(_ isDelete: Bool) {
-      self.isDelete = isDelete
-    }
-
-    public func setDone(_ isDone: Bool) {
-      self.isDone = isDone
-    }
-
-    public func setName(_ newName: String) {
-      self.name = newName
-    }
-
-    public func setAlarm(isOn: Bool, time: Double) {
-      self.isAlarmOn = isOn
-      self.alarmTime = time
-    }
-
-    public func setPeriod(start: String, end: String) {
-      self.isOnlyToday = false
-      self.startDay = start
-      self.endDay = end
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneEntity/HomeSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneEntity/HomeSceneModels.swift
@@ -22,9 +22,9 @@ public enum HomeScene {
     
     public struct Response: Codable, Sendable {
       public let date: String
-      public let list: [TodoListGroup]
-      
-      public init(date: String, list: [TodoListGroup]) {
+      public let list: [SharedEntity.TodoListGroup]
+
+      public init(date: String, list: [SharedEntity.TodoListGroup]) {
         self.date = date
         self.list = list
       }
@@ -38,54 +38,6 @@ public enum HomeScene {
       public init(data: [TodoBatchItem]) {
         self.data = data
       }
-    }
-  }
-}
-
-// MARK: DTO
-extension HomeScene {
-  public final class TodoListGroup: Codable, @unchecked Sendable {
-    public let localId: String
-    public let name: String
-    public let color: String
-    public var todoList: [TodoListItem]?
-    public let progressRate: Double
-    
-    public init(localId: String, name: String, color: String, todoList: [TodoListItem]?, progressRate: Double) {
-      self.localId = localId
-      self.name = name
-      self.color = color
-      self.todoList = todoList
-      self.progressRate = progressRate
-    }
-  }
-  
-  public final class TodoListItem: Codable, @unchecked Sendable {
-    public var name: String
-    public let endDay: String?
-    public var isDone: Bool
-    public let localID: String
-    public let startDay: String?
-    public let alarmTime: Int?
-    public let isAlarmOn: Bool
-    public let isOnlyToday: Bool
-    public let repeatToDoId: String?
-    
-    enum CodingKeys: String, CodingKey {
-      case name, endDay, isDone, startDay, alarmTime, isAlarmOn, isOnlyToday, repeatToDoId
-      case localID = "local_id"
-    }
-    
-    public init(name: String, endDay: String?, isDone: Bool, localID: String, startDay: String?, alarmTime: Int?, isAlarmOn: Bool, isOnlyToday: Bool, repeatToDoId: String?) {
-      self.name = name
-      self.endDay = endDay
-      self.isDone = isDone
-      self.localID = localID
-      self.startDay = startDay
-      self.alarmTime = alarmTime
-      self.isAlarmOn = isAlarmOn
-      self.isOnlyToday = isOnlyToday
-      self.repeatToDoId = repeatToDoId
     }
   }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #913 

## 🎉 변경 사항
- Home에서 사용하던 ToDo, Group 데이터를 TDFoundation에 옮겼습니다.
- 홈 화면 -> 투두 수정 화면으로 이동하는 기능을 추가하였습니다.

## 📌 PR Point
FileChanged상으로는 Home에 변경사항이 많지만, 기존 동작에 변경을 준 건 없습니다.

### SharedEntity
울버린께서 사용하시던 `ToDoListItem`, `ToDoBatchItem`, `ToDoListGroup` 데이터를 TDFoundation으로 이동시켰습니다.
- 두 화면에서 공통으로 사용되기에 옮겼습니다. 

### Routing VIP 사이클 추가
- 수정 스와이프 액션을 눌렀을 때, VIP 사이클을 실행하도록 수정하였습니다.
- `dataStore 전달할 투두 데이터 저장`하기 위함입니다.

### EditToDoScene이 이상하다
SharedEntity 변경사항을 일단 빨리 머지하고자 PR을 올렸습니다.
- `Group 데이터의 코드 위치 변경`된 점이 울버린이 작업중이신 내용과 겹칠까봐 먼저 했습니다.

현재 EditTodoScene 비즈니스 로직은 주석 처리되었으며, `다음 PR`에서 작업을 진행할 예정입니다.

### 실행 동작
<img width="250" src="https://github.com/user-attachments/assets/083afed5-67f4-4d15-aeee-6c494b6eb4a9">


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?