### PR TITLE
키보드 동작 설정(서치가든 / 홈)

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/KeyboardEvent/KeyboardEvent.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/KeyboardEvent/KeyboardEvent.swift
@@ -14,7 +14,6 @@ public enum KeyboardEvent: Sendable {
 
 public enum UITextFieldNotificationObserver {
   public static func observeKeyboardEvents(
-    for textField: UITextField,
     handler: @Sendable @escaping (KeyboardEvent) -> Void
   ) {
     let notificationCenter = NotificationCenter.default

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/KeyboardEvent/KeyboardEvent.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/KeyboardEvent/KeyboardEvent.swift
@@ -1,0 +1,43 @@
+//
+//  KeyboardEvent.swift
+//  TDFoundation
+//
+//  Created by SONG on 4/4/25.
+//
+
+import UIKit
+
+public enum KeyboardEvent: Sendable {
+  case willShow(height: CGFloat, duration: TimeInterval)
+  case willHide(duration: TimeInterval)
+}
+
+public enum UITextFieldNotificationObserver {
+  public static func observeKeyboardEvents(
+    for textField: UITextField,
+    handler: @Sendable @escaping (KeyboardEvent) -> Void
+  ) {
+    let notificationCenter = NotificationCenter.default
+
+    notificationCenter.addObserver(
+      forName: UIResponder.keyboardWillShowNotification,
+      object: nil,
+      queue: .main
+    ) { notification in
+      guard let keys = notification.userInfo,
+        let frame = keys[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+        let duration = keys[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval else { return }
+      handler(KeyboardEvent.willShow(height: frame.height, duration: duration))
+    }
+
+    notificationCenter.addObserver(
+      forName: UIResponder.keyboardWillHideNotification,
+      object: nil,
+      queue: .main
+    ) { notification in
+      guard let keys = notification.userInfo,
+        let duration = keys[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval else { return }
+      handler(KeyboardEvent.willHide(duration: duration))
+    }
+  }
+}

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/KeyboardEvent/KeyboardEvent.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/KeyboardEvent/KeyboardEvent.swift
@@ -40,3 +40,9 @@ public enum UITextFieldNotificationObserver {
     }
   }
 }
+
+public extension UIViewController {
+  func checkIfVisible() -> Bool {
+    return self.isViewLoaded && self.view.window != nil
+  }
+}

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/KeyboardEvent/KeyboardEvent.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/KeyboardEvent/KeyboardEvent.swift
@@ -42,7 +42,7 @@ public enum UITextFieldNotificationObserver {
 }
 
 public extension UIViewController {
-  func checkIfVisible() -> Bool {
+  func isTopViewController() -> Bool {
     return self.isViewLoaded && self.view.window != nil
   }
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -429,6 +429,25 @@ extension HomeSceneViewController: @preconcurrency TransitionHandlable {
   }
 }
 
+extension HomeSceneViewController {
+  private func setupKeyboardObservers() {
+    UITextFieldNotificationObserver.observeKeyboardEvents { [weak self] event in
+      guard let self else { return }
+      
+      switch event {
+      case .willShow(let height, let duration):
+        Task { @MainActor in
+          self.showKeyboard(keyboardHeight: height, duration: duration)
+        }
+      case .willHide(let duration):
+        Task { @MainActor in
+          self.hideKeyboard(duration: duration)
+        }
+      }
+    }
+  }
+}
+
 #if DEBUG
 @available(iOS 17.0, *)
 #Preview {

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -450,11 +450,19 @@ extension HomeSceneViewController {
   }
   
   private func showKeyboard(keyboardHeight: CGFloat, duration: TimeInterval) {
-    
+    self.bottomSheet.animateBottomSheet(to: BottomSheet.State.expanded)
+    UIView.animate(withDuration: duration) {
+      self.todoListView?.contentView.contentInset.bottom = keyboardHeight
+      self.todoListView?.contentView.verticalScrollIndicatorInsets.bottom = keyboardHeight
+    }
   }
   
   private func hideKeyboard(duration: TimeInterval) {
-
+    self.bottomSheet.animateBottomSheet(to: BottomSheet.State.normal)
+    UIView.animate(withDuration: duration) {
+      self.todoListView?.contentView.contentInset.bottom = 0
+      self.todoListView?.contentView.verticalScrollIndicatorInsets.bottom = 0
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -450,11 +450,11 @@ extension HomeSceneViewController {
   }
   
   private func showKeyboard(keyboardHeight: CGFloat, duration: TimeInterval) {
-    self.bottomSheet.animateBottomSheet(to: BottomSheet.State.expanded)
     UIView.animate(withDuration: duration) {
       self.todoListView?.contentView.contentInset.bottom = keyboardHeight
       self.todoListView?.contentView.verticalScrollIndicatorInsets.bottom = keyboardHeight
     }
+    self.bottomSheet.animateBottomSheet(to: BottomSheet.State.expanded)
   }
   
   private func hideKeyboard(duration: TimeInterval) {

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -66,6 +66,7 @@ open class HomeSceneViewController: UIViewController, HomeSceneViewControllable 
   open override func viewDidLoad() {
     super.viewDidLoad()
     self.setupViews()
+    self.setupKeyboardObservers()
   }
   
   open override func viewDidDisappear(_ animated: Bool) {
@@ -432,19 +433,28 @@ extension HomeSceneViewController: @preconcurrency TransitionHandlable {
 extension HomeSceneViewController {
   private func setupKeyboardObservers() {
     UITextFieldNotificationObserver.observeKeyboardEvents { [weak self] event in
-      guard let self else { return }
-      
-      switch event {
-      case .willShow(let height, let duration):
-        Task { @MainActor in
+      guard let self = self else { return }
+
+      Task { @MainActor in
+        guard self.checkIfVisible() else { return }
+
+        switch event {
+        case .willShow(let height, let duration):
           self.showKeyboard(keyboardHeight: height, duration: duration)
-        }
-      case .willHide(let duration):
-        Task { @MainActor in
+
+        case .willHide(let duration):
           self.hideKeyboard(duration: duration)
         }
       }
     }
+  }
+  
+  private func showKeyboard(keyboardHeight: CGFloat, duration: TimeInterval) {
+    
+  }
+  
+  private func hideKeyboard(duration: TimeInterval) {
+
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -436,7 +436,7 @@ extension HomeSceneViewController {
       guard let self = self else { return }
 
       Task { @MainActor in
-        guard self.checkIfVisible() else { return }
+        guard self.isTopViewController() else { return }
 
         switch event {
         case .willShow(let height, let duration):

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -108,6 +108,7 @@ extension SearchGardenViewController {
   }
   
   private func setupSearchGardenView() {
+    self.searchGardenView.keyboardDelegate = self
     self.searchGardenView.tableView.delegate = self
     self.searchGardenView.tableView.onEndReached = {
       self.interactor?.loadSearchedGardenContinue()
@@ -324,6 +325,22 @@ extension SearchGardenViewController: UITableViewDataSourcePrefetching {
     
     if shouldLoadNextPage {
       self.interactor?.loadSearchedGardenContinue()
+    }
+  }
+}
+
+extension SearchGardenViewController: SearchGardenViewKeyboardDelegate {
+  func showKeyboard(_ view: SearchGardenView, keyboardHeight: CGFloat, duration: TimeInterval) {
+    UIView.animate(withDuration: duration) {
+      view.tableView.contentInset.bottom = keyboardHeight
+      view.tableView.verticalScrollIndicatorInsets.bottom = keyboardHeight
+    }
+  }
+  
+  func hideKeyboard(_ view: SearchGardenView, duration: TimeInterval) {
+    UIView.animate(withDuration: duration) {
+      view.tableView.contentInset.bottom = 0
+      view.tableView.verticalScrollIndicatorInsets.bottom = 0
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -64,6 +64,7 @@ final class SearchGardenViewController: UIViewController, SearchGardenViewContro
   override func viewDidLoad() {
     super.viewDidLoad()
     self.setupView()
+    self.setupKeyboardObservers()
   }
   
   func clear() {
@@ -108,7 +109,6 @@ extension SearchGardenViewController {
   }
   
   private func setupSearchGardenView() {
-    self.searchGardenView.keyboardDelegate = self
     self.searchGardenView.tableView.delegate = self
     self.searchGardenView.tableView.onEndReached = {
       self.interactor?.loadSearchedGardenContinue()
@@ -329,18 +329,36 @@ extension SearchGardenViewController: UITableViewDataSourcePrefetching {
   }
 }
 
-extension SearchGardenViewController: SearchGardenViewKeyboardDelegate {
-  func showKeyboard(_ view: SearchGardenView, keyboardHeight: CGFloat, duration: TimeInterval) {
-    UIView.animate(withDuration: duration) {
-      view.tableView.contentInset.bottom = keyboardHeight
-      view.tableView.verticalScrollIndicatorInsets.bottom = keyboardHeight
+extension SearchGardenViewController{
+  private func setupKeyboardObservers() {
+    UITextFieldNotificationObserver.observeKeyboardEvents { [weak self] event in
+      guard let self else { return }
+
+      switch event {
+      case .willShow(let height, let duration):
+        Task { @MainActor in
+          self.showKeyboard(keyboardHeight: height, duration: duration)
+        }
+      case .willHide(let duration):
+        Task { @MainActor in
+          self.hideKeyboard(duration: duration)
+        }
+      }
     }
   }
   
-  func hideKeyboard(_ view: SearchGardenView, duration: TimeInterval) {
+  private func showKeyboard(keyboardHeight: CGFloat, duration: TimeInterval) {
+    print(Thread.isMainThread)
     UIView.animate(withDuration: duration) {
-      view.tableView.contentInset.bottom = 0
-      view.tableView.verticalScrollIndicatorInsets.bottom = 0
+      self.searchGardenView.tableView.contentInset.bottom = keyboardHeight
+      self.searchGardenView.tableView.verticalScrollIndicatorInsets.bottom = keyboardHeight
+    }
+  }
+  
+  private func hideKeyboard(duration: TimeInterval) {
+    UIView.animate(withDuration: duration) {
+      self.searchGardenView.tableView.contentInset.bottom = 0
+      self.searchGardenView.tableView.verticalScrollIndicatorInsets.bottom = 0
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -348,7 +348,6 @@ extension SearchGardenViewController {
   }
   
   private func showKeyboard(keyboardHeight: CGFloat, duration: TimeInterval) {
-    print(Thread.isMainThread)
     UIView.animate(withDuration: duration) {
       self.searchGardenView.tableView.contentInset.bottom = keyboardHeight
       self.searchGardenView.tableView.verticalScrollIndicatorInsets.bottom = keyboardHeight

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -329,7 +329,7 @@ extension SearchGardenViewController: UITableViewDataSourcePrefetching {
   }
 }
 
-extension SearchGardenViewController{
+extension SearchGardenViewController {
   private func setupKeyboardObservers() {
     UITextFieldNotificationObserver.observeKeyboardEvents { [weak self] event in
       guard let self else { return }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -332,15 +332,16 @@ extension SearchGardenViewController: UITableViewDataSourcePrefetching {
 extension SearchGardenViewController {
   private func setupKeyboardObservers() {
     UITextFieldNotificationObserver.observeKeyboardEvents { [weak self] event in
-      guard let self else { return }
+      guard let self = self else { return }
 
-      switch event {
-      case .willShow(let height, let duration):
-        Task { @MainActor in
+      Task { @MainActor in
+        guard self.checkIfVisible() else { return }
+
+        switch event {
+        case .willShow(let height, let duration):
           self.showKeyboard(keyboardHeight: height, duration: duration)
-        }
-      case .willHide(let duration):
-        Task { @MainActor in
+
+        case .willHide(let duration):
           self.hideKeyboard(duration: duration)
         }
       }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -335,7 +335,7 @@ extension SearchGardenViewController {
       guard let self = self else { return }
 
       Task { @MainActor in
-        guard self.checkIfVisible() else { return }
+        guard self.isTopViewController() else { return }
 
         switch event {
         case .willShow(let height, let duration):

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/Views/SearchGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/Views/SearchGardenView.swift
@@ -7,10 +7,18 @@
 
 import UIKit
 
+import TDFoundation
 import ToDoGardenUIComponent
 import ToDoGardenUIResource
 
+protocol SearchGardenViewKeyboardDelegate: AnyObject {
+  @MainActor func showKeyboard(_ view: SearchGardenView, keyboardHeight: CGFloat, duration: TimeInterval)
+  @MainActor func hideKeyboard(_ view: SearchGardenView, duration: TimeInterval)
+}
+
 final class SearchGardenView: UIVStackView {
+  weak var keyboardDelegate: SearchGardenViewKeyboardDelegate?
+  
   let textField: UITextField
   let tableView: SearchGardenTableView
   
@@ -24,6 +32,7 @@ final class SearchGardenView: UIVStackView {
     self.isUserInteractionEnabled = true
     self.backgroundColor = UIColor.white
     self.setupSubViews()
+    self.setupKeyboardObservers()
   }
   
   func clear() {
@@ -81,5 +90,25 @@ extension SearchGardenView {
         self.tableView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
       ]
     )
+  }
+}
+
+// MARK: - Keyboard Delegate Forwarding
+extension SearchGardenView {
+  private func setupKeyboardObservers() {
+    UITextFieldNotificationObserver.observeKeyboardEvents(for: self.textField) { [weak self] event in
+      guard let self else { return }
+
+      switch event {
+      case .willShow(let height, let duration):
+        Task { @MainActor in
+          self.keyboardDelegate?.showKeyboard(self, keyboardHeight: height, duration: duration)
+        }
+      case .willHide(let duration):
+        Task { @MainActor in
+          self.keyboardDelegate?.hideKeyboard(self, duration: duration)
+        }
+      }
+    }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/Views/SearchGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/Views/SearchGardenView.swift
@@ -11,14 +11,7 @@ import TDFoundation
 import ToDoGardenUIComponent
 import ToDoGardenUIResource
 
-protocol SearchGardenViewKeyboardDelegate: AnyObject {
-  @MainActor func showKeyboard(_ view: SearchGardenView, keyboardHeight: CGFloat, duration: TimeInterval)
-  @MainActor func hideKeyboard(_ view: SearchGardenView, duration: TimeInterval)
-}
-
 final class SearchGardenView: UIVStackView {
-  weak var keyboardDelegate: SearchGardenViewKeyboardDelegate?
-  
   let textField: UITextField
   let tableView: SearchGardenTableView
   
@@ -32,7 +25,6 @@ final class SearchGardenView: UIVStackView {
     self.isUserInteractionEnabled = true
     self.backgroundColor = UIColor.white
     self.setupSubViews()
-    self.setupKeyboardObservers()
   }
   
   func clear() {
@@ -90,25 +82,5 @@ extension SearchGardenView {
         self.tableView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
       ]
     )
-  }
-}
-
-// MARK: - Keyboard Delegate Forwarding
-extension SearchGardenView {
-  private func setupKeyboardObservers() {
-    UITextFieldNotificationObserver.observeKeyboardEvents(for: self.textField) { [weak self] event in
-      guard let self else { return }
-
-      switch event {
-      case .willShow(let height, let duration):
-        Task { @MainActor in
-          self.keyboardDelegate?.showKeyboard(self, keyboardHeight: height, duration: duration)
-        }
-      case .willHide(let duration):
-        Task { @MainActor in
-          self.keyboardDelegate?.hideKeyboard(self, duration: duration)
-        }
-      }
-    }
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Modal/Sheet.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Modal/Sheet.swift
@@ -141,7 +141,7 @@ extension BottomSheet {
     return false
   }
 
-  private func animateBottomSheet(to state: State = .normal) {
+  public func animateBottomSheet(to state: State = .normal) {
     guard let superview = self.superview else { return }
     let finalConstant: CGFloat
     if state == .normal {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/TextFieldStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/TextField/TextFieldStyle.swift
@@ -6,7 +6,7 @@ import ToDoGardenUIConstant
 private typealias ViewMode = UIKit.UITextField.ViewMode
 
 extension Styled {
-  public final class TextField: UITextField {
+  public final class TextField: UITextField, UITextFieldDelegate {
     public var mainColor: UIColor? {
       get {
         if let model = self.configuration.groupEditModel {
@@ -32,6 +32,7 @@ extension Styled {
       self.configuration = configuration
       super.init(frame: CGRect.zero)
       self.build()
+      self.delegate = self
     }
     
     public required init?(coder: NSCoder) {
@@ -40,6 +41,11 @@ extension Styled {
     
     deinit {
       self.cancellables.removeAll()
+    }
+    
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+      _ = self.resignFirstResponder()
+      return true
     }
     
     public override func textRect(forBounds bounds: CGRect) -> CGRect {
@@ -107,6 +113,7 @@ extension Styled {
     }
     
     private func build() {
+      self.returnKeyType = .done
       self.clearButtonMode = ViewMode.whileEditing
       switch configuration {
       case let Configuration.primary(primaryModel):

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoListView/ToDoListView.swift
@@ -18,7 +18,7 @@ extension ToDoListView {
 }
 
 public final class ToDoListView: UIView {
-  private lazy var contentView: UICollectionView = {
+  public lazy var contentView: UICollectionView = {
     let toDoListView = UICollectionView(
       frame: CGRect.zero,
       collectionViewLayout: self.makeToDoListViewLayout()


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #939 
## 🎉 변경 사항
- 키보드가 올라왔을때 컨텐츠가 가려지지 않도록 세팅합니다. 
## 📌 PR Point

### 키보드가 올라가고 내려가는 노티를 받았을 때의 동작을 정의합니다. 
### 키보드가 올라왔을때, 컬렉션뷰/ 테이블뷰의 바텀 인셋을 키보드 높이 만큼 추가됩니다. 
### 키보드가 내려갔을때, 원상복귀됩니다. 

### 실행화면 
| 가든검색| 홈 |
|------------------|------------------|
| ![GIF 1](https://github.com/user-attachments/assets/a43dab17-da5a-4865-9531-202068515006) | ![GIF 2](https://github.com/user-attachments/assets/302ca609-b6df-4d60-8341-beb032edac69) |


## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?