### PR TITLE
#969: ImageView ContentMode 변경

### DIFF
--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/Styled/Row/Style/ProfileStyle.swift
@@ -28,6 +28,7 @@ extension Styled.Row {
       size: model[style: \.imageSize]
     )
     profileImageView.layer.cornerRadius = model[style: \.imageSize].width / 2
+    profileImageView.contentMode = .scaleAspectFill
     profileImageView.clipsToBounds = true
     self.bindingProfileImageState(imageView: profileImageView)
     let profileImageTrailingPadding = UIView()


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #969 
## 🎉 변경 사항
- scaleAspectFill로 변경합니다.
## 📌 PR Point
- Styled.Row ProfileRow의 ImageView의 ContentMode를 ScaleAspectFill로 변경합니다.

<img width="364" alt="스크린샷 2025-04-17 오후 9 05 52" src="https://github.com/user-attachments/assets/2497325f-5895-4366-a2d1-798604046b53" />

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?