### PR TITLE
친구의 가든 이미지가 노출되도록 수정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/ShareGardenSceneWorker.swift
@@ -34,6 +34,7 @@ public struct ShareGardenSceneWorker: ShareGardenSceneWorkable {
           let friendGarden = ShareGardenScene.FriendsGarden(
             id: UUID(uuidString: friendGardenDTO.id) ?? UUID(),
             nickname: friendGardenDTO.nickname,
+            imageUrl: friendGardenDTO.imageUrl,
             focusStreakDays: friendGardenDTO.maxstreakcount ?? Int.zero,
             pomodoroRecords: self.makePomodoroCollection(from: friendGardenDTO.pomodororecords)
           )

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsProfileContentConfiguration.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/FriendsProfileContentConfiguration.swift
@@ -7,6 +7,7 @@
 
 @preconcurrency import UIKit
 
+import TDFoundation
 import ToDoGardenUIComponent
 
 import ShareGardenSceneEntity
@@ -96,6 +97,8 @@ extension ShareGardenSceneViewController {
       }
     }
     
+    private var task: Task<Void, any Error>?
+    
     private var isEditing: Bool {
       didSet {
         if let profileInfoStackView = self.profileInfoView.subviews.first as? UIStackView {
@@ -161,6 +164,17 @@ extension ShareGardenSceneViewController.FriendsGardenProfileInfoView {
         description: "연속 \(friendsGarden.focusStreakDays)일 집중"
       )
     )
+    self.task?.cancel()
+    self.task = Task {
+      guard
+        let urlString = friendsGarden.imageUrl,
+        let url = URL(string: urlString)
+      else {
+        return
+      }
+      let image = try await Cache.shared.execute(id: url)
+      self.profileInfoView.configuration.profileModel?.image = image
+    }
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneEntity/ShareGardenSceneModels.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenSceneEntity/ShareGardenSceneModels.swift
@@ -13,17 +13,20 @@ public enum ShareGardenScene {
   public struct FriendsGarden: Identifiable, Sendable {
     public let id: UUID
     public let nickname: String
+    public let imageUrl: String?
     public let focusStreakDays: Int
     public let pomodoroRecords: PomodoroRecordCollection
     
     public init(
       id: UUID = UUID(),
       nickname: String,
+      imageUrl: String? = nil,
       focusStreakDays: Int,
       pomodoroRecords: PomodoroRecordCollection
     ) {
       self.id = id
       self.nickname = nickname
+      self.imageUrl = imageUrl
       self.focusStreakDays = focusStreakDays
       self.pomodoroRecords = pomodoroRecords
     }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/RowModel.swift
@@ -6,11 +6,17 @@ import ToDoGardenUIResource
 
 extension Styled.Row {
   public enum Configuration {
-    var profileModel: ProfileModel? {
-      if case let Self.profile(model) = self {
-        return model
+    public var profileModel: ProfileModel? {
+      get {
+        if case let Self.profile(model) = self {
+          return model
+        }
+        return nil
       }
-      return nil
+      set {
+        guard let newValue else { return }
+        self = .profile(newValue)
+      }
     }
     
     var listPrimaryModel: ListPrimaryModel? {

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
@@ -27,6 +27,8 @@ extension Styled.Row {
       image: model[style: \.defaultImage],
       size: model[style: \.imageSize]
     )
+    profileImageView.layer.cornerRadius = model[style: \.imageSize].width / 2
+    profileImageView.clipsToBounds = true
     self.bindingProfileImageState(imageView: profileImageView)
     let profileImageTrailingPadding = UIView()
     


### PR DESCRIPTION
## 💡 관련 이슈
#944 

## 🎉 변경 사항
친구의 가든이 정상적으로 노출되도록 수정했습니다.
![image](https://github.com/user-attachments/assets/a4cfe3c1-4e31-4d7a-bd5a-bef6b1e25cc0)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?