### PR TITLE
Bug/#957 fix search garden

### DIFF
--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Cache+ImageClient.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/Cache/Cache+ImageClient.swift
@@ -15,7 +15,7 @@ public struct ImageClient: Requestable {
     let data = try await request(id)
     
     return isDownsample
-    ? downsample(imageData: data, for: CGSize(width: 90, height: 90), scale: 1.0)
+    ? downsample(imageData: data, for: CGSize(width: 180, height: 180), scale: 1.0)
     : try UIImage(data: data) ?? { throw CocoaError(.coderInvalidValue) }()
   }
   

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/Database/Schema.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/Database/Schema.swift
@@ -119,6 +119,7 @@ extension DatabaseWriter {
           .defaults(to: false)
         t.column("groupId", .text)
           .notNull()
+          .references(MyGroup.databaseTableName, onDelete: .cascade)
       }
     }
   }

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/FallbackFlow/FallbackFlow.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/FallbackFlow/FallbackFlow.swift
@@ -1,0 +1,35 @@
+//
+//  FallbackFlow.swift
+//  TDFoundation
+//
+//  Created by SONG on 4/9/25.
+//
+
+public enum FallbackFlow {
+  @MainActor public static func run<T: Sendable>(
+    online: @escaping () async throws -> T,
+    offline: @escaping () async throws -> T,
+    handleError: ((Error) -> Void)? = nil,
+    checkNetworkConnection: (() -> Bool)
+  ) async -> T? {
+    if checkNetworkConnection() {
+      do {
+        return try await online()
+      } catch {
+        do {
+          return try await offline()
+        } catch {
+          handleError?(error)
+          return nil
+        }
+      }
+    } else {
+      do {
+        return try await offline()
+      } catch {
+        handleError?(error)
+        return nil
+      }
+    }
+  }
+}

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/InfiniteScrollHandler/ScrollView+Extension.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/InfiniteScrollHandler/ScrollView+Extension.swift
@@ -9,9 +9,6 @@ import UIKit
 
 import TDUtility
 
-import UIKit
-import TDUtility
-
 extension UIScrollView {
   private var onEndReachedKey: String { "onEndReachedKey" }
   private var scrollHandlerKey: String { "scrollHandlerKey" }

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/InfiniteScrollHandler/ScrollView+Extension.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/InfiniteScrollHandler/ScrollView+Extension.swift
@@ -46,7 +46,7 @@ extension UIScrollView {
       let height = scrollView.frame.size.height
       let contentYOffset = scrollView.contentOffset.y
       let distanceFromBottom = scrollView.contentSize.height - contentYOffset
-      let threshold: CGFloat = 100.0
+      let threshold: CGFloat = 200.0
 
       if distanceFromBottom < height + threshold {
         scrollView.onEndReached?()

--- a/ToDo-Garden/TDFoundation/Sources/TDFoundation/InfiniteScrollHandler/ScrollView+Extension.swift
+++ b/ToDo-Garden/TDFoundation/Sources/TDFoundation/InfiniteScrollHandler/ScrollView+Extension.swift
@@ -9,65 +9,65 @@ import UIKit
 
 import TDUtility
 
+import UIKit
+import TDUtility
+
 extension UIScrollView {
-  private var onEndReachedKey: String {
-    return "onEndReachedKey"
-  }
-  
+  private var onEndReachedKey: String { "onEndReachedKey" }
+  private var scrollHandlerKey: String { "scrollHandlerKey" }
+
   public var onEndReached: (() -> Void)? {
     get {
       self.ao_get(key: self.onEndReachedKey) as? (() -> Void)
     }
     set {
       self.ao_setOptional(newValue, key: self.onEndReachedKey, policy: AssociationPolicy.copyNonatomic)
-      self.setEndReachedDelegate()
-    }
-  }
-  
-  private func setEndReachedDelegate() {
-    InfiniteScrollHandler.shared.originalDelegates[self] = self.delegate
-    self.delegate = InfiniteScrollHandler.shared
-  }
-}
 
-final class InfiniteScrollHandler: NSObject, UIScrollViewDelegate {
-  static let shared = InfiniteScrollHandler()
-  var originalDelegates: [UIScrollView: UIScrollViewDelegate?] = [:]
-  
-  func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    guard self.originalDelegates.keys.contains(scrollView) else { return }
-    
-    let height = scrollView.frame.size.height
-    let contentYOffset = scrollView.contentOffset.y
-    let distanceFromBottom = scrollView.contentSize.height - contentYOffset
-    let threshold: CGFloat = 200.0
-    
-    if distanceFromBottom < height + threshold {
-      scrollView.onEndReached?()
-    }
-    
-    self.originalDelegates[scrollView]??.scrollViewDidScroll?(scrollView)
-  }
-  
-  @preconcurrency
-  override func responds(to aSelector: Selector!) -> Bool {
-    MainActor.assumeIsolated {
-      if let scrollView = self.originalDelegates.keys.first(where: { $0.delegate === self }),
-        let originalDelegate = self.originalDelegates[scrollView] {
-        return super.responds(to: aSelector) || originalDelegate?.responds(to: aSelector) == true
+      if newValue != nil {
+        let handler = InfiniteScrollHandler(scrollView: self, originalDelegate: self.delegate)
+        self.ao_set(handler, key: self.scrollHandlerKey, policy: AssociationPolicy.retainNonatomic)
+        self.delegate = handler
+      } else {
+        self.delegate = (self.ao_get(key: self.scrollHandlerKey) as? InfiniteScrollHandler)?.originalDelegate
+        self.ao_setOptional(nil, key: self.scrollHandlerKey, policy: AssociationPolicy.assign)
       }
-      return super.responds(to: aSelector)
     }
   }
   
-  @preconcurrency
-  override func forwardingTarget(for aSelector: Selector!) -> Any? {
-    let target: UIScrollViewDelegate? = MainActor.assumeIsolated {
-      if let scrollView = self.originalDelegates.keys.first(where: { $0.delegate === self }) {
-        return self.originalDelegates[scrollView] ?? nil
-      }
-      return nil
+  @MainActor private final class InfiniteScrollHandler: NSObject, UIScrollViewDelegate {
+    weak var originalDelegate: UIScrollViewDelegate?
+    weak var scrollView: UIScrollView?
+
+    init(scrollView: UIScrollView, originalDelegate: UIScrollViewDelegate?) {
+      self.scrollView = scrollView
+      self.originalDelegate = originalDelegate
     }
-    return target
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+      guard let scrollView = self.scrollView else { return }
+
+      let height = scrollView.frame.size.height
+      let contentYOffset = scrollView.contentOffset.y
+      let distanceFromBottom = scrollView.contentSize.height - contentYOffset
+      let threshold: CGFloat = 100.0
+
+      if distanceFromBottom < height + threshold {
+        scrollView.onEndReached?()
+      }
+
+      self.originalDelegate?.scrollViewDidScroll?(scrollView)
+    }
+
+    @preconcurrency override func responds(to aSelector: Selector!) -> Bool {
+      MainActor.assumeIsolated {
+        return super.responds(to: aSelector) || self.originalDelegate?.responds(to: aSelector) == true
+      }
+    }
+
+    @preconcurrency override func forwardingTarget(for aSelector: Selector!) -> Any? {
+      MainActor.assumeIsolated {
+        return self.originalDelegate
+      }
+    }
   }
 }

--- a/ToDo-Garden/TDFoundation/Tests/InfiniteScrollHandlerTests/InfiniteScrollHandlerTests.swift
+++ b/ToDo-Garden/TDFoundation/Tests/InfiniteScrollHandlerTests/InfiniteScrollHandlerTests.swift
@@ -15,104 +15,105 @@ import Testing
 final class ScrollViewTests {
   @Test("스크롤뷰가 하단에 도달했을 때 onEndReached가 호출되어야 한다")
   func testEndReachedCallback() async throws {
-    self.reset()
     let scrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 300, height: 500))
     scrollView.contentSize = CGSize(width: 300, height: 1000)
-    
+
     var endReachedCallCount = 0
     scrollView.onEndReached = {
       endReachedCallCount += 1
     }
+
     let nearBottomOffset = CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.frame.height - 100)
     scrollView.setContentOffset(nearBottomOffset, animated: false)
-    InfiniteScrollHandler.shared.scrollViewDidScroll(scrollView)
-    
-    #expect(endReachedCallCount == 2)
+
+    (scrollView.delegate)?.scrollViewDidScroll?(scrollView)
+
+    #expect(endReachedCallCount == 1)
   }
-  
+
   @Test("delegate 메서드가 정상적으로 포워딩되어야 한다")
   func testDelegateForwarding() async throws {
-    self.reset()
     let scrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 300, height: 500))
     let mockDelegate = MockScrollViewDelegate()
     scrollView.delegate = mockDelegate
+
     scrollView.onEndReached = {}
-    
-    #expect(scrollView.delegate === InfiniteScrollHandler.shared)
-    
-    let target = InfiniteScrollHandler.shared.originalDelegates[scrollView] as? UIScrollViewDelegate
-    #expect(target === mockDelegate)
-    
+
+    // 핸들러가 delegate로 설정되었는지 확인
+    guard let handler = scrollView.delegate as? NSObject else {
+      return #expect(Bool(false), "delegate가 InfiniteScrollHandler로 설정되어야 함")
+    }
+
+    // 포워딩 되는지 확인
     scrollView.setContentOffset(CGPoint(x: 0, y: 100), animated: false)
-    InfiniteScrollHandler.shared.scrollViewDidScroll(scrollView)
-    
-    #expect(mockDelegate.scrollDidCallCount == 2)
+    (handler as? UIScrollViewDelegate)?.scrollViewDidScroll?(scrollView)
+
+    #expect(mockDelegate.scrollDidCallCount == 1)
   }
-  
+
   @Test("여러 스크롤뷰가 독립적으로 동작해야 한다")
   func testMultipleScrollViews() async throws {
-    self.reset()
     let firstScrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 300, height: 500))
     let secondScrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 300, height: 500))
     firstScrollView.contentSize = CGSize(width: 300, height: 1000)
     secondScrollView.contentSize = CGSize(width: 300, height: 1000)
-    
+
     var firstScrollEndReachedCount = 0
     var secondScrollEndReachedCount = 0
+
     firstScrollView.onEndReached = { firstScrollEndReachedCount += 1 }
     secondScrollView.onEndReached = { secondScrollEndReachedCount += 1 }
-    
-    let nearBottomOffset = CGPoint(x: 0, y: firstScrollView.contentSize.height - firstScrollView.frame.height - 100)
+
+    let nearBottomOffset = CGPoint(x: 0, y: 1000 - 500 - 100)
     firstScrollView.setContentOffset(nearBottomOffset, animated: false)
-    InfiniteScrollHandler.shared.scrollViewDidScroll(firstScrollView)
-    
-    #expect(firstScrollEndReachedCount == 2)
+
+    (firstScrollView.delegate)?.scrollViewDidScroll?(firstScrollView)
+
+    #expect(firstScrollEndReachedCount == 1)
     #expect(secondScrollEndReachedCount == 0)
   }
-  
+
   @Test("스크롤뷰의 threshold 값이 제대로 적용되어야 한다")
   func testScrollThreshold() async throws {
-    self.reset()
     let scrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 300, height: 500))
     scrollView.contentSize = CGSize(width: 300, height: 1000)
-    
+
     var endReachedCallCount = 0
     scrollView.onEndReached = {
       endReachedCallCount += 1
     }
-    
-    let farFromBottomOffset = CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.frame.height - 300)
+
+    let farFromBottomOffset = CGPoint(x: 0, y: 1000 - 500 - 300)
     scrollView.setContentOffset(farFromBottomOffset, animated: false)
-    InfiniteScrollHandler.shared.scrollViewDidScroll(scrollView)
-    
+
+    (scrollView.delegate)?.scrollViewDidScroll?(scrollView)
+
     #expect(endReachedCallCount == 0, "threshold보다 멀 때는 호출되지 않아야 함")
-    
-    let nearBottomOffset = CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.frame.height - 100)
+
+    let nearBottomOffset = CGPoint(x: 0, y: 1000 - 500 - 100)
     scrollView.setContentOffset(nearBottomOffset, animated: false)
-    InfiniteScrollHandler.shared.scrollViewDidScroll(scrollView)
-    
-    #expect(endReachedCallCount == 2, "threshold 내에 있을 때는 호출되어야 함")
+
+    (scrollView.delegate)?.scrollViewDidScroll?(scrollView)
+
+    #expect(endReachedCallCount == 1, "threshold 내에 있을 때는 호출되어야 함")
   }
-  
+
   @Test("InfiniteScrollHandler가 delegate 메서드 응답을 올바르게 처리해야 한다")
   func testDelegateResponding() async throws {
-    self.reset()
     let scrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 300, height: 500))
     let mockDelegate = MockScrollViewDelegate()
     scrollView.delegate = mockDelegate
     scrollView.onEndReached = {}
-    
-    let selector = #selector(UIScrollViewDelegate.scrollViewDidScroll(_:))
-    #expect(InfiniteScrollHandler.shared.responds(to: selector))
-    
-    let target = InfiniteScrollHandler.shared.forwardingTarget(for: selector) as? UIScrollViewDelegate
-    #expect(target === mockDelegate)
-  }
-}
 
-extension ScrollViewTests {
-  private func reset() {
-    InfiniteScrollHandler.shared.originalDelegates.removeAll()
+    guard let handler = scrollView.delegate as? NSObject else {
+      return #expect(Bool(false), "handler가 delegate여야 함")
+    }
+
+    let selector = #selector(UIScrollViewDelegate.scrollViewDidScroll(_:))
+
+    #expect(handler.responds(to: selector), "scrollViewDidScroll:을 응답해야 함")
+    let target = handler.forwardingTarget(for: selector) as? UIScrollViewDelegate
+    #expect(target === mockDelegate)
   }
 }
 // swiftlint:enable all

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -82,6 +82,7 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
     }
   }
   
+  
   func fetchToDoList(request: HomeScene.FetchToDoList.Request) async {
     if self.checkNetworkConnection() {
       do {
@@ -128,7 +129,12 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
       where: { UUID(uuidString: $0.localId) == group.id }
     ) {
       let targetGroup = self.monthlyData[dateString]?[targetGroupIndex]
-      targetGroup?.todoList?.append(self.makeToDoListItem(batchItem: newToDo))
+      let newItem = self.makeToDoListItem(batchItem: newToDo)
+      if targetGroup?.todoList == nil {
+        targetGroup?.todoList = [newItem]
+      } else {
+        targetGroup?.todoList?.append(newItem)
+      }
     }
   
     self.presenter?.presentCreateToDo(newToDo: newToDo)

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -71,35 +71,72 @@ final class HomeSceneInteractor: HomeSceneDataStore {
 // swiftlint: disable all
 extension HomeSceneInteractor: HomeSceneBusinessLogic {
   func syncronizeServerEditGroups() async {
-    if self.checkNetworkConnection() {
-      do {
+    await FallbackFlow.run(
+      online: { [weak self] in
+        guard let self = self else { return }
+        
         try await self.homeSceneWorker.syncronizeServerEditGroups()
-      } catch let error {
-        self.handleErrors(error)
+      },
+      offline: { return },
+      handleError: { [weak self] error in
+        self?.handleErrors(error)
+      },
+      checkNetworkConnection: { [weak self] in
+        guard let self = self else { return false }
+        
+        return self.checkNetworkConnection()
       }
-    } else {
-      return
-    }
+    )
   }
   
-  
   func fetchToDoList(request: HomeScene.FetchToDoList.Request) async {
-    if self.checkNetworkConnection() {
-      do {
+    await FallbackFlow.run(
+      online: { [weak self] in
+        guard let self = self else { return }
+        
         let fetchedToDoList = try await self.homeSceneWorker.fetchToDoList(dateString: request.dateString)
         self.presenter?.presentFetchedToDoList(monthlyData: fetchedToDoList)
-      } catch let error {
-        self.handleErrors(error)
-      }
-    } else {
-      do {
+      },
+      offline: { [weak self] in
+        guard let self = self else { return }
+        
         let (newMonthlyData, response) = try await self.loadMonthlyToDoListFromGRDB(request: request)
         self.monthlyData = newMonthlyData
         self.presenter?.presentFetchedToDoList(monthlyData: response)
-      } catch let error {
-        self.handleErrors(error)
+      },
+      handleError: { [weak self] error in
+        self?.handleErrors(error)
+      },
+      checkNetworkConnection: { [weak self] in
+        guard let self = self else { return false }
+        
+        return self.checkNetworkConnection()
       }
-    }
+    )
+  }
+  
+  func requestBatchUpdateToServer() async {
+    await FallbackFlow.run(
+      online: { [weak self] in
+        guard let self = self else { return }
+        
+        try await self.homeSceneWorker.requestBatchUpdateToServer()
+        self.itemsForBatch.removeAll()
+      },
+      offline: { [weak self] in
+        guard let self = self else { return }
+        
+        try await self.homeSceneWorker.syncronizeGRDBWithBatchItems()
+      },
+      handleError: { [weak self] error in
+        self?.handleErrors(error)
+      },
+      checkNetworkConnection: { [weak self] in
+        guard let self = self else { return false }
+        
+        return self.checkNetworkConnection()
+      }
+    )
   }
   
   func loadDailyToDoList(targetDate: String) async {
@@ -198,23 +235,6 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
       self.itemsForBatch.removeAll()
     } catch let error {
       self.handleErrors(error)
-    }
-  }
-  
-  func requestBatchUpdateToServer() async {
-    if self.checkNetworkConnection() {
-      do {
-        try await self.homeSceneWorker.requestBatchUpdateToServer()
-        self.itemsForBatch.removeAll()
-      } catch let error {
-        self.handleErrors(error)
-      }
-    } else {
-      do {
-        try await self.homeSceneWorker.syncronizeGRDBWithBatchItems()
-      } catch let error {
-        self.handleErrors(error)
-      }
     }
   }
   

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -73,9 +73,9 @@ open class HomeSceneViewController: UIViewController, HomeSceneViewControllable 
   open override func viewDidDisappear(_ animated: Bool) {
     super.viewDidDisappear(animated)
     Task {
+      await self.interactor?.syncronizeServerEditGroups()
       await self.interactor?.writeBatchItemsToGRDB()
       await self.interactor?.requestBatchUpdateToServer()
-      await self.interactor?.syncronizeServerEditGroups()
     }
   }
   
@@ -439,9 +439,9 @@ extension HomeSceneViewController {
 extension HomeSceneViewController: @preconcurrency TransitionHandlable {
   public func handleBackgroundTransition() {
     Task {
+      await self.interactor?.syncronizeServerEditGroups()
       await self.interactor?.writeBatchItemsToGRDB()
       await self.interactor?.requestBatchUpdateToServer()
-      await self.interactor?.syncronizeServerEditGroups()
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -184,8 +184,8 @@ extension HomeSceneViewController {
     self.loadingIndicator.isHidden = false
     self.loadingIndicator.startAnimation()
     Task {
-      await interactor.requestBatchUpdateToServer()
       await interactor.syncronizeServerEditGroups()
+      await interactor.requestBatchUpdateToServer()
       await interactor.fetchToDoList(request: HomeScene.FetchToDoList.Request(dateString: targetMonth))
     }
   }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
@@ -62,6 +62,7 @@ public struct HomeSceneWorker: HomeSceneWorkable, Sendable {
       input: request,
       serializer: { $0 },
       deserializer: { response in
+        if response.statusCode == 409 { return }
         try response.validateStatusCode()
       }
     )

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
@@ -34,6 +34,8 @@ public struct HomeSceneWorker: HomeSceneWorkable, Sendable {
       }
     )
     
+    try await self.syncDeletedGroups(from: fetchedToDoList)
+    
     for dailyToDoListData in fetchedToDoList {
       let (myGroups, myToDos) = self.convertToMyGroupsAndMyToDos(from: dailyToDoListData)
       try await self.writeFetchedToDoListToGRDB(myGroups: myGroups, myToDos: myToDos)
@@ -234,6 +236,24 @@ extension HomeSceneWorker {
       }
       
       return dailyDataDict.map { DailyToDoListData(date: $0.key, list: $0.value) }
+    }
+  }
+  
+  private func syncDeletedGroups(from fetchedToDoList: [DailyToDoListData]) async throws {
+    let allServerGroupIds: Set<String> = fetchedToDoList.flatMap { dailyData in
+      dailyData.list.map { $0.localId.lowercased() }
+    }.reduce(into: Set<String>()) { result, id in
+      result.insert(id)
+    }
+
+    try await self.database.write { db in
+      let serverIds = allServerGroupIds
+      let existingGroups = try MyGroup.fetchAll(db)
+      for group in existingGroups {
+        if !serverIds.contains(group.groupId) {
+          try group.delete(db)
+        }
+      }
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
@@ -62,7 +62,6 @@ public struct HomeSceneWorker: HomeSceneWorkable, Sendable {
       input: request,
       serializer: { $0 },
       deserializer: { response in
-        if response.statusCode == 409 { return }
         try response.validateStatusCode()
       }
     )

--- a/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/ManageGroupScene/Sources/ManageGroupScene/ManageGroupInteractor.swift
@@ -51,7 +51,7 @@ class ManageGroupInteractor: ManageGroupDataStore {
 }
 
 // MARK: - Request to worker
-
+// swiftlint: disable all
 extension ManageGroupInteractor: ManageGroupBusinessLogic {
   func fetchGroupList(request: ManageGroup.FetchGroupList.Request) {
     self.tasks[TaskKey.fetchGroups] = Task {
@@ -59,16 +59,34 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
       
       do {
         try Task.checkCancellation()
-        var result: [ManageGroup.ToDoGroup]
-        if self.checkNetworkConnection() {
-          result = try await self.manageGroupWorker.fetchGroupList(request: request)
-        } else {
-          result = try await self.manageGroupWorker.fetchGroupListFromGRDB()
-        }
-        try Task.checkCancellation()
-        self.currentGroups = result
-        let response = ManageGroup.FetchGroupList.Response(with: result)
-        self.presenter?.presentFetchedGroupList(response: response)
+        await FallbackFlow.run(
+          online: { [weak self] in
+            guard let self = self else { return }
+            
+            let result = try await self.manageGroupWorker.fetchGroupList(request: request)
+            let response = ManageGroup.FetchGroupList.Response(with: result)
+            try Task.checkCancellation()
+            self.currentGroups = result
+            self.presenter?.presentFetchedGroupList(response: response)
+          },
+          offline: { [weak self] in
+            guard let self = self else { return }
+            
+            let result = try await self.manageGroupWorker.fetchGroupListFromGRDB()
+            let response = ManageGroup.FetchGroupList.Response(with: result)
+            try Task.checkCancellation()
+            self.currentGroups = result
+            self.presenter?.presentFetchedGroupList(response: response)
+          },
+          handleError: { [weak self] error in
+            self?.handleError(error, about: TaskKey.fetchGroups)
+          },
+          checkNetworkConnection: { [weak self] in
+            guard let self = self else { return false }
+            
+            return self.checkNetworkConnection()
+          }
+        )
       } catch let error {
         self.handleError(error, about: TaskKey.fetchGroups)
       }
@@ -78,24 +96,43 @@ extension ManageGroupInteractor: ManageGroupBusinessLogic {
   func saveGroupList(request: ManageGroupSceneEntity.ManageGroup.SaveGroupList.Request) {
     self.tasks[TaskKey.saveGroups] = Task {
       defer { self.tasks[TaskKey.saveGroups] = nil }
-      
       do {
         try Task.checkCancellation()
-        var result: [ManageGroup.ToDoGroup]
-        if self.checkNetworkConnection() {
-          result = try await self.manageGroupWorker.saveGroupList(request: request)
-        } else {
-          result = try await self.manageGroupWorker.saveGroupListToGRDB(request: request)
-        }
-        try Task.checkCancellation()
-        self.currentGroups = result
-        let response = ManageGroup.SaveGroupList.Response(with: result)
-        self.presenter?.presentSavedGroupList(response: response)
+        await FallbackFlow.run(
+          online: { [weak self] in
+            guard let self = self else { return }
+            
+            let result = try await self.manageGroupWorker.saveGroupList(request: request)
+            let response = ManageGroup.SaveGroupList.Response(with: result)
+            try Task.checkCancellation()
+            self.currentGroups = result
+            self.presenter?.presentSavedGroupList(response: response)
+          },
+          offline: { [weak self] in
+            guard let self = self else { return }
+            
+            let result = try await self.manageGroupWorker.saveGroupListToGRDB(request: request)
+            let response = ManageGroup.SaveGroupList.Response(with: result)
+            try Task.checkCancellation()
+            self.currentGroups = result
+            self.presenter?.presentSavedGroupList(response: response)
+          },
+          handleError: { [weak self] error in
+            self?.handleError(error, about: TaskKey.saveGroups)
+          },
+          checkNetworkConnection: { [weak self] in
+            guard let self = self else { return false }
+            
+            return self.checkNetworkConnection()
+          }
+        )
       } catch let error {
         self.handleError(error, about: TaskKey.saveGroups)
       }
     }
   }
+  
+  // swiftlint: enable all
   
   func addGroupDirectly(request: ManageGroup.AddGroup.Request) {
     self.tasks[TaskKey.addGroupDirectly] = Task {

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -114,7 +114,7 @@ extension SearchGardenViewController {
     self.searchGardenView.tableView.onEndReached = {
       self.interactor?.loadSearchedGardenContinue()
     }
-    self.searchGardenView.tableView.prefetchDataSource = self
+    // self.searchGardenView.tableView.prefetchDataSource = self
     self.searchGardenView.textField.delegate = self
     self.searchGardenView.textField.returnKeyType = .search
     self.view.addSubview(self.searchGardenView)
@@ -318,20 +318,20 @@ extension SearchGardenViewController: DefaultModalNavigationBarDelegate {
   }
 }
 
-extension SearchGardenViewController: UITableViewDataSourcePrefetching {
-  func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
-    let shouldLoadNextPage = indexPaths.contains { indexPath in
-      guard let user = self.searchGardenView.tableView.userForCell(at: indexPath) else {
-        return false
-      }
-      return user.isDummyData
-    }
-    
-    if shouldLoadNextPage {
-      self.interactor?.loadSearchedGardenContinue()
-    }
-  }
-}
+//  extension SearchGardenViewController: UITableViewDataSourcePrefetching {
+//    func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
+//      let shouldLoadNextPage = indexPaths.contains { indexPath in
+//        guard let user = self.searchGardenView.tableView.userForCell(at: indexPath) else {
+//          return false
+//        }
+//        return user.isDummyData
+//      }
+//
+//      if shouldLoadNextPage {
+//        self.interactor?.loadSearchedGardenContinue()
+//      }
+//    }
+//  }
 
 extension SearchGardenViewController {
   private func setupKeyboardObservers() {

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -65,6 +65,7 @@ final class SearchGardenViewController: UIViewController, SearchGardenViewContro
     super.viewDidLoad()
     self.setupView()
     self.setupKeyboardObservers()
+    self.presentationController?.delegate = self
   }
   
   func clear() {
@@ -363,5 +364,12 @@ extension SearchGardenViewController {
       self.searchGardenView.tableView.contentInset.bottom = 0
       self.searchGardenView.tableView.verticalScrollIndicatorInsets.bottom = 0
     }
+  }
+}
+
+extension SearchGardenViewController: UIAdaptivePresentationControllerDelegate {
+  func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+    self.searchGardenView.tableView.onEndReached = nil
+    self.clear()
   }
 }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/SearchGardenViewController.swift
@@ -170,6 +170,8 @@ extension SearchGardenViewController {
   }
   
   private func doneButtonTapped() {
+    self.searchGardenView.tableView.onEndReached = nil
+    self.searchGardenView.clear()
     self.router?.dismissModal()
   }
   
@@ -309,6 +311,7 @@ extension SearchGardenViewController: UITextFieldDelegate {
 
 extension SearchGardenViewController: DefaultModalNavigationBarDelegate {
   func didTapRightButton() {
+    self.searchGardenView.tableView.onEndReached = nil
     self.clear()
     self.router?.dismissModal()
   }

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/Views/SearchGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Sources/SearchGardenScene/Views/SearchGardenView.swift
@@ -28,7 +28,7 @@ final class SearchGardenView: UIVStackView {
   }
   
   func clear() {
-    self.tableView.clearItemsInMainSection()
+    self.tableView.cleanUpDeinit()
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/SearchGardenScene/Tests/SearchGardenSceneTests/SearchGardenSceneTests.swift
+++ b/ToDo-Garden/ToDo-Garden/SearchGardenScene/Tests/SearchGardenSceneTests/SearchGardenSceneTests.swift
@@ -90,8 +90,22 @@ final class SearchGardenSceneTests{
   @Test func testBuilder() {
     self.reset()
     let builder = SearchGardenSceneBuilder(dependency: .init(searchGardenWorker: self.worker))
-    let viewController = builder.build()
+    let viewController = builder.build(with: PayloadMock(searchGardenSceneDelegate: DelegateMock()))
     #expect(viewController is SearchGardenViewController)
+  }
+}
+
+struct PayloadMock: SearchGardenScenePayloadable {
+  let searchGardenSceneDelegate: any SearchGardenSceneAPI.SearchGardenSceneDelegate
+  
+  init(searchGardenSceneDelegate: any SearchGardenSceneAPI.SearchGardenSceneDelegate) {
+    self.searchGardenSceneDelegate = searchGardenSceneDelegate
+  }
+}
+
+class DelegateMock: SearchGardenSceneDelegate {
+  func searchGardenDoneButtonDidTap() {
+    return
   }
 }
 

--- a/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
+++ b/ToDo-Garden/ToDo-Garden/ShareGardenScene/Sources/ShareGardenScene/View/MyGardenView.swift
@@ -195,7 +195,7 @@ extension ShareGardenSceneViewController.MyGardenView {
     Task {
       guard let imageURL = imageURL else { return }
       
-      let image = try await Cache.shared.execute(id: imageURL, isDownsample: true)
+      let image = try await Cache.shared.execute(id: imageURL)
       self.profileInfoView.iconImage = image
     }
   }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenSection+User.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenSection+User.swift
@@ -45,12 +45,14 @@ extension SearchGardenUser: Hashable {
     return lhs.id == rhs.id
   }
   
-  public static let placeholderData = SearchGardenUser(
-    id: UUID(),
-    nickname: "Dummy",
-    customId: "@DummyID",
-    userImage: nil,
-    userImageURL: nil,
-    isDummyData: true
-  )
+  public static func placeholderData() -> SearchGardenUser {
+    return SearchGardenUser(
+      id: UUID(),
+      nickname: "Dummy",
+      customId: "@DummyID",
+      userImage: nil,
+      userImageURL: nil,
+      isDummyData: true
+    )
+  }
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
@@ -10,6 +10,7 @@ import UIKit
 final public class SearchGardenTableView: UITableView {
   private var diffableDataSource: UITableViewDiffableDataSource<SearchGardenSection, SearchGardenUser>!
   private var snapshot: NSDiffableDataSourceSnapshot<SearchGardenSection, SearchGardenUser>!
+  private var placeHolderData: SearchGardenUser? = SearchGardenUser.placeholderData()
 
   public override init(frame: CGRect, style: UITableView.Style) {
     super.init(frame: frame, style: style)
@@ -33,10 +34,18 @@ final public class SearchGardenTableView: UITableView {
     self.snapshot.appendItems(users)
     self.diffableDataSource.apply(self.snapshot, animatingDifferences: true)
   }
+  
   public func clearItemsInMainSection(completion: (() -> Void)? = nil) {
     self.snapshot.deleteItems(snapshot.itemIdentifiers(inSection: SearchGardenSection.main))
     self.diffableDataSource.apply(self.snapshot, animatingDifferences: false)
     completion?()
+  }
+  
+  public func cleanUpDeinit() {
+    self.placeHolderData = nil
+    self.snapshot = NSDiffableDataSourceSnapshot<SearchGardenSection, SearchGardenUser>()
+    self.snapshot.appendSections([.main])
+    self.diffableDataSource.apply(self.snapshot, animatingDifferences: false)
   }
   
   public func userForCell(at indexPath: IndexPath) -> SearchGardenUser? {
@@ -49,16 +58,18 @@ final public class SearchGardenTableView: UITableView {
   }
   
   public func appendPlaceholderCell() {
-    self.snapshot.appendItems([SearchGardenUser.placeholderData])
+    guard let placeHolderData = self.placeHolderData else { return }
+    self.snapshot.appendItems([placeHolderData])
     self.diffableDataSource.apply(self.snapshot, animatingDifferences: false)
   }
   
   public func deletePlaceholderCell() {
-    guard self.snapshot.itemIdentifiers.contains(SearchGardenUser.placeholderData) else {
+    guard let placeHolderData = self.placeHolderData else { return }
+    guard self.snapshot.itemIdentifiers.contains(placeHolderData) else {
       return
     }
     
-    self.snapshot.deleteItems([SearchGardenUser.placeholderData])
+    self.snapshot.deleteItems([placeHolderData])
     self.diffableDataSource.apply(self.snapshot, animatingDifferences: false)
   }
   

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/SearchGardenTableView/SearchGardenTableView.swift
@@ -77,13 +77,15 @@ final public class SearchGardenTableView: UITableView {
     self.diffableDataSource = UITableViewDiffableDataSource<
       SearchGardenSection,
       SearchGardenUser
-    >(tableView: self) { (tableView, indexPath, userData) -> TableRow? in
-      guard let tableRow = tableView.dequeueReusableCell(
+    >(tableView: self) { [weak self] (tableView, indexPath, userData) -> TableRow? in
+      guard let self = self,
+        let tableRow = tableView.dequeueReusableCell(
         withIdentifier: TableRow.identifier,
         for: indexPath
       ) as? TableRow else {
         return nil
       }
+
       self.diffableDataSource.defaultRowAnimation = UITableView.RowAnimation.fade
       self.updateTableRow(userData: userData, tableRow: tableRow)
       self.setDummyOrNot(userData: userData, tableRow: tableRow)


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #957 
## 🎉 변경 사항
- 셀 먹통현상 해결
- 메모리 릴리즈 정상화
- 가든검색 부정확 수정 

## 📌 PR Point

### dismiss시 정상적으로 "가든검색"과 관련된 객체들이 릴리즈 될 수 있도록 수정하였습니다. 
   - 잔류 참조객체 명시적 해제 
   - 싱글톤객체에서 강하게 참조하고 있던 부분 변경 
   - 싱글톤구조를 제거하고, 인스턴스로 사용합니다. 구조적 변경이 일어나서 테스트 코드가 깨진것도 수정하였습니다. 
 
### 가든 검색이 정상적으로 동작합니다. 
   - 프리페칭과 무한스크롤이 꼬여서 그랬습니다. 일시적으로 프리페칭을 주석처리합니다.  
   
### 탭 이동이후 가든 검색에서 검색후, 셀 터치가 안되던 부분 수정하였습니다. 
   - 가든검색 진입시 생성 , 탈출시 해제 하는 로직을 통해 해결되었습니다. 

## 📝 셀프체크리스트
- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?