### PR TITLE
투두 수정화면 UI 업데이트 로직 추가

### DIFF
--- a/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
+++ b/ToDo-Garden/ToDo-Garden/AppCore/Sources/AppCore/StaticObjects.swift
@@ -30,7 +30,7 @@ extension HomeSceneBuilder.Dependency {
       httpClient: HTTPClient.live
     ),
     manageGroupSceneBuilder: ManageGroupSceneBuilder.init(dependency: .live),
-    editToDoSceneBuilder: EditToDoSceneBuilder(dependency: .live),
+    editToDoSceneBuilder: EditToDoSceneBuilder(),
     timerSceneBuilder: TimerSceneBuilder(dependency: .live),
     retryManager: NetworkRetryManager()
   )
@@ -86,8 +86,6 @@ extension PostGroupSceneBuilder.Dependency {
 
 // MARK: EDIT TODO SCENE
 extension EditToDoSceneBuilder.Dependency {
-  @MainActor
-  static let live = EditToDoSceneBuilder.Dependency.init(editToDoWorker: EditToDoWorker(httpClient: HTTPClient.live))
 }
 
 // MARK: SIGN UP SCENE

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Package.swift
@@ -34,7 +34,11 @@ let package = Package(
       ]
     ),
     .target(
-      name: "EditToDoSceneEntity"
+      name: "EditToDoSceneEntity",
+      dependencies: [
+        .product(name: "SharedEntity", package: "TDFoundation"),
+        .product(name: "TDFoundation", package: "TDFoundation")
+      ]
     ),
     .target(
       name: "EditToDoScene",

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -38,19 +38,19 @@ final class EditToDoInteractor: EditToDoDataStore {
 
   // MARK: VIP Objects
   var presenter: EditToDoPresentationLogic?
-  private let editToDoWorker: EditToDoWorkable
-
-  private var tasks: [EditToDoInteractor.TaskKey: Task<Void, Never>]
-
-  public init(editToDoWorker: EditToDoWorkable) {
-    self.editToDoWorker = editToDoWorker
-    self.tasks = [:]
-  }
 }
 
 // MARK: - Non-REST API Logics
 
 extension EditToDoInteractor: EditToDoBusinessLogic {
+  func prepareSceneData() {
+    if let toDo = self.toDo, let groups = self.groups {
+      self.presenter?.presentFetchedToDo(toDo: toDo, groups: groups)
+    } else {
+      self.presenter?.presentError(EditToDo.ErrorType.failToFetch)
+    }
+  }
+
   /// 사용자가 투두 알림 스위치를 통해 활성화 여부를 변경했을 때 호출되는 메서드입니다.
   func changeAlarmActivation() {
 //    self.toDo.isAlarmOn.toggle()
@@ -110,50 +110,6 @@ import HTTPClient
 import HTTPClientAPI
 
 extension EditToDoInteractor {
-  func prepareSceneData() {
-    self.fetchToDo()
-    self.fetchGroupList()
-  }
-
-  /// 서버로부터 수정할 투두의 정보를 받아오는 메서드입니다.
-  private func fetchToDo() {
-//    guard let id = self.toDoId else {
-//      self.presenter?.presentError(.network)
-//      return
-//    }
-//
-//    self.tasks[TaskKey.fetchToDo] = Task {
-//      defer { self.tasks[TaskKey.fetchToDo] = nil }
-//
-//      do {
-//        try Task.checkCancellation()
-//        let toDo = try await self.editToDoWorker.fetchToDo(id: id)
-//        try Task.checkCancellation()
-//        self.toDo = toDo
-//        let response = EditToDo.FetchToDo.Response(toDo: toDo)
-//        self.presenter?.presentFetchedToDo(response: response)
-//      } catch let error {
-//        debugPrint(error.localizedDescription)
-//        self.presenter?.presentError(.failToFetch)
-//      }
-//    }
-  }
-
-  private func fetchGroupList() {
-    self.tasks[TaskKey.fetchGroup] = Task {
-      defer { self.tasks[TaskKey.fetchGroup] = nil }
-
-      do {
-        try Task.checkCancellation()
-        let groupList = try await self.editToDoWorker.fetchGroupList()
-        try Task.checkCancellation()
-        self.presenter?.presentFetchedGroupList(groupList: groupList)
-      } catch let error {
-        debugPrint(error.localizedDescription)
-      }
-    }
-  }
-
   /// 서버에 투두의 수정을 요청하는 메서드입니다.
   func editToDo(request: EditToDo.CompleteEditToDo.Request) {
 //    guard let toDo else {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -27,8 +27,8 @@ protocol EditToDoBusinessLogic {
   func changeAlarmTime(_ time: Double)
 
   func prepareSceneData()
+  func editToDo(name: String, groupId: String)
   func deleteToDo()
-  func editToDo(request: EditToDo.CompleteEditToDo.Request)
 }
 
 @MainActor
@@ -38,6 +38,8 @@ final class EditToDoInteractor: EditToDoDataStore {
 
   // MARK: VIP Objects
   var presenter: EditToDoPresentationLogic?
+
+  public init() {}
 }
 
 // MARK: - Non-REST API Logics
@@ -94,71 +96,30 @@ extension EditToDoInteractor: EditToDoBusinessLogic {
 import HTTPClient
 import HTTPClientAPI
 
+// swiftlint:disable multiline_arguments
 extension EditToDoInteractor {
   /// 서버에 투두의 수정을 요청하는 메서드입니다.
-  func editToDo(request: EditToDo.CompleteEditToDo.Request) {
-//    guard let toDo else {
-//      self.presenter?.presentError(.failToFetch)
-//      return
-//    }
-//
-//    self.toDo?.name = request.toDoName
-//    self.toDo?.groupData = EditToDo.Group(
-//      id: request.displayedGroup.id,
-//      name: request.displayedGroup.name,
-//      color: request.displayedGroup.color.hexStringFromColor(),
-//      orderIdx: 0
-//    )
-//
-//    self.tasks[TaskKey.editToDo] = Task {
-//      defer { self.tasks[TaskKey.editToDo] = nil }
-//
-//      do {
-//        try Task.checkCancellation()
-//        try await self.editToDoWorker.editToDo(toDo)
-//        try Task.checkCancellation()
-//        self.presenter?.presentDismiss()
-//      } catch let error {
-//        debugPrint(error.localizedDescription)
-//        self.presenter?.presentError(.network)
-//      }
-//    }
+  func editToDo(name: String, groupId: String) {
+    guard let toDo = self.toDo
+    else { return }
+
+    let startDay = toDo.isOnlyToday ? nil : toDo.startDay
+    let endDay = toDo.isOnlyToday ? nil : toDo.endDay
+    self.toDo = TodoBatchItem(
+      localId: toDo.groupId, name: toDo.name, isDone: toDo.isDone, createdAt: toDo.createdAt,
+      isAlarmOn: toDo.isAlarmOn, alarmTime: toDo.alarmTime, isOnlyToday: toDo.isOnlyToday,
+      startDay: startDay, endDay: endDay, groupId: groupId, isDelete: false
+    )
   }
 
-  /// 서버에 투두의 삭제를 요청하는 메서드입니다.
+  // TODO: 서버에 투두의 삭제를 요청하는 메서드입니다.
   func deleteToDo() {
-//    guard let toDoId else {
-//      self.presenter?.presentError(.failToFetch)
-//      return
-//    }
-//
-//    self.tasks[TaskKey.deleteToDo] = Task {
-//      defer { self.tasks[TaskKey.deleteToDo] = nil }
-//
-//      do {
-//        try Task.checkCancellation()
-//        try await self.editToDoWorker.deleteToDo(id: toDoId)
-//        try Task.checkCancellation()
-//        self.presenter?.presentDismiss()
-//      } catch let error {
-//        debugPrint(error.localizedDescription)
-//        self.presenter?.presentError(.network)
-//      }
-//    }
   }
 }
+// swiftlint:enable multiline_arguments
 
 // MARK: Errors
 
 enum EditToDoInteractorError: Error {
   case toDoDataNotExisted
-}
-
-extension EditToDoInteractor {
-  enum TaskKey {
-    case fetchToDo
-    case fetchGroup
-    case deleteToDo
-    case editToDo
-  }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -21,10 +21,10 @@ protocol EditToDoDataStore {
 @MainActor
 protocol EditToDoBusinessLogic {
   func changeRepetition(isOnlyToday: Bool)
-  func changeReptitionRange(request: EditToDo.ChangeRepetitionRange.Request)
+  func changeReptitionRange(start: Date, end: Date)
   func changeAlarmActivation()
   func fetchAlarmTime()
-  func changeAlarmTime(request: EditToDo.ChangeAlarmTime.Request)
+  func changeAlarmTime(_ time: Double)
 
   func prepareSceneData()
   func deleteToDo()
@@ -53,55 +53,40 @@ extension EditToDoInteractor: EditToDoBusinessLogic {
 
   /// 사용자가 투두 알림 스위치를 통해 활성화 여부를 변경했을 때 호출되는 메서드입니다.
   func changeAlarmActivation() {
-//    self.toDo.isAlarmOn.toggle()
-//    let response = EditToDo.ChangeAlarmActivation.Response(isAlarmOn: self.toDo.isAlarmOn)
-//    self.presenter?.presentAlarmActivation(response: response)
+    self.toDo?.isAlarmOn.toggle()
+    guard let isAlarmOn = self.toDo?.isAlarmOn else { return }
+    let response = EditToDo.ChangeAlarmActivation.Response(isAlarmOn: isAlarmOn)
+    self.presenter?.presentAlarmActivation(response: response)
   }
 
   /// 사용자가 투두 알림 시간 설정 버튼을 눌렀을 때, 기존에 설정했던 시간을 보여주기 위해 호출되는 메서드입니다.
   func fetchAlarmTime() {
-//    let alarmTime = self.toDo?.alarm.alarmTime
-//    let response = EditToDo.FetchAlarmTime.Response(alarmTime: alarmTime)
-//    self.presenter?.presentFetchedAlarmTime(response: response)
+    guard let alarmTime = self.toDo?.alarmTime else { return }
+    let response = EditToDo.FetchAlarmTime.Response(alarmTime: alarmTime)
+    self.presenter?.presentFetchedAlarmTime(response: response)
   }
 
-  func changeAlarmTime(request: EditToDo.ChangeAlarmTime.Request) {
-//    let alarmTime = request.alarmTime
-//    self.toDo?.alarm.alarmTime = alarmTime
-//    let response = EditToDo.ChangeAlarmTime.Response(alarmTime: alarmTime)
-//    self.presenter?.presentChangedAlarmTime(response: response)
+  func changeAlarmTime(_ time: Double) {
+    self.toDo?.alarmTime = time
+    let response = EditToDo.ChangeAlarmTime.Response(alarmTime: time)
+    self.presenter?.presentChangedAlarmTime(response: response)
   }
 
   func changeRepetition(isOnlyToday: Bool) {
-//    self.toDo?.repetition.isOnlyToday = isOnlyToday
-//    if isOnlyToday {
-//      self.presenter?.presentRepeatOnlyToday()
-//    } else {
-//      let currentDate = Date()
-//      let tomorrowDate = currentDate.addingTimeInterval(60 * 60 * 24)
-//      let repetition = self.toDo?.repetition
-//      if repetition?.startDate == nil && repetition?.endDate == nil {
-//        self.toDo?.repetition.startDate = currentDate
-//        self.toDo?.repetition.endDate = tomorrowDate
-//      }
-//
-//      let response = EditToDo.ChangeRepetitionRange.Response(
-//        startDate: self.toDo?.repetition.startDate ?? currentDate,
-//        endDate: self.toDo?.repetition.endDate ?? tomorrowDate
-//      )
-//      self.presenter?.presentChangedRepetitionRange(response: response)
+    self.toDo?.isOnlyToday = isOnlyToday
+    if isOnlyToday {
+      self.presenter?.presentRepeatOnlyToday()
+    } else {
+      self.presenter?.presentRepeatOtherDays()
+    }
   }
 
   /// 사용자가 투두 반복 설정 뷰를 선택했을 때 호출하는 메서드입니다.
-  func changeReptitionRange(request: EditToDo.ChangeRepetitionRange.Request) {
-//    self.toDo?.repetition.isOnlyToday = false
-//    let startDate = request.startDate
-//    let endDate = request.endDate
-//    self.toDo?.repetition.startDate = startDate
-//    self.toDo?.repetition.endDate = endDate
-//
-//    let response = EditToDo.ChangeRepetitionRange.Response(startDate: startDate, endDate: endDate)
-//    self.presenter?.presentChangedRepetitionRange(response: response)
+  func changeReptitionRange(start: Date, end: Date) {
+    self.toDo?.isOnlyToday = false
+    self.toDo?.startDay = start.toISOString()
+    self.toDo?.endDay = end.toISOString()
+    self.presenter?.presentChangedRepetitionRange(start: start, end: end)
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
@@ -21,7 +21,8 @@ protocol EditToDoPresentationLogic {
   func presentFetchedAlarmTime(response: EditToDo.FetchAlarmTime.Response)
   func presentChangedAlarmTime(response: EditToDo.ChangeAlarmTime.Response)
   func presentRepeatOnlyToday()
-  func presentChangedRepetitionRange(response: EditToDo.ChangeRepetitionRange.Response)
+  func presentRepeatOtherDays()
+  func presentChangedRepetitionRange(start: Date, end: Date)
 }
 
 final class EditToDoPresenter {
@@ -70,11 +71,15 @@ extension EditToDoPresenter: EditToDoPresentationLogic {
     self.viewController?.displayRepeatOnlyToday()
   }
 
-  func presentChangedRepetitionRange(response: EditToDo.ChangeRepetitionRange.Response) {
-    let startDay = self.dateFormatter.string(from: response.startDate)
-    let endDay = self.dateFormatter.string(from: response.endDate)
-    let viewModel = EditToDo.ChangeRepetitionRange.ViewModel(startDay: startDay, endDay: endDay)
-    self.viewController?.displayChangedRepetition(viewModel: viewModel)
+  func presentRepeatOtherDays() {
+    self.viewController?.displayRepeatOtherDays()
+  }
+
+  func presentChangedRepetitionRange(start: Date, end: Date) {
+    self.viewController?.displayChangedRepetition(
+      start: self.dateFormatter.string(from: start),
+      end: self.dateFormatter.string(from: end)
+    )
   }
 
   func presentError(_ type: EditToDo.ErrorType) {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoPresenter.swift
@@ -8,11 +8,12 @@
 import UIKit
 
 import EditToDoSceneEntity
+import SharedEntity
+import TDFoundation
 
 @MainActor
 protocol EditToDoPresentationLogic {
-  func presentFetchedToDo(response: EditToDo.FetchToDo.Response)
-  func presentFetchedGroupList(groupList: [EditToDo.Group])
+  func presentFetchedToDo(toDo: TodoBatchItem, groups: [TodoListGroup])
   func presentDismiss()
   func presentError(_ type: EditToDo.ErrorType)
 
@@ -36,21 +37,11 @@ final class EditToDoPresenter {
 // MARK: - Request to ViewController
 
 extension EditToDoPresenter: EditToDoPresentationLogic {
-  func presentFetchedToDo(response: EditToDo.FetchToDo.Response) {
-    let viewModel = EditToDo.FetchToDo.ViewModel(toDo: self.makeDisplayedToDo(from: response.toDo))
+  func presentFetchedToDo(toDo: TodoBatchItem, groups: [TodoListGroup]) {
+    let alarmTime = self.makeAlarmTime(of: toDo.alarmTime)
+    let alarmTimeString = String(format: "%02d:%02d", alarmTime.hour, alarmTime.minute)
+    let viewModel = EditToDo.FetchToDo.ViewModel(toDo: toDo, alarmTime: alarmTimeString, groups: groups)
     self.viewController?.displayFetchedToDo(viewModel: viewModel)
-  }
-
-  func presentFetchedGroupList(groupList: [EditToDo.Group]) {
-    let displayedGroupList = groupList.map {
-      return EditToDo.DisplayedGroup(
-        id: $0.id,
-        name: $0.name,
-        color: (try? UIColor().fromHex($0.color)) ?? UIColor.toDoGardenGreenDark,
-        orderIdx: $0.orderIdx
-      )
-    }
-    self.viewController?.displayFetchedGroupList(displayedGroupList)
   }
 
   func presentDismiss() {
@@ -97,31 +88,6 @@ extension EditToDoPresenter {
   private struct AlarmTime {
     let hour: Int
     let minute: Int
-  }
-
-  private func makeDisplayedToDo(
-    from fetchedToDo: EditToDo.ToDo
-  ) -> EditToDo.FetchToDo.ViewModel.DisplayedToDo {
-    let displayedGroup = EditToDo.DisplayedGroup(
-      id: fetchedToDo.groupData.id,
-      name: fetchedToDo.groupData.name,
-      color: (try? UIColor().fromHex(fetchedToDo.groupData.color)) ?? UIColor.toDoGardenGreenDark,
-      orderIdx: fetchedToDo.groupData.orderIdx
-    )
-    let alarmTime = self.makeAlarmTime(of: fetchedToDo.alarm.alarmTime)
-    let alarmTimeString = String(format: "%02d:%02d", alarmTime.hour, alarmTime.minute)
-    let startDay = self.makeDayString(from: fetchedToDo.repetition.startDate)
-    let endDay = self.makeDayString(from: fetchedToDo.repetition.endDate)
-
-    return EditToDo.FetchToDo.ViewModel.DisplayedToDo(
-      toDoName: fetchedToDo.name,
-      group: displayedGroup,
-      isAlarmOn: fetchedToDo.alarm.isAlarmOn,
-      alarmTime: alarmTimeString,
-      isOnlyToday: fetchedToDo.repetition.isOnlyToday,
-      startDay: startDay,
-      endDay: endDay
-    )
   }
 
   private func makeAlarmTime(of time: Double?) -> AlarmTime {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoRouter.swift
@@ -9,23 +9,36 @@ import Foundation
 
 import EditToDoSceneAPI
 
+@MainActor
 protocol EditToDoRoutingLogic {
-  func routeToToDoListScene()
+  func routeToHomeScene()
+  func routeToHomeSceneWithToDo()
 }
 
+@MainActor
 protocol EditToDoDataPassing {
   var dataStore: EditToDoDataStore? { get set }
+  var delegate: EditToDoSceneDelegate? { get set }
 }
 
+@MainActor
 class EditToDoRouter: EditToDoDataPassing {
   weak var viewController: EditToDoViewController?
+  weak var delegate: EditToDoSceneDelegate?
   var dataStore: EditToDoDataStore?
 }
 
 // MARK: - Routing
 
+// swiftlint:disable all
 extension EditToDoRouter: EditToDoRoutingLogic {
-  func routeToToDoListScene() {
+  func routeToHomeScene() {
     self.viewController?.navigationController?.popViewController(animated: true)
   }
+
+  func routeToHomeSceneWithToDo() {
+    self.delegate?.didEdit(toDo: self.dataStore!.toDo!)
+    self.routeToHomeScene()
+  }
 }
+// swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneBuilder.swift
@@ -13,18 +13,9 @@ import EditToDoSceneAPI
 public struct EditToDoSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
-    let editToDoWorker: EditToDoWorkable
-
-    public init(editToDoWorker: EditToDoWorkable) {
-      self.editToDoWorker = editToDoWorker
-    }
   }
 
-  private let dependency: Dependency
-
-  public init(dependency: Dependency) {
-    self.dependency = dependency
-  }
+  public init() {}
 }
 
 extension EditToDoSceneBuilder: EditToDoSceneBuildable {
@@ -44,7 +35,7 @@ extension EditToDoSceneBuilder {
   /// - Parameter viewController: VIPCycle을 설정할 viewController입니다.
   /// - Returns: VIP Cycle 설정이 완료된 `ViewControllable` 프로토콜을 준수한 `ViewController` 인스턴스를 반환합니다.
   private func configureVIPCycle(for viewController: EditToDoViewController) -> EditToDoViewController {
-    let interactor = EditToDoInteractor(editToDoWorker: self.dependency.editToDoWorker)
+    let interactor = EditToDoInteractor()
     let presenter = EditToDoPresenter()
     let router = EditToDoRouter()
     viewController.interactor = interactor

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoSceneBuilder.swift
@@ -55,5 +55,6 @@ extension EditToDoSceneBuilder {
   private func setPayload(for viewController: EditToDoViewController, with payload: EditToDoScenePayloadable) {
     viewController.router?.dataStore?.toDo = payload.toDo
     viewController.router?.dataStore?.groups = payload.groups
+    viewController.router?.delegate = payload.delegate
   }
 }

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -297,7 +297,7 @@ extension EditToDoView {
     self.toDoNameInputView.changeBottomLine(color: UIColor.toDoGardenYellow)
     self.groupSelectionView.updateGroup(
       current: GroupSelectionViewItem(
-        groupId: UUID(),
+        groupId: UUID().uuidString,
         groupName: text,
         groupColor: UIColor.toDoGardenYellow
       )

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -94,18 +94,10 @@ extension EditToDoViewController: ToDoAlarmTimeSettingModalDelegate, ToDoRepetit
 
 extension EditToDoViewController: EditToDoScheduleViewDelegate {
   func editToDo() {
-    if let toDoNameForEdit = self.editToDoView.getEditingText(),
-    let groupForEdit = self.editToDoView.getCurrentGroup() {
-      let request = EditToDo.CompleteEditToDo.Request(
-        toDoName: toDoNameForEdit,
-        displayedGroup: EditToDo.DisplayedGroup(
-          id: groupForEdit.groupId,
-          name: groupForEdit.groupName,
-          color: groupForEdit.groupColor,
-          orderIdx: 0
-        )
-      )
-      self.interactor?.editToDo(request: request)
+    if let name = self.editToDoView.getEditingText(),
+    let group = self.editToDoView.getCurrentGroup() {
+      self.interactor?.editToDo(name: name, groupId: group.groupId)
+      self.router?.routeToHomeScene()
     }
   }
 
@@ -148,7 +140,7 @@ extension EditToDoViewController: EditToDoDisplayLogic {
     self.updateEditToDoScheduleView(toDo: viewModel.toDo, alarmTime: viewModel.alarmTime)
   }
 
-  private func updateEditToDoView(toDo: TodoBatchItem, groups: [SharedEntity.TodoListGroup]) {
+  private func updateEditToDoView(toDo: TodoBatchItem, groups: [TodoListGroup]) {
     self.editToDoView.updateToDoName(toDo.name)
     var order = 0
     let groups = groups.map {
@@ -198,7 +190,7 @@ extension EditToDoViewController: EditToDoDisplayLogic {
   }
 
   func displayDismiss() {
-    self.router?.routeToToDoListScene()
+    self.router?.routeToHomeScene()
   }
 
   func displayRepeatOnlyToday() {
@@ -246,7 +238,7 @@ extension EditToDoViewController: ToDoGardenAlertControllerDelegate {
     case ToDoGardenUIConstant.Constant.ToDoGardenAlertView.Content.ButtonActionType.retry:
       self.interactor?.prepareSceneData()
     case ToDoGardenUIConstant.Constant.ToDoGardenAlertView.Content.ButtonActionType.goHome:
-      self.router?.routeToToDoListScene()
+      self.router?.routeToHomeScene()
     case ToDoGardenUIConstant.Constant.ToDoGardenAlertView.Content.ButtonActionType.delete:
       self.interactor?.deleteToDo()
     default:
@@ -318,6 +310,7 @@ extension EditToDoViewController {
   struct EditToDoScenePayload: EditToDoScenePayloadable {
     var toDo: TodoBatchItem
     var groups: [SharedEntity.TodoListGroup]
+    var delegate: EditToDoSceneAPI.EditToDoSceneDelegate?
   }
 
   class SomeViewController: UIViewController {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -38,6 +38,7 @@ final public class EditToDoViewController: UIViewController, EditToDoViewControl
   private(set) var completeEditButton: ToDoGardenBoxButton
 
   private let alarmTimeSettingModal = ToDoAlarmTimeSettingModal()
+  private let repetitionSettingModal = ToDoRepetitionSettingModal()
 
   @ExecuteOnce private var scrollToEditToDoMode: (() -> Void)?
 
@@ -70,7 +71,12 @@ final public class EditToDoViewController: UIViewController, EditToDoViewControl
   public override func viewDidLoad() {
     super.viewDidLoad()
     self.setup()
+    self.setupModalDelegate()
+  }
+
+  private func setupModalDelegate() {
     self.alarmTimeSettingModal.delegate = self
+    self.repetitionSettingModal.delegate = self
   }
 
   public override func viewIsAppearing(_ animated: Bool) {
@@ -122,9 +128,8 @@ extension EditToDoViewController: EditToDoScheduleViewDelegate {
   }
 
   func didSelectRepetitionDateButton() {
-    let repetitionSelectionModal = ToDoRepetitionSettingModal()
-    repetitionSelectionModal.delegate = self
-    self.present(repetitionSelectionModal, animated: true)
+    self.repetitionSettingModal.setupPresentationStyle()
+    self.present(self.repetitionSettingModal, animated: true)
   }
 
   func didSelectRepetitionRange(_ startDate: Date, _ endDate: Date) {
@@ -176,12 +181,16 @@ extension EditToDoViewController: EditToDoDisplayLogic {
       self.editToDoScheduleView.updateToAlarmOff()
     }
     self.editToDoScheduleView.updateAlarmTime(alarmTime: alarmTime)
+
     if toDo.isOnlyToday {
       self.editToDoScheduleView.updateToRepeatOnlyToday()
     } else {
       if let startDay = toDo.startDay, let endDay = toDo.endDay {
         self.editToDoScheduleView.updateToRepeatInRange(startDay: startDay, endDay: endDay)
       }
+    }
+    if let start = toDo.startDay, let end = toDo.endDay {
+      self.repetitionSettingModal.updateRange(start: start, end: end)
     }
   }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -23,7 +23,8 @@ protocol EditToDoDisplayLogic: AnyObject {
   func showErrorAlert(_ type: EditToDo.ErrorType)
 
   func displayRepeatOnlyToday()
-  func displayChangedRepetition(viewModel: EditToDo.ChangeRepetitionRange.ViewModel)
+  func displayRepeatOtherDays()
+  func displayChangedRepetition(start: String, end: String)
   func displayChangedAlarm(viewModel: EditToDo.ChangeAlarmActivation.ViewModel)
   func displayFetchedAlarmTime(viewModel: EditToDo.FetchAlarmTime.ViewModel)
   func displayChangedAlarmTime(viewModel: EditToDo.ChangeAlarmTime.ViewModel)
@@ -35,6 +36,8 @@ final public class EditToDoViewController: UIViewController, EditToDoViewControl
   private(set) var editToDoView: EditToDoView
   private(set) var editToDoScheduleView: EditToDoScheduleView
   private(set) var completeEditButton: ToDoGardenBoxButton
+
+  private let alarmTimeSettingModal = ToDoAlarmTimeSettingModal()
 
   @ExecuteOnce private var scrollToEditToDoMode: (() -> Void)?
 
@@ -66,8 +69,8 @@ final public class EditToDoViewController: UIViewController, EditToDoViewControl
 
   public override func viewDidLoad() {
     super.viewDidLoad()
-    print("i'm called")
     self.setup()
+    self.alarmTimeSettingModal.delegate = self
   }
 
   public override func viewIsAppearing(_ animated: Bool) {
@@ -115,12 +118,15 @@ extension EditToDoViewController: EditToDoScheduleViewDelegate {
   }
 
   func didSelectAlarmTime(_ alarmTime: Double) {
-    let request = EditToDo.ChangeAlarmTime.Request(alarmTime: alarmTime)
-    self.interactor?.changeAlarmTime(request: request)
+    self.interactor?.changeAlarmTime(alarmTime)
   }
 
-  func didSelectOnlyTodayView(isOnlyToday: Bool) {
-    self.interactor?.changeRepetition(isOnlyToday: isOnlyToday)
+  func didSelectOnlyTodayView() {
+    self.interactor?.changeRepetition(isOnlyToday: true)
+  }
+
+  func didSelectRepeatOtherDaysView() {
+    self.interactor?.changeRepetition(isOnlyToday: false)
   }
 
   func didSelectRepetitionDateButton() {
@@ -130,8 +136,7 @@ extension EditToDoViewController: EditToDoScheduleViewDelegate {
   }
 
   func didSelectRepetitionRange(_ startDate: Date, _ endDate: Date) {
-    let request = EditToDo.ChangeRepetitionRange.Request(startDate: startDate, endDate: endDate)
-    self.interactor?.changeReptitionRange(request: request)
+    self.interactor?.changeReptitionRange(start: startDate, end: endDate)
   }
 }
 
@@ -200,10 +205,12 @@ extension EditToDoViewController: EditToDoDisplayLogic {
     self.editToDoScheduleView.updateToRepeatOnlyToday()
   }
 
-  func displayChangedRepetition(viewModel: EditToDo.ChangeRepetitionRange.ViewModel) {
-    let startDay = viewModel.startDay
-    let endDay = viewModel.endDay
-    self.editToDoScheduleView.updateToRepeatInRange(startDay: startDay, endDay: endDay)
+  func displayRepeatOtherDays() {
+    self.editToDoScheduleView.updateToRepeatOtherDays()
+  }
+
+  func displayChangedRepetition(start: String, end: String) {
+    self.editToDoScheduleView.updateToRepeatInRange(startDay: start, endDay: end)
   }
 
   func displayChangedAlarm(viewModel: EditToDo.ChangeAlarmActivation.ViewModel) {
@@ -215,8 +222,7 @@ extension EditToDoViewController: EditToDoDisplayLogic {
   }
 
   func displayFetchedAlarmTime(viewModel: EditToDo.FetchAlarmTime.ViewModel) {
-    let alarmTimeSettingModal = ToDoAlarmTimeSettingModal()
-    alarmTimeSettingModal.delegate = self
+    self.alarmTimeSettingModal.sheetPresentationController?.detents = [.medium()]
     let hour = viewModel.hour
     let minute = viewModel.minute
     alarmTimeSettingModal.updateInitialAlarmTime(hour: hour, minute: minute)

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 
 import EditToDoSceneAPI
 import EditToDoSceneEntity
+import SharedEntity
+import TDFoundation
 import TDUtility
 import ToDoGardenUIAPI
 import ToDoGardenUIComponent
@@ -137,18 +139,46 @@ extension EditToDoViewController: EditToDoScheduleViewDelegate {
 
 extension EditToDoViewController: EditToDoDisplayLogic {
   func displayFetchedToDo(viewModel: EditToDo.FetchToDo.ViewModel) {
-    let toDo = viewModel.toDo
-    self.editToDoView.updateToDoName(toDo.toDoName)
-    self.editToDoView.updateGroup(current: toDo.group)
+    self.updateEditToDoView(toDo: viewModel.toDo, groups: viewModel.groups)
+    self.updateEditToDoScheduleView(toDo: viewModel.toDo, alarmTime: viewModel.alarmTime)
+  }
+
+  private func updateEditToDoView(toDo: TodoBatchItem, groups: [SharedEntity.TodoListGroup]) {
+    self.editToDoView.updateToDoName(toDo.name)
+    var order = 0
+    let groups = groups.map {
+      order += 1
+      return EditToDo.DisplayedGroup(
+        id: $0.localId,
+        name: $0.name,
+        color: (try? UIColor().fromHex($0.color)) ?? UIColor.toDoGardenGreenDark,
+        orderIdx: order
+      )
+    }
+    var newOrder = 0
+    guard let group = groups.first(where: {
+      newOrder += 1
+      return $0.id == toDo.groupId
+    }) else { return }
+
+    self.editToDoView.updateGroup(
+      current: EditToDo.DisplayedGroup(
+        id: group.id,
+        name: group.name,
+        color: group.color,
+        orderIdx: newOrder
+      )
+    )
+    self.editToDoView.updateGroupList(groups)
+  }
+
+  private func updateEditToDoScheduleView(toDo: TodoBatchItem, alarmTime: String) {
     if toDo.isAlarmOn {
       self.editToDoScheduleView.updateToAlarmOn()
     } else {
       self.editToDoScheduleView.updateToAlarmOff()
     }
-    if let alarmTime = toDo.alarmTime {
-      self.editToDoScheduleView.updateAlarmTime(alarmTime: alarmTime)
-    }
-    self.editToDoView.updateToDoName(toDo.toDoName)
+    self.editToDoScheduleView.updateAlarmTime(alarmTime: alarmTime)
     if toDo.isOnlyToday {
       self.editToDoScheduleView.updateToRepeatOnlyToday()
     } else {
@@ -277,9 +307,7 @@ extension EditToDoViewController: UIScrollViewDelegate {
 }
 
 import HTTPClient
-import SharedEntity
-import TDFoundation
-
+// swiftlint:disable all
 extension EditToDoViewController {
   struct EditToDoScenePayload: EditToDoScenePayloadable {
     var toDo: TodoBatchItem
@@ -288,16 +316,35 @@ extension EditToDoViewController {
 
   class SomeViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
-      //      super.viewDidAppear(animated)
-      //      let editToDoViewController = EditToDoSceneBuilder(
-      //        dependency: EditToDoSceneBuilder.Dependency(
-      //          editToDoWorker: EditToDoWorker(httpClient: HTTPClient.live)
-      //        )
-      //      ).build(with: EditToDoViewController.EditToDoScenePayload(toDoId: UUID()))
-      //      self.navigationController?.pushViewController(editToDoViewController, animated: true)
+      super.viewDidAppear(animated)
+      let editToDoViewController = EditToDoSceneBuilder().build(
+        with: EditToDoViewController.EditToDoScenePayload(
+          toDo: TodoBatchItem(
+            localId: "sadfasdfsdf", name: "temp", isDone: true,
+            createdAt: "1212", isAlarmOn: true, alarmTime: Double(43450),
+            isOnlyToday: true, startDay: nil, endDay: nil, groupId: "1111", isDelete: false
+          ),
+          groups: [
+            TodoListGroup(
+              localId: "2222", name: "그룹2", color: UIColor.blue.hexStringFromColor(),
+              todoList: nil, progressRate: Double(0)
+            ),
+            TodoListGroup(
+              localId: "1111", name: "그룹1", color: UIColor.toDoGardenGreenDark.hexStringFromColor(),
+              todoList: nil, progressRate: Double(0.4)
+            ),
+            TodoListGroup(
+              localId: "3333", name: "그룹3", color: UIColor.red.hexStringFromColor(),
+              todoList: nil, progressRate: Double(0.1)
+            )
+          ]
+        )
+      )
+      self.navigationController?.pushViewController(editToDoViewController, animated: true)
     }
   }
 }
+// swiftlint:enable all
 
 extension EditToDoViewController {
   public func setForGuide(index: Int) {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoRepetitionView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoRepetitionView.swift
@@ -35,7 +35,8 @@ final class EditToDoRepetitionView: UIView {
   }
 
   func setRepeatRangeSelected() {
-    self.setRepeatOtherDaysViewSelected()
+    self.repeatOnlyTodayView.setDeSelected()
+    self.repeatOtherDaysView.setSelected()
     self.repeatOtherDaysView.updateDateButtonState(isSelected: true)
   }
 
@@ -47,7 +48,8 @@ final class EditToDoRepetitionView: UIView {
 // MARK: EditToDoRepetitionView Delegate
 
 protocol EditToDoRepetitionViewDelegate: AnyObject {
-  func didSelectOnlyTodayView(isOnlyToday: Bool)
+  func didSelectOnlyTodayView()
+  func didSelectRepeatOtherDaysView()
   func didSelectRepetitionDateButton()
 }
 
@@ -76,13 +78,11 @@ extension EditToDoRepetitionView {
 
   private func setupRepeatOnlyTodayViewDelegate() {
     self.repeatOnlyTodayView.bindTapGesture { _ in
-      let isOnlyToday = true
-      self.delegate?.didSelectOnlyTodayView(isOnlyToday: isOnlyToday)
+      self.delegate?.didSelectOnlyTodayView()
     }
 
     self.repeatOtherDaysView.bindTapGesture { _ in
-      let isOnlyToday = false
-      self.delegate?.didSelectOnlyTodayView(isOnlyToday: isOnlyToday)
+      self.delegate?.didSelectRepeatOtherDaysView()
     }
   }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoScheduleView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/EditToDoScheduleView.swift
@@ -43,16 +43,20 @@ final class EditToDoScheduleView: UIView {
     self.editToDoRepetitionView.setRepeatOnlyTodaySelected()
   }
 
+  func updateToRepeatOtherDays() {
+    self.editToDoRepetitionView.setRepeatRangeSelected()
+  }
+
   func updateToRepeatInRange(startDay: String, endDay: String) {
     self.editToDoRepetitionView.updateRepetitionRange(startDay: startDay, endDay: endDay)
-    self.editToDoRepetitionView.setRepeatRangeSelected()
   }
 }
 
 // MARK: Delegate Functions
 
 protocol EditToDoScheduleViewDelegate: AnyObject {
-  func didSelectOnlyTodayView(isOnlyToday: Bool)
+  func didSelectOnlyTodayView()
+  func didSelectRepeatOtherDaysView()
   func didSelectRepetitionDateButton()
   func didToggleSwitch()
   func didSelectAlarmSettingButton()
@@ -60,8 +64,12 @@ protocol EditToDoScheduleViewDelegate: AnyObject {
 
 /// 하위 뷰들에서 이벤트를 입력받았을 때 Delegate로 전달받아 호출되는 메서드들입니다.
 extension EditToDoScheduleView: EditToDoRepetitionViewDelegate, EditToDoAlarmViewDelegate {
-  func didSelectOnlyTodayView(isOnlyToday: Bool) {
-    self.delegate?.didSelectOnlyTodayView(isOnlyToday: isOnlyToday)
+  func didSelectOnlyTodayView() {
+    self.delegate?.didSelectOnlyTodayView()
+  }
+
+  func didSelectRepeatOtherDaysView() {
+    self.delegate?.didSelectRepeatOtherDaysView()
   }
 
   func didSelectRepetitionDateButton() {

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/ToDoRepetitionSettingModal.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/ToDoRepetitionSettingModal.swift
@@ -34,6 +34,19 @@ final class ToDoRepetitionSettingModal: UIViewController {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+
+  func updateRange(start: String, end: String) {
+    self.dateRangePicker.updateRange(startDate: start, endDate: end)
+  }
+
+  func setupPresentationStyle() {
+    if #available(iOS 16.0, *) {
+      self.sheetPresentationController?.detents = [
+        .custom { _ in return 500 }
+      ]
+    }
+    self.sheetPresentationController?.prefersGrabberVisible = true
+  }
 }
 
 // MARK: View Life Cycle
@@ -46,15 +59,6 @@ extension ToDoRepetitionSettingModal {
 }
 
 extension ToDoRepetitionSettingModal {
-  private func setupPresentationStyle() {
-    if #available(iOS 16.0, *) {
-      self.sheetPresentationController?.detents = [
-        .custom { _ in return 500 }
-      ]
-    }
-    self.sheetPresentationController?.prefersGrabberVisible = true
-  }
-
   private func setup() {
     self.setupCompleteButton()
     self.setupCompleteButtonActivation()

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/ToDoRepetitionSettingModal.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/View/ToDoRepetitionSettingModal.swift
@@ -27,7 +27,7 @@ final class ToDoRepetitionSettingModal: UIViewController {
     self.startDate = startDate
     self.endDate = endDate
     super.init(nibName: nil, bundle: nil)
-    print("modal presented")
+    self.setupPresentationStyle()
   }
 
   @available(*, unavailable)
@@ -47,9 +47,11 @@ extension ToDoRepetitionSettingModal {
 
 extension ToDoRepetitionSettingModal {
   private func setupPresentationStyle() {
-    self.sheetPresentationController?.detents = [
-      UISheetPresentationController.Detent.large()
-    ]
+    if #available(iOS 16.0, *) {
+      self.sheetPresentationController?.detents = [
+        .custom { _ in return 500 }
+      ]
+    }
     self.sheetPresentationController?.prefersGrabberVisible = true
   }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneAPI/EditToDoSceneBuildable.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneAPI/EditToDoSceneBuildable.swift
@@ -11,9 +11,11 @@ import SharedEntity
 import TDFoundation
 
 /// 런타임에 전달받을 의존성을 선언한 구조체입니다.
+@MainActor
 public protocol EditToDoScenePayloadable {
-  var toDo: TodoBatchItem { get set }
+  var toDo: TDFoundation.TodoBatchItem { get set }
   var groups: [SharedEntity.TodoListGroup] { get set }
+  var delegate: EditToDoSceneDelegate? { get set }
 }
 
 @MainActor

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneAPI/EditToDoSceneDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneAPI/EditToDoSceneDelegate.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  EditToDoScene
+//
+//  Created by Wood on 4/6/25.
+//
+
+import Foundation
+
+import TDFoundation
+
+@MainActor
+public protocol EditToDoSceneDelegate: AnyObject {
+  func didEdit(toDo: TodoBatchItem)
+  func didRemove(toDo: TodoBatchItem)
+}

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
@@ -7,55 +7,21 @@
 
 import UIKit.UIColor
 
-// swiftlint:disable file_length
+import SharedEntity
+import TDFoundation
+
 public enum EditToDo {
   // MARK: Use cases
   public enum FetchToDo {
-    public struct Request {
-      public init() {}
-    }
-
-    public struct Response {
-      public let toDo: ToDo
-
-      public init(toDo: ToDo) {
-        self.toDo = toDo
-      }
-    }
-
     public struct ViewModel {
-      public struct DisplayedToDo {
-        public let toDoName: String
-        public let group: DisplayedGroup
-        public let isAlarmOn: Bool
-        public let alarmTime: String?
-        public let isOnlyToday: Bool
-        public let startDay: String?
-        public let endDay: String?
+      public let toDo: TodoBatchItem
+      public let alarmTime: String
+      public let groups: [TodoListGroup]
 
-        public init(
-          toDoName: String,
-          group: DisplayedGroup,
-          isAlarmOn: Bool,
-          alarmTime: String?,
-          isOnlyToday: Bool,
-          startDay: String?,
-          endDay: String?
-        ) {
-          self.toDoName = toDoName
-          self.group = group
-          self.isAlarmOn = isAlarmOn
-          self.alarmTime = alarmTime
-          self.isOnlyToday = isOnlyToday
-          self.startDay = startDay
-          self.endDay = endDay
-        }
-      }
-
-      public let toDo: DisplayedToDo
-
-      public init(toDo: DisplayedToDo) {
+      public init(toDo: TodoBatchItem, alarmTime: String, groups: [TodoListGroup]) {
         self.toDo = toDo
+        self.alarmTime = alarmTime
+        self.groups = groups
       }
     }
   }
@@ -252,13 +218,13 @@ extension EditToDo {
   }
 
   public struct DisplayedGroup {
-    public let id: UUID
+    public let id: String
     public let name: String
     public let color: UIColor
     public let orderIdx: Int
 
     public init(
-      id: UUID, 
+      id: String,
       name: String,
       color: UIColor,
       orderIdx: Int
@@ -419,4 +385,3 @@ extension EditToDo {
     case failToFetch
   }
 }
-// swiftlint:enable file_length

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneEntity/EditToDoModels.swift
@@ -14,11 +14,15 @@ public enum EditToDo {
   // MARK: Use cases
   public enum FetchToDo {
     public struct ViewModel {
-      public let toDo: TodoBatchItem
+      public let toDo: TDFoundation.TodoBatchItem
       public let alarmTime: String
       public let groups: [TodoListGroup]
 
-      public init(toDo: TodoBatchItem, alarmTime: String, groups: [TodoListGroup]) {
+      public init(
+        toDo: TDFoundation.TodoBatchItem,
+        alarmTime: String,
+        groups: [TodoListGroup]
+      ) {
         self.toDo = toDo
         self.alarmTime = alarmTime
         self.groups = groups

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneRouter.swift
@@ -53,7 +53,7 @@ extension HomeSceneRouter: HomeSceneRoutingLogic {
   func routeToEditToDoScene() {
     guard let toDo = self.dataStore?.toDo, let groups = self.dataStore?.groups
     else { return }
-    let payload = EditToDoScenePayload(toDo: toDo, groups: groups)
+    let payload = EditToDoScenePayload(toDo: toDo, groups: groups, delegate: self.viewController)
     let destinationViewController = self.editToDoSceneBuilder.build(with: payload)
     self.viewController?.navigationController?.pushViewController(destinationViewController, animated: true)
   }
@@ -70,6 +70,7 @@ extension HomeSceneRouter: HomeSceneRoutingLogic {
 struct EditToDoScenePayload: EditToDoScenePayloadable {
   var toDo: TodoBatchItem
   var groups: [SharedEntity.TodoListGroup]
+  var delegate: EditToDoSceneDelegate?
 }
 
 struct TimerScenePayload: TimerScenePayloadable {

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import EditToDoSceneAPI
 import HomeSceneAPI
 import HomeSceneEntity
 import SharedEntity
@@ -261,6 +262,17 @@ extension HomeSceneViewController: HomeSceneDisplayLogic {
 
   func routeToEditToDoScene() {
     self.router?.routeToEditToDoScene()
+  }
+}
+
+// MARK: - Route From EditToDoScene
+extension HomeSceneViewController: EditToDoSceneDelegate {
+  public func didEdit(toDo: TodoBatchItem) {
+
+  }
+
+  public func didRemove(toDo: TodoBatchItem) {
+    
   }
 }
 

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateRangePicker/DateRangePicker.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateRangePicker/DateRangePicker.swift
@@ -34,7 +34,11 @@ public final class DateRangePicker: UIView {
   public func getEndDate() -> Date? {
     self.dateRangePickerCalendar.getEndDate()
   }
-  
+
+  public func updateRange(startDate: String, endDate: String) {
+    self.dateRangePickerCalendar.updateRange(startDate: startDate, endDate: endDate)
+  }
+
   private func setup() {
     self.setupHeader()
     self.setupCalendar()

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateRangePicker/DateRangePickerCalendar.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateRangePicker/DateRangePickerCalendar.swift
@@ -43,6 +43,15 @@ public final class DateRangePickerCalendar: CalendarView {
   func register(_ picker: DateRangePresentDelegate) {
     (self.calendarViewDelegate as? DateRangeSelectionDelegate)?.dateRangePresentDelegate = picker
   }
+
+  /// ⬇️ DateRangePickerCalendar 에 추가
+  func updateRange(startDate: String, endDate: String) {
+    (self.calendarViewDelegate as? DateRangeSelectionDelegate)?
+      .updateRange(
+        start: startDate.toDateISO8601Format(),
+        end: startDate.toDateISO8601Format()
+      )
+  }
 }
 
 #if DEBUG

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateRangePicker/DateRangeSelectionDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/DateRangePicker/DateRangeSelectionDelegate.swift
@@ -12,9 +12,9 @@ final class DateRangeSelectionDelegate: CalendarViewSingleSelectionDelegate {
   var startDate: CalendarItem?
   var endDate: CalendarItem?
   var dateRangePresentDelegate: DateRangePresentDelegate?
-  
+
   private var lastScrollTime: TimeInterval = 0
-  
+
   override init(
     collectionView: UICollectionView,
     collectionViewLayoutModel: CalendarView.Model.CollectionViewLayout,
@@ -28,11 +28,11 @@ final class DateRangeSelectionDelegate: CalendarViewSingleSelectionDelegate {
       cellIdentifier: cellIdentifier
     )
   }
-  
+
   // MARK: - UICollectionViewDelegate Methods
   func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
     guard let touchedItem = self.collectionViewDataSource.itemIdentifier(for: indexPath) else { return }
-    
+
     switch self.currentSelectionState {
     case RangeSelectionState.startAndEnd:
       self.clearSelection()
@@ -47,7 +47,7 @@ final class DateRangeSelectionDelegate: CalendarViewSingleSelectionDelegate {
     case RangeSelectionState.empty:
       break
     }
-    
+
     self.updateSelectionState()
     self.updateSelectionSnapshot()
     self.dateRangePresentDelegate?.didTouchCell(
@@ -55,12 +55,12 @@ final class DateRangeSelectionDelegate: CalendarViewSingleSelectionDelegate {
       endDate: self.endDate?.date
     )
   }
-  
+
   override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     super.collectionView(collectionView, didSelectItemAt: indexPath)
-    
+
     guard let selectedItem = self.collectionViewDataSource.itemIdentifier(for: indexPath) else { return }
-    
+
     switch self.currentSelectionState {
     case RangeSelectionState.startAndEnd:
       self.clearSelection()
@@ -85,9 +85,9 @@ final class DateRangeSelectionDelegate: CalendarViewSingleSelectionDelegate {
     self.updateSelectionSnapshot()
     self.dateRangePresentDelegate?.didTouchCell(startDate: self.startDate?.date, endDate: self.endDate?.date)
   }
-  
+
   // MARK: - UIScrollViewDelegate Methods
-  
+
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
     let debounceInterval: TimeInterval = 0.07
     let currentTime = Date().timeIntervalSince1970
@@ -96,12 +96,27 @@ final class DateRangeSelectionDelegate: CalendarViewSingleSelectionDelegate {
       self.lastScrollTime = currentTime
     }
   }
-  
+
   override func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
     return
   }
-  
+
   override func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
     return
+  }
+}
+
+/// ⬇️ DateRangeSelectionDelegate 에 추가
+extension DateRangeSelectionDelegate {
+  func updateRange(start: Date, end: Date) {
+    let allItems = self.collectionViewDataSource.snapshot().itemIdentifiers
+    guard let startItem = allItems.first(where: { $0.date == start }),
+    let endItem = allItems.first(where: { $0.date == end }) else { return }
+    
+    self.startDate = startItem
+    self.endDate = endItem
+    self.updateSelectionState()
+    self.updateSelectionSnapshot()
+    self.dateRangePresentDelegate?.didTouchCell(startDate: start, endDate: end)
   }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupListTableViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupListTableViewDelegate.swift
@@ -12,7 +12,7 @@ import ToDoGardenUIConstant
 
 final class GroupListTableViewDelegate: NSObject {
   private let cellHeight: CGFloat
-  private var editableGroupIndexDictionary: [UUID: Int]
+  private var editableGroupIndexDictionary: [String: Int]
   private var tableViewDataSource: UITableViewDiffableDataSource<
     GroupSelectionViewSection,
     GroupSelectionViewItem
@@ -117,12 +117,14 @@ extension GroupListTableViewDelegate {
       let id = item.groupId
       self.editableGroupIndexDictionary[id] = index
     }
+//    debugPrint(self.editableGroupIndexDictionary)
   }
 
   private func reloadNewEditableGroups(groupItems: [GroupSelectionViewItem]) {
     var snapshot = NSDiffableDataSourceSnapshot<GroupSelectionViewSection, GroupSelectionViewItem>()
     snapshot.appendSections([.main])
     let items = groupItems.filter { (item: GroupSelectionViewItem) in
+      debugPrint(item)
       if let currentGroupItem = self.currentGroupItem {
         return item != currentGroupItem
       }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupListTableViewDelegate.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupListTableViewDelegate.swift
@@ -117,14 +117,12 @@ extension GroupListTableViewDelegate {
       let id = item.groupId
       self.editableGroupIndexDictionary[id] = index
     }
-//    debugPrint(self.editableGroupIndexDictionary)
   }
 
   private func reloadNewEditableGroups(groupItems: [GroupSelectionViewItem]) {
     var snapshot = NSDiffableDataSourceSnapshot<GroupSelectionViewSection, GroupSelectionViewItem>()
     snapshot.appendSections([.main])
     let items = groupItems.filter { (item: GroupSelectionViewItem) in
-      debugPrint(item)
       if let currentGroupItem = self.currentGroupItem {
         return item != currentGroupItem
       }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionViewCell.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionViewCell.swift
@@ -99,10 +99,10 @@ extension GroupSelectionViewCell {
 @available(iOS 17.0, *)
 #Preview {
   let cell = GroupSelectionViewCell()
-  cell.updateUI(
-    groupItem: GroupSelectionViewItem(
-      groupId: UUID(), groupName: "영어독해", groupColor: UIColor.toDoGardenGreenDark
-    )
-  )
+//  cell.updateUI(
+//    groupItem: GroupSelectionViewItem(
+//      groupId: UUID(), groupName: "영어독해", groupColor: UIColor.toDoGardenGreenDark
+//    )
+//  )
   return cell
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionViewSection.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/GroupSelectionView/GroupSelectionViewSection.swift
@@ -14,11 +14,11 @@ enum GroupSelectionViewSection {
 }
 
 public struct GroupSelectionViewItem {
-  public let groupId: UUID
+  public let groupId: String
   public let groupName: String
   public let groupColor: UIColor
 
-  public init(groupId: UUID, groupName: String, groupColor: UIColor) {
+  public init(groupId: String, groupName: String, groupColor: UIColor) {
     self.groupId = groupId
     self.groupName = groupName
     self.groupColor = groupColor


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #946 

## 🎉 변경 사항
- SharedEntity 구현으로 인해 주석 처리했던 수정 화면의 UI 업데이트 로직을 정상화했습니다.

## 📌 PR Point

- 기존 FullScreen으로 뜨던 반복일 범위 선택 Modal의 detent를 Figma에 맞게 조정했습니다.
- Home <- EditToDoScene 이전화면으로 데이터 전달을 위해 `EditToDoSceneDelegate` 객체를 추가했습니다.
- Home에서 데이터 전달을 받기 쉽게 `ToDoBatchItem`을 전달했습니다.

## 울버린과의 의논
### DateRangePicker 함수 추가 요청
DateRangePicker에 범위를 미리 선택되게 하는 기능 추가 요청드려도 될까요?    
기존에 반복이 있는 투두는 캘린더를 띄웠을 때 미리 선택된 상태로 만드려고 합니다.

### 추가 작업
수정 결과를 HomeScene에 전달 후 사후 조치가 필요한데, 다음 PR에서 작업할 예정입니다.
   - Interactor에서 추가 구현이 있을 예정이라 미리 알려드립니다. 
   - 만약, 생각하신 방향이나 구현한게 있다면 리뷰에 언급 부탁드리겠습니다!

1. 수정된 투두 동기화
2. 반복일 변경(또는 반복 해제)시 `기존 날짜별 반복 투두 삭제`
3. 삭제시 BatchItem 딕셔너리에 추가
4. `로컬에서 생성된 ToDo`의 경우, 삭제하면 Batch 딕셔너리에서 삭제

### 동작 GIF
<img width="250" src="https://github.com/user-attachments/assets/276036a6-de46-4e68-978a-b6b735e8d890">

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?