### PR TITLE
DailyToDoAlertViewController 메모리 누수 제거

### DIFF
--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/DailyToDoAlerts/DailyToDoAlertViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/DailyToDoAlerts/DailyToDoAlertViewController.swift
@@ -22,7 +22,7 @@ final class DailyToDoAlertViewController: UIViewController {
   private var dailyToDoAlertsTask: Task<Void, Never>?
   
   @Dependency(\.defaultDatabase) private var database
-
+  
   @SharedReader(.fetch(DailyToDoAlerts())) private var dailyToDoAlerts: [DailyToDoAlert]
   
   override func viewDidLoad() {
@@ -134,8 +134,10 @@ final class DailyToDoAlertViewController: UIViewController {
     let safeAreaFrame = self.view.safeAreaLayoutGuide.layoutFrame
     let maxAvailableHeight = safeAreaFrame.maxY - self.noticeLabel.frame.maxY - (self.addTimerButton.frame.height + 40)
     let tableHeightStream = self.tableView.heightStream(maxAvailableHeight: maxAvailableHeight)
-    self.tableViewHeightViewTask = Task {
+    self.tableViewHeightViewTask?.cancel()
+    self.tableViewHeightViewTask = Task { [weak self] in
       for await height in tableHeightStream {
+        guard let self else { return }
         self.tableViewHeightConstraint.constant = height
         UIView.animate(withDuration: 0.3) {
           self.view.layoutIfNeeded()
@@ -202,10 +204,11 @@ final class DailyToDoAlertViewController: UIViewController {
       .publisher
       .map { $0.map(\.rowModel) }
       .removeDuplicates()
-      .asyncStream
+      .values
     
-    self.dailyToDoAlertsTask = Task { @MainActor in
+    self.dailyToDoAlertsTask = Task { @MainActor [weak self] in
       for await models in dailyToDoAlertStream {
+        guard let self else { return }
         var snapshot = NSDiffableDataSourceSnapshot<Int, RowModel>()
         var indexPath: IndexPath?
         for (index, alert) in models.enumerated() {


### PR DESCRIPTION
## 💡 관련 이슈
#919 

## 🎉 변경 사항
DailyToDoAlertViewController의 라이프 사이클을 준수하지 않는 객체들이 해제되지 않는 현상을 수정했습니다.
수정전
<img width="469" alt="Screenshot 2025-04-02 at 12 05 24 AM" src="https://github.com/user-attachments/assets/3615d0c3-6e10-455b-88d8-57a525dec8f4" />

수정후
<img width="494" alt="Screenshot 2025-04-02 at 12 05 07 AM" src="https://github.com/user-attachments/assets/2e1ae4c3-e955-4ed4-a585-b86f4b42b690" />


## 📝 셀프체크리스트
- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?