### PR TITLE
#949: ImageClient.live.execute() 대체

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Cache+ImageClient.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Cache+ImageClient.swift
@@ -15,7 +15,7 @@ public struct ImageClient: Requestable {
     let data = try await request(id)
     
     return isDownsample
-    ? downsample(imageData: data, for: CGSize(width: 72, height: 72), scale: 1.0)
+    ? downsample(imageData: data, for: CGSize(width: 90, height: 90), scale: 1.0)
     : try UIImage(data: data) ?? { throw CocoaError(.coderInvalidValue) }()
   }
   

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -235,7 +235,7 @@ extension SearchGardenViewController: SearchGardenDisplayLogic {
       guard let imageURL = user.userImageURL else { continue }
       Task {
         do {
-          let image = try await ImageClient.live.execute(id: imageURL, isDownsample: true)
+          let image = try await Cache.shared.execute(id: imageURL, isDownsample: true)
           let updatedUser = user
           
           updatedUser.userImage = image

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/SettingViewController.swift
@@ -92,7 +92,7 @@ extension SettingViewController: SettingDisplayLogic {
 
     Task {
       do {
-        let image = try await ImageClient.live.execute(id: imageUrl, isDownsample: true)
+        let image = try await Cache.shared.execute(id: imageUrl, isDownsample: true)
         self.profileRow.iconImage = image
       } catch {
         debugPrint("SettingScene: Image Download failed")

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -195,7 +195,7 @@ extension ShareGardenSceneViewController.MyGardenView {
     Task {
       guard let imageURL = imageURL else { return }
       
-      let image = try await ImageClient.live.execute(id: imageURL, isDownsample: true)
+      let image = try await Cache.shared.execute(id: imageURL, isDownsample: true)
       self.profileInfoView.iconImage = image
     }
   }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #949 
## 🎉 변경 사항
- ImageClient.live.execute() -> Cache.share.execute() 로 대체합니다.
- ++ 다운샘플링 이후 해상도 관련 이슈를 해결하고자 이미지 크기를 25% 늘렸습니다. 
## 📌 PR Point
- X
## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?