### PR TITLE
Feature/#971 update repeat todo

### DIFF
--- a/ToDo-Garden/TDUtility/Sources/TDFoundationExtension/Date+Extension.swift
+++ b/ToDo-Garden/TDUtility/Sources/TDFoundationExtension/Date+Extension.swift
@@ -8,6 +8,11 @@
 import Foundation
 
 public extension Date {
+  func toKSTDate() -> Date {
+    let secondsFromGMT = TimeZone(identifier: "Asia/Seoul")?.secondsFromGMT(for: self) ?? 0
+    return self.addingTimeInterval(TimeInterval(secondsFromGMT))
+  }
+  
   func toStringDefaultFormat() -> String {
     let dateFormatter = DateFormatter()
     dateFormatter.dateFormat = "yyyy.MM.dd"

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -28,7 +28,6 @@ protocol EditToDoBusinessLogic {
 
   func prepareSceneData()
   func editToDo(name: String, groupId: String)
-  func deleteToDo()
 }
 
 @MainActor
@@ -111,10 +110,6 @@ extension EditToDoInteractor {
       startDay: startDay, endDay: endDay, groupId: groupId, isDelete: false
     )
     self.presenter?.presentEditedToDo()
-  }
-
-  // TODO: 서버에 투두의 삭제를 요청하는 메서드입니다.
-  func deleteToDo() {
   }
 }
 // swiftlint:enable multiline_arguments

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoInteractor.swift
@@ -20,6 +20,7 @@ protocol EditToDoDataStore {
 
 @MainActor
 protocol EditToDoBusinessLogic {
+  var needsAlert: Bool { get }
   func changeRepetition(isOnlyToday: Bool)
   func changeReptitionRange(start: Date, end: Date)
   func changeAlarmActivation()
@@ -34,7 +35,7 @@ protocol EditToDoBusinessLogic {
 final class EditToDoInteractor: EditToDoDataStore {
   var toDo: TodoBatchItem?
   var groups: [SharedEntity.TodoListGroup]?
-
+  var needsAlert: Bool = false
   // MARK: VIP Objects
   var presenter: EditToDoPresentationLogic?
 
@@ -74,6 +75,9 @@ extension EditToDoInteractor: EditToDoBusinessLogic {
   }
 
   func changeRepetition(isOnlyToday: Bool) {
+    let previousValue = self.toDo?.isOnlyToday
+    self.needsAlert = (previousValue == false && isOnlyToday == true)
+    
     self.toDo?.isOnlyToday = isOnlyToday
     if isOnlyToday {
       self.presenter?.presentRepeatOnlyToday()

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoRouter.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoRouter.swift
@@ -12,7 +12,7 @@ import EditToDoSceneAPI
 @MainActor
 protocol EditToDoRoutingLogic {
   func routeToHomeScene()
-  func routeToHomeSceneWithToDo()
+  func routeToHomeSceneWithToDo(isNeededDeletionBySelection: Bool)
   func routeToHomeSceneWithDeletedToDo()
 }
 
@@ -37,8 +37,11 @@ extension EditToDoRouter: EditToDoRoutingLogic {
     self.viewController?.navigationController?.popViewController(animated: true)
   }
 
-  func routeToHomeSceneWithToDo() {
-    self.delegate?.didEdit(toDo: self.dataStore!.toDo!)
+  func routeToHomeSceneWithToDo(isNeededDeletionBySelection: Bool) {
+    self.delegate?.didEdit(
+      toDo: self.dataStore!.toDo!,
+      isNeededDeletionBySelection: isNeededDeletionBySelection
+    )
     self.routeToHomeScene()
   }
 

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoScene/EditToDoViewController.swift
@@ -16,6 +16,7 @@ import ToDoGardenUIAPI
 import ToDoGardenUIComponent
 import ToDoGardenUIConstant
 
+// swiftlint: disable all
 protocol EditToDoDisplayLogic: AnyObject {
   func displayFetchedToDo(viewModel: EditToDo.FetchToDo.ViewModel)
   func displayEditedToDo()
@@ -146,7 +147,13 @@ extension EditToDoViewController: EditToDoDisplayLogic {
   }
 
   func displayEditedToDo() {
-    self.router?.routeToHomeSceneWithToDo()
+    guard let interactor = self.interactor else { return }
+    
+    if interactor.needsAlert {
+      self.showDeleteRepeatToDoAlert()
+    } else {
+      self.router?.routeToHomeSceneWithToDo(isNeededDeletionBySelection: false)
+    }
   }
 
   private func updateEditToDoView(toDo: TodoBatchItem, groups: [TodoListGroup]) {
@@ -253,6 +260,11 @@ extension EditToDoViewController: ToDoGardenAlertControllerDelegate {
       self.router?.routeToHomeScene()
     case ToDoGardenUIConstant.Constant.ToDoGardenAlertView.Content.ButtonActionType.delete:
       self.router?.routeToHomeSceneWithDeletedToDo()
+      
+    case .deleteEntireToDoRepeat:
+      self.router?.routeToHomeSceneWithToDo(isNeededDeletionBySelection: false)
+    case .deleteUncompletedToDoRepeat:
+      self.router?.routeToHomeSceneWithToDo(isNeededDeletionBySelection: true)
     default:
       break
     }
@@ -272,6 +284,12 @@ extension EditToDoViewController: ToDoGardenAlertControllerDelegate {
       failToFetchAlert.delegate = self
       self.showAlert(failToFetchAlert)
     }
+  }
+  
+  func showDeleteRepeatToDoAlert() {
+    let alertView = ToDoGardenAlertController(for: ToDoGardenAlertView.Configuration.deleteToDoRepeat)
+    alertView.delegate = self
+    self.showAlert(alertView)
   }
 }
 
@@ -317,7 +335,7 @@ extension EditToDoViewController: UIScrollViewDelegate {
 }
 
 import HTTPClient
-// swiftlint:disable all
+
 extension EditToDoViewController {
   struct EditToDoScenePayload: EditToDoScenePayloadable {
     var toDo: TodoBatchItem
@@ -355,7 +373,6 @@ extension EditToDoViewController {
     }
   }
 }
-// swiftlint:enable all
 
 extension EditToDoViewController {
   public func setForGuide(index: Int) {
@@ -394,3 +411,5 @@ extension EditToDoViewController {
   return UINavigationController(rootViewController: EditToDoViewController.SomeViewController())
 }
 #endif
+
+// swiftlint: enable all

--- a/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneAPI/EditToDoSceneDelegate.swift
+++ b/ToDo-Garden/ToDo-Garden/EditToDoScene/Sources/EditToDoSceneAPI/EditToDoSceneDelegate.swift
@@ -11,6 +11,6 @@ import TDFoundation
 
 @MainActor
 public protocol EditToDoSceneDelegate: AnyObject {
-  func didEdit(toDo: TodoBatchItem)
+  func didEdit(toDo: TodoBatchItem, isNeededDeletionBySelection: Bool)
   func didRemove(toDo: TodoBatchItem)
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -29,7 +29,10 @@ protocol HomeSceneBusinessLogic {
   func setMonthlyData(_ monthlyData: [String: [SharedEntity.TodoListGroup]]) async
   func loadDailyToDoList(targetDate: String) async
   func updateText(text: String, indexPath: IndexPath, date: Date)
-  func updateToDo(group: ToDoListView.ToDoSection, batchItem: TodoBatchItem, indexPath: IndexPath, date: Date) async
+  func updateToDo(
+    group: ToDoListView.ToDoSection, batchItem: TodoBatchItem,
+    indexPath: IndexPath, date: Date, isNeededDeletionBySelection: Bool
+  ) async
   func updateSelection(isSelected: Bool, indexPath: IndexPath, date: Date)
   func writeBatchItemsToGRDB() async
   func requestBatchUpdateToServer() async
@@ -232,7 +235,8 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
     group: ToDoListView.ToDoSection,
     batchItem: TodoBatchItem,
     indexPath: IndexPath,
-    date: Date
+    date: Date,
+    isNeededDeletionBySelection: Bool
   ) async {
     let targetDate = date.description.toYYYYMMDDStringFromISO8601Space()
     guard let targetGroup = self.monthlyData[targetDate]?[indexPath.section],
@@ -245,13 +249,15 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
       )
     case .changed:
       await self.updateRepeatToDos(
-        batchItem: batchItem, targetToDo: targetToDo, group: group, indexPath: indexPath, date: date
+        batchItem: batchItem, targetToDo: targetToDo, group: group,
+        indexPath: indexPath, date: date
       )
     case .deleted:
-      self.removeRepeatToDos(
-        batchItem: batchItem, targetToDo: targetToDo, group: group, indexPath: indexPath, date: date
+      await self.removeRepeatToDos(
+        batchItem: batchItem, targetToDo: targetToDo,
+        group: group, indexPath: indexPath, date: date,
+        isNeededDeletionBySelection: isNeededDeletionBySelection
       )
-      return
     default:
       break
     }
@@ -284,6 +290,7 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
     
     if isSelected == targetToDo.isDone { return }
     targetToDo.isDone = isSelected
+    print(targetToDo.localID)
     if let batchItem = self.itemsForBatch[targetToDo.localID] {
       batchItem.setDone(isSelected)
     } else {
@@ -299,6 +306,9 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
 
   // EditToDoScene으로 넘겨주기 위한 데이터를 준비하는 작업입니다.
   func prepareDataForEditTodoScene(request: HomeScene.PrepareDataForEditToDoScene.Request) {
+    Task {
+      try await self.homeSceneWorker.syncronizeGRDBWithBatchItems()
+    }
     let dateString = request.selectedDate.description.toYYYYMMDDStringFromISO8601Space()
     let groups = self.monthlyData[dateString]
     let group = groups?.first(where: { (group: SharedEntity.TodoListGroup) in
@@ -406,6 +416,7 @@ extension HomeSceneInteractor {
         if oldTodo.todoId.lowercased() == batchItem.localId.lowercased() {
           continue
         }
+        
         let batchItem = self.makeBatchItemFrom(myToDo: oldTodo, isDelete: true)
         self.removeBatchItem(deletedToDo: batchItem)
       }
@@ -414,7 +425,7 @@ extension HomeSceneInteractor {
       try await self.homeSceneWorker.clearRepeatToDos(repeatToDoId: batchItem.localId)
       
       while currentDate <= endDate {
-        if currentDate == date {
+        if currentDate.toStringYYYYMMDD() == date.toStringYYYYMMDD() {
           currentDate = Calendar.current.date(byAdding: .day, value: 1, to: currentDate)!
           continue
         }
@@ -437,20 +448,26 @@ extension HomeSceneInteractor {
     targetToDo: TodoListItem,
     group: ToDoListView.ToDoSection,
     indexPath: IndexPath,
-    date: Date
-  ) {
-    let formatter = ISO8601DateFormatter()
-    var currentDate = formatter.date(from: targetToDo.startDay!)!
-    let endDate = formatter.date(from: targetToDo.endDay!)!
-    while currentDate <= endDate {
-      let existedToDo = self.makeItemForDeleteToDo(group: group, todo: targetToDo, date: currentDate)
-      self.addBatchItem(newToDo: existedToDo)
-      let targetGroup = self.monthlyData[currentDate.toStringYYYYMMDD()]?[indexPath.section]
-      let deleteTodoIndex = targetGroup?.todoList?.firstIndex {
-        $0.repeatToDoId?.lowercased() == targetToDo.localID.lowercased() || $0.localID == targetToDo.localID
+    date: Date,
+    isNeededDeletionBySelection: Bool
+  ) async {
+    do {
+      let oldTodos = try await self.homeSceneWorker.getRepeatToDos(repeatToDoId: batchItem.localId)
+      for oldTodo in oldTodos {
+        if oldTodo.todoId.lowercased() == batchItem.localId.lowercased() {
+          continue
+        }
+        
+        if isNeededDeletionBySelection == true && oldTodo.isDone == true {
+          continue
+        }
+        
+        let batchItem = self.makeBatchItemFrom(myToDo: oldTodo, isDelete: true)
+        self.removeBatchItem(deletedToDo: batchItem)
       }
-      targetGroup?.todoList?.remove(at: deleteTodoIndex!)
-      currentDate = Calendar.current.date(byAdding: .day, value: 1, to: currentDate)!
+      await self.writeBatchItemsToGRDB()
+    } catch let error {
+      self.handleErrors(error)
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -23,7 +23,7 @@ protocol HomeSceneDataStore {
 
 @MainActor
 protocol HomeSceneBusinessLogic {
-  func fetchToDoList(request: HomeScene.FetchToDoList.Request) async
+  func fetchToDoList(request: HomeScene.FetchToDoList.Request, isForRouting: Bool) async
   func createToDo(group: ToDoListView.ToDoSection, date: Date) async
   func deleteToDo(group: ToDoListView.ToDoSection, todo: ToDoListView.ToDoItem, date: Date) async
   func setMonthlyData(_ monthlyData: [String: [SharedEntity.TodoListGroup]]) async
@@ -93,20 +93,24 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
     )
   }
   
-  func fetchToDoList(request: HomeScene.FetchToDoList.Request) async {
+  func fetchToDoList(request: HomeScene.FetchToDoList.Request, isForRouting: Bool) async {
     await FallbackFlow.run(
       online: { [weak self] in
         guard let self = self else { return }
         
         let fetchedToDoList = try await self.homeSceneWorker.fetchToDoList(dateString: request.dateString)
-        self.presenter?.presentFetchedToDoList(monthlyData: fetchedToDoList)
+        if isForRouting == false {
+          self.presenter?.presentFetchedToDoList(monthlyData: fetchedToDoList)
+        }
       },
       offline: { [weak self] in
         guard let self = self else { return }
         
         let (newMonthlyData, response) = try await self.loadMonthlyToDoListFromGRDB(request: request)
         self.monthlyData = newMonthlyData
-        self.presenter?.presentFetchedToDoList(monthlyData: response)
+        if isForRouting == false {
+          self.presenter?.presentFetchedToDoList(monthlyData: response)
+        }
       },
       handleError: { [weak self] error in
         self?.handleErrors(error)
@@ -290,7 +294,6 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
     
     if isSelected == targetToDo.isDone { return }
     targetToDo.isDone = isSelected
-    print(targetToDo.localID)
     if let batchItem = self.itemsForBatch[targetToDo.localID] {
       batchItem.setDone(isSelected)
     } else {
@@ -299,7 +302,7 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
         localId: targetToDo.localID, name: targetToDo.name, isDone: isSelected,
         createdAt: date.toISOString(), isAlarmOn: targetToDo.isAlarmOn, alarmTime: alarmTime,
         isOnlyToday: targetToDo.isOnlyToday, startDay: targetToDo.startDay, endDay: targetToDo.endDay,
-        groupId: targetGroup.localId, isDelete: false
+        groupId: targetGroup.localId, isDelete: false, repeatToDoId: targetToDo.repeatToDoId
       )
     }
   }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneInteractor.swift
@@ -236,18 +236,16 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
   ) async {
     let targetDate = date.description.toYYYYMMDDStringFromISO8601Space()
     guard let targetGroup = self.monthlyData[targetDate]?[indexPath.section],
-          let targetToDo = targetGroup.todoList?[indexPath.item]
-    else { return }
+      let targetToDo = targetGroup.todoList?[indexPath.item] else { return }
 
-    let formatter = ISO8601DateFormatter()
     switch self.getRepetitionStatus(toDo: targetToDo, batchItem: batchItem) {
     case .made:
       self.addRepeatToDos(
         batchItem: batchItem, targetToDo: targetToDo, group: group, indexPath: indexPath, date: date
       )
     case .changed:
-      self.updateRepeatToDos(
-        batchItem: batchItem, targetToDo: targetToDo, group: group, date: date
+      await self.updateRepeatToDos(
+        batchItem: batchItem, targetToDo: targetToDo, group: group, indexPath: indexPath, date: date
       )
     case .deleted:
       self.removeRepeatToDos(
@@ -264,7 +262,6 @@ extension HomeSceneInteractor: HomeSceneBusinessLogic {
     targetToDo.isOnlyToday = batchItem.isOnlyToday
     targetToDo.startDay = batchItem.startDay
     targetToDo.endDay = batchItem.endDay
-    self.monthlyData[targetDate]?[indexPath.section].todoList?[indexPath.item] = targetToDo
     self.itemsForBatch[targetToDo.localID] = batchItem
   }
 
@@ -366,25 +363,20 @@ extension HomeSceneInteractor {
     guard
         let startDayString = batchItem.startDay,
         let endDayString = batchItem.endDay,
-        let startDate = ISO8601DateFormatter().date(from: startDayString),
-        let endDate = ISO8601DateFormatter().date(from: endDayString)
+        let startDate = formatter.date(from: startDayString)?.toKSTDate(),
+        let endDate = formatter.date(from: endDayString)?.toKSTDate(),
+        let targetGroup = self.groups?.first(where: { $0.localId == batchItem.groupId })
       else { return }
-
+    
     var currentDate = startDate
     while currentDate <= endDate {
-      if currentDate == date {
+      if currentDate == date.toKSTDate() {
         currentDate = Calendar.current.date(byAdding: .day, value: 1, to: currentDate)!
         continue
       }
-      let newToDo = TodoListItem(
-        name: targetToDo.name, endDay: nil, isDone: targetToDo.isDone,
-        localID: batchItem.groupId, startDay: nil, alarmTime: targetToDo.alarmTime,
-        isAlarmOn: targetToDo.isAlarmOn, isOnlyToday: true,
-        repeatToDoId: targetToDo.localID
-      )
-      let currentGroup = self.monthlyData[currentDate.toStringYYYYMMDD()]?[indexPath.section]
-      currentGroup?.todoList?.append(newToDo)
-      let newBatchItem = self.makeItemForCreateToDo(group: group, date: currentDate)
+      
+      let newToDoID = UUID()
+      let newBatchItem = self.makeItemForCreateToDo(group: group, newGroupId: targetGroup.localId, newToDoID: newToDoID, date: currentDate, isOnlyToday: false, repeatToDoId: targetToDo.localID)
       newBatchItem.setName(batchItem.name)
       self.addBatchItem(newToDo: newBatchItem)
       currentDate = Calendar.current.date(byAdding: .day, value: 1, to: currentDate)!
@@ -395,38 +387,48 @@ extension HomeSceneInteractor {
     batchItem: TodoBatchItem,
     targetToDo: TodoListItem,
     group: ToDoListView.ToDoSection,
+    indexPath: IndexPath,
     date: Date
-  ) {
-    let formatter = ISO8601DateFormatter()
-    guard
+  ) async {
+    do {
+      let formatter = ISO8601DateFormatter()
+      guard
         let startDayString = batchItem.startDay,
         let endDayString = batchItem.endDay,
-        let startDate = ISO8601DateFormatter().date(from: startDayString),
-        let endDate = ISO8601DateFormatter().date(from: endDayString)
+        let startDate = formatter.date(from: startDayString),
+        let endDate = formatter.date(from: endDayString),
+        let targetGroup = self.groups?.first(where: { $0.localId == batchItem.groupId })
       else { return }
 
-    var currentDate = startDate
-    while currentDate <= endDate {
-      if currentDate == date {
-        currentDate = Calendar.current.date(byAdding: .day, value: 1, to: currentDate)!
-        continue
+      var currentDate = startDate
+      let oldTodos = try await self.homeSceneWorker.getRepeatToDos(repeatToDoId: batchItem.localId)
+      for oldTodo in oldTodos {
+        if oldTodo.todoId.lowercased() == batchItem.localId.lowercased() {
+          continue
+        }
+        let batchItem = self.makeBatchItemFrom(myToDo: oldTodo, isDelete: true)
+        self.removeBatchItem(deletedToDo: batchItem)
       }
-
-      let existedToDo = self.makeItemForDeleteToDo(group: group, todo: targetToDo, date: currentDate)
-      self.addBatchItem(newToDo: existedToDo)
-      currentDate = Calendar.current.date(byAdding: .day, value: 1, to: currentDate)!
-    }
-
-    currentDate = startDate
-    while currentDate <= endDate {
-      if currentDate == date {
+      await self.writeBatchItemsToGRDB()
+      
+      try await self.homeSceneWorker.clearRepeatToDos(repeatToDoId: batchItem.localId)
+      
+      while currentDate <= endDate {
+        if currentDate == date {
+          currentDate = Calendar.current.date(byAdding: .day, value: 1, to: currentDate)!
+          continue
+        }
+        
+        let newToDoID = UUID()
+        let newToDo = self.makeItemForCreateToDo(group: group, newGroupId: targetGroup.localId, newToDoID: newToDoID, date: currentDate, isOnlyToday: false, repeatToDoId: targetToDo.localID)
+        
+        newToDo.setName(batchItem.name)
+        self.addBatchItem(newToDo: newToDo)
         currentDate = Calendar.current.date(byAdding: .day, value: 1, to: currentDate)!
-        continue
       }
-
-      let newToDo = self.makeItemForCreateToDo(group: group, date: currentDate)
-      self.addBatchItem(newToDo: newToDo)
-      currentDate = Calendar.current.date(byAdding: .day, value: 1, to: currentDate)!
+      
+    } catch let error {
+      self.handleErrors(error)
     }
   }
 
@@ -470,21 +472,31 @@ extension HomeSceneInteractor {
     }
   }
   
-  private func makeItemForCreateToDo(group: ToDoListView.ToDoSection, date: Date) -> TodoBatchItem {
-    let newToDoID = UUID()
-    let groupID = group.id.uuidString.lowercased()
+  private func makeBatchItemFrom(myToDo: MyToDo, isDelete: Bool = true) -> TodoBatchItem {
+    return TodoBatchItem(
+      localId: myToDo.todoId.lowercased(), name: myToDo.name, isDone: myToDo.isDone,
+      createdAt: myToDo.date, isAlarmOn: myToDo.isAlarmOn, alarmTime: Double.zero,
+      isOnlyToday: myToDo.isOnlyToday, startDay: myToDo.startDay,
+      endDay: myToDo.endDay, groupId: myToDo.groupId, isDelete: isDelete
+    )
+  }
+  
+  private func makeItemForCreateToDo(group: ToDoListView.ToDoSection, newGroupId: String? = nil, newToDoID: UUID = UUID(), date: Date, isOnlyToday: Bool = true, repeatToDoId: String? = nil) -> TodoBatchItem {
+
+    let groupID = (newGroupId != nil) ? newGroupId! : group.id.uuidString.lowercased()
     let newItem = TodoBatchItem(
       localId: newToDoID.uuidString.lowercased(),
       name: "New ToDo",
       isDone: false,
       createdAt: date.toISOString(),
       isAlarmOn: false,
-      alarmTime: 0, // 기본값 뭐임?
-      isOnlyToday: true,
+      alarmTime: 0,
+      isOnlyToday: isOnlyToday,
       startDay: nil,
       endDay: nil,
       groupId: groupID,
-      isDelete: false
+      isDelete: false,
+      repeatToDoId: repeatToDoId
     )
     return newItem
   }
@@ -504,7 +516,8 @@ extension HomeSceneInteractor {
       startDay: todo.startDay,
       endDay: todo.endDay,
       groupId: groupID,
-      isDelete: true
+      isDelete: true,
+      repeatToDoId: todo.localID
     )
     return deletedItem
   }
@@ -512,14 +525,14 @@ extension HomeSceneInteractor {
   private func makeToDoListItem(batchItem: TodoBatchItem) -> TodoListItem {
     let todoListItem = TodoListItem(
       name: batchItem.name,
-      endDay: nil,
-      isDone: false,
+      endDay: batchItem.endDay,
+      isDone: batchItem.isDone,
       localID: batchItem.localId.lowercased(),
-      startDay: nil,
-      alarmTime: nil,
-      isAlarmOn: false,
-      isOnlyToday: true,
-      repeatToDoId: nil // TODO: 이건 어떻게 특정하지?
+      startDay: batchItem.startDay,
+      alarmTime: Int(batchItem.alarmTime),
+      isAlarmOn: batchItem.isAlarmOn,
+      isOnlyToday: batchItem.isOnlyToday,
+      repeatToDoId: batchItem.repeatToDoId
     )
     return todoListItem
   }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -187,6 +187,7 @@ extension HomeSceneViewController {
     self.loadingIndicator.startAnimation()
     Task {
       await interactor.syncronizeServerEditGroups()
+      await interactor.writeBatchItemsToGRDB()
       await interactor.requestBatchUpdateToServer()
       await interactor.fetchToDoList(request: HomeScene.FetchToDoList.Request(dateString: targetMonth))
     }
@@ -280,25 +281,29 @@ extension HomeSceneViewController: EditToDoSceneDelegate {
   public func didEdit(toDo: TodoBatchItem) {
     Task {
       defer { self.editingContext = nil }
-
+      self.loadingIndicator.isHidden = false
+      self.loadingIndicator.startAnimation()
+      
       guard
         let context = self.editingContext,
         let date = self.calendarView.getSelectedDate(),
         let snapshot = self.todoListView?.getSnapShot(),
-        let section = snapshot.indexOfSection(context.group)
+        let sectionIndex = snapshot.indexOfSection(context.group)
       else { return }
-
+      
       let items = snapshot.itemIdentifiers(inSection: context.group)
       guard let itemIndex = items.firstIndex(where: { $0.id == context.todo.id }) else { return }
 
-      let indexPath = IndexPath(item: itemIndex, section: section)
-
+      let indexPath = IndexPath(item: itemIndex, section: sectionIndex)
+      
       await self.interactor?.updateToDo(
         group: context.group,
         batchItem: toDo,
         indexPath: indexPath,
         date: date
       )
+      
+      self.fetchToDoList()
     }
   }
 

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -278,7 +278,7 @@ extension HomeSceneViewController: EditToDoSceneDelegate {
     let todo: ToDoListView.ToDoItem
   }
 
-  public func didEdit(toDo: TodoBatchItem) {
+  public func didEdit(toDo: TodoBatchItem, isNeededDeletionBySelection: Bool) {
     Task {
       defer { self.editingContext = nil }
       self.loadingIndicator.isHidden = false
@@ -300,7 +300,8 @@ extension HomeSceneViewController: EditToDoSceneDelegate {
         group: context.group,
         batchItem: toDo,
         indexPath: indexPath,
-        date: date
+        date: date,
+        isNeededDeletionBySelection: isNeededDeletionBySelection
       )
       
       self.fetchToDoList()

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneViewController.swift
@@ -74,10 +74,15 @@ open class HomeSceneViewController: UIViewController, HomeSceneViewControllable 
   
   open override func viewDidDisappear(_ animated: Bool) {
     super.viewDidDisappear(animated)
+    let targetMonth = self.calendarView.getCurrentMonth().toYYYYMMDDStringFromYYYYMM()
     Task {
       await self.interactor?.syncronizeServerEditGroups()
       await self.interactor?.writeBatchItemsToGRDB()
       await self.interactor?.requestBatchUpdateToServer()
+      await self.interactor?.fetchToDoList(
+        request: HomeScene.FetchToDoList.Request(dateString: targetMonth),
+        isForRouting: true
+      )
     }
   }
   
@@ -189,7 +194,10 @@ extension HomeSceneViewController {
       await interactor.syncronizeServerEditGroups()
       await interactor.writeBatchItemsToGRDB()
       await interactor.requestBatchUpdateToServer()
-      await interactor.fetchToDoList(request: HomeScene.FetchToDoList.Request(dateString: targetMonth))
+      await interactor.fetchToDoList(
+        request: HomeScene.FetchToDoList.Request(dateString: targetMonth),
+        isForRouting: false
+      )
     }
   }
 }

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
@@ -66,9 +66,7 @@ public struct HomeSceneWorker: HomeSceneWorkable, Sendable {
       }
     )
 
-    _ = try await database.write { db in
-      try TodoBatchItem.deleteAll(db)
-    }
+    try await self.clearToDoBatchItemTable()
   }
   
   public func loadMonthlyToDoListFromGRDB(dateString: String) async throws -> [DailyToDoListData] {
@@ -76,9 +74,32 @@ public struct HomeSceneWorker: HomeSceneWorkable, Sendable {
     
     return localMonthlyData
   }
+  
+  public func getRepeatToDos(repeatToDoId: String) async throws -> [MyToDo] {
+    let todos: [MyToDo] = try await database.read { db in
+      try MyToDo
+        .filter(Column("repeatToDoId") == repeatToDoId)
+        .fetchAll(db)
+    }
+    return todos
+  }
+  
+  public func clearRepeatToDos(repeatToDoId: String) async throws {
+    _ = try await database.write { db in
+      try MyToDo
+        .filter(Column("repeatToDoId") == repeatToDoId)
+        .deleteAll(db)
+    }
+  }
 }
 
 extension HomeSceneWorker {
+  private func clearToDoBatchItemTable() async throws {
+    _ = try await database.write { db in
+      try TodoBatchItem.deleteAll(db)
+    }
+  }
+  
   private func convertToMyGroupsAndMyToDos(from dailyData: DailyToDoListData) -> ([MyGroup], [MyToDo]) {
     var myGroups: [MyGroup] = []
     var myToDos: [MyToDo] = []
@@ -113,6 +134,7 @@ extension HomeSceneWorker {
     return (myGroups, myToDos)
   }
   
+  // 일단 커밋 정리해. 범위 조절은 완벽하다.
   public func writeBatchItemsToGRDB(data: [TodoBatchItem]) async throws {
     try await self.database.write { db in
       for var item in data {

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeScene/HomeSceneWorker.swift
@@ -134,7 +134,6 @@ extension HomeSceneWorker {
     return (myGroups, myToDos)
   }
   
-  // 일단 커밋 정리해. 범위 조절은 완벽하다.
   public func writeBatchItemsToGRDB(data: [TodoBatchItem]) async throws {
     try await self.database.write { db in
       for var item in data {

--- a/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneAPI/HomeSceneWorkable.swift
+++ b/ToDo-Garden/ToDo-Garden/HomeScene/Sources/HomeSceneAPI/HomeSceneWorkable.swift
@@ -18,4 +18,6 @@ public protocol HomeSceneWorkable: Sendable {
   func loadMonthlyToDoListFromGRDB(dateString: String) async throws -> [DailyToDoListData]
   func syncronizeGRDBWithBatchItems() async throws
   func syncronizeServerEditGroups() async throws
+  func getRepeatToDos(repeatToDoId: String) async throws -> [MyToDo]
+  func clearRepeatToDos(repeatToDoId: String) async throws
 }

--- a/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
+++ b/ToDo-Garden/ToDoGardenUI/Sources/ToDoGardenUIComponent/ToDoGardenAlertView.swift
@@ -12,9 +12,9 @@ import ToDoGardenUIConstant
 final public class ToDoGardenAlertView: UIView {
   private var configuration: Configuration
   
-  var buttonActionHandler: ((Constant.ToDoGardenAlertView.Content.ButtonActionType) -> Void)?
+  public var buttonActionHandler: ((Constant.ToDoGardenAlertView.Content.ButtonActionType) -> Void)?
   
-  init(configuration: Configuration) {
+  public init(configuration: Configuration) {
     self.configuration = configuration
     super.init(frame: CGRect.zero)
     self.build()


### PR DESCRIPTION
## 💡 관련 이슈
- #971 
## 🎉 변경 사항
- 리모트DB - 로컬DB - UI 동기화 로직 개선 
## 📌 PR Point

### 1) 반복 투두를 생성하면, 한국 시간기준이 아닌, 세계 표준시 날짜 기준으로 생성되던 문제 수정 
### 2) 생성된 반복투두의 범위를 바꿨을때, 현재 선택중인 투두를 제외한 모든 연관 투두를 날리고, 새로 설정된 범위에 반복투두를 생성합니다
### 3) didEdit() 로 인해 트리거되는 흐름에서의 연산과정이 꽤 많습니다. ViewIsAppearing 내부의 fetchToDoList 와 호출 타이밍이 어긋나는 현상이 있었습니다. didEdit()이 완료된 후에, fetchToDoList를 호출하여 리모트DB - 로컬DB - UI상태의 싱크를 완벽하게 맞춥니다. 

## 📝 셀프체크리스트

- [x]  머지하려고 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?