### PR TITLE
DailyToDoAlertViewController 테이블 뷰 업데이트 이슈

### DIFF
--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/DailyToDoAlerts/DailyToDoAlertViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/DailyToDoAlerts/DailyToDoAlertViewController.swift
@@ -203,7 +203,6 @@ final class DailyToDoAlertViewController: UIViewController {
     let dailyToDoAlertStream = self.$dailyToDoAlerts
       .publisher
       .map { $0.map(\.rowModel) }
-      .removeDuplicates()
       .values
     
     self.dailyToDoAlertsTask = Task { @MainActor [weak self] in
@@ -261,6 +260,11 @@ private extension DailyToDoAlertViewController {
     
     static func == (lhs: Self, rhs: Self) -> Bool {
       lhs.id == rhs.id && lhs.alertTime == rhs.alertTime
+    }
+    
+    func hash(into hasher: inout Hasher) {
+      hasher.combine(self.id)
+      hasher.combine(self.alertTime)
     }
   }
   


### PR DESCRIPTION
## 💡 관련 이슈
#924 

## 🎉 변경 사항
알림 값을 변경한후 셀을 재사용하고 원래 스크롤 위치로 돌아왔을때 변경된 값이 정상적으로 노출하지 못하던 문제가 있었습니다.
데이터를 퍼블리시하는 공간에서 중복을 제거하는 방식이 아닌, 뷰에서 렌더링할 때 hash값을 동일하게 만들어서 렌더링이 발생하지 않게 했지만 변경된 데이터는 전달되도록 수정했습니다.

https://github.com/user-attachments/assets/2218c07a-49ee-4784-8ca4-538f58bda0b8




## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?