### PR TITLE
#960 fix mystats dto

### DIFF
--- a/ToDo-Garden/TDUtility/Sources/TDFoundationExtension/Double+Extension.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDFoundationExtension/Double+Extension.swift
@@ -11,4 +11,8 @@ public extension Double {
     ? floor((self.truncatingRemainder(dividingBy: 3600)) / 60)
     : floor(self / 60)
   }
+  
+  func roundedToInt() -> Int {
+    return Int(self.rounded())
+  }
 }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Package.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
         .product(name: "HTTPClient", package: "TDFoundation"),
         .product(name: "HTTPClientAPI", package: "TDFoundation"),
         .product(name: "TDUtility", package: "TDUtility"),
+        .product(name: "TDFoundationExtension", package: "TDUtility"),
         .product(name: "ToDoGardenUIAPI", package: "ToDoGardenUI"),
         .product(name: "ToDoGardenUIResource", package: "ToDoGardenUI"),
         .product(name: "TDFoundation", package: "TDFoundation")

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsInteractor.swift
@@ -10,6 +10,7 @@ import UIKit
 import HTTPClientAPI
 import MyStatsSceneAPI
 import MyStatsSceneEntity
+import TDFoundationExtension
 import ToDoGardenUIComponent // PomodoroRecordCollection 이관 예정
 
 protocol MyStatsDataStore {
@@ -98,16 +99,16 @@ extension MyStatsInteractor {
     let dataSet = response.summaryViewData
     self.periodicState = PeriodicState(
       daily: (
-        focusTime: dataSet.dailyAverageFocusTime,
-        pomodoroCount: dataSet.dailyAveragePomodoroCount
+        focusTime: dataSet.dailyAverageFocusTime.roundedToInt(),
+        pomodoroCount: dataSet.dailyAveragePomodoroCount.roundedToInt()
       ),
       weekly: (
-        focusTime: dataSet.weeklyAverageFocusTime,
-        pomodoroCount: dataSet.weeklyAveragePomodoroCount
+        focusTime: dataSet.weeklyAverageFocusTime.roundedToInt(),
+        pomodoroCount: dataSet.weeklyAveragePomodoroCount.roundedToInt()
       ),
       monthly: (
-        focusTime: dataSet.monthlyAverageFocusTime,
-        pomodoroCount: dataSet.monthlyAveragePomodoroCount
+        focusTime: dataSet.monthlyAverageFocusTime.roundedToInt(),
+        pomodoroCount: dataSet.monthlyAveragePomodoroCount.roundedToInt()
       )
     )
   }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsPresenter.swift
@@ -88,9 +88,9 @@ extension MyStatsPresenter {
     let convertedDate = fetchedData.maxPomodoroRecord?.recordDate.toDateISO8601Format().toStringDefaultFormat()
     let viewModel = MyStats.LongestRecordViewModel(
       concentratedRecordGroupName: fetchedData.maxPomodoroRecord?.groupName ?? "",
-      concentratedRecordCount: fetchedData.maxPomodoroRecord?.maxPomodoroCount ?? 0,
+      concentratedRecordCount: fetchedData.maxPomodoroRecord?.maxPomodoroCount.roundedToInt() ?? 0,
       concentratedRecordDate: convertedDate ?? "",
-      longestContinuousRecordCount: fetchedData.maxContinuousDays?.maxCount ?? 0,
+      longestContinuousRecordCount: fetchedData.maxContinuousDays?.maxCount.roundedToInt() ?? 0,
       longestContinuousRecordStartDate: fetchedData.maxContinuousDays?.startDate ?? "",
       longestContinuousRecordEndDate: fetchedData.maxContinuousDays?.endDate ?? "기록이 없습니다"
     )
@@ -114,18 +114,18 @@ extension MyStatsPresenter {
     }
 
     let dailyViewModel = MyStats.SummaryViewModel(
-      concentratedTime: formatTime(fetchedData.dailyAverageFocusTime),
-      completedCount: "\(fetchedData.dailyAveragePomodoroCount)개 목표"
+      concentratedTime: formatTime(fetchedData.dailyAverageFocusTime.roundedToInt()),
+      completedCount: "\(fetchedData.dailyAveragePomodoroCount.roundedToInt())개 목표"
     )
 
     let weeklyViewModel = MyStats.SummaryViewModel(
-      concentratedTime: formatTime(fetchedData.weeklyAverageFocusTime),
-      completedCount: "\(fetchedData.weeklyAveragePomodoroCount)개 목표"
+      concentratedTime: formatTime(fetchedData.weeklyAverageFocusTime.roundedToInt()),
+      completedCount: "\(fetchedData.weeklyAveragePomodoroCount.roundedToInt())개 목표"
     )
 
     let monthlyViewModel = MyStats.SummaryViewModel(
-      concentratedTime: formatTime(fetchedData.monthlyAverageFocusTime),
-      completedCount: "\(fetchedData.monthlyAveragePomodoroCount)개 목표"
+      concentratedTime: formatTime(fetchedData.monthlyAverageFocusTime.roundedToInt()),
+      completedCount: "\(fetchedData.monthlyAveragePomodoroCount.roundedToInt())개 목표"
     )
 
     return [dailyViewModel, weeklyViewModel, monthlyViewModel]

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsPresenter.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsPresenter.swift
@@ -91,8 +91,10 @@ extension MyStatsPresenter {
       concentratedRecordCount: fetchedData.maxPomodoroRecord?.maxPomodoroCount.roundedToInt() ?? 0,
       concentratedRecordDate: convertedDate ?? "",
       longestContinuousRecordCount: fetchedData.maxContinuousDays?.maxCount.roundedToInt() ?? 0,
-      longestContinuousRecordStartDate: fetchedData.maxContinuousDays?.startDate ?? "",
-      longestContinuousRecordEndDate: fetchedData.maxContinuousDays?.endDate ?? "기록이 없습니다"
+      longestContinuousRecordStartDate:
+        fetchedData.maxContinuousDays?.startDate.toDateISO8601Format().toStringDefaultFormat() ?? "",
+      longestContinuousRecordEndDate:
+        fetchedData.maxContinuousDays?.endDate.toDateISO8601Format().toStringDefaultFormat() ?? "기록이 없습니다"
     )
     return viewModel
   }

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsScene/MyStatsWorker.swift
@@ -26,7 +26,7 @@ public struct MyStatsWorker: MyStatsWorkable {
     return MyStats.FetchedProfileViewData(
       nickname: result.nickname,
       profileImage: imageData,
-      continuousRecordCount: result.continuousRecordCount,
+      continuousRecordCount: result.continuousRecordCount.roundedToInt(),
       continuousRecordStartDate: result.continuousRecordStartDate,
       continuousRecordEndDate: result.continuousRecordEndDate
     )

--- a/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneEntity/MyStatsModels.swift
+++ b/ToDo-Garden/ToDo-Garden/MyStatsScene/Sources/MyStatsSceneEntity/MyStatsModels.swift
@@ -165,21 +165,21 @@ extension MyStats {
   }
   
   public struct FetchedSummaryViewData: Sendable, Codable {
-    public let dailyAverageFocusTime: Int
-    public let weeklyAverageFocusTime: Int
-    public let monthlyAverageFocusTime: Int
+    public let dailyAverageFocusTime: Double
+    public let weeklyAverageFocusTime: Double
+    public let monthlyAverageFocusTime: Double
     
-    public let dailyAveragePomodoroCount: Int
-    public let weeklyAveragePomodoroCount: Int
-    public let monthlyAveragePomodoroCount: Int
+    public let dailyAveragePomodoroCount: Double
+    public let weeklyAveragePomodoroCount: Double
+    public let monthlyAveragePomodoroCount: Double
     
     public init(
-      dailyAverageFocusTime: Int,
-      weeklyAverageFocusTime: Int,
-      monthlyAverageFocusTime: Int,
-      dailyAveragePomodoroCount: Int,
-      weeklyAveragePomodoroCount: Int,
-      monthlyAveragePomodoroCount: Int
+      dailyAverageFocusTime: Double,
+      weeklyAverageFocusTime: Double,
+      monthlyAverageFocusTime: Double,
+      dailyAveragePomodoroCount: Double,
+      weeklyAveragePomodoroCount: Double,
+      monthlyAveragePomodoroCount: Double
     ) {
       self.dailyAverageFocusTime = dailyAverageFocusTime
       self.weeklyAverageFocusTime = weeklyAverageFocusTime
@@ -203,14 +203,14 @@ extension MyStats {
     public let imageUrl: String?
     public let continuousRecordStartDate: String
     public let continuousRecordEndDate: String
-    public let continuousRecordCount: Int
+    public let continuousRecordCount: Double
     
     public init(
       nickname: String,
       imageUrl: String?,
       continuousRecordStartDate: String,
       continuousRecordEndDate: String,
-      continuousRecordCount: Int
+      continuousRecordCount: Double
     ) {
       self.nickname = nickname
       self.imageUrl = imageUrl
@@ -223,9 +223,9 @@ extension MyStats {
   public struct MaxPomodoroRecordDTO: Sendable, Codable {
     public let groupName: String
     public let recordDate: String
-    public let maxPomodoroCount: Int
+    public let maxPomodoroCount: Double
     
-    public init(groupName: String, recordDate: String, maxPomodoroCount: Int) {
+    public init(groupName: String, recordDate: String, maxPomodoroCount: Double) {
       self.groupName = groupName
       self.recordDate = recordDate
       self.maxPomodoroCount = maxPomodoroCount
@@ -235,9 +235,9 @@ extension MyStats {
   public struct MaxContinuousDaysDTO: Sendable, Codable {
     public let startDate: String
     public let endDate: String
-    public let maxCount: Int
+    public let maxCount: Double
     
-    public init(startDate: String, endDate: String, maxCount: Int) {
+    public init(startDate: String, endDate: String, maxCount: Double) {
       self.startDate = startDate
       self.endDate = endDate
       self.maxCount = maxCount


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #960 
## 🎉 변경 사항
- mystats Scene의 디코딩에러 가능성을 없앱니다. 
## 📌 PR Point
- 서버로부터 받아오는 데이터 단위가 "count(개수)" 라서 Int로 받아오던 DataModel을 수정합니다. 
- Double로 대체하고, 소수점 이하 반올림한 수치를 Int로 변환하여 UI에 표시합니다.
## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?