### PR TITLE
Feature/#923 apply grdb manage group

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPMethod.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPMethod.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum HTTPMethod: String, Sendable {
+public enum HTTPMethod: String, Sendable, Codable {
   case post = "POST"
   case get = "GET"
   case put = "PUT"

--- a/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPRequest.swift
+++ b/ToDo-Garden/TDFoundation/Sources/HTTPClientAPI/HTTPRequest.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// HTTP 요청 정보를 표현하는 HTTPRequest 구조체입니다.
 /// HTTP request method, end point url, 요청 헤더, 쿼리 파라미터, 요청 본문을 가질 수 있습니다.
-public struct HTTPRequest: Sendable, Equatable {
+public struct HTTPRequest: Sendable, Equatable, Codable {
   public let method: HTTPMethod
   public let endPoint: URL
   public var header: [String: String]

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/Database/Schema+ToDoList.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/Database/Schema+ToDoList.swift
@@ -5,6 +5,9 @@
 //  Created by SONG on 3/31/25.
 //
 
+import Foundation
+
+import HTTPClientAPI
 import SharedEntity
 import SharingGRDB
 
@@ -15,8 +18,8 @@ public struct MyGroup: Codable, FetchableRecord, MutablePersistableRecord, Senda
   
   public let groupId: String
   public let date: String
-  public let name: String
-  public let color: String
+  public var name: String
+  public var color: String
   
   public init(groupId: String, date: String, name: String, color: String) {
     self.groupId = groupId
@@ -137,6 +140,20 @@ extension TodoBatchItem: FetchableRecord, MutablePersistableRecord {
       isOnlyToday: self.isOnlyToday,
       repeatToDoId: nil
     )
+  }
+}
+
+public struct PendingEditGroup: Codable, FetchableRecord, MutablePersistableRecord {
+  public static let databaseTableName: String = "pendingEditGroup"
+  
+  var requestData: Data
+  
+  public init(request: HTTPRequest) throws {
+    self.requestData = try JSONEncoder().encode(request)
+  }
+  
+  public func toHTTPRequest() throws -> HTTPRequest {
+    return try JSONDecoder().decode(HTTPRequest.self, from: requestData)
   }
 }
 // swiftlint: enable line_length

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/Database/Schema.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/Database/Schema.swift
@@ -49,6 +49,7 @@ extension DatabaseWriter {
     try createDailyToDoAlertsTable(migrator: &migrator)
     try createMyGroupsAndMyToDosTables(migrator: &migrator)
     try createTodoBatchItemTable(migrator: &migrator)
+    try createPendingEditGroupTable(migrator: &migrator)
   }
   
   private func createDailyToDoAlertsTable(migrator: inout DatabaseMigrator) throws {
@@ -118,6 +119,14 @@ extension DatabaseWriter {
           .defaults(to: false)
         t.column("groupId", .text)
           .notNull()
+      }
+    }
+  }
+  
+  private func createPendingEditGroupTable(migrator: inout DatabaseMigrator) throws {
+    migrator.registerMigration("Create 'pendingEditGroup' table") { db in
+      try db.create(table: "pendingEditGroup") { t in
+        t.column("requestData", .blob).notNull()
       }
     }
   }

--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
@@ -74,7 +74,8 @@ extension ManageGroupSceneBuilder.Dependency {
   @MainActor
   static let live = ManageGroupSceneBuilder.Dependency.init(
     manageGroupWorker: ManageGroupWorker(httpClient: HTTPClient.live),
-    postGroupSceneBuilder: PostGroupSceneBuilder.init(dependency: .live)
+    postGroupSceneBuilder: PostGroupSceneBuilder.init(dependency: .live),
+    retryManager: NetworkRetryManager()
   )
 }
 

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -33,6 +33,7 @@ protocol HomeSceneBusinessLogic {
   func writeBatchItemsToGRDB() async
   func requestBatchUpdateToServer() async
   func prepareDataForEditTodoScene(request: HomeScene.PrepareDataForEditToDoScene.Request)
+  func syncronizeServerEditGroups() async
 }
 
 @MainActor
@@ -69,6 +70,18 @@ final class HomeSceneInteractor: HomeSceneDataStore {
 // MARK: - Request to worker
 // swiftlint: disable all
 extension HomeSceneInteractor: HomeSceneBusinessLogic {
+  func syncronizeServerEditGroups() async {
+    if self.checkNetworkConnection() {
+      do {
+        try await self.homeSceneWorker.syncronizeServerEditGroups()
+      } catch let error {
+        self.handleErrors(error)
+      }
+    } else {
+      return
+    }
+  }
+  
   func fetchToDoList(request: HomeScene.FetchToDoList.Request) async {
     if self.checkNetworkConnection() {
       do {

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -236,8 +236,7 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
   func prepareDataForEditTodoScene(request: HomeScene.PrepareDataForEditToDoScene.Request) {
     let dateString = request.selectedDate.description.toYYYYMMDDStringFromISO8601Space()
     let groups = self.monthlyData[dateString]
-    print(request.groupId.uuidString.lowercased())
-    print(groups?[1].localId == request.groupId.uuidString.lowercased())
+ 
     let group = groups?.first(where: { (group: SharedEntity.TodoListGroup) in
       return group.localId.lowercased() == request.groupId.uuidString.lowercased()
     })!

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -307,6 +307,7 @@ extension HomeSceneViewController: CalendarViewDateSelectionDelegate {
   public func didSelectDate(_ date: Date) {
     self.hideToDoList()
     Task {
+      await self.interactor?.writeBatchItemsToGRDB()
       await self.interactor?.loadDailyToDoList(targetDate: date.description)
     }
   }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -73,6 +73,7 @@ open class HomeSceneViewController: UIViewController, HomeSceneViewControllable 
     Task {
       await self.interactor?.writeBatchItemsToGRDB()
       await self.interactor?.requestBatchUpdateToServer()
+      await self.interactor?.syncronizeServerEditGroups()
     }
   }
   
@@ -182,6 +183,7 @@ extension HomeSceneViewController {
     self.loadingIndicator.startAnimation()
     Task {
       await interactor.requestBatchUpdateToServer()
+      await interactor.syncronizeServerEditGroups()
       await interactor.fetchToDoList(request: HomeScene.FetchToDoList.Request(dateString: targetMonth))
     }
   }
@@ -425,6 +427,7 @@ extension HomeSceneViewController: @preconcurrency TransitionHandlable {
     Task {
       await self.interactor?.writeBatchItemsToGRDB()
       await self.interactor?.requestBatchUpdateToServer()
+      await self.interactor?.syncronizeServerEditGroups()
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
@@ -131,13 +131,16 @@ extension HomeSceneWorker {
   
   public func syncronizeGRDBWithBatchItems() async throws {
     let batchItems = try await self.readBatchItemsFromGRDB()
-    
     let updatedToDos = batchItems.compactMap { $0.convertToMyToDo() }
-    
     let deletedToDoIds = batchItems.filter { $0.isDelete }.map { $0.localId }
     
     try await self.database.write { db in
+      let existingGroupIds = Set(try MyGroup.fetchAll(db).map { $0.groupId })
+      
       for var todo in updatedToDos {
+        if !existingGroupIds.contains(todo.groupId) {
+          continue
+        }
         try todo.insert(db)
       }
       

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
@@ -149,6 +149,32 @@ extension HomeSceneWorker {
     }
   }
   
+  public func syncronizeServerEditGroups() async throws {
+    guard let request = try await self.loadPendingEditGroup() else { return }
+    
+    try await self.httpClient.send(
+      input: request,
+      serializer: { $0 },
+      deserializer: { response in
+        try response.validateStatusCode()
+      }
+    )
+    
+    try await self.deletePendingEditGroup()
+  }
+  
+  private func loadPendingEditGroup() async throws -> HTTPRequest? {
+      try await database.read { db in
+          try PendingEditGroup.fetchOne(db)?.toHTTPRequest()
+      }
+  }
+  
+  private func deletePendingEditGroup() async throws {
+      try await database.write { db in
+          try db.execute(sql: "DELETE FROM \(PendingEditGroup.databaseTableName)")
+      }
+  }
+  
   private func writeFetchedToDoListToGRDB(myGroups: [MyGroup], myToDos: [MyToDo]) async throws {
     try await self.database.write { db in
       for var group in myGroups {

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneAPI/HomeSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneAPI/HomeSceneWorkable.swift
@@ -17,4 +17,5 @@ public protocol HomeSceneWorkable: Sendable {
   func requestBatchUpdateToServer() async throws
   func loadMonthlyToDoListFromGRDB(dateString: String) async throws -> [DailyToDoListData]
   func syncronizeGRDBWithBatchItems() async throws
+  func syncronizeServerEditGroups() async throws
 }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Package.swift
@@ -24,7 +24,8 @@ let package = Package(
     .package(name: "ToDoGardenUI", path: "../ToDoGardenUI"),
     .package(name: "PostGroupScene", path: "./PostGroupScene"),
     .package(path: "../TDUtility"),
-    .package(path: "../TDFoundation")
+    .package(path: "../TDFoundation"),
+    Package.Dependency.package(url: "https://github.com/pointfreeco/sharing-grdb", from: "0.1.0")
   ],
   targets: [
     .target(
@@ -45,7 +46,11 @@ let package = Package(
         "ManageGroupSceneAPI",
         "ManageGroupSceneEntity",
         .product(name: "TDUtility", package: "TDUtility"),
-        .product(name: "TDFoundation", package: "TDFoundation")
+        .product(name: "TDFoundation", package: "TDFoundation"),
+        Target.Dependency.product(
+          name: "SharingGRDB",
+          package: "sharing-grdb"
+        )
       ]
     ),
     .testTarget(

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -102,7 +102,7 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
           groupID: groupID,
           groupName: request.groupName,
           progressColor: request.groupColor,
-          progressRate: Float.zero
+          progressRate: 1.0
         )
         self.currentGroups.append(group)
         let response = ManageGroup.AddGroup.Response(group: group)

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -59,7 +59,12 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
       
       do {
         try Task.checkCancellation()
-        let result = try await self.manageGroupWorker.fetchGroupList(request: request)
+        var result: [ManageGroup.ToDoGroup]
+        if self.checkNetworkConnection() {
+          result = try await self.manageGroupWorker.fetchGroupList(request: request)
+        } else {
+          result = try await self.manageGroupWorker.fetchGroupListFromGRDB()
+        }
         try Task.checkCancellation()
         self.currentGroups = result
         let response = ManageGroup.FetchGroupList.Response(with: result)
@@ -76,7 +81,12 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
       
       do {
         try Task.checkCancellation()
-        let result = try await self.manageGroupWorker.saveGroupList(request: request)
+        var result: [ManageGroup.ToDoGroup]
+        if self.checkNetworkConnection() {
+          result = try await self.manageGroupWorker.saveGroupList(request: request)
+        } else {
+          result = try await self.manageGroupWorker.saveGroupListToGRDB(request: request)
+        }
         try Task.checkCancellation()
         self.currentGroups = result
         let response = ManageGroup.SaveGroupList.Response(with: result)
@@ -143,6 +153,10 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
     } else {
       return
     }
+  }
+  
+  private func checkNetworkConnection() -> Bool {
+    self.retryManager.isConnected()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -10,6 +10,7 @@ import Foundation
 import HTTPClientAPI
 import ManageGroupSceneAPI
 import ManageGroupSceneEntity
+import TDFoundation
 
 protocol ManageGroupDataStore {
 }
@@ -28,14 +29,18 @@ protocol ManageGroupBusinessLogic {
 class ManageGroupInteractor: ManageGroupDataStore {
   var presenter: ManageGroupPresentationLogic?
   private let manageGroupWorker: ManageGroupWorkable
+  private let retryManager: NetworkRetryManagerAPI
   
   var currentGroups: [ManageGroup.ToDoGroup]
   private var tasks: [ManageGroupInteractor.TaskKey: Task<Void, Never>] = [:]
   
   init(
-    worker: ManageGroupWorkable
+    worker: ManageGroupWorkable,
+    retryManager: NetworkRetryManagerAPI
   ) {
     self.manageGroupWorker = worker
+    self.retryManager = retryManager
+    self.retryManager.execute(isRetryingOn: false)
     self.currentGroups = []
   }
   

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupSceneBuilder.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import ManageGroupSceneAPI
 import PostGroupSceneAPI
+import TDFoundation
 import ToDoGardenUIAPI
 
 public struct ManageGroupSceneBuilder {
@@ -16,13 +17,16 @@ public struct ManageGroupSceneBuilder {
   public struct Dependency {
     let manageGroupWorker: ManageGroupWorkable
     let postGroupSceneBuilder: PostGroupSceneBuildable?
+    let retryManager: NetworkRetryManagerAPI
     
     public init(
       manageGroupWorker: ManageGroupWorkable,
-      postGroupSceneBuilder: PostGroupSceneBuildable?
+      postGroupSceneBuilder: PostGroupSceneBuildable?,
+      retryManager: NetworkRetryManagerAPI
     ) {
       self.manageGroupWorker = manageGroupWorker
       self.postGroupSceneBuilder = postGroupSceneBuilder
+      self.retryManager = retryManager
     }
   }
   
@@ -52,7 +56,8 @@ extension ManageGroupSceneBuilder {
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
   private func configureVIPCycle(for viewController: ManageGroupViewController) -> ManageGroupViewController {
     let interactor = ManageGroupInteractor(
-      worker: self.dependency.manageGroupWorker
+      worker: self.dependency.manageGroupWorker,
+      retryManager: self.dependency.retryManager
     )
     
     let presenter = ManageGroupPresenter()

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupTableViewDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupTableViewDelegate.swift
@@ -51,6 +51,20 @@ public final class ManageGroupTableViewDelegate: NSObject {
   func saveDisplayGroupsBeforeEditing() {
     self.displayedGroupsBeforeEditing = self.displayedGroups
   }
+  
+  func showFooterView() {
+    guard let button = self.footerView.subviews[0] as? UIButton else { return }
+    
+    button.alpha = 1.0
+    button.isEnabled = true
+  }
+  
+  func hideFooterView() {
+    guard let button = self.footerView.subviews[0] as? UIButton else { return }
+    
+    button.alpha = 0.5
+    button.isEnabled = false
+  }
 }
 
 // MARK: - UITableViewDataSource

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -216,7 +216,7 @@ extension ManageGroupViewController {
         groupID: groupID,
         groupName: groupName,
         progressColor: groupColor,
-        progressRate: Float.zero
+        progressRate: 1.0
       )
       self?.routeToPostGroupScene(groupInfo: groupInfo)
     }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupViewController.swift
@@ -68,6 +68,7 @@ open class ManageGroupViewController: UIViewController, ManageGroupViewControlla
     self.view.backgroundColor = UIColor.white
     self.setupTableView()
     self.setupNavigationBar()
+    self.manageGroupTableViewDelegate?.hideFooterView()
   }
   
   open override func viewIsAppearing(_ animated: Bool) {
@@ -147,7 +148,10 @@ extension ManageGroupViewController {
     let isEditingMode = self.groupListTableView.isEditing
     self.updateBarButtonItems(isEditingMode: isEditingMode)
     if isEditingMode {
+      self.manageGroupTableViewDelegate?.hideFooterView()
       self.cancelEditing()
+    } else {
+      self.manageGroupTableViewDelegate?.showFooterView()
     }
     self.rightBarButtonCustomView.isEnabled = true
   }
@@ -158,6 +162,7 @@ extension ManageGroupViewController {
     if isEditingMode {
       self.saveGroupList()
     }
+    self.manageGroupTableViewDelegate?.hideFooterView()
     self.rightBarButtonCustomView.isEnabled = true
   }
   

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
@@ -47,7 +47,7 @@ public class ManageGroupWorker: ManageGroupWorkable {
       groupID: request.groupID,
       groupName: request.groupName,
       progressColor: request.groupColor,
-      progressRate: Float.zero
+      progressRate: 1.0
     )
     return group
   }
@@ -117,7 +117,7 @@ public class ManageGroupWorker: ManageGroupWorkable {
           groupID: groupID,
           groupName: item.name,
           progressColor: try UIColor().fromHex(item.color),
-          progressRate: Float(item.progressrate)
+          progressRate: 1.0
         )
       )
     }

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupWorker.swift
@@ -10,13 +10,17 @@ import UIKit
 import HTTPClientAPI
 import ManageGroupSceneAPI
 import ManageGroupSceneEntity
+import SharingGRDB
 import TDFoundation
 import TDUtility
 
 public class ManageGroupWorker: ManageGroupWorkable {
   private let httpClient: HTTPClientAPI
+  @Dependency(\.defaultDatabase) private var database
   
-  public init(httpClient: HTTPClientAPI) {
+  public init(
+    httpClient: HTTPClientAPI
+  ) {
     self.httpClient = httpClient
   }
   
@@ -24,7 +28,7 @@ public class ManageGroupWorker: ManageGroupWorkable {
     request: ManageGroupSceneEntity.ManageGroup.FetchGroupList.Request
   ) async throws -> [ManageGroup.ToDoGroup] {
     do {
-      let groups = try await self.fetchGroupsFromDatabase()
+      let groups = try await self.fetchGroupsFromServer()
       return groups
     } catch let error {
       throw error
@@ -35,7 +39,7 @@ public class ManageGroupWorker: ManageGroupWorkable {
     request: ManageGroupSceneEntity.ManageGroup.SaveGroupList.Request
   ) async throws -> [ManageGroup.ToDoGroup] {
     do {
-      let groups = try await self.saveGroupsInDatabase(groupList: request.list)
+      let groups = try await self.saveGroupsToServer(groupList: request.list)
       return groups
     } catch let error {
       throw error
@@ -66,11 +70,11 @@ public class ManageGroupWorker: ManageGroupWorkable {
   }
   
   public func addGroupDirectly(request: ManageGroup.AddGroup.Request) async throws -> UUID {
-    let groupID = try await self.addGroupDirectlyInDatabase(request: request)
+    let groupID = try await self.addGroupDirectlyToServer(request: request)
     return groupID
   }
   
-  private func saveGroupsInDatabase(groupList: [ManageGroup.ToDoGroup]) async throws -> [ManageGroup.ToDoGroup] {
+  private func saveGroupsToServer(groupList: [ManageGroup.ToDoGroup]) async throws -> [ManageGroup.ToDoGroup] {
     let request = try self.makeSaveGroupHTTPResquest(groupList: groupList)
     try await self.httpClient.send(
       input: request,
@@ -84,7 +88,7 @@ public class ManageGroupWorker: ManageGroupWorkable {
     return groupList
   }
   // swiftlint: disable all
-  private func fetchGroupsFromDatabase() async throws -> [ManageGroup.ToDoGroup] {
+  private func fetchGroupsFromServer() async throws -> [ManageGroup.ToDoGroup] {
     let fetchedData = try await self.httpClient.send(
       input: ManageGroup.FetchGroupList.RequestDTO(),
       serializer: { data in
@@ -125,7 +129,7 @@ public class ManageGroupWorker: ManageGroupWorkable {
     return groups
   }
   
-  private func addGroupDirectlyInDatabase(request: ManageGroup.AddGroup.Request) async throws -> UUID {
+  private func addGroupDirectlyToServer(request: ManageGroup.AddGroup.Request) async throws -> UUID {
     guard let groupID = try await self.httpClient.send(
       input: ManageGroup.AddGroup.RequestDTO(
         name: request.groupName,
@@ -179,6 +183,55 @@ public class ManageGroupWorker: ManageGroupWorkable {
       body: body
     )
     return request
+  }
+}
+
+extension ManageGroupWorker {
+  public func fetchGroupListFromGRDB() async throws -> [ManageGroup.ToDoGroup] {
+    let myGroups: [MyGroup] = try await database.read { db in
+      try MyGroup.fetchAll(db)
+    }
+    
+    return myGroups.compactMap { $0.toToDoGroup() }
+  }
+  
+  public func saveGroupListToGRDB(request: ManageGroup.SaveGroupList.Request) async throws -> [ManageGroup.ToDoGroup] {
+    let updatedGroups = request.list.map { $0.toMyGroup() }
+    
+    try await database.write { db in
+      let existingGroups = try MyGroup.fetchAll(db)
+      let updatedGroupIDs = Set(updatedGroups.map { $0.groupId })
+      
+      let groupsToDelete = existingGroups.filter { !updatedGroupIDs.contains($0.groupId) }
+      for group in groupsToDelete {
+        try group.delete(db)
+      }
+
+      for var updatedGroup in updatedGroups {
+        if let existingGroup = existingGroups.first(where: { $0.groupId == updatedGroup.groupId }) {
+          var updatedGroup = existingGroup
+          updatedGroup.name = updatedGroup.name
+          updatedGroup.color = updatedGroup.color
+          try updatedGroup.update(db)
+        } else {
+          try updatedGroup.insert(db)
+        }
+      }
+    }
+    
+    let pending = try self.makeSaveGroupHTTPResquest(groupList: request.list)
+    
+    try await self.savePendingEditGroup(pending)
+    
+    return request.list
+  }
+  
+  private func savePendingEditGroup(_ request: HTTPRequest) async throws {
+    try await database.write { db in
+      var pendingRequest = try PendingEditGroup(request: request)
+      try db.execute(sql: "DELETE FROM \(PendingEditGroup.databaseTableName)")
+      try pendingRequest.insert(db)
+    }
   }
 }
 // swiftlint: enable all

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/Model+Converting.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/Model+Converting.swift
@@ -1,0 +1,38 @@
+//
+//  Model+Converting.swift
+//  ManageGroupScene
+//
+//  Created by SONG on 4/3/25.
+//
+
+import UIKit
+
+import ManageGroupSceneEntity
+import TDFoundation
+
+extension ManageGroup.ToDoGroup {
+  func toMyGroup() -> MyGroup {
+    return MyGroup(
+      groupId: self.groupID.uuidString.lowercased(),
+      date: Date.now.description.toYYYYMMDDStringFromISO8601Space(),
+      name: self.groupName,
+      color: self.progressColor.hexStringFromColor()
+    )
+  }
+}
+
+extension MyGroup {
+  func toToDoGroup() -> ManageGroup.ToDoGroup? {
+    guard let uuid = UUID(uuidString: groupId.lowercased()) else { return nil }
+    
+    do {
+      let progressColor = try UIColor().fromHex(self.color)
+      return ManageGroup.ToDoGroup(
+        groupID: uuid,
+        groupName: name,
+        progressColor: progressColor,
+        progressRate: 1.0
+      )
+    } catch { return nil }
+  }
+}

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneAPI/ManageGroupWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupSceneAPI/ManageGroupWorkable.swift
@@ -23,4 +23,6 @@ public protocol ManageGroupWorkable {
     progressRate: Float
   ) -> ManageGroup.ToDoGroup
   func addGroupDirectly(request: ManageGroup.AddGroup.Request) async throws -> UUID
+  func fetchGroupListFromGRDB() async throws -> [ManageGroup.ToDoGroup]
+  func saveGroupListToGRDB(request: ManageGroup.SaveGroupList.Request) async throws -> [ManageGroup.ToDoGroup]
 }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #923 
## 🎉 변경 사항
- 그룹관리에서도 오프라인환경을 지원합니다. 
## 📌 PR Point
- 홈화면과 마찬가지로, 네트워크 상태에따른 분기가 됩니다. 
- 그룹관리 내에서의 변경사항은 홈화면에도 반영이 되어야합니다. 
- 만약, 동기화되지 않은 투두변경사항이 존재하는 상태에서, 동기화되지 않은 그룹변경사항을 서버에 먼저 반영해버리면, 
동기화 되지 않은 투두 변경사항이 속하는 그룹이 사라진 상태일 수 있으므로, 투두 변경사항 동기화 -> 그룹변경사항 동기화 -> 투두리스트 fetching이 이루어 집니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?