### PR TITLE
Continuation misuse 해결 및 이미지만 고를 수 있도록 설정 수정

### DIFF
--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneInteractor.swift
@@ -73,14 +73,15 @@ extension UserInfoSceneInteractor: UserInfoSceneBusinessLogic {
   func changeUserProfileImage() {
     self.requestUserPhotoTask = Task {
       do {
-        let profileImageToChange = try await self.userPhotoWorker.requestPhoto()
-        if let imageData = profileImageToChange.jpegData(compressionQuality: 0.7) {
-          try await self.userInfoWorker.requestChangeProfileImage(with: imageData)
-          let response = UserInfoScene.ChangeProfileImage.Response(
-            changeResult: Result.success(profileImageToChange)
-          )
-
-          self.presenter?.presentChangedProfileImage(response: response)
+        if let profileImageToChange = try await self.userPhotoWorker.requestPhoto() {
+          if let imageData = profileImageToChange.jpegData(compressionQuality: 0.7) {
+            try await self.userInfoWorker.requestChangeProfileImage(with: imageData)
+            let response = UserInfoScene.ChangeProfileImage.Response(
+              changeResult: Result.success(profileImageToChange)
+            )
+            
+            self.presenter?.presentChangedProfileImage(response: response)
+          }
         }
       } catch let error {
         let response = UserInfoScene.ChangeProfileImage.Response(

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneSceneBuilder.swift
@@ -17,7 +17,6 @@ import UserInfoSceneEntity
 public struct UserInfoSceneSceneBuilder {
   /// 컴파일 타임에 필요한 의존성을 선언한 구조체입니다.
   public struct Dependency {
-    let photoPicker: PHPickerViewController
     let appServiceWorker: AppServiceWorkable
     let userPhotoWorker: UserPhotoWorker
     let userInfoWorker: UserInfoSceneWorkable
@@ -25,14 +24,12 @@ public struct UserInfoSceneSceneBuilder {
     let editUserNameSceneBuilder: EditUserNameSceneSceneBuildable?
 
     public init(
-      photoPicker: PHPickerViewController,
       appServiceWorker: AppServiceWorkable,
       userPhotoWorker: UserPhotoWorker,
       userInfoWorker: UserInfoSceneWorkable,
       editUserIntroductionSceneBuilder: EditUserIntroductionSceneBuildable?,
       editUserNameSceneBuilder: EditUserNameSceneSceneBuildable?
     ) {
-      self.photoPicker = photoPicker
       self.appServiceWorker = appServiceWorker
       self.userPhotoWorker = userPhotoWorker
       self.userInfoWorker = userInfoWorker
@@ -51,7 +48,6 @@ public struct UserInfoSceneSceneBuilder {
 extension UserInfoSceneSceneBuilder {
   public static func live(signout: @escaping () -> Void) -> Self {
     Self(dependency: Dependency(
-      photoPicker: PHPickerViewController(configuration: PHPickerConfiguration()),
       appServiceWorker: AppServiceWorker(),
       userPhotoWorker: UserPhotoWorker(),
       userInfoWorker: UserInfoSceneWorker(httpClient: HTTPClient.live, signout: signout),
@@ -66,10 +62,8 @@ extension UserInfoSceneSceneBuilder: UserInfoSceneSceneBuildable {
   /// - Parameter payload: 런타임에 전달받아야 하는 의존성입니다.
   /// - Returns: 런타임 의존성, VIP Cycle이 설정된 ViewController를 반환합니다.
   public func build() -> UserInfoSceneViewControllable {
-    self.dependency.photoPicker.delegate = self.dependency.userPhotoWorker
-    let userInfoSceneViewController = UserInfoSceneViewController(
-      photoPicker: self.dependency.photoPicker
-    )
+    let userInfoSceneViewController = UserInfoSceneViewController()
+    userInfoSceneViewController.photoPickerDelegate = self.dependency.userPhotoWorker
     let configuredVIPCycleViewController = self.configureVIPCycle(for: userInfoSceneViewController)
     return configuredVIPCycleViewController
   }

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserInfoSceneViewController.swift
@@ -35,7 +35,8 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   private let userInfoCollectionView: UICollectionView
   private var userInfoCollectionViewDataSource: DiffableDataSource?
   private let manageAccountView: ManageAccountView
-  private let photoPicker: PHPickerViewController
+  private var photoPicker: PHPickerViewController?
+  weak var photoPickerDelegate: PHPickerViewControllerDelegate?
 
   // MARK: - VIP Properties
   
@@ -44,14 +45,13 @@ final class UserInfoSceneViewController: UIViewController, UserInfoSceneViewCont
   
   // MARK: - Object lifecycle
   
-  init(photoPicker: PHPickerViewController) {
+  init() {
     self.profileInfoView = ProfileInfoView()
     self.userInfoCollectionView = UICollectionView(
       frame: CGRect.zero,
       collectionViewLayout: UICollectionViewLayout()
     )
     self.manageAccountView = ManageAccountView()
-    self.photoPicker = photoPicker
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -103,7 +103,14 @@ extension UserInfoSceneViewController: UserInfoSceneDisplayLogic {
 
   func displayUserPhotoAccess(viewModel: UserInfoScene.FetchUserPhotoAccess.ViewModel) {
     if viewModel.isPhotoAccessible {
-      self.present(self.photoPicker, animated: true)
+      var configuration = PHPickerConfiguration()
+      configuration.filter = .images
+      self.photoPicker = PHPickerViewController(configuration: configuration)
+      self.photoPicker?.delegate = self.photoPickerDelegate
+      
+      guard let photoPicker else { return }
+      
+      self.present(photoPicker, animated: true)
       self.interactor?.changeUserProfileImage()
     } else {
       self.showMovingToSettingAppAlert()

--- a/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserPhotoWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/UserInfoScene/Sources/UserInfoScene/UserPhotoWorker.swift
@@ -14,12 +14,14 @@ public final class UserPhotoWorker: PHPickerViewControllerDelegate {
 
   public func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
     picker.dismiss(animated: true)
-
+    
     if let itemProvider = results.first?.itemProvider, itemProvider.canLoadObject(ofClass: UIImage.self) {
       itemProvider.loadObject(ofClass: UIImage.self) { (loadedObject, error) in
         let newProfileImage = loadedObject as? UIImage
         self.selectedImagesHandler?(newProfileImage, error)
       }
+    } else {
+      self.selectedImagesHandler?(nil, nil)
     }
   }
 
@@ -32,14 +34,15 @@ public final class UserPhotoWorker: PHPickerViewControllerDelegate {
     }
   }
 
-  func requestPhoto() async throws -> UIImage {
+  func requestPhoto() async throws -> UIImage? {
     try await withCheckedThrowingContinuation { [weak self] continuation in
       self?.selectedImagesHandler = { image, error in
         if let image {
           continuation.resume(returning: image)
-        } else {
-          let error = error ?? UserPhotoworkerError.unknownError
+        } else if let error {
           continuation.resume(throwing: error)
+        } else {
+          continuation.resume(returning: nil)
         }
       }
     }


### PR DESCRIPTION
## 💡 관련 이슈
- closed: #968 
## 🎉 변경 사항
- 사진을 고르지 않을 경우 발생하는 Continuation leak을 해결하였습니다.
- configuration을 추가하여 프로필 이미지를 사진만 고를 수 있도록 하였습니다.(기존의 경우 동영상도 선택가능)

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?