### PR TITLE
가이드씬 , 유저인포씬 QA 관련 버그 수정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
     .target(
       name: "EditToDoSceneAPI",
       dependencies: [
+        "EditToDoSceneEntity",
         .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI"),
         .product(name: "TDFoundation", package: "TDFoundation")
       ]

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoView.swift
@@ -293,6 +293,7 @@ extension EditToDoView {
 extension EditToDoView {
   func setForGuide() {
     let text = "영어독해"
+    self.toDoNameInputView.setPlaceholderForGuide()
     self.toDoNameInputView.setBeginEditing(with: text)
     self.toDoNameInputView.changeBottomLine(color: UIColor.toDoGardenYellow)
     self.groupSelectionView.updateGroup(
@@ -302,6 +303,7 @@ extension EditToDoView {
         groupColor: UIColor.toDoGardenYellow
       )
     )
+    _ = self.toDoNameInputView.resignFirstResponder()
   }
   
   func getToDoNameInputView() -> UIView {

--- a/ToDo-Garden/ToDo-Garden/GuideScene/Sources/GuideScene/GuideDetailViewController+static.swift
+++ b/ToDo-Garden/ToDo-Garden/GuideScene/Sources/GuideScene/GuideDetailViewController+static.swift
@@ -6,8 +6,19 @@
 //
 
 extension GuideDetailViewController {
-  public static let todoCreate = GuideDetailViewController(.todoCreate)
-  public static let groupManagement = GuideDetailViewController(.groupManagement)
-  public static let shareTab = GuideDetailViewController(.shareTab)
-  public static let todoEdit = GuideDetailViewController(.todoEdit)
+  public static func todoCreate() -> GuideDetailViewController {
+    return GuideDetailViewController(.todoCreate)
+  }
+
+  public static func groupManagement() -> GuideDetailViewController {
+    return GuideDetailViewController(.groupManagement)
+  }
+
+  public static func shareTab() -> GuideDetailViewController {
+    return GuideDetailViewController(.shareTab)
+  }
+
+  public static func todoEdit() -> GuideDetailViewController {
+    return GuideDetailViewController(.todoEdit)
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/GuideScene/Sources/GuideScene/GuideDetailViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/GuideScene/Sources/GuideScene/GuideDetailViewController.swift
@@ -69,8 +69,8 @@ public final class GuideDetailViewController: UIViewController {
       arrangedSubviews: []
     )
     self.bottomView = BottomView()
-    self.bottomView.backButtonAction = {
-      self.dismiss(animated: true)
+    self.bottomView.backButtonAction = { [weak self] in
+      self?.dismiss(animated: true)
     }
     self.bindingCurrentIndex()
     self.layoutScrollView()

--- a/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/EnterGuideSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SettingScene/Sources/SettingScene/Views/EnterGuideSceneViewController.swift
@@ -84,7 +84,7 @@ extension EnterGuideSceneViewController {
       guard let self = self else { return }
       
       self.navigationController?.present(
-        self.withFullScreenModal(GuideDetailViewController.todoCreate),
+        self.withFullScreenModal(GuideDetailViewController.todoCreate()),
         animated: true
       )
     }, for: UIControl.Event.touchUpInside)
@@ -93,7 +93,7 @@ extension EnterGuideSceneViewController {
       guard let self = self else { return }
       
       self.navigationController?.present(
-        self.withFullScreenModal(GuideDetailViewController.groupManagement),
+        self.withFullScreenModal(GuideDetailViewController.groupManagement()),
         animated: true
       )
     }, for: UIControl.Event.touchUpInside)
@@ -102,7 +102,7 @@ extension EnterGuideSceneViewController {
       guard let self = self else { return }
       
       self.navigationController?.present(
-        self.withFullScreenModal(GuideDetailViewController.todoEdit),
+        self.withFullScreenModal(GuideDetailViewController.todoEdit()),
         animated: true
       )
     }, for: UIControl.Event.touchUpInside)
@@ -111,7 +111,7 @@ extension EnterGuideSceneViewController {
       guard let self = self else { return }
       
       self.navigationController?.present(
-        self.withFullScreenModal(GuideDetailViewController.shareTab),
+        self.withFullScreenModal(GuideDetailViewController.shareTab()),
         animated: true
       )
     }, for: UIControl.Event.touchUpInside)

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -68,6 +68,11 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
     self.interactor?.configureCollectionView()
     self.interactor?.fetchProfileImage()
   }
+  
+  override func viewIsAppearing(_ animated: Bool) {
+    super.viewIsAppearing(animated)
+    self.navigationController?.navigationBar.isHidden = false
+  }
 }
 
 // MARK: - Confirm display logic protocol

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/TextInputView.swift
@@ -69,6 +69,10 @@ public final class TextInputView: UIView, TextInputViewAPI {
   public func getEditingText() -> String? {
     return self.inputTextField.text
   }
+  
+  public func setPlaceholderForGuide() {
+    self.placeholderLabel.text = ""
+  }
 }
 
 // MARK: Private Functions


### PR DESCRIPTION
## 💡 관련 이슈
- #951 
## 🎉 변경 사항
- 가이드씬 메모리 해제 정상화 + 하이라이트 영역 깨짐현상 수정
- 유저인포씬 내비게이션 숨김처리 
- 패키지 의존성 빌드에러 수정

## 📌 PR Point

### 가이드씬 메모리 해제 정상화 + 하이라이트 영역 깨짐현상 수정
- static 상수로 VC객체를 재사용하고 있었던점 수정 
- 내부에서 self를 강하게 참조하고 있던점 수정 
- 하이라이트 영역 정상화 
### 가이드씬에서 키보드가 올라오던 점 수정 
- 이제 안올라옵니다. 
### 유저인포씬 내비게이션 숨김처리 
- viewIsAppearing에서 내비게이션 숨김 처리 
### 패키지 의존성 빌드에러 수정
- 빌드에러 나길래 의존성 추가 



## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?