### PR TITLE
#937 fix mystats scene

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Cache.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Cache.swift
@@ -71,7 +71,8 @@ public final actor Cache<Request: Requestable>: Sendable {
   
   public func execute(
     id: Request.ID,
-    expiration: StorageExpiration? = nil
+    expiration: StorageExpiration? = nil,
+    isDownsample: Bool = false
   ) async throws -> Request.Response {
     let task = self.storage.object(forKey: id.description)?.loadingState?.task
     guard !Task.isCancelled else {
@@ -92,7 +93,12 @@ public final actor Cache<Request: Requestable>: Sendable {
         case nil:
           ExpirationLocals.$value.withValue(expiration ?? configuration.expiration) {
             self.storage.setRequestState(
-              .loading(.init(task: initialTask(id), continuations: [continuation])),
+              .loading(
+                .init(
+                  task: initialTask(id, isDownsample: isDownsample),
+                  continuations: [continuation]
+                )
+              ),
               forKey: id.description
             )
           }
@@ -107,10 +113,10 @@ public final actor Cache<Request: Requestable>: Sendable {
     }
   }
   
-  private func initialTask(_ id: Request.ID) -> Task<Void, Never> {
+  private func initialTask(_ id: Request.ID, isDownsample: Bool) -> Task<Void, Never> {
     Task {
       do {
-        let response = try await self.request.execute(id: id, isDownsample: false)
+        let response = try await self.request.execute(id: id, isDownsample: isDownsample)
         try Task.checkCancellation()
         let key = id.description
         let continuations = self.storage.continuations(forKey: key)

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsInteractor.swift
@@ -48,13 +48,13 @@ extension MyStatsInteractor: MyStatsBusinessLogic {
   func loadMyStatsViewData(request: MyStats.LoadMyStatsViewData.Request) {
     self.loadMyStatsViewDataTask = Task {
       defer { self.loadMyStatsViewDataTask = nil }
+      
       do {
         try Task.checkCancellation()
-        let payload = self.createPayload()
         let response = try await self.fetchViewData()
         try Task.checkCancellation()
         self.savePeriodicState(with: response)
-        self.presenter?.presentMyStatsViewData(response: response, with: payload)
+        self.presenter?.presentMyStatsViewData(response: response, with: self.myGarden)
       } catch let error {
         debugPrint(error)
       }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsInteractor.swift
@@ -13,8 +13,6 @@ import MyStatsSceneEntity
 import ToDoGardenUIComponent // PomodoroRecordCollection 이관 예정
 
 protocol MyStatsDataStore {
-//  var myName: String { get set }
-//  var myImage: UIImage { get set }
   var myGarden: PomodoroRecordCollection { get set }
 }
 
@@ -59,13 +57,6 @@ extension MyStatsInteractor: MyStatsBusinessLogic {
         debugPrint(error)
       }
     }
-  }
-  
-  private func createPayload() -> MyStats.Payload {
-    // TODO: 화면 연결완료되면 제거 될 예정
-    return MyStats.Payload(
-      myGarden: self.myGarden
-    )
   }
   
   private func fetchViewData() async throws -> MyStats.LoadMyStatsViewData.Response {

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsPresenter.swift
@@ -50,7 +50,7 @@ extension MyStatsPresenter {
       profileViewModel: profileViewModel,
       gardenViewModel: gardenViewModel,
       longestRecordViewModel: longestRecordViewModel,
-      summaryViewModel: summaryViewModel
+      summaryViewModels: summaryViewModel
     )
     return myStatsViewModel
   }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsPresenter.swift
@@ -85,36 +85,49 @@ extension MyStatsPresenter {
   private func makeLongestRecordViewModel(
     fetchedData: MyStats.FetchedLongestRecordViewData
   ) -> MyStats.LongestRecordViewModel {
-    let convertedDate = fetchedData.maxPomodoroRecord.recordDate.toDateISO8601Format().toStringDefaultFormat()
+    let convertedDate = fetchedData.maxPomodoroRecord?.recordDate.toDateISO8601Format().toStringDefaultFormat()
     let viewModel = MyStats.LongestRecordViewModel(
-      concentratedRecordGroupName: fetchedData.maxPomodoroRecord.groupName,
-      concentratedRecordCount: fetchedData.maxPomodoroRecord.maxPomodoroCount,
-      concentratedRecordDate: convertedDate,
+      concentratedRecordGroupName: fetchedData.maxPomodoroRecord?.groupName ?? "",
+      concentratedRecordCount: fetchedData.maxPomodoroRecord?.maxPomodoroCount ?? 0,
+      concentratedRecordDate: convertedDate ?? "",
       longestContinuousRecordCount: fetchedData.maxContinuousDays?.maxCount ?? 0,
       longestContinuousRecordStartDate: fetchedData.maxContinuousDays?.startDate ?? "",
-      longestContinuousRecordEndDate: fetchedData.maxContinuousDays?.endDate ?? ""
+      longestContinuousRecordEndDate: fetchedData.maxContinuousDays?.endDate ?? "기록이 없습니다"
     )
     return viewModel
   }
   
-  private func makeSummaryViewModel(fetchedData: MyStats.FetchedSummaryViewData) -> MyStats.SummaryViewModel {
-    let totalMinutes = fetchedData.weeklyAverageFocusTime / 60
-    let hours = totalMinutes / 60
-    let minutes = totalMinutes % 60
+  private func makeSummaryViewModel(fetchedData: MyStats.FetchedSummaryViewData) -> [MyStats.SummaryViewModel] {
     
-    let timeString: String
-    if hours > 0 && minutes > 0 {
-      timeString = "\(hours)시간 \(minutes)분"
-    } else if hours > 0 {
-      timeString = "\(hours)시간"
-    } else {
-      timeString = "\(minutes)분"
+    func formatTime(_ seconds: Int) -> String {
+      let totalMinutes = seconds / 60
+      let hours = totalMinutes / 60
+      let minutes = totalMinutes % 60
+
+      if hours > 0 && minutes > 0 {
+        return "\(hours)시간 \(minutes)분"
+      } else if hours > 0 {
+        return "\(hours)시간"
+      } else {
+        return "\(minutes)분"
+      }
     }
-    
-    let viewModel = MyStats.SummaryViewModel(
-      concentratedTime: timeString,
+
+    let dailyViewModel = MyStats.SummaryViewModel(
+      concentratedTime: formatTime(fetchedData.dailyAverageFocusTime),
+      completedCount: "\(fetchedData.dailyAveragePomodoroCount)개 목표"
+    )
+
+    let weeklyViewModel = MyStats.SummaryViewModel(
+      concentratedTime: formatTime(fetchedData.weeklyAverageFocusTime),
       completedCount: "\(fetchedData.weeklyAveragePomodoroCount)개 목표"
     )
-    return viewModel
+
+    let monthlyViewModel = MyStats.SummaryViewModel(
+      concentratedTime: formatTime(fetchedData.monthlyAverageFocusTime),
+      completedCount: "\(fetchedData.monthlyAveragePomodoroCount)개 목표"
+    )
+
+    return [dailyViewModel, weeklyViewModel, monthlyViewModel]
   }
 }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsPresenter.swift
@@ -59,8 +59,8 @@ extension MyStatsPresenter {
     fetchedData: MyStats.FetchedProfileViewData
   ) -> MyStats.ProfileViewModel {
     var image: UIImage
-    if let imageData = fetchedData.profileImage, let profielImage = UIImage(data: imageData) {
-      image = profielImage
+    if let profileImage = fetchedData.profileImage {
+      image = profileImage
     } else {
       image = UIImage.defaultProfileImage
     }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsPresenter.swift
@@ -12,7 +12,7 @@ import TDFoundationExtension
 import ToDoGardenUIComponent // TODO: - PomodoroRecordCollection 이관 예정
 
 protocol MyStatsPresentationLogic {
-  func presentMyStatsViewData(response: MyStats.LoadMyStatsViewData.Response, with payload: MyStats.Payload)
+  func presentMyStatsViewData(response: MyStats.LoadMyStatsViewData.Response, with payload: PomodoroRecordCollection)
 }
 
 class MyStatsPresenter {
@@ -24,7 +24,7 @@ class MyStatsPresenter {
 extension MyStatsPresenter: MyStatsPresentationLogic {
   func presentMyStatsViewData(
     response: MyStats.LoadMyStatsViewData.Response,
-    with payload: MyStats.Payload
+    with payload: PomodoroRecordCollection
   ) {
     let viewModel = self.makeViewModel(response: response, with: payload)
     
@@ -37,12 +37,12 @@ extension MyStatsPresenter: MyStatsPresentationLogic {
 // MARK: - Make ViewModels
 
 extension MyStatsPresenter {
-  private func makeViewModel(response: MyStats.LoadMyStatsViewData.Response, with payload: MyStats.Payload)
+  private func makeViewModel(response: MyStats.LoadMyStatsViewData.Response, with payload: PomodoroRecordCollection)
   -> MyStats.LoadMyStatsViewData.ViewModel {
     let profileViewModel = self.makeProfileViewModel(
       fetchedData: response.profileViewData
     )
-    let gardenViewModel = self.makeGardenViewModel(myGarden: payload.myGarden)
+    let gardenViewModel = self.makeGardenViewModel(myGarden: payload)
     let longestRecordViewModel = self.makeLongestRecordViewModel(fetchedData: response.longestRecordViewData)
     let summaryViewModel = self.makeSummaryViewModel(fetchedData: response.summaryViewData)
     

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsRouter.swift
@@ -14,7 +14,7 @@ protocol MyStatsRoutingLogic {
 }
 
 protocol MyStatsDataPassing {
-  var dataStore: MyStatsDataStore? { get }
+  var dataStore: MyStatsDataStore? { get set }
 }
 
 class MyStatsRouter: MyStatsDataPassing {

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsSceneBuilder.swift
@@ -62,6 +62,6 @@ extension MyStatsSceneBuilder {
   ///   - viewController: 런타임 의존성을 설정할 ViewController 객체입니다.
   ///   - payload: 런타임에 전달할 의존성입니다.
   private func setPayload(for viewController: MyStatsViewController, with payload: MyStatsScenePayloadable) {
-    // viewController.router?.dataStore?.name = payload.name
+    viewController.router?.dataStore?.myGarden = payload.myGarden
   }
 }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsViewController.swift
@@ -76,6 +76,7 @@ extension MyStatsViewController {
 extension MyStatsViewController {
   private func setupMyStatsView() {
     self.view.addSubview(self.myStatsView)
+    self.myStatsView.periodicSummaryView.segmentedControl.delegate = self
     self.setupConstraints()
   }
   
@@ -130,5 +131,11 @@ extension MyStatsViewController {
       leftDescription: viewModel.concentratedTime,
       rightDescription: viewModel.completedCount
     )
+  }
+}
+
+extension MyStatsViewController: PeriodSegmentedControlDelegate {
+  func periodSegmentedControlDidSelectIndex(selectedIndex: Int) {
+    self.updateSummaryView(viewModel: self.summaryData[selectedIndex])
   }
 }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsViewController.swift
@@ -9,12 +9,13 @@ import UIKit
 
 import MyStatsSceneAPI
 import MyStatsSceneEntity
+import ToDoGardenUIComponent
 
 protocol MyStatsDisplayLogic: AnyObject {
   func displayMyStatsView(viewModel: MyStats.LoadMyStatsViewData.ViewModel)
 }
 
-class MyStatsViewController: UIViewController, MyStatsViewControllable {
+final class MyStatsViewController: UIViewController, MyStatsViewControllable {
   
   // MARK: - VIP Properties
   
@@ -22,7 +23,7 @@ class MyStatsViewController: UIViewController, MyStatsViewControllable {
   var router: (MyStatsRoutingLogic & MyStatsDataPassing)?
   
   private var myStatsView: MyStatsView
-  
+  private var summaryData: [MyStats.SummaryViewModel] = []
   // MARK: - Object lifecycle
   
   init() {
@@ -55,11 +56,13 @@ class MyStatsViewController: UIViewController, MyStatsViewControllable {
 
 extension MyStatsViewController: MyStatsDisplayLogic {
   func displayMyStatsView(viewModel: MyStats.LoadMyStatsViewData.ViewModel) {
+    self.summaryData = viewModel.summaryViewModels
+    
     self.myStatsView.stopShimmering()
     self.updateProfileView(viewModel: viewModel.profileViewModel)
     self.updateGardenView(viewModel: viewModel.gardenViewModel)
     self.updateLongestRecordView(viewModel: viewModel.longestRecordViewModel)
-    self.updateSummaryView(viewModel: viewModel.summaryViewModel)
+    self.updateSummaryView(viewModel: self.summaryData[1])
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsWorker.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 import HTTPClientAPI
 import MyStatsSceneAPI
@@ -15,9 +15,10 @@ public struct MyStatsWorker: MyStatsWorkable {
   public func fetchProfileViewData() async throws -> MyStats.FetchedProfileViewData {
     let result = try await self.downloadProfileData()
     
-    var imageData: Data?
-    if let imageUrlString = result.imageUrl {
-      imageData = try await self.downloadImageData(urlString: imageUrlString)
+    var imageData: UIImage?
+    if let urlString = result.imageUrl,
+      let imageUrl = URL(string: urlString) {
+      imageData = try await Cache.shared.execute(id: imageUrl, isDownsample: true)
     } else {
       imageData = nil
     }
@@ -102,29 +103,6 @@ extension MyStatsWorker {
         }
         
         return try JSONDecoder().decode(MyStats.FetchedSummaryViewData.self, from: data)
-      }
-    )
-    return result
-  }
-  
-  private func downloadImageData(urlString: String) async throws -> Data {
-    guard let url = URL(string: urlString) else {
-      throw URLError(.badURL)
-    }
-    
-    let request = HTTPRequest(method: .get, endPoint: url)
-    let result = try await self.httpClient.send(
-      input: request,
-      serializer: { $0 },
-      deserializer: { response in
-        guard response.statusCode >= 200 && response.statusCode < 400 else {
-          throw HTTPClientError.badStatusCode(response.statusCode)
-        }
-        
-        guard let data = response.body else {
-          throw HTTPClientError.deserializationError
-        }
-        return data
       }
     )
     return result

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsPeriodicSummaryView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsPeriodicSummaryView.swift
@@ -11,7 +11,7 @@ import ToDoGardenUIComponent
 
 final class MyStatsPeriodicSummaryView: UIView {
   private let titleLabel: UILabel
-  private let segmentedControl: PeriodSegmentedControl
+  let segmentedControl: PeriodSegmentedControl
   private let summaryView: MyStatsSummaryView
   
   private typealias Constants = Constant.MyStatsPeriodicSummaryView

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
@@ -14,7 +14,7 @@ final class MyStatsView: UIView {
   private let profileView: Styled.Row
   private let gardenView: GardenView
   private let longestRecordStackView: LongestRecordStackView
-  private let periodicSummaryView: MyStatsPeriodicSummaryView
+  let periodicSummaryView: MyStatsPeriodicSummaryView
   
   private let constants = Constant.Layout.self
   

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/Views/MyStatsView.swift
@@ -71,15 +71,7 @@ final class MyStatsView: UIView {
           equalTo: self.profileView.bottomAnchor,
           constant: constants.topMargin
         ),
-        self.gardenView.leadingAnchor.constraint(
-          equalTo: self.leadingAnchor,
-          constant: constants.horizontalMargin
-        ),
-        self.gardenView.trailingAnchor.constraint(
-          equalTo: self.trailingAnchor,
-          constant: -constants.horizontalMargin
-        ),
-        self.gardenView.heightAnchor.constraint(equalToConstant: constants.gardenViewHeight)
+        self.gardenView.centerXAnchor.constraint(equalTo: self.centerXAnchor)
       ]
     )
   }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneEntity/MyStatsModels.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneEntity/MyStatsModels.swift
@@ -124,14 +124,6 @@ extension MyStats {
       self.completedCount = completedCount
     }
   }
-  
-  public struct Payload {
-    public let myGarden: PomodoroRecordCollection
-    
-    public init(myGarden: PomodoroRecordCollection) {
-      self.myGarden = myGarden
-    }
-  }
 }
 
 // MARK: Data Models

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneEntity/MyStatsModels.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneEntity/MyStatsModels.swift
@@ -139,14 +139,14 @@ extension MyStats {
 extension MyStats {
   public struct FetchedProfileViewData: Sendable {
     public let nickname: String
-    public let profileImage: Data? // TODO: 이미지 캐싱이 Data를 뱉는지, UIImage를 뱉는지에 따라 달라짐
+    public let profileImage: UIImage?
     public let continuousRecordCount: Int
     public let continuousRecordStartDate: String
     public let continuousRecordEndDate: String
     
     public init(
       nickname: String,
-      profileImage: Data?,
+      profileImage: UIImage?,
       continuousRecordCount: Int,
       continuousRecordStartDate: String,
       continuousRecordEndDate: String

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneEntity/MyStatsModels.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneEntity/MyStatsModels.swift
@@ -160,11 +160,11 @@ extension MyStats {
   }
   
   public struct FetchedLongestRecordViewData: Sendable, Codable {
-    public let maxPomodoroRecord: MaxPomodoroRecordDTO
+    public let maxPomodoroRecord: MaxPomodoroRecordDTO?
     public let maxContinuousDays: MaxContinuousDaysDTO?
     
     public init(
-      maxPomodoroRecord: MaxPomodoroRecordDTO,
+      maxPomodoroRecord: MaxPomodoroRecordDTO?,
       maxContinuousDays: MaxContinuousDaysDTO?
     ) {
       self.maxPomodoroRecord = maxPomodoroRecord

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneEntity/MyStatsModels.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneEntity/MyStatsModels.swift
@@ -38,18 +38,18 @@ public enum MyStats {
       public let profileViewModel: ProfileViewModel
       public let gardenViewModel: GardenViewModel
       public let longestRecordViewModel: LongestRecordViewModel
-      public let summaryViewModel: SummaryViewModel
+      public let summaryViewModels: [SummaryViewModel]
       
       public init(
         profileViewModel: ProfileViewModel,
         gardenViewModel: GardenViewModel,
         longestRecordViewModel: LongestRecordViewModel,
-        summaryViewModel: SummaryViewModel
+        summaryViewModels: [SummaryViewModel]
       ) {
         self.profileViewModel = profileViewModel
         self.gardenViewModel = gardenViewModel
         self.longestRecordViewModel = longestRecordViewModel
-        self.summaryViewModel = summaryViewModel
+        self.summaryViewModels = summaryViewModels
       }
     }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/PeriodSegmentedControl.swift
@@ -10,6 +10,10 @@ import UIKit
 import ToDoGardenUIConstant
 import ToDoGardenUIResource
 
+public protocol PeriodSegmentedControlDelegate: AnyObject {
+  func periodSegmentedControlDidSelectIndex(selectedIndex: Int)
+}
+
 public final class PeriodSegmentedControl: UIControl {
   private let items: [String]
   private let feedbackGenerator: UISelectionFeedbackGenerator
@@ -17,6 +21,7 @@ public final class PeriodSegmentedControl: UIControl {
   private var targetXPositions: [CGFloat]
   private var periodSegmentedControlGestureRecognizer: PeriodSegmentedControlGestureRecognizer?
   private var expectedXPosition: CGFloat
+  public weak var delegate: PeriodSegmentedControlDelegate?
   
   public init(items: [String] = Constant.PeriodSegmentedControl.Content.defaultItems) {
     self.items = items
@@ -59,7 +64,13 @@ public final class PeriodSegmentedControl: UIControl {
   
   public func highlightedIndex() -> Int? {
     let currentX = self.calculateClosestX(from: self.expectedXPosition)
-    return currentX.calculateHighlightedIndex()
+    let newIndex = currentX.calculateHighlightedIndex()
+
+    if let index = newIndex {
+      self.delegate?.periodSegmentedControlDidSelectIndex(selectedIndex: index)
+    }
+
+    return newIndex
   }
 }
 
@@ -149,6 +160,7 @@ extension PeriodSegmentedControl {
       }
       self.feedbackGenerator.selectionChanged()
       self.expectedXPosition = closestX
+      _ = self.highlightedIndex()
     }
     
     self.expectedXPosition = newX
@@ -188,6 +200,7 @@ extension PeriodSegmentedControl {
       }
       self.feedbackGenerator.selectionChanged()
       self.expectedXPosition = closestX
+      _ = self.highlightedIndex()
     default:
       break
     }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #937 
## 🎉 변경 사항
- 디코딩 에러를 해결합니다. 
- UI표시 작업을 마무리합니다. 
- 
## 📌 PR Point

### 가든뷰 위치조정: 홈화면과 똑같은 사이즈로 표시됩니다. 
아시다시피 가든뷰는 가로-세로비율이 생명입니다. 화면크기에 따라 동적으로 레이아웃을 설정하게 되면 비율이 깨질 가능성이 매우 높습니다.
비율이 깨지면 비정상적으로 표시되기 때문에, 포지션에 대한 레이아웃만 지정하고 가로세로 길이는 건들지 않는 방식으로 변경하였습니다. 

### 디코딩 에러는 널러블을 옵셔널이 아닌 일반타입으로 받고있어서 생기는 문제였습니다. 
### 이미지 불러오기 로직이 이미지캐시 구현 전에 정의된 부분이라, 이미지캐시를 적용시키는 방향으로 수정했습니다. 
### 이제 segmentedControl 조작에 따라 각각 다른 수치를 보여줄 수 있게 수정하였습니다. 

<img width="356" alt="스크린샷 2025-04-04 오전 1 48 23" src="https://github.com/user-attachments/assets/29989922-13fb-4ed7-aaaa-f79ceb5c23d4" />

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?