### PR TITLE
NotificationManager 수정

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/NotificationManager.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/NotificationManager.swift
@@ -32,11 +32,15 @@ public final class NotificationManager: NSObject, Sendable, UNUserNotificationCe
   }
 
   public func makeFocusNotification(after seconds: Double) {
-    makeNotification(seconds: seconds, isFocus: true)
+    self.makeNotification(NotificationType.focus(seconds))
   }
 
   public func makeRestNotification(after seconds: Double) {
-    self.makeNotification(seconds: seconds, isFocus: false)
+    self.makeNotification(NotificationType.rest(seconds))
+  }
+  
+  public func pushDailyToDoReminder(count: Int) {
+    self.makeNotification(NotificationType.dailyToDoReminder(count))
   }
 
   public func clearPendingNotifications() {
@@ -56,15 +60,51 @@ extension NotificationManager {
 // MARK: Private Functions
 
 extension NotificationManager {
-  private func makeNotification(seconds: Double, isFocus: Bool) {
+  enum NotificationType {
+    var body: String {
+      switch self {
+      case .focus:
+        return Constant.focusBody
+      case .rest:
+        return Constant.restBody
+      case .dailyToDoReminder(let count):
+        return "아직 완료 하지 않은 ToDo가 \(count)개 남아있어요!"
+      }
+    }
+    
+    var delay: Double {
+      switch self {
+      case .focus(let seconds), .rest(let seconds):
+        return seconds
+      case .dailyToDoReminder:
+        return 0.1
+      }
+    }
+    
+    var identifier: String {
+      switch self {
+      case .focus:
+        return Constant.focusIdentifier
+      case .rest:
+        return Constant.restIdentifier
+      case .dailyToDoReminder:
+        return Constant.dailyToDoReminderIdentifier
+      }
+    }
+    
+    case focus(Double)
+    case rest(Double)
+    case dailyToDoReminder(Int)
+  }
+  
+  private func makeNotification(_ type: NotificationType) {
     let notiContent = UNMutableNotificationContent()
     let constant = NotificationManager.Constant.self
     notiContent.title = constant.title
-    notiContent.body = isFocus ? constant.focusBody : constant.restBody
+    notiContent.body = type.body
 
-    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: seconds, repeats: false)
-    let identifier = isFocus ? constant.focusIdentifier : constant.restIdentifier
-    let request = UNNotificationRequest(identifier: identifier, content: notiContent, trigger: trigger)
+    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: type.delay, repeats: false)
+    let request = UNNotificationRequest(identifier: type.identifier, content: notiContent, trigger: trigger)
 
     UNUserNotificationCenter.current().add(request)
   }
@@ -83,5 +123,6 @@ extension NotificationManager {
     static let restBody = "충전완료! 이제 다시 열심히 힘을 내볼까요?"
     static let focusIdentifier = "focusComplete"
     static let restIdentifier = "restComplete"
+    static let dailyToDoReminderIdentifier = "dailyToDoReminderComplete"
   }
 }

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/AppCore.swift
@@ -22,6 +22,8 @@ public final class AppCore {
     }
   }
   
+  private var notificationTask: Task<Void, any Error>?
+  
   public init(dependency: Dependency) {
     self.dependency = dependency
     self.destination = .none
@@ -47,10 +49,17 @@ public final class AppCore {
   private func switchToHome() {
     let builder = self.dependency.router.sceneBuilder.home
     self.destination = Destination.home(builder.build())
-    
-    // 앱의 생명주기를 같이하는 작업이기 때문에 관리할 필요없습니다.
-    Task {
-      for await _ in self.dependency.scheduledAlertClient.stream() {
+  }
+  
+  public func didBecomeActive() {
+    self.notificationTask?.cancel()
+    self.notificationTask = Task {
+      let manager = self.dependency.notificationManager
+      let isAuthorized = try await manager.fetchPermission()
+      if isAuthorized {
+        for await _ in self.dependency.scheduledAlertClient.stream() {
+          manager.pushDailyToDoReminder(count: 5)
+        }
       }
     }
   }

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/Dependency.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/Dependency.swift
@@ -45,7 +45,8 @@ extension AppCore {
           let refreshToken = try? manager.load(forKey: KeychainManager.KeychainKey.refreshToken)
           return accessToken != nil && refreshToken != nil
         },
-        scheduledAlertClient: ScheduledAlertClient.live
+        scheduledAlertClient: ScheduledAlertClient.live,
+        notificationManager: NotificationManager.shared
       )
     }()
     public let router: AppRouter
@@ -53,5 +54,6 @@ extension AppCore {
     public let httpClient: HTTPClient
     public let isLoggedIn: () -> Bool
     public let scheduledAlertClient: ScheduledAlertClient
+    public let notificationManager: NotificationManager
   }
 }

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/ScheduledAlertClient.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/ScheduledAlertClient.swift
@@ -32,7 +32,7 @@ extension ScheduledAlertClient {
       let (stream, continuation) = AsyncStream<Void>.makeStream()
       let task = Task {
         while true {
-          try await Task.sleep(nanoseconds: 5 * NSEC_PER_SEC)
+          try await Task.sleep(nanoseconds: 60 * NSEC_PER_SEC)
           let key = Date().asDouble()
           if let isRepeating = alertSchedule[key], isRepeating {
             continuation.yield(())

--- a/ToDo-Garden/ToDo-Garden/Sources/Application/SceneDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/Sources/Application/SceneDelegate.swift
@@ -13,9 +13,7 @@ import ToDoGardenUIResource
 
 final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   var window: UIWindow?
-  var appCore = AppCore(
-    dependency: AppCore.Dependency.live
-  )
+  var appCore = AppCore(dependency: AppCore.Dependency.live)
   
   func scene(
     _ scene: UIScene,
@@ -25,6 +23,10 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     self.setupWindow(with: scene)
     self.prepare()
     self.appCore.getStarted()
+  }
+  
+  func sceneDidBecomeActive(_ scene: UIScene) {
+    self.appCore.didBecomeActive()
   }
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
#917 

## 🎉 변경 사항
- DailyToDoAlert을 처리할 수 있도록 NotificationManager 수정
- 앱이 foreground로 진입할때 알림 권한에 따른 이벤트 처리 구현
  - 권한 요청을 DailyToDoAlertViewController진입시가 아닌 sceneDidBecomeActive 시점으로 요청하도록 구현했습니다. 사용자가 권한을 변경하고 돌아왔을 경우에도 권한에 따른 요청을 준비해야하기 때문에 sceneDidBecomeActive 시점이 더 적합하다고 생각했습니다.
![image](https://github.com/user-attachments/assets/afa25772-67d7-4c86-a424-a025e1b4db4e)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?